### PR TITLE
fix: sync state and data-attributes in form-field and form-control - control status

### DIFF
--- a/packages/ng-primitives/form-field/src/form-field/form-field.ts
+++ b/packages/ng-primitives/form-field/src/form-field/form-field.ts
@@ -123,8 +123,10 @@ export class NgpFormField implements OnDestroy {
     // set the initial values
     this.updateStatus();
 
-    // Listen for changes to the form control.
-    this.subscription = control?.valueChanges?.subscribe(this.updateStatus.bind(this));
+    const underlyingControl = control?.control;
+
+    // Listen for changes to the underlying control's status.
+    this.subscription = underlyingControl?.events?.subscribe(this.updateStatus.bind(this));
   }
 
   private updateStatus(): void {

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -1,4 +1,4 @@
-import { Signal, inject, signal } from '@angular/core';
+import { DestroyRef, Signal, WritableSignal, afterNextRender, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgControl } from '@angular/forms';
 
@@ -12,6 +12,39 @@ export interface NgpControlStatus {
   disabled: boolean | null;
 }
 
+function setStatusSignal(
+  control: NgControl | null,
+  status: WritableSignal<NgpControlStatus>,
+): void {
+  if (!control?.control) {
+    return;
+  }
+
+  status.set({
+    valid: control?.control?.valid ?? null,
+    invalid: control?.control?.invalid ?? null,
+    pristine: control?.control?.pristine ?? null,
+    dirty: control?.control?.dirty ?? null,
+    touched: control?.control?.touched ?? null,
+    pending: control?.control?.pending ?? null,
+    disabled: control?.control?.disabled ?? null,
+  });
+}
+
+function subscribeToControlStatus(
+  control: NgControl | null,
+  status: WritableSignal<NgpControlStatus>,
+  destroyRef?: DestroyRef,
+): void {
+  if (!control?.control) {
+    return;
+  }
+
+  control.control.events
+    .pipe(takeUntilDestroyed(destroyRef))
+    .subscribe(() => setStatusSignal(control, status));
+}
+
 /**
  * A utility function to get the status of an Angular form control as a reactive signal.
  * This function injects the NgControl and returns a signal that reflects the control's status.
@@ -19,6 +52,7 @@ export interface NgpControlStatus {
  */
 export function controlStatus(): Signal<NgpControlStatus> {
   const control = inject(NgControl, { optional: true });
+  const destroyRef = inject(DestroyRef);
 
   const status = signal<NgpControlStatus>({
     valid: null,
@@ -32,20 +66,22 @@ export function controlStatus(): Signal<NgpControlStatus> {
 
   // Fallback if control is not yet available
   if (!control?.control) {
+    // There is still a chance that the control will be available i.e. after executing OnInit lifecycle hook
+    // in `formControlName` directive, so we set up an effect to subscribe to the control status
+    afterNextRender({
+      write: () => {
+        // If control is still not available, we do nothing, otherwise we subscribe to the control status
+        if (control?.control) {
+          subscribeToControlStatus(control, status, destroyRef);
+          // We re-set the status to ensure it reflects the current state on initialization
+          setStatusSignal(control, status);
+        }
+      },
+    });
     return status;
   }
 
-  control.control.statusChanges.pipe(takeUntilDestroyed()).subscribe(() => {
-    status.set({
-      valid: control?.control?.valid ?? null,
-      invalid: control?.control?.invalid ?? null,
-      pristine: control?.control?.pristine ?? null,
-      dirty: control?.control?.dirty ?? null,
-      touched: control?.control?.touched ?? null,
-      pending: control?.control?.pending ?? null,
-      disabled: control?.control?.disabled ?? null,
-    });
-  });
+  subscribeToControlStatus(control, status);
 
   return status;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

This PR introduces two fixes for form-field and form-control

### `form-field` now correctly syncs data-attributes and its state
Previous solution was updating state based on `valueChanges` stream, which would not update state and data-attribs on events such as `touch`, without changing value of the control, i.e. user clicking input and immediately clicking away. My proposed solutions uses recently introduced `events` stream on internal ngControl's control which reacts to more events, more can be found here: https://github.com/angular/angular/issues/10887.
Take note that:
- `statusChanges` wouldn't work as it primarily emits when control's validity changes, not other events
- `events` adds slight perf overhead to the solution, as it may emit multiple times (i.e. when value and validity change at the same time). It is mostly neglegible, as most of the signals are updated with primitive values and won't be updated anyway, except `errors` which is an array

### `form-control` now correctly syncs data-attributes and its state, including its initialization and ngControl.control recognition
Setting up form control had three main issues, which made it more challenging that form-field:
- initialization of state and data-attribs didn't work sometimes (there were no data-attribs at all)
- some examples in the docs were working correctly, with correct initial state and partially correct updates, and some were not
- even if they were updating, updates only happened on `statusChange` (so mainly form-field case)

I've spent some time and figured out that there is a fundamental difference in how you should handle controls applied via `ngModel` and `formControl|formControlName` directives. Currently, i.e for input directive, we are setting up form control in `constructor`, which works fine with `ngModel` as it creates its internal formcontrol right away. Unfortunately, `formControl|formControlName` directives set up their controls in `ngOnChanges`, which is updated roughly at the same time as `ngOnInit` for these directives, but still later than our `constructor` form control setup. That caused it to never subscribe to changes or set its init state correctly for controls that used reactive forms (ngControl was never fully initialized at this point in time, so we didn't have access to its state, streams or underlying control). I'm not sure if my proposed solutions is the best available, but I decided to implement it with the use of `afterRenderEffects` as we are quite sure that at this point all controls that can be reached are available. This way we can successfully set initial state and subscribe in reactive forms.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
