### PR TITLE
feat(button): add size support for NgpButton directive with tests and…

### DIFF
--- a/apps/documentation/src/app/examples/button/button-sizes.example.ts
+++ b/apps/documentation/src/app/examples/button/button-sizes.example.ts
@@ -1,0 +1,64 @@
+import { Component } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+
+@Component({
+  selector: 'app-button-sizes',
+  imports: [NgpButton],
+  template: `
+    <div class="button-container">
+      <button ngpButton size="sm">Small</button>
+      <button ngpButton>Medium</button>
+      <button ngpButton size="lg">Large</button>
+      <button ngpButton size="xl">Extra Large</button>
+    </div>
+  `,
+  styles: `
+    .button-container {
+      display: flex;
+      gap: 0.75rem;
+      align-items: center;
+    }
+
+    [ngpButton] {
+      padding-left: 1rem;
+      padding-right: 1rem;
+      border-radius: 0.5rem;
+      color: var(--ngp-text-primary);
+      border: none;
+      font-weight: 500;
+      background-color: var(--ngp-background);
+      transition: all 300ms cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: var(--ngp-button-shadow);
+    }
+
+    [ngpButton][data-size='sm'] {
+      height: 2rem;
+      padding-left: 0.75rem;
+      padding-right: 0.75rem;
+      font-size: 0.875rem;
+    }
+
+    [ngpButton][data-size='md'],
+    [ngpButton]:not([data-size]) {
+      height: 2.5rem;
+      padding-left: 1rem;
+      padding-right: 1rem;
+      font-size: 0.875rem;
+    }
+
+    [ngpButton][data-size='lg'] {
+      height: 3rem;
+      padding-left: 1.25rem;
+      padding-right: 1.25rem;
+      font-size: 1rem;
+    }
+
+    [ngpButton][data-size='xl'] {
+      height: 3.5rem;
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
+      font-size: 1.125rem;
+    }
+  `,
+})
+export default class ButtonSizesExample {}

--- a/apps/documentation/src/app/examples/button/button-sizes.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/button/button-sizes.tailwind.example.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+
+@Component({
+  selector: 'app-button-sizes-tailwind',
+  imports: [NgpButton],
+  template: `
+    <div class="flex items-center gap-3">
+      <button ngpButton size="sm">Small</button>
+      <button ngpButton>Medium</button>
+      <button ngpButton size="lg">Large</button>
+      <button ngpButton size="xl">Extra Large</button>
+    </div>
+  `,
+  styles: `
+    [ngpButton] {
+      @apply rounded-md border border-gray-200 bg-white font-medium text-gray-900 shadow-sm transition-colors dark:border-gray-700 dark:bg-gray-800 dark:text-white;
+    }
+
+    /* Size variants based on data-size attribute */
+    [ngpButton][data-size='sm'] {
+      @apply px-3 py-1.5 text-sm;
+    }
+
+    [ngpButton][data-size='md'] {
+      @apply px-4 py-2;
+    }
+
+    [ngpButton][data-size='lg'] {
+      @apply rounded-lg px-5 py-2.5;
+    }
+
+    [ngpButton][data-size='xl'] {
+      @apply rounded-lg px-6 py-3 text-lg;
+    }
+  `,
+})
+export default class ButtonSizesTailwindExample {}

--- a/apps/documentation/src/app/pages/primitives/button.md
+++ b/apps/documentation/src/app/pages/primitives/button.md
@@ -30,6 +30,12 @@ Create a button component that uses the `NgpButton` directive.
 
 <docs-snippet name="button"></docs-snippet>
 
+## Sizes
+
+The button component supports different sizes that can be applied using the `size` input.
+
+<docs-example name="button-sizes"></docs-example>
+
 ## Schematics
 
 Generate a reusable button component using the Angular CLI.
@@ -54,11 +60,23 @@ The following directives are available to import from the `ng-primitives/button`
 
 <api-docs name="NgpButton"></api-docs>
 
+#### Sizes
+
+The button component supports different sizes that can be applied using the `size` input.
+
+| Size | Description                                    |
+| ---- | ---------------------------------------------- |
+| `sm` | Small button size.                             |
+| `md` | Medium button size (default if not specified). |
+| `lg` | Large button size.                             |
+| `xl` | Extra large button size.                       |
+
 #### Data Attributes
 
-| Attribute            | Description                        |
-| -------------------- | ---------------------------------- |
-| `data-hover`         | Added to the button when hovered.  |
-| `data-focus-visible` | Added to the button when focused.  |
-| `data-press`         | Added to the button when pressed.  |
-| `data-disabled`      | Added to the button when disabled. |
+| Attribute            | Description                               |
+| -------------------- | ----------------------------------------- |
+| `data-hover`         | Added to the button when hovered.         |
+| `data-focus-visible` | Added to the button when focused.         |
+| `data-press`         | Added to the button when pressed.         |
+| `data-disabled`      | Added to the button when disabled.        |
+| `data-size`          | Indicates the current size of the button. |

--- a/packages/ng-primitives/button/src/button/button-state.ts
+++ b/packages/ng-primitives/button/src/button/button-state.ts
@@ -6,7 +6,7 @@ import {
   createStateProvider,
   createStateToken,
 } from 'ng-primitives/state';
-import type { NgpButton } from './button';
+import type { NgpButton, NgpButtonSize } from './button';
 
 /**
  * The state token  for the Button primitive.
@@ -30,13 +30,18 @@ export const buttonState = createState(NgpButtonStateToken);
 
 interface SyncButton {
   disabled: Signal<boolean>;
+  size?: Signal<NgpButtonSize>;
 }
 
 /**
  * Sync the button state with control state.
  * @param disabled The disabled state of the control.
+ * @param size The size of the button.
  */
-export function syncButton({ disabled }: SyncButton) {
+export function syncButton({ disabled, size }: SyncButton) {
   const button = injectButtonState();
   syncState(disabled, button().disabled);
+  if (size) {
+    syncState(size, button().size);
+  }
 }

--- a/packages/ng-primitives/button/src/button/button.spec.ts
+++ b/packages/ng-primitives/button/src/button/button.spec.ts
@@ -2,7 +2,7 @@ import { FocusMonitor } from '@angular/cdk/a11y';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { fireEvent, render } from '@testing-library/angular';
-import { NgpButton } from './button';
+import { NgpButton, NgpButtonSize } from './button';
 
 describe('NgpButton', () => {
   it('should set the disabled attribute when disabled', async () => {
@@ -146,5 +146,45 @@ describe('NgpButton', () => {
     const button = container.getByRole('button');
     fireEvent.mouseEnter(button);
     expect(button).not.toHaveAttribute('data-hover');
+  });
+
+  it('should set the data-size attribute with default value', async () => {
+    const container = await render(`<button ngpButton></button>`, {
+      imports: [NgpButton],
+    });
+
+    const button = container.getByRole('button');
+    expect(button).toHaveAttribute('data-size', 'md');
+  });
+
+  it.each(['sm', 'md', 'lg', 'xl'] as NgpButtonSize[])(
+    'should set the data-size attribute with %s value',
+    async size => {
+      const container = await render(`<button ngpButton [size]="'${size}'"></button>`, {
+        imports: [NgpButton],
+      });
+
+      const button = container.getByRole('button');
+      expect(button).toHaveAttribute('data-size', size);
+    },
+  );
+
+  it('should update the data-size attribute when size changes', async () => {
+    const { fixture, getByRole } = await render<{ size: NgpButtonSize }>(
+      `<button ngpButton [size]="size"></button>`,
+      {
+        imports: [NgpButton],
+        componentProperties: {
+          size: 'sm',
+        },
+      },
+    );
+
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('data-size', 'sm');
+
+    fixture.componentInstance.size = 'lg';
+    fixture.detectChanges();
+    expect(button).toHaveAttribute('data-size', 'lg');
   });
 });

--- a/packages/ng-primitives/button/src/button/button.ts
+++ b/packages/ng-primitives/button/src/button/button.ts
@@ -3,6 +3,11 @@ import { booleanAttribute, Directive, HOST_TAG_NAME, inject, input } from '@angu
 import { setupInteractions } from 'ng-primitives/internal';
 import { buttonState, provideButtonState } from './button-state';
 
+/**
+ * The size of the button.
+ */
+export type NgpButtonSize = 'sm' | 'md' | 'lg' | 'xl';
+
 @Directive({
   selector: '[ngpButton]',
   exportAs: 'ngpButton',
@@ -10,6 +15,7 @@ import { buttonState, provideButtonState } from './button-state';
   host: {
     '[attr.data-disabled]': 'state.disabled() ? "" : null',
     '[attr.disabled]': 'isButton && state.disabled() ? true : null',
+    '[attr.data-size]': 'state.size()',
   },
 })
 export class NgpButton {
@@ -24,6 +30,11 @@ export class NgpButton {
   readonly disabled = input<boolean, BooleanInput>(false, {
     transform: booleanAttribute,
   });
+
+  /**
+   * The size of the button.
+   */
+  readonly size = input<NgpButtonSize>('md');
 
   /**
    * Detect if this is an HTML button element.


### PR DESCRIPTION
# feat(button): add size support for NgpButton directive with tests and documentation examples

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What does this PR implement/fix?

This PR adds size support for the NgpButton directive with the following features:

- Added `size` input property of type `'sm' | 'md' | 'lg' | 'xl'` to the NgpButton directive
- Added `[attr.data-size]` host binding to expose the size for styling
- Updated button state to sync the size property
- Created examples (button-sizes.example.ts and button-sizes.tailwind.example.ts) to demonstrate different button sizes with both regular CSS and Tailwind styling
- Added comprehensive tests for the size functionality
- Updated documentation with size information and examples

The implementation follows the project's headless UI approach where the component handles logic and sets attributes, while styling is left to the consumer.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This change is fully backward compatible. Existing applications using the NgpButton directive will continue to work as before, with buttons defaulting to the 'md' size if not specified.