### PR TITLE
fix(combobox): Emit ngpComboboxOpenChange event when dropdown is opened.

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox/combobox.spec.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.spec.ts
@@ -8,6 +8,8 @@ import { NgpComboboxOption } from '../combobox-option/combobox-option';
 import { NgpComboboxPortal } from '../combobox-portal/combobox-portal';
 import { NgpCombobox } from './combobox';
 
+import exp = require('constants');
+
 @Component({
   imports: [
     NgpCombobox,
@@ -22,6 +24,7 @@ import { NgpCombobox } from './combobox';
       [ngpComboboxValue]="value"
       [ngpComboboxDisabled]="disabled"
       (ngpComboboxValueChange)="onValueChange($event)"
+      (ngpComboboxOpenChange)="onOpenChange($event)"
       ngpCombobox
     >
       <input
@@ -49,6 +52,7 @@ class TestComponent {
   value: string | undefined = undefined;
   disabled = false;
   filter = '';
+  open = false;
   options = ['Apple', 'Banana', 'Cherry', 'Dragon Fruit', 'Elderberry'];
 
   filteredOptions() {
@@ -64,6 +68,10 @@ class TestComponent {
 
   onFilterChange(event: Event) {
     this.filter = (event.target as HTMLInputElement).value;
+  }
+
+  onOpenChange(event: boolean) {
+    this.open = event;
   }
 }
 
@@ -231,6 +239,25 @@ describe('NgpCombobox', () => {
     // Select with Enter
     await userEvent.keyboard('{enter}');
     expect(component.value).toBe('Banana');
+  });
+
+  it('should emit open/close events', async () => {
+    const { fixture } = await render(TestComponent);
+    const component = fixture.componentInstance;
+
+    const button = screen.getByTestId('combobox-button');
+    await userEvent.click(button);
+
+    // Dropdown should be open
+    expect(component.open).toBeTruthy();
+
+    // Click outside
+    await userEvent.click(document.body);
+
+    // Dropdown should be closed
+    await waitFor(() => {
+      expect(component.open).toBeFalsy();
+    });
   });
 
   it('should close dropdown when clicking outside', async () => {

--- a/packages/ng-primitives/combobox/src/combobox/combobox.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.ts
@@ -187,6 +187,7 @@ export class NgpCombobox {
       return;
     }
 
+    this.openChange.emit(true);
     await this.portal()?.show();
 
     // if there is a selected option(s), set the active descendant to the first selected option


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #356 

## What does this PR implement/fix?

Combobox never emits an event when the dropdown is opened (only when it's closed).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
