### PR TITLE
fix(overlay): ensure destroy overlay when trigger is destroyed

### DIFF
--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -320,6 +320,7 @@ export class NgpOverlay<T = unknown> {
    */
   destroy(): void {
     this.hideImmediate();
+    this.destroyOverlay();
     this.disposePositioning?.();
     this.scrollStrategy.disable();
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

When an overlay is visible and the trigger is destroyed it sometimes leaves the overlay (the setTimeout is not fired in hide). 

## What does this PR implement/fix?

This fix ensures clean up and destroying the overlay.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
