### PR TITLE
fix(combobox): Select input after dropdown opened

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox-button/combobox-button.ts
+++ b/packages/ng-primitives/combobox/src/combobox-button/combobox-button.ts
@@ -46,8 +46,8 @@ export class NgpComboboxButton {
   }
 
   @HostListener('click')
-  protected toggleDropdown(): void {
-    this.state().toggleDropdown();
+  protected async toggleDropdown(): Promise<void> {
+    await this.state().toggleDropdown();
     this.state().input()?.focus();
   }
 }

--- a/packages/ng-primitives/combobox/src/combobox/combobox.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.ts
@@ -198,11 +198,11 @@ export class NgpCombobox {
    * Toggle the dropdown.
    * @internal
    */
-  toggleDropdown(): void {
+  async toggleDropdown(): Promise<void> {
     if (this.open()) {
       this.closeDropdown();
     } else {
-      this.openDropdown();
+      await this.openDropdown();
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #266

## What does this PR implement/fix?

Tries to select the input field after the dropdown opens so it also works for use cases where the input in placed in the dropdown

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
