### PR TITLE
feat(file-upload): filter dropped files by accepted fileTypes and lim…

### DIFF
--- a/apps/documentation/src/app/examples/file-upload/file-dropzone.example.ts
+++ b/apps/documentation/src/app/examples/file-upload/file-dropzone.example.ts
@@ -7,6 +7,7 @@ import { NgpFileDropzone } from 'ng-primitives/file-upload';
   template: `
     <div
       (ngpFileDropzoneSelected)="onFilesSelected($event)"
+      (ngpFileDropzoneRejected)="onFilesRejected()"
       ngpFileDropzoneFileTypes=".svg, .pdf"
       ngpFileDropzone
     >
@@ -58,5 +59,9 @@ export default class FileDropzoneExample {
     if (files) {
       alert(`Selected ${files.length} files.`);
     }
+  }
+
+  onFilesRejected(): void {
+    alert('File type not supported.');
   }
 }

--- a/apps/documentation/src/app/examples/file-upload/file-upload.example.ts
+++ b/apps/documentation/src/app/examples/file-upload/file-upload.example.ts
@@ -10,6 +10,7 @@ import { NgpFileUpload } from 'ng-primitives/file-upload';
   template: `
     <div
       (ngpFileUploadSelected)="onFilesSelected($event)"
+      (ngpFileUploadRejected)="onFilesRejected()"
       ngpFileUploadFileTypes=".svg, .pdf"
       ngpFileUpload
       ngpFileUploadMultiple
@@ -67,5 +68,9 @@ export default class FileUploadExample {
     if (files) {
       alert(`Selected ${files.length} files.`);
     }
+  }
+
+  onFilesRejected(): void {
+    alert('File type not supported.');
   }
 }

--- a/packages/ng-primitives/file-upload/src/file-dropzone/file-drop-filter.spec.ts
+++ b/packages/ng-primitives/file-upload/src/file-dropzone/file-drop-filter.spec.ts
@@ -1,0 +1,66 @@
+import { isFileTypeAccepted } from './file-drop-filter';
+
+describe('isFileTypeAccepted', () => {
+  const createFile = (name: string, type: string): File =>
+    new File(['dummy content'], name, { type });
+
+  test('returns true if no acceptedTypes are provided', () => {
+    const file = createFile('image.jpg', 'image/jpeg');
+    expect(isFileTypeAccepted(file, undefined)).toBe(true);
+    expect(isFileTypeAccepted(file, [])).toBe(true);
+  });
+
+  test('matches exact MIME types', () => {
+    const file = createFile('image.jpg', 'image/jpeg');
+    expect(isFileTypeAccepted(file, ['image/jpeg'])).toBe(true);
+    expect(isFileTypeAccepted(file, ['image/png'])).toBe(false);
+  });
+
+  test('matches wildcard MIME types', () => {
+    const file = createFile('image.jpg', 'image/jpeg');
+    expect(isFileTypeAccepted(file, ['image/*'])).toBe(true);
+    expect(isFileTypeAccepted(file, ['application/*'])).toBe(false);
+  });
+
+  test('matches file extensions', () => {
+    const file = createFile('photo.JPG', 'image/jpeg');
+    expect(isFileTypeAccepted(file, ['.jpg'])).toBe(true);
+    expect(isFileTypeAccepted(file, ['.jpeg'])).toBe(false);
+    expect(isFileTypeAccepted(file, ['.png'])).toBe(false);
+  });
+
+  test('ignores case in acceptedTypes', () => {
+    const file = createFile('photo.jpg', 'image/jpeg');
+    expect(isFileTypeAccepted(file, ['.JPG', 'IMAGE/*'])).toBe(true);
+  });
+
+  test('does not match extension if only MIME type matches', () => {
+    const file = createFile('photo.jpg', 'image/jpeg');
+    expect(isFileTypeAccepted(file, ['.png'])).toBe(false);
+  });
+
+  test('matches application/pdf MIME type', () => {
+    const file = createFile('document.pdf', 'application/pdf');
+
+    expect(isFileTypeAccepted(file, ['application/pdf'])).toBe(true);
+    expect(isFileTypeAccepted(file, ['application/*'])).toBe(true);
+    expect(isFileTypeAccepted(file, ['.pdf'])).toBe(true);
+    expect(isFileTypeAccepted(file, ['image/*'])).toBe(false);
+  });
+
+  test('handles PDF file without extension', () => {
+    const file = createFile('document', 'application/pdf');
+
+    expect(isFileTypeAccepted(file, ['application/pdf'])).toBe(true);
+    expect(isFileTypeAccepted(file, ['application/*'])).toBe(true);
+    expect(isFileTypeAccepted(file, ['.pdf'])).toBe(false);
+  });
+
+  test('handles PNG file without extension', () => {
+    const file = createFile('image', 'image/png');
+
+    expect(isFileTypeAccepted(file, ['image/png'])).toBe(true);
+    expect(isFileTypeAccepted(file, ['image/*'])).toBe(true);
+    expect(isFileTypeAccepted(file, ['.png'])).toBe(false);
+  });
+});

--- a/packages/ng-primitives/file-upload/src/file-dropzone/file-drop-filter.ts
+++ b/packages/ng-primitives/file-upload/src/file-dropzone/file-drop-filter.ts
@@ -10,11 +10,27 @@ export function fileDropFilter(
   return limitedFiles.length > 0 ? filesToFileList(limitedFiles) : null;
 }
 
-function isFileTypeAccepted(file: File, acceptedTypes: string[] | undefined) {
+export function isFileTypeAccepted(file: File, acceptedTypes: string[] | undefined) {
   // allow all file types if no types are specified
   if (!acceptedTypes || acceptedTypes.length === 0) return true;
 
-  return acceptedTypes.some(acceptedType => file.type.match(acceptedType));
+  const mimeType = file.type;
+  const fileName = file.name.toLowerCase();
+
+  return acceptedTypes.some(type => {
+    type = type.toLowerCase();
+
+    if (type.startsWith('.')) {
+      return fileName.endsWith(type);
+    }
+
+    if (type.endsWith('/*')) {
+      const baseType = type.replace('/*', '');
+      return mimeType.startsWith(baseType);
+    }
+
+    return mimeType === type;
+  });
 }
 
 function filesToFileList(files: File[]): FileList {

--- a/packages/ng-primitives/file-upload/src/file-dropzone/file-drop-filter.ts
+++ b/packages/ng-primitives/file-upload/src/file-dropzone/file-drop-filter.ts
@@ -1,0 +1,24 @@
+export function fileDropFilter(
+  fileList: FileList,
+  acceptedTypes: string[] | undefined,
+  multiple: boolean,
+) {
+  const validFiles = Array.from(fileList).filter(file => isFileTypeAccepted(file, acceptedTypes));
+
+  const limitedFiles = multiple ? validFiles : validFiles.slice(0, 1);
+
+  return limitedFiles.length > 0 ? filesToFileList(limitedFiles) : null;
+}
+
+function isFileTypeAccepted(file: File, acceptedTypes: string[] | undefined) {
+  // allow all file types if no types are specified
+  if (!acceptedTypes || acceptedTypes.length === 0) return true;
+
+  return acceptedTypes.some(acceptedType => file.type.match(acceptedType));
+}
+
+function filesToFileList(files: File[]): FileList {
+  const dataTransfer = new DataTransfer();
+  files.forEach(file => dataTransfer.items.add(file));
+  return dataTransfer.files;
+}

--- a/packages/ng-primitives/file-upload/src/file-dropzone/file-dropzone.ts
+++ b/packages/ng-primitives/file-upload/src/file-dropzone/file-dropzone.ts
@@ -72,6 +72,13 @@ export class NgpFileDropzone {
   });
 
   /**
+   * Emits when uploaded files are rejected because they do not match the allowed {@link fileTypes}.
+   */
+  readonly rejected = output<void>({
+    alias: 'ngpFileDropzoneRejected',
+  });
+
+  /**
    * Emits when the user drags a file over the file upload.
    */
   readonly dragOver = output<boolean>({
@@ -148,6 +155,8 @@ export class NgpFileDropzone {
 
       if (filteredFiles) {
         this.selected.emit(filteredFiles);
+      } else {
+        this.rejected.emit();
       }
     }
   }

--- a/packages/ng-primitives/file-upload/src/file-dropzone/file-dropzone.ts
+++ b/packages/ng-primitives/file-upload/src/file-dropzone/file-dropzone.ts
@@ -10,6 +10,7 @@ import {
   signal,
 } from '@angular/core';
 import { setupHover } from 'ng-primitives/internal';
+import { fileDropFilter } from './file-drop-filter';
 import { fileDropzoneState, provideFileDropzoneState } from './file-dropzone-state';
 
 /**
@@ -141,8 +142,13 @@ export class NgpFileDropzone {
     this.isDragOver.set(false);
     this.dragOver.emit(false);
 
-    if (event.dataTransfer?.files) {
-      this.selected.emit(event.dataTransfer.files);
+    const fileList = event.dataTransfer?.files;
+    if (fileList) {
+      const filteredFiles = fileDropFilter(fileList, this.state.fileTypes(), this.state.multiple());
+
+      if (filteredFiles) {
+        this.selected.emit(filteredFiles);
+      }
     }
   }
 }

--- a/packages/ng-primitives/file-upload/src/file-upload/file-upload.ts
+++ b/packages/ng-primitives/file-upload/src/file-upload/file-upload.ts
@@ -80,10 +80,17 @@ export class NgpFileUpload {
   });
 
   /**
-   * Emits when the user selects files.
+   * Emits when the user cancel the file selection.
    */
   readonly canceled = output<void>({
     alias: 'ngpFileUploadCanceled',
+  });
+
+  /**
+   * Emits when uploaded files are rejected because they do not match the allowed {@link fileTypes}.
+   */
+  readonly rejected = output<void>({
+    alias: 'ngpFileUploadRejected',
   });
 
   /**
@@ -197,6 +204,8 @@ export class NgpFileUpload {
 
       if (filteredFiles) {
         this.selected.emit(filteredFiles);
+      } else {
+        this.rejected.emit();
       }
     }
   }

--- a/packages/ng-primitives/file-upload/src/file-upload/file-upload.ts
+++ b/packages/ng-primitives/file-upload/src/file-upload/file-upload.ts
@@ -190,8 +190,32 @@ export class NgpFileUpload {
     this.isDragOver.set(false);
     this.dragOver.emit(false);
 
-    if (event.dataTransfer?.files) {
-      this.selected.emit(event.dataTransfer.files);
+    const fileList = event.dataTransfer?.files;
+    if (fileList) {
+      const validFiles = Array.from(fileList).filter(file => this.isFileTypeAccepted(file));
+
+      const limitedFiles = this.state.multiple() ? validFiles : validFiles.slice(0, 1);
+
+      if (limitedFiles.length > 0) {
+        this.selected.emit(this.filesToFileList(limitedFiles));
+      } else {
+        this.selected.emit(null);
+      }
     }
+  }
+
+  private isFileTypeAccepted(file: File) {
+    const acceptedTypes = this.state.fileTypes();
+
+    // allow all file types if no types are specified
+    if (!acceptedTypes || acceptedTypes.length === 0) return true;
+
+    return acceptedTypes.some(acceptedType => file.type.match(acceptedType));
+  }
+
+  private filesToFileList(files: File[]): FileList {
+    const dataTransfer = new DataTransfer();
+    files.forEach(file => dataTransfer.items.add(file));
+    return dataTransfer.files;
   }
 }

--- a/packages/ng-primitives/file-upload/src/file-upload/file-upload.ts
+++ b/packages/ng-primitives/file-upload/src/file-upload/file-upload.ts
@@ -10,6 +10,7 @@ import {
   signal,
 } from '@angular/core';
 import { setupInteractions } from 'ng-primitives/internal';
+import { fileDropFilter } from '../file-dropzone/file-drop-filter';
 import { fileUploadState, provideFileUploadState } from './file-upload-state';
 
 /**
@@ -192,30 +193,11 @@ export class NgpFileUpload {
 
     const fileList = event.dataTransfer?.files;
     if (fileList) {
-      const validFiles = Array.from(fileList).filter(file => this.isFileTypeAccepted(file));
+      const filteredFiles = fileDropFilter(fileList, this.state.fileTypes(), this.state.multiple());
 
-      const limitedFiles = this.state.multiple() ? validFiles : validFiles.slice(0, 1);
-
-      if (limitedFiles.length > 0) {
-        this.selected.emit(this.filesToFileList(limitedFiles));
-      } else {
-        this.selected.emit(null);
+      if (filteredFiles) {
+        this.selected.emit(filteredFiles);
       }
     }
-  }
-
-  private isFileTypeAccepted(file: File) {
-    const acceptedTypes = this.state.fileTypes();
-
-    // allow all file types if no types are specified
-    if (!acceptedTypes || acceptedTypes.length === 0) return true;
-
-    return acceptedTypes.some(acceptedType => file.type.match(acceptedType));
-  }
-
-  private filesToFileList(files: File[]): FileList {
-    const dataTransfer = new DataTransfer();
-    files.forEach(file => dataTransfer.items.add(file));
-    return dataTransfer.files;
   }
 }


### PR DESCRIPTION
…it to one when multiple is false

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

`NgpFileUpload` / `NgpFileDropzone` ignore the inputs `multiple` and `fileTypes` for the `drop` event listener.

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

`NgpFileUpload` filters files from the drop event to match the `fileTypes` and only returns one file when `multiple` is false.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This might be a breaking change for someone that relied on the previous behavior for the drop event.
