### PR TITLE
feat(tooltip): add data placement attribute support

### DIFF
--- a/apps/documentation/src/app/pages/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/primitives/tooltip.md
@@ -60,10 +60,11 @@ The following directives are available to import from the `ng-primitives/tooltip
 
 #### Data Attributes
 
-| Attribute    | Description                                                                                     |
-| ------------ | ----------------------------------------------------------------------------------------------- |
-| `data-enter` | Applied when the tooltip is being added to the DOM. This can be used to trigger animations.     |
-| `data-exit`  | Applied when the tooltip is being removed from the DOM. This can be used to trigger animations. |
+| Attribute         | Description                                                                                     |
+| ----------------- |-------------------------------------------------------------------------------------------------|
+| `data-enter`      | Applied when the tooltip is being added to the DOM. This can be used to trigger animations.     |
+| `data-exit`       | Applied when the tooltip is being removed from the DOM. This can be used to trigger animations. |
+| `data-placement`  | The final rendered placement of the tooltip.                                                    |
 
 The following CSS custom properties are applied to the `ngpTooltip` directive:
 
@@ -86,6 +87,18 @@ The following CSS custom properties are applied to the `ngpTooltip` directive:
 ### NgpTooltipArrow
 
 The `NgpTooltipArrow` directive is used to add an arrow to the tooltip. It should be placed inside the tooltip content. It will receive `inset-inline-start` or `inset-block-start` styles to position the arrow based on the tooltip's placement. As a result it should be positioned absolutely within the tooltip content.
+
+The arrow can be styled conditionally based on the tooltip's final placement using the `data-placement` attribute:
+
+```css
+[ngpTooltip][data-placement="top"] [ngpTooltipArrow] {
+  /* Arrow styles when tooltip is positioned on top */
+}
+
+[ngpTooltip][data-placement="bottom"] [ngpTooltipArrow] {
+  /* Arrow styles when tooltip is positioned on bottom */
+}
+```
 
 <api-docs name="NgpTooltipArrow"></api-docs>
 

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -132,6 +132,9 @@ export class NgpOverlay<T = unknown> {
   /** The transform origin for the overlay */
   readonly transformOrigin = signal<string>('center center');
 
+  /** Signal tracking the final placement of the overlay */
+  readonly finalPlacement = signal<Placement | null>(null);
+
   /** Function to dispose the positioning auto-update */
   private disposePositioning?: () => void;
 
@@ -465,6 +468,9 @@ export class NgpOverlay<T = unknown> {
     // Update position signal
     this.position.set({ x: position.x, y: position.y });
 
+    // Update final placement signal
+    this.finalPlacement.set(position.placement);
+
     // Update arrow position if available
     if (this.arrowElement) {
       this.arrowPosition.set({
@@ -499,6 +505,9 @@ export class NgpOverlay<T = unknown> {
 
     // Mark as closed
     this.isOpen.set(false);
+
+    // Reset final placement
+    this.finalPlacement.set(null);
 
     // disable scroll strategy
     this.scrollStrategy.disable();

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
@@ -30,4 +30,30 @@ describe('NgpTooltipTrigger', () => {
       expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
     });
   });
+
+  it('should set the data-placement attribute on the tooltip element', async () => {
+    const { getByRole } = await render(
+      `
+        <button [ngpTooltipTrigger]="content" ngpTooltipTriggerPlacement="top"></button>
+
+        <ng-template #content>
+          <div ngpTooltip>
+            Tooltip content
+          </div>
+        </ng-template>
+      `,
+      {
+        imports: [NgpTooltipTrigger, NgpTooltip],
+      },
+    );
+
+    const trigger = getByRole('button');
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      const tooltip = document.querySelector('[ngpTooltip]');
+      expect(tooltip).toBeInTheDocument();
+      expect(tooltip?.getAttribute('data-placement')).toBeTruthy();
+    });
+  });
 });

--- a/packages/ng-primitives/tooltip/src/tooltip/tooltip.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip/tooltip.ts
@@ -13,6 +13,7 @@ import { injectOverlay } from 'ng-primitives/portal';
     '[style.top.px]': 'overlay.position().y',
     '[style.--ngp-tooltip-trigger-width.px]': 'overlay.triggerWidth()',
     '[style.--ngp-tooltip-transform-origin]': 'overlay.transformOrigin()',
+    '[attr.data-placement]': 'overlay.finalPlacement()',
   },
 })
 export class NgpTooltip {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

## What does this PR implement/fix?

This PR adds data placement attribute support to the tooltip component. The feature enables tooltips to automatically set a `data-placement` attribute on the tooltip element, indicating the current placement position (top, bottom, left, right, etc.). This is useful for styling tooltips based on their placement position.

**Changes include:**
- Added data placement attribute functionality to the tooltip component
- Updated tooltip trigger tests to verify the new behavior
- Enhanced portal/overlay implementation to support placement data attributes
- Updated documentation to reflect the new feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No