### PR TITLE
fix(listbox): resolve reusable template not working with reactive forms OOTB

### DIFF
--- a/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
+++ b/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
@@ -34,6 +34,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
         [ngpListboxMode]="mode()"
         [ngpListboxDisabled]="disabled()"
         [ngpListboxCompareWith]="compareWith()"
+        (ngpListboxValueChange)="onListboxValueChange($event)"
         ngpPopover
         ngpListbox
       >
@@ -136,5 +137,10 @@ export class Listbox implements ControlValueAccessor {
 
   setDisabledState(isDisabled: boolean): void {
     this.state()?.disabled.set(isDisabled);
+  }
+  
+  onListboxValueChange(value: string[]): void {
+    this.value.set(value);
+    if (this.onChange) this.onChange(value);
   }
 }

--- a/packages/ng-primitives/schematics/ng-generate/templates/listbox/listbox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/listbox/listbox.__fileSuffix@dasherize__.ts.template
@@ -34,6 +34,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
         [ngpListboxMode]="mode()"
         [ngpListboxDisabled]="disabled()"
         [ngpListboxCompareWith]="compareWith()"
+        (ngpListboxValueChange)="onListboxValueChange($event)"
         ngpPopover
         ngpListbox
       >
@@ -138,5 +139,10 @@ export class Listbox<%= componentSuffix %> implements ControlValueAccessor {
 
   setDisabledState(isDisabled: boolean): void {
     this.state()?.disabled.set(isDisabled);
+  }
+  
+  onListboxValueChange(value: string[]): void {
+    this.value.set(value);
+    if (this.onChange) this.onChange(value);
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

I'm sorry, but I couldn't get pnpm install to finish, it kept complaining I don't have node installed even though I do (volta node manager).

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

## Issue
I was migrating from Select to Listbox and I used the generate component schematic and discovered it didn't work out of the box with reactive forms. 

Ashley has noticed this earlier in discord: 
https://discord.com/channels/1266512674498412596/1266512674498412600/1382819163780808714
https://stackblitz.com/edit/angular-2gtnz9xd?file=src%2Fmain.ts

I'm not an angular expert, so if this is not idiomatic I apologize in advance.

## What does this PR implement/fix?

It makes the Listbox resuable component template actually work with reactive forms.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No