### PR TITLE
feat(dialog): allow opening dialogs using service and allow passing data

### DIFF
--- a/apps/documentation/src/app/examples/dialog/dialog-data.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-data.example.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NgpButton } from 'ng-primitives/button';
 import {
   injectDialogRef,
@@ -15,7 +15,7 @@ import {
   selector: 'app-dialog',
   imports: [NgpButton],
   template: `
-    <button (click)="openDialogService()" ngpButton>Launch Dialog Service</button>
+    <button (click)="openDialog()" ngpButton>Launch Dialog</button>
   `,
   styles: `
     :host,
@@ -74,15 +74,12 @@ import {
     }
   `,
 })
-export default class DialogExample {
+export default class DialogDataExample {
   private dialogManager = inject(NgpDialogManager);
 
-  openDialogService() {
-    const dialogRef = this.dialogManager.open(DialogServiceExample, {
-      data: 'test',
-    });
-    dialogRef.closed.subscribe(result => {
-      console.log(result);
+  openDialog() {
+    this.dialogManager.open(Dialog, {
+      data: 'This came from the dialog opener!',
     });
   }
 }
@@ -100,10 +97,11 @@ export default class DialogExample {
   template: `
     <div ngpDialogOverlay>
       <div ngpDialog>
-        <h1 ngpDialogTitle>Publish this article?</h1>
-        <p ngpDialogDescription>
-          Are you sure you want to publish this article? This action is irreversible.
-        </p>
+        <h1 ngpDialogTitle>Dialog data example</h1>
+        <p ngpDialogDescription>The following value was passed to the dialog:</p>
+
+        <p class="dialog-data">{{ dialogRef.data }}</p>
+
         <div class="dialog-footer">
           <button (click)="close()" ngpButton>Cancel</button>
           <button (click)="close()" ngpButton>Confirm</button>
@@ -135,6 +133,9 @@ export default class DialogExample {
       --dialog-bg-dark: #121212;
       --dialog-title-color-dark: #fff;
       --dialog-description-color-dark: rgba(255, 255, 255, 0.6);
+
+      --dialog-data-color: rgba(0, 0, 0, 0.87);
+      --dialog-data-color-dark: #fff;
     }
 
     button {
@@ -207,6 +208,14 @@ export default class DialogExample {
       margin: 0;
     }
 
+    .dialog-data {
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 20px;
+      color: light-dark(var(--dialog-data-color), var(--dialog-data-color-dark));
+      margin: 8px 0 0;
+    }
+
     .dialog-footer {
       display: flex;
       justify-content: flex-end;
@@ -223,12 +232,8 @@ export default class DialogExample {
     }
   `,
 })
-export class DialogServiceExample implements OnInit {
-  private dialogRef = injectDialogRef<string>();
-
-  ngOnInit() {
-    console.log(this.dialogRef.data);
-  }
+export class Dialog {
+  protected readonly dialogRef = injectDialogRef<string>();
 
   close() {
     this.dialogRef.close();

--- a/apps/documentation/src/app/examples/dialog/dialog-service.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-service.example.ts
@@ -1,0 +1,236 @@
+import { Component, inject, OnInit } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import {
+  injectDialogRef,
+  NgpDialog,
+  NgpDialogDescription,
+  NgpDialogManager,
+  NgpDialogOverlay,
+  NgpDialogTitle,
+  NgpDialogTrigger,
+} from 'ng-primitives/dialog';
+
+@Component({
+  standalone: true,
+  selector: 'app-dialog',
+  imports: [NgpButton],
+  template: `
+    <button (click)="openDialogService()" ngpButton>Launch Dialog Service</button>
+  `,
+  styles: `
+    :host,
+    [ngpDialogOverlay] {
+      --button-color: rgb(10 10 10);
+      --button-background-color: rgb(255 255 255);
+      --button-hover-color: rgb(10 10 10);
+      --button-hover-background-color: rgb(250 250 250);
+      --button-focus-shadow: rgb(59 130 246);
+      --button-pressed-background-color: rgb(245 245 245);
+
+      --button-color-dark: rgb(255 255 255);
+      --button-background-color-dark: rgb(43 43 43);
+      --button-hover-color-dark: rgb(255 255 255);
+      --button-hover-background-color-dark: rgb(63, 63, 70);
+      --button-focus-shadow-dark: rgb(59 130 246);
+      --button-pressed-background-color-dark: rgb(39, 39, 42);
+    }
+
+    button {
+      padding-left: 1rem;
+      padding-right: 1rem;
+      border-radius: 0.5rem;
+      color: light-dark(var(--button-color), var(--button-color-dark));
+      border: none;
+      outline: none;
+      height: 2.5rem;
+      font-weight: 500;
+      background-color: light-dark(
+        var(--button-background-color),
+        var(--button-background-color-dark)
+      );
+      transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow:
+        0 1px 3px 0 rgb(0 0 0 / 0.1),
+        0 1px 2px -1px rgb(0 0 0 / 0.1),
+        0 0 0 1px rgb(0 0 0 / 0.05);
+    }
+
+    button[data-hover] {
+      background-color: light-dark(
+        var(--button-hover-background-color),
+        var(--button-hover-background-color-dark)
+      );
+    }
+
+    button[data-focus-visible] {
+      box-shadow: 0 0 0 2px light-dark(var(--button-focus-shadow), var(--button-focus-shadow-dark));
+    }
+
+    button[data-press] {
+      background-color: light-dark(
+        var(--button-pressed-background-color),
+        var(--button-pressed-background-color-dark)
+      );
+    }
+  `,
+})
+export default class DialogExample {
+  private dialogManager = inject(NgpDialogManager);
+
+  openDialogService() {
+    const dialogRef = this.dialogManager.open(DialogServiceExample, {
+      data: 'test',
+    });
+    dialogRef.closed.subscribe(result => {
+      console.log(result);
+    });
+  }
+}
+
+@Component({
+  standalone: true,
+  imports: [
+    NgpButton,
+    NgpDialog,
+    NgpDialogOverlay,
+    NgpDialogTitle,
+    NgpDialogDescription,
+    NgpDialogTrigger,
+  ],
+  template: `
+    <div ngpDialogOverlay>
+      <div ngpDialog>
+        <h1 ngpDialogTitle>Publish this article?</h1>
+        <p ngpDialogDescription>
+          Are you sure you want to publish this article? This action is irreversible.
+        </p>
+        <div class="dialog-footer">
+          <button (click)="close()" ngpButton>Cancel</button>
+          <button (click)="close()" ngpButton>Confirm</button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    :host,
+    [ngpDialogOverlay] {
+      --button-color: rgb(10 10 10);
+      --button-background-color: rgb(255 255 255);
+      --button-hover-color: rgb(10 10 10);
+      --button-hover-background-color: rgb(250 250 250);
+      --button-focus-shadow: rgb(59 130 246);
+      --button-pressed-background-color: rgb(245 245 245);
+
+      --button-color-dark: rgb(255 255 255);
+      --button-background-color-dark: rgb(43 43 43);
+      --button-hover-color-dark: rgb(255 255 255);
+      --button-hover-background-color-dark: rgb(63, 63, 70);
+      --button-focus-shadow-dark: rgb(59 130 246);
+      --button-pressed-background-color-dark: rgb(39, 39, 42);
+
+      --dialog-bg: #fff;
+      --dialog-title-color: rgba(0, 0, 0, 0.87);
+      --dialog-description-color: rgba(0, 0, 0, 0.6);
+
+      --dialog-bg-dark: #121212;
+      --dialog-title-color-dark: #fff;
+      --dialog-description-color-dark: rgba(255, 255, 255, 0.6);
+    }
+
+    button {
+      padding-left: 1rem;
+      padding-right: 1rem;
+      border-radius: 0.5rem;
+      color: light-dark(var(--button-color), var(--button-color-dark));
+      border: none;
+      outline: none;
+      height: 2.5rem;
+      font-weight: 500;
+      background-color: light-dark(
+        var(--button-background-color),
+        var(--button-background-color-dark)
+      );
+      transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow:
+        0 1px 3px 0 rgb(0 0 0 / 0.1),
+        0 1px 2px -1px rgb(0 0 0 / 0.1),
+        0 0 0 1px rgb(0 0 0 / 0.05);
+    }
+
+    button[data-hover] {
+      background-color: light-dark(
+        var(--button-hover-background-color),
+        var(--button-hover-background-color-dark)
+      );
+    }
+
+    button[data-focus-visible] {
+      box-shadow: 0 0 0 2px light-dark(var(--button-focus-shadow), var(--button-focus-shadow-dark));
+    }
+
+    button[data-press] {
+      background-color: light-dark(
+        var(--button-pressed-background-color),
+        var(--button-pressed-background-color-dark)
+      );
+    }
+
+    [ngpDialogOverlay] {
+      background-color: rgba(0, 0, 0, 0.5);
+      backdrop-filter: blur(4px);
+      position: fixed;
+      inset: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+
+    [ngpDialog] {
+      background-color: light-dark(var(--dialog-bg), var(--dialog-bg-dark));
+      padding: 24px;
+      border-radius: 8px;
+      box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
+    }
+
+    [ngpDialogTitle] {
+      font-size: 18px;
+      line-height: 28px;
+      font-weight: 600;
+      color: light-dark(var(--dialog-title-color), var(--dialog-title-color-dark));
+      margin: 0 0 4px;
+    }
+
+    [ngpDialogDescription] {
+      font-size: 14px;
+      line-height: 20px;
+      color: light-dark(var(--dialog-description-color), var(--dialog-description-color-dark));
+      margin: 0;
+    }
+
+    .dialog-footer {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 32px;
+      column-gap: 4px;
+    }
+
+    .dialog-footer [ngpButton]:not([data-focus-visible]) {
+      box-shadow: none;
+    }
+
+    .dialog-footer [ngpButton]:last-of-type {
+      color: rgb(59 130 246);
+    }
+  `,
+})
+export class DialogServiceExample implements OnInit {
+  private dialogRef = injectDialogRef<string>();
+
+  ngOnInit() {
+    console.log(this.dialogRef.data);
+  }
+
+  close() {
+    this.dialogRef.close();
+  }
+}

--- a/apps/documentation/src/app/pages/primitives/dialog.md
+++ b/apps/documentation/src/app/pages/primitives/dialog.md
@@ -8,6 +8,8 @@ A dialog is a floating window that can be used to display information or prompt 
 
 <docs-example name="dialog"></docs-example>
 
+<docs-example name="dialog-service"></docs-example>
+
 ## Import
 
 Import the Dialog primitives from `ng-primitives/dialog`.

--- a/apps/documentation/src/app/pages/primitives/dialog.md
+++ b/apps/documentation/src/app/pages/primitives/dialog.md
@@ -8,8 +8,6 @@ A dialog is a floating window that can be used to display information or prompt 
 
 <docs-example name="dialog"></docs-example>
 
-<docs-example name="dialog-service"></docs-example>
-
 ## Import
 
 Import the Dialog primitives from `ng-primitives/dialog`.
@@ -104,6 +102,14 @@ The dialog overlay.
 
 - Selector: `[ngpDialogOverlay]`
 - Exported As: `ngpDialogOverlay`
+
+## Examples
+
+### Dialog with external data
+
+Data can be passed to the dialog using the `NgpDialogManager`.
+
+<docs-example name="dialog-data"></docs-example>
 
 ## Accessibility
 

--- a/packages/ng-primitives/dialog/src/config/dialog.config.ts
+++ b/packages/ng-primitives/dialog/src/config/dialog.config.ts
@@ -11,7 +11,7 @@ import { InjectionToken, Injector, Provider, ViewContainerRef, inject } from '@a
 /** Valid ARIA roles for a dialog. */
 export type NgpDialogRole = 'dialog' | 'alertdialog';
 
-export interface NgpDialogConfig {
+export interface NgpDialogConfig<T = any> {
   /** The view container to attach the dialog to. */
   viewContainerRef?: ViewContainerRef;
 
@@ -35,6 +35,8 @@ export interface NgpDialogConfig {
    * history.
    */
   closeOnNavigation?: boolean;
+
+  data?: T;
 }
 
 export const defaultDialogConfig: NgpDialogConfig = {

--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -15,7 +15,7 @@ import { NgpDialogConfig } from '../config/dialog.config';
 /**
  * Reference to a dialog opened via the Dialog service.
  */
-export class NgpDialogRef {
+export class NgpDialogRef<T = any> {
   /** Whether the user is allowed to close the dialog. */
   disableClose: boolean | undefined;
 
@@ -28,6 +28,9 @@ export class NgpDialogRef {
   /** Emits on pointer events that happen outside of the dialog. */
   readonly outsidePointerEvents: Observable<MouseEvent>;
 
+  /** Data passed from the dialog opener. */
+  readonly data?: T;
+
   /** Unique ID for the dialog. */
   readonly id: string;
 
@@ -36,8 +39,9 @@ export class NgpDialogRef {
 
   constructor(
     readonly overlayRef: OverlayRef,
-    readonly config: NgpDialogConfig,
+    readonly config: NgpDialogConfig<T>,
   ) {
+    this.data = config.data;
     this.keydownEvents = overlayRef.keydownEvents();
     this.outsidePointerEvents = overlayRef.outsidePointerEvents();
     this.id = config.id!; // By the time the dialog is created we are guaranteed to have an ID.
@@ -71,6 +75,6 @@ export class NgpDialogRef {
   }
 }
 
-export function injectDialogRef(): NgpDialogRef {
-  return inject(NgpDialogRef);
+export function injectDialogRef<T>(): NgpDialogRef<T> {
+  return inject(NgpDialogRef<T>);
 }

--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -15,7 +15,7 @@ import { NgpDialogConfig } from '../config/dialog.config';
 /**
  * Reference to a dialog opened via the Dialog service.
  */
-export class NgpDialogRef<T = any> {
+export class NgpDialogRef<T = unknown> {
   /** Whether the user is allowed to close the dialog. */
   disableClose: boolean | undefined;
 
@@ -75,6 +75,6 @@ export class NgpDialogRef<T = any> {
   }
 }
 
-export function injectDialogRef<T>(): NgpDialogRef<T> {
-  return inject(NgpDialogRef<T>);
+export function injectDialogRef<T = unknown>(): NgpDialogRef<T> {
+  return inject<NgpDialogRef<T>>(NgpDialogRef);
 }

--- a/packages/ng-primitives/dialog/src/dialog/dialog.directive.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.directive.ts
@@ -28,11 +28,11 @@ import { NgpDialogToken } from './dialog.token';
     '[attr.aria-describedby]': 'describedBy().join(" ")',
   },
 })
-export class NgpDialog implements OnDestroy {
+export class NgpDialog<T = unknown> implements OnDestroy {
   private readonly config = injectDialogConfig();
 
   /** Access the dialog ref */
-  private readonly dialogRef = injectDialogRef();
+  private readonly dialogRef = injectDialogRef<T>();
 
   /** The id of the dialog */
   readonly id = input<string>(uniqueId('ngp-dialog'));

--- a/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { Overlay, OverlayConfig, OverlayContainer, ScrollStrategy } from '@angular/cdk/overlay';
-import { TemplatePortal } from '@angular/cdk/portal';
+import { ComponentPortal, ComponentType, TemplatePortal } from '@angular/cdk/portal';
 import {
   Injectable,
   Injector,
@@ -73,7 +73,10 @@ export class NgpDialogManager implements OnDestroy {
   /**
    * Opens a modal dialog containing the given template.
    */
-  open(templateRef: TemplateRef<NgpDialogContext>, config?: NgpDialogConfig): NgpDialogRef {
+  open(
+    templateRefOrComponentType: TemplateRef<NgpDialogContext> | ComponentType<any>,
+    config?: NgpDialogConfig,
+  ): NgpDialogRef {
     const defaults = this.defaultOptions;
     config = { ...defaults, ...config };
     config.id = config.id ?? uniqueId('ngp-dialog');
@@ -91,7 +94,15 @@ export class NgpDialogManager implements OnDestroy {
       close: dialogRef.close.bind(dialogRef),
     };
 
-    overlayRef.attach(new TemplatePortal(templateRef, config.viewContainerRef!, context, injector));
+    if (templateRefOrComponentType instanceof TemplateRef) {
+      overlayRef.attach(
+        new TemplatePortal(templateRefOrComponentType, config.viewContainerRef!, context, injector),
+      );
+    } else {
+      overlayRef.attach(
+        new ComponentPortal(templateRefOrComponentType, config.viewContainerRef!, injector),
+      );
+    }
 
     // If this is the first dialog that we're opening, hide all the non-overlay content.
     if (!this.openDialogs.length) {

--- a/packages/ng-primitives/dialog/src/index.ts
+++ b/packages/ng-primitives/dialog/src/index.ts
@@ -15,5 +15,7 @@ export { NgpDialogTitle } from './dialog-title/dialog-title.directive';
 export { NgpDialogTitleToken } from './dialog-title/dialog-title.token';
 export { NgpDialogTrigger } from './dialog-trigger/dialog-trigger.directive';
 export { NgpDialogTriggerToken } from './dialog-trigger/dialog-trigger.token';
+export { injectDialogRef } from './dialog/dialog-ref';
 export { NgpDialog } from './dialog/dialog.directive';
+export { NgpDialogManager } from './dialog/dialog.service';
 export { NgpDialogToken } from './dialog/dialog.token';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

This PR introduces functionality to open dialogs using the `NgpDialogManager`, enabling developers to pass a data property when instantiating dialogs. Additionally, it enhances the `close` method of `NgpDialogRef`, allowing developers to retrieve result data from the dialog upon closing.

### Key Changes

- **Dialog Opening**:
   -  Implemented a feature in `NgpDialogManager` to accept and pass data properties to dialogs.
   - Allow opening Components.
- **Dialog Closure**: Modified the `close` method of `NgpDialogRef` to return result data, improving the workflow for developers interacting with dialog results.

### Benefits

These enhancements provide greater flexibility and usability for developers, facilitating more dynamic interactions with dialogs within the application.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
