### PR TITLE
feat: allows responsive toast width

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
@@ -142,7 +142,7 @@ bootstrapApplication(AppComponent, {
   The duration in milliseconds that the toast will be visible.
 </prop-details>
 
-<prop-details name="width" type="number | undefined" default="undefined">
+<prop-details name="width" type="number | undefined" default="360">
   The width of each toast in pixels. If not provided, the toast will be responsive based on viewport width, allowing for custom styling via CSS.
 </prop-details>
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
@@ -142,8 +142,8 @@ bootstrapApplication(AppComponent, {
   The duration in milliseconds that the toast will be visible.
 </prop-details>
 
-<prop-details name="width" type="number" default="360">
-  The width of each toast in pixels.
+<prop-details name="width" type="number | undefined" default="undefined">
+  The width of each toast in pixels. If not provided, the toast will be responsive based on viewport width, allowing for custom styling via CSS.
 </prop-details>
 
 <prop-details name="offsetTop" type="number" default="24">

--- a/packages/ng-primitives/toast/src/config/toast-config.ts
+++ b/packages/ng-primitives/toast/src/config/toast-config.ts
@@ -14,8 +14,9 @@ export interface NgpToastConfig {
 
   /**
    * The width of each toast in pixels.
+   * If not provided, the toast will be responsive based on viewport width.
    */
-  width: number;
+  width?: number;
 
   /**
    * The offset from the top of the viewport in pixels.

--- a/packages/ng-primitives/toast/src/toast/toast-manager.ts
+++ b/packages/ng-primitives/toast/src/toast/toast-manager.ts
@@ -123,14 +123,22 @@ export class NgpToastManager {
 
     container.style.setProperty('position', 'fixed');
     container.style.setProperty('z-index', `${this.config.zIndex}`);
-    container.style.setProperty('width', `${this.config.width}px`);
+    
+    // Only set width if it's specified in the config
+    if (this.config.width !== undefined) {
+      container.style.setProperty('width', `${this.config.width}px`);
+    }
 
     container.style.setProperty('--ngp-toast-offset-top', `${this.config.offsetTop}px`);
     container.style.setProperty('--ngp-toast-offset-bottom', `${this.config.offsetBottom}px`);
     container.style.setProperty('--ngp-toast-offset-left', `${this.config.offsetLeft}px`);
     container.style.setProperty('--ngp-toast-offset-right', `${this.config.offsetRight}px`);
     container.style.setProperty('--ngp-toast-gap', `${this.config.gap}px`);
-    container.style.setProperty('--ngp-toast-width', `${this.config.width}px`);
+    
+    // Only set width CSS variable if it's specified in the config
+    if (this.config.width !== undefined) {
+      container.style.setProperty('--ngp-toast-width', `${this.config.width}px`);
+    }
 
     // mark the container as expanded
     this.renderer.listen(container, 'mouseenter', () =>

--- a/packages/ng-primitives/toast/src/toast/toast-manager.ts
+++ b/packages/ng-primitives/toast/src/toast/toast-manager.ts
@@ -123,7 +123,7 @@ export class NgpToastManager {
 
     container.style.setProperty('position', 'fixed');
     container.style.setProperty('z-index', `${this.config.zIndex}`);
-    
+
     // Only set width if it's specified in the config
     if (this.config.width !== undefined) {
       container.style.setProperty('width', `${this.config.width}px`);

--- a/packages/ng-primitives/toast/src/toast/toast-manager.ts
+++ b/packages/ng-primitives/toast/src/toast/toast-manager.ts
@@ -134,7 +134,7 @@ export class NgpToastManager {
     container.style.setProperty('--ngp-toast-offset-left', `${this.config.offsetLeft}px`);
     container.style.setProperty('--ngp-toast-offset-right', `${this.config.offsetRight}px`);
     container.style.setProperty('--ngp-toast-gap', `${this.config.gap}px`);
-    
+
     // Only set width CSS variable if it's specified in the config
     if (this.config.width !== undefined) {
       container.style.setProperty('--ngp-toast-width', `${this.config.width}px`);

--- a/packages/ng-primitives/toast/src/toast/toast.ts
+++ b/packages/ng-primitives/toast/src/toast/toast.ts
@@ -30,7 +30,7 @@ import { toastTimer } from './toast-timer';
     '[style.--ngp-toast-z-index]': 'zIndex()',
     '[style.--ngp-toasts-before]': 'index()',
     '[style.--ngp-toast-index]': 'index() + 1',
-    '[style.--ngp-toast-width.px]': 'config.width',
+    '[style.--ngp-toast-width.px]': 'config.width !== undefined ? config.width : null',
     '[style.--ngp-toast-height.px]': 'dimensions().height',
     '[style.--ngp-toast-offset.px]': 'offset()',
     '[style.--ngp-toast-front-height.px]': 'frontToastHeight()',


### PR DESCRIPTION
# feat(toast): Make width optional to support responsive styling without !important overrides"

This change provides more flexibility in styling toasts, allowing developers to leverage CSS for responsive designs without needing to use `!important` overrides.

## Changes

- Made the `width` property optional in the NgpToastConfig interface
- Updated the toast manager to conditionally apply width styles only when width is specified
- Updated the toast component to conditionally bind CSS variables
- Updated documentation to reflect that width is now optional
- Removed the default fixed width from the default toast config

These changes allow toast width to be controlled via CSS when no width is specified in the configuration, making it easier to create responsive toast notifications that adapt to different viewport sizes.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

## What does this PR implement/fix?

This PR makes toast width responsive by default when no width is specified in the configuration. Previously, toast width was fixed at 360px by default, which caused issues with centered toast placement and made it difficult to create responsive designs without using `!important` CSS overrides.

Now, developers can:
- Use responsive toast width by omitting the `width` property in configuration
- Continue using fixed width toasts by specifying a width value
- Style toast width using CSS without needing `!important` overrides
- Create better responsive designs that adapt to different viewport sizes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The change is backward compatible as existing code that specifies a width will continue to work as before. Only the default behavior has changed to be responsive when width is omitted.