### PR TITLE
fix(popover): fix sometimes popover trigger is not focused on close

### DIFF
--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
@@ -303,16 +303,16 @@ export class NgpPopoverTrigger implements OnDestroy {
     }
 
     this.state.set('closing');
-    this.disposables.setTimeout(() => this.destroyPopover(), this.hideDelay());
+    this.disposables.setTimeout(() => {
+      this.destroyPopover();
+      // ensure the trigger is focused after closing the popover
+      setTimeout(() => this.focusTrigger(origin), 0);
+    }, this.hideDelay());
 
     // Remove the document click listener when the popover is hidden
     if (this.documentClickListener) {
       this.document.removeEventListener('click', this.documentClickListener, true);
     }
-
-    // ensure the trigger is focused after closing the popover
-    // we need this delay but I can't quite figure out why?
-    setTimeout(() => this.focusTrigger(origin), 1);
   }
 
   private onDocumentClick(event: MouseEvent): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->
Sometimes when the popover is closed the popover trigger was not focused. Seamed to be a race condition between disposing the popover and focusing the trigger. By moving the focusing the trigger after disposing it ensures that the popover is destroyed and focus traps is gone and there by the trigger is able to focus.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
