### PR TITLE
fix(combobox): update z-index of dropdown to fix menu item visibility in dialog

### DIFF
--- a/apps/documentation/src/app/examples/combobox/combobox.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox.example.ts
@@ -110,6 +110,7 @@ import {
       margin-top: 4px;
       max-height: 240px;
       overflow-y: auto;
+      z-index: 1001;
     }
 
     [ngpComboboxDropdown][data-enter] {

--- a/apps/documentation/src/app/examples/combobox/combobox.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox.tailwind.example.ts
@@ -47,7 +47,7 @@ import {
       </button>
 
       <div
-        class="absolute left-0 z-10 mt-1 box-border max-h-[240px] w-[300px] overflow-y-auto rounded-[12px] border border-gray-200 bg-white p-1 shadow-lg outline-none dark:border-gray-700 dark:bg-black dark:ring-white/10"
+        class="absolute left-0 z-[1001] mt-1 box-border max-h-[240px] w-[300px] overflow-y-auto rounded-[12px] border border-gray-200 bg-white p-1 shadow-lg outline-none dark:border-gray-700 dark:bg-black dark:ring-white/10"
         *ngpComboboxPortal
         ngpComboboxDropdown
       >


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #347

## What does this PR implement/fix?
This PR resolves an documentation issue in which the combobox dropdown options rendered via cdk-overlay-container were not visible when used inside a modal dialog. The root cause was a z-index conflict: the cdk-overlay-container has a z-index of 1000, which caused the dropdown to appear behind the dialog backdrop.

It's just a fix for the documentation example.

<img width="1700" alt="Screenshot 2025-07-09 at 20 53 41" src="https://github.com/user-attachments/assets/ae339bdf-371f-42ee-b64d-a9fbc25b1e11" />



Before:

<img width="849" alt="Screenshot 2025-07-09 at 20 42 01" src="https://github.com/user-attachments/assets/ab40d1ad-29a8-4690-bda9-1d6a645acb64" />

After:
<img width="785" alt="Screenshot 2025-07-09 at 21 02 45" src="https://github.com/user-attachments/assets/160721a6-ccf4-4162-b5ed-3b9c8a2107a5" />


## Does this PR introduce a breaking change?



- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
