### PR TITLE
fix(form-control): apply native disabled attribute to ngpFormControl host element

### DIFF
--- a/packages/ng-primitives/form-field/src/form-control/form-control.spec.ts
+++ b/packages/ng-primitives/form-field/src/form-control/form-control.spec.ts
@@ -1,78 +1,72 @@
-import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { render } from '@testing-library/angular';
 import { NgpFormControl } from './form-control';
 
 describe('NgpFormControl', () => {
   it('should initialise correctly', async () => {
-    const container = await render(`<div ngpFormControl></div>`, {
+    await render(`<div ngpFormControl></div>`, {
       imports: [NgpFormControl],
     });
   });
 
-  it('should apply disabled attribute when disabled is true', async () => {
-    const { getByTestId } = await render(
-      `<div ngpFormControl data-testid="control" [ngpFormControlDisabled]="true"></div>`,
-      {
-        imports: [NgpFormControl],
-      },
-    );
-
-    const control = getByTestId('control');
-    expect(control).toHaveAttribute('disabled');
-  });
-
-  it('should not apply disabled attribute when disabled is false', async () => {
-    const { getByTestId } = await render(
-      `<div ngpFormControl data-testid="control" [ngpFormControlDisabled]="false"></div>`,
-      {
-        imports: [NgpFormControl],
-      },
-    );
-
-    const control = getByTestId('control');
-    expect(control).not.toHaveAttribute('disabled');
-  });
-
-  it('should not apply disabled attribute by default', async () => {
-    const { getByTestId } = await render(`<div ngpFormControl data-testid="control"></div>`, {
-      imports: [NgpFormControl],
+  describe('disabled attribute', () => {
+    it('should not apply disabled attribute on div even if disabled is true', async () => {
+      const { getByTestId } = await render(
+        `<div ngpFormControl data-testid="control" [ngpFormControlDisabled]="true"></div>`,
+        {
+          imports: [NgpFormControl],
+        },
+      );
+      const control = getByTestId('control');
+      expect(control).not.toHaveAttribute('disabled');
     });
 
-    const control = getByTestId('control');
-    expect(control).not.toHaveAttribute('disabled');
-  });
-
-  it('should apply disabled attribute when form control is disabled', async () => {
-    const { getByTestId, detectChanges } = await render(
-      `<input ngpFormControl data-testid="control" [formControl]="control" />`,
-      {
-        imports: [NgpFormControl, ReactiveFormsModule],
-        componentProperties: {
-          control: new FormControl({ value: '', disabled: true }),
+    it('should not apply disabled attribute on custom element even if disabled is true', async () => {
+      const { getByTestId } = await render(
+        `<custom-element ngpFormControl data-testid="control" [ngpFormControlDisabled]="true"></custom-element>`,
+        {
+          imports: [NgpFormControl],
         },
-      },
-    );
+      );
+      const control = getByTestId('control');
+      expect(control).not.toHaveAttribute('disabled');
+    });
 
-    detectChanges();
+    ['button', 'fieldset', 'optgroup', 'option', 'select', 'textarea', 'input'].forEach(element => {
+      it(`should apply disabled attribute on <${element}> when disabled is true`, async () => {
+        const markup =
+          element === 'input'
+            ? `<input ngpFormControl data-testid="control" [ngpFormControlDisabled]="true" />`
+            : `<${element} ngpFormControl data-testid="control" [ngpFormControlDisabled]="true"></${element}>`;
+        const { getByTestId } = await render(markup, {
+          imports: [NgpFormControl],
+        });
+        const control = getByTestId('control');
+        expect(control).toHaveAttribute('disabled');
+      });
 
-    const control = getByTestId('control');
-    expect(control).toHaveAttribute('disabled');
-  });
+      it(`should not apply disabled attribute on <${element}> when disabled is false`, async () => {
+        const markup =
+          element === 'input'
+            ? `<input ngpFormControl data-testid="control" [ngpFormControlDisabled]="false" />`
+            : `<${element} ngpFormControl data-testid="control" [ngpFormControlDisabled]="false"></${element}>`;
+        const { getByTestId } = await render(markup, {
+          imports: [NgpFormControl],
+        });
+        const control = getByTestId('control');
+        expect(control).not.toHaveAttribute('disabled');
+      });
 
-  it('should combine disabled state from input and form control', async () => {
-    const { getByTestId, detectChanges } = await render(
-      `<input ngpFormControl data-testid="control" [formControl]="control" [ngpFormControlDisabled]="true" />`,
-      {
-        imports: [NgpFormControl, ReactiveFormsModule],
-        componentProperties: {
-          control: new FormControl({ value: '', disabled: false }),
-        },
-      },
-    );
-
-    detectChanges();
-
-    const control = getByTestId('control');
-    expect(control).toHaveAttribute('disabled');
+      it(`should not apply disabled attribute on <${element}> by default`, async () => {
+        const markup =
+          element === 'input'
+            ? `<input ngpFormControl data-testid="control" />`
+            : `<${element} ngpFormControl data-testid="control"></${element}>`;
+        const { getByTestId } = await render(markup, {
+          imports: [NgpFormControl],
+        });
+        const control = getByTestId('control');
+        expect(control).not.toHaveAttribute('disabled');
+      });
+    });
   });
 });

--- a/packages/ng-primitives/form-field/src/form-control/form-control.spec.ts
+++ b/packages/ng-primitives/form-field/src/form-control/form-control.spec.ts
@@ -1,3 +1,4 @@
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { render } from '@testing-library/angular';
 import { NgpFormControl } from './form-control';
 
@@ -6,5 +7,72 @@ describe('NgpFormControl', () => {
     const container = await render(`<div ngpFormControl></div>`, {
       imports: [NgpFormControl],
     });
+  });
+
+  it('should apply disabled attribute when disabled is true', async () => {
+    const { getByTestId } = await render(
+      `<div ngpFormControl data-testid="control" [ngpFormControlDisabled]="true"></div>`,
+      {
+        imports: [NgpFormControl],
+      },
+    );
+
+    const control = getByTestId('control');
+    expect(control).toHaveAttribute('disabled');
+  });
+
+  it('should not apply disabled attribute when disabled is false', async () => {
+    const { getByTestId } = await render(
+      `<div ngpFormControl data-testid="control" [ngpFormControlDisabled]="false"></div>`,
+      {
+        imports: [NgpFormControl],
+      },
+    );
+
+    const control = getByTestId('control');
+    expect(control).not.toHaveAttribute('disabled');
+  });
+
+  it('should not apply disabled attribute by default', async () => {
+    const { getByTestId } = await render(`<div ngpFormControl data-testid="control"></div>`, {
+      imports: [NgpFormControl],
+    });
+
+    const control = getByTestId('control');
+    expect(control).not.toHaveAttribute('disabled');
+  });
+
+  it('should apply disabled attribute when form control is disabled', async () => {
+    const { getByTestId, detectChanges } = await render(
+      `<input ngpFormControl data-testid="control" [formControl]="control" />`,
+      {
+        imports: [NgpFormControl, ReactiveFormsModule],
+        componentProperties: {
+          control: new FormControl({ value: '', disabled: true }),
+        },
+      },
+    );
+
+    detectChanges();
+
+    const control = getByTestId('control');
+    expect(control).toHaveAttribute('disabled');
+  });
+
+  it('should combine disabled state from input and form control', async () => {
+    const { getByTestId, detectChanges } = await render(
+      `<input ngpFormControl data-testid="control" [formControl]="control" [ngpFormControlDisabled]="true" />`,
+      {
+        imports: [NgpFormControl, ReactiveFormsModule],
+        componentProperties: {
+          control: new FormControl({ value: '', disabled: false }),
+        },
+      },
+    );
+
+    detectChanges();
+
+    const control = getByTestId('control');
+    expect(control).toHaveAttribute('disabled');
   });
 });

--- a/packages/ng-primitives/form-field/src/form-control/form-control.ts
+++ b/packages/ng-primitives/form-field/src/form-control/form-control.ts
@@ -4,8 +4,6 @@ import {
   booleanAttribute,
   computed,
   Directive,
-  HOST_TAG_NAME,
-  inject,
   input,
   signal,
   Signal,
@@ -14,12 +12,6 @@ import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
 import { controlStatus, NgpControlStatus, uniqueId } from 'ng-primitives/utils';
 import { injectFormFieldState } from '../form-field/form-field-state';
 import { formControlState, provideFormControlState } from './form-control-state';
-
-/**
- * Custom elements that support the disabled attribute.
- * Example: 'mat-select', 'ng-select'
- */
-const CUSTOM_ELEMENTS_WITH_DISABLED_ATTRIBUTE: string[] = [];
 
 /**
  * Typically this primitive would be not be used directly, but instead a more specific form control primitive would be used (e.g. `ngpInput`). All of our form control primitives use `ngpFormControl` internally so they will have the same accessibility features as described below.
@@ -31,7 +23,7 @@ const CUSTOM_ELEMENTS_WITH_DISABLED_ATTRIBUTE: string[] = [];
   exportAs: 'ngpFormControl',
   providers: [provideFormControlState()],
   host: {
-    '[attr.disabled]': 'isDisabledAttributeSupported() && status().disabled ? "" : null',
+    '[attr.disabled]': 'supportsDisabledAttribute && status().disabled ? "" : null',
   },
 })
 export class NgpFormControl {
@@ -54,21 +46,14 @@ export class NgpFormControl {
   readonly status: Signal<NgpControlStatus>;
 
   /**
-   * Whether the element supports the disabled attribute.
-   */
-  readonly isDisabledAttributeSupported = computed(() =>
-    this.checkDisabledAttributeSupport(this.elementRef.nativeElement, this.tagName),
-  );
-
-  /**
    * The element reference.
    */
   private readonly elementRef = injectElementRef();
 
   /**
-   * The tag name of the element.
+   * Whether the element supports the disabled attribute.
    */
-  private readonly tagName = inject(HOST_TAG_NAME);
+  protected readonly supportsDisabledAttribute = 'disabled' in this.elementRef.nativeElement;
 
   /**
    * The state of the form control.
@@ -78,16 +63,6 @@ export class NgpFormControl {
   constructor() {
     // Sync the form control state with the control state.
     this.status = setupFormControl({ id: this.state.id, disabled: this.state.disabled });
-  }
-
-  /**
-   * Check if the element supports the disabled attribute.
-   * - HTML elements that support the disabled attribute.
-   * - Custom elements that support the disabled attribute.
-   * @param element The element to check.
-   */
-  private checkDisabledAttributeSupport(element: HTMLElement, tagName: string): boolean {
-    return 'disabled' in element || CUSTOM_ELEMENTS_WITH_DISABLED_ATTRIBUTE.includes(tagName);
   }
 }
 

--- a/packages/ng-primitives/form-field/src/form-control/form-control.ts
+++ b/packages/ng-primitives/form-field/src/form-control/form-control.ts
@@ -22,6 +22,9 @@ import { formControlState, provideFormControlState } from './form-control-state'
   selector: '[ngpFormControl]',
   exportAs: 'ngpFormControl',
   providers: [provideFormControlState()],
+  host: {
+    '[attr.disabled]': 'status().disabled ? "" : null',
+  },
 })
 export class NgpFormControl {
   /**
@@ -38,13 +41,18 @@ export class NgpFormControl {
   });
 
   /**
+   * The status of the form control.
+   */
+  readonly status: Signal<NgpControlStatus>;
+
+  /**
    * The state of the form control.
    */
   private readonly state = formControlState<NgpFormControl>(this);
 
   constructor() {
     // Sync the form control state with the control state.
-    setupFormControl({ id: this.state.id, disabled: this.state.disabled });
+    this.status = setupFormControl({ id: this.state.id, disabled: this.state.disabled });
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #362 

## What does this PR implement/fix?

This PR fixes an issue where the ngpFormControl directive was not properly disabling native form elements.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
