### PR TITLE
fix(search): clear signal value

### DIFF
--- a/packages/ng-primitives/input/src/input/input.directive.ts
+++ b/packages/ng-primitives/input/src/input/input.directive.ts
@@ -36,7 +36,7 @@ export class NgpInput implements NgpCanDisable {
    * Access the underlying input element.
    * @internal
    */
-  readonly element = inject<ElementRef<HTMLInputElement>>(ElementRef);
+  private readonly elementRef = inject<ElementRef<HTMLInputElement>>(ElementRef);
 
   /**
    * Whether the element is disabled.
@@ -49,10 +49,21 @@ export class NgpInput implements NgpCanDisable {
    * Sync the input value.
    * @internal
    */
-  readonly value = signal<string>(this.element.nativeElement.value);
+  readonly value = signal<string>(this.elementRef.nativeElement.value);
+
+  /**
+   * Set the element input value and dispatch input event.
+   * @param value The value to set.
+   * @description The HTML input event triggers when a user interacts with an input field and changes its value. However, if the value is changed programmatically, the input event doesn't fire automatically, so we manually dispatch the InputEvent.
+   * @internal
+   */
+  setInputValue(value: string) {
+    this.elementRef.nativeElement.value = value;
+    this.elementRef.nativeElement.dispatchEvent(new InputEvent('input'));
+  }
 
   @HostListener('input')
   protected valueDidChange(): void {
-    this.value.set(this.element.nativeElement.value);
+    this.value.set(this.elementRef.nativeElement.value);
   }
 }

--- a/packages/ng-primitives/search/src/search-field/search-field.directive.ts
+++ b/packages/ng-primitives/search/src/search-field/search-field.directive.ts
@@ -33,6 +33,6 @@ export class NgpSearchField {
 
   @HostListener('keydown.escape')
   clear(): void {
-    this.input().element.nativeElement.value = '';
+    this.input().setInputValue('');
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

NgpSearchField clear method directly mutates the HTML input value. However, this programmatic change doesn't trigger input event, unlike changes made by the user. As a result, the signal and the native element values are out of sync.

The second option is to directly set the signal value instead of dispatching an event. This way we can avoid events chaining. 🤔 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
