### PR TITLE
fix(tabs): moving tab panel visibility to user space

### DIFF
--- a/apps/documentation/src/app/examples/tabs/tabs.example.ts
+++ b/apps/documentation/src/app/examples/tabs/tabs.example.ts
@@ -53,6 +53,10 @@ import { NgpTabButton, NgpTabList, NgpTabPanel, NgpTabset } from 'ng-primitives/
       padding: 0.5rem 0;
       outline: none;
     }
+
+    [ngpTabPanel][data-active='false'] {
+      display: none;
+    }
   `,
   template: `
     <div [(ngpTabsetValue)]="selectedTab" ngpTabset>

--- a/packages/ng-primitives/tabs/src/tab-panel/tab-panel.directive.ts
+++ b/packages/ng-primitives/tabs/src/tab-panel/tab-panel.directive.ts
@@ -20,7 +20,6 @@ import { NgpTabPanelToken } from './tab-panel.token';
     '[attr.aria-labelledby]': 'labelledBy()',
     '[attr.data-active]': 'active()',
     '[attr.data-orientation]': 'tabset.orientation()',
-    '[hidden]': '!active()',
   },
 })
 export class NgpTabPanel {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently tab panels are hidden using the `[hidden]` attribute. This does however make it hard for transitions when appearing etc.. Instead, users would now be responsible for showing/hiding the tab based on the `data-active` attribute. 

## Issue

N/A

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Users will now be required to hide the panels using CSS.