### PR TITLE
  feat(tooltip): add useTextContent feature for automatic text content tooltips

### DIFF
--- a/apps/documentation/src/app/examples/tooltip/tooltip.example.ts
+++ b/apps/documentation/src/app/examples/tooltip/tooltip.example.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 import { NgpButton } from 'ng-primitives/button';
 import { NgpTooltip, NgpTooltipArrow, NgpTooltipTrigger } from 'ng-primitives/tooltip';
 
@@ -6,7 +6,14 @@ import { NgpTooltip, NgpTooltipArrow, NgpTooltipTrigger } from 'ng-primitives/to
   selector: 'app-tooltip',
   imports: [NgpTooltipTrigger, NgpTooltip, NgpTooltipArrow, NgpButton],
   template: `
-    <button [ngpTooltipTrigger]="tooltip" ngpButton type="button">Tooltip</button>
+    <div class="examples">
+      <button [ngpTooltipTrigger]="tooltip" ngpButton type="button">Custom Tooltip</button>
+
+      <button class="ellipsis-text" ngpTooltipTrigger>
+        This is a very long text that will be truncated with ellipsis and show the full content in a
+        tooltip when you hover over it
+      </button>
+    </div>
 
     <ng-template #tooltip>
       <div ngpTooltip>
@@ -18,29 +25,50 @@ import { NgpTooltip, NgpTooltipArrow, NgpTooltipTrigger } from 'ng-primitives/to
     </ng-template>
   `,
   styles: `
-    button {
-      padding-left: 1rem;
-      padding-right: 1rem;
-      border-radius: 0.5rem;
-      color: var(--ngp-text-primary);
-      outline: none;
-      height: 2.5rem;
-      font-weight: 500;
-      background-color: var(--ngp-background);
-      transition: background-color 300ms cubic-bezier(0.4, 0, 0.2, 1);
-      box-shadow: var(--ngp-button-shadow);
-    }
+    app-tooltip {
+      .examples {
+        display: flex;
+        gap: 1rem;
+        align-items: center;
+        flex-wrap: wrap;
+      }
 
-    button[data-hover] {
-      background-color: var(--ngp-background-hover);
-    }
+      .ellipsis-text {
+        max-width: 200px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 0.875rem;
+      }
 
-    button[data-focus-visible] {
-      outline: 2px solid var(--ngp-focus-ring);
-    }
+      .ellipsis-text:hover {
+        background-color: var(--ngp-background-hover);
+      }
 
-    button[data-press] {
-      background-color: var(--ngp-background-active);
+      button {
+        padding-left: 1rem;
+        padding-right: 1rem;
+        border-radius: 0.5rem;
+        color: var(--ngp-text-primary);
+        outline: none;
+        height: 2.5rem;
+        font-weight: 500;
+        background-color: var(--ngp-background);
+        transition: background-color 300ms cubic-bezier(0.4, 0, 0.2, 1);
+        box-shadow: var(--ngp-button-shadow);
+      }
+
+      button[data-hover] {
+        background-color: var(--ngp-background-hover);
+      }
+
+      button[data-focus-visible] {
+        outline: 2px solid var(--ngp-focus-ring);
+      }
+
+      button[data-press] {
+        background-color: var(--ngp-background-active);
+      }
     }
 
     [ngpTooltip] {
@@ -101,5 +129,6 @@ import { NgpTooltip, NgpTooltipArrow, NgpTooltipTrigger } from 'ng-primitives/to
       }
     }
   `,
+  encapsulation: ViewEncapsulation.None,
 })
 export default class TooltipExample {}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -108,6 +108,43 @@ The arrow can be styled conditionally based on the tooltip's final placement usi
 | ---------------- | -------------------------------------------- |
 | `data-placement` | The final rendered placement of the tooltip. |
 
+## Using Text Content as Tooltip
+
+The `useTextContent` input (enabled by default) allows the tooltip to automatically use the text content of the trigger element as the tooltip content. This is particularly useful for displaying full text when content is truncated with ellipsis.
+
+```html
+<!-- Simple usage - uses text content automatically -->
+<div class="truncated-text" ngpTooltipTrigger>
+  This text might be truncated with ellipsis and show the full content in the tooltip
+</div>
+
+<!-- Passing content directly takes precedence -->
+<button [ngpTooltipTrigger]="myToolip">This won't show a tooltip unless content is provided</button>
+```
+
+### Important: Global Styles Required
+
+When using the `useTextContent` feature or string values, the tooltip styles **must be global** and not encapsulated to the component. This is because the tooltip content is rendered in a portal outside of your component's scope.
+
+```css
+/* ✅ Global styles (in styles.css or with ViewEncapsulation.None) */
+[ngpTooltip] {
+  position: absolute;
+  background-color: #333;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+/* ❌ Encapsulated styles won't work with useTextContent */
+.my-component [ngpTooltip] {
+  /* This won't be applied to text content tooltips */
+}
+```
+
+If you need component-scoped styles, use template-based or component-based tooltips instead of `useTextContent`.
+
 ## Conditional Tooltips
 
 The `showOnOverflow` input allows you to show tooltips only when the trigger element has overflowing content. This is particularly useful for text that might be truncated with ellipsis.
@@ -165,6 +202,7 @@ bootstrapApplication(AppComponent, {
       flip: true,
       container: document.body,
       showOnOverflow: false,
+      useTextContent: true,
     }),
   ],
 });
@@ -198,4 +236,8 @@ Define the offset from the trigger element.
 
 <prop-details name="showOnOverflow" type="boolean" default="false">
   Define if the tooltip should only show when the trigger element has overflowing content. This is useful for showing tooltips only when content is truncated.
+</prop-details>
+
+<prop-details name="useTextContent" type="boolean" default="true">
+  Define whether to use the text content of the trigger element as the tooltip content. When enabled, the tooltip will automatically display the text content of the trigger element. Note that this requires global styles to work properly since the tooltip is rendered in a portal.
 </prop-details>

--- a/packages/ng-primitives/tooltip/src/config/tooltip-config.ts
+++ b/packages/ng-primitives/tooltip/src/config/tooltip-config.ts
@@ -43,6 +43,12 @@ export interface NgpTooltipConfig {
    * @default false
    */
   showOnOverflow: boolean;
+
+  /**
+   * Whether to use the text content of the trigger element as the tooltip content.
+   * @default true
+   */
+  useTextContent: boolean;
 }
 
 export const defaultTooltipConfig: NgpTooltipConfig = {
@@ -53,6 +59,7 @@ export const defaultTooltipConfig: NgpTooltipConfig = {
   flip: true,
   container: null,
   showOnOverflow: false,
+  useTextContent: true,
 };
 
 export const NgpTooltipConfigToken = new InjectionToken<NgpTooltipConfig>('NgpTooltipConfigToken');

--- a/packages/ng-primitives/tooltip/src/tooltip-text-content/tooltip-text-content.component.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-text-content/tooltip-text-content.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { injectOverlayContext } from 'ng-primitives/portal';
+import { NgpTooltip } from '../tooltip/tooltip';
+
+
+/**
+ * Internal component for wrapping string content in tooltip portals
+ * @internal
+ */
+@Component({
+  template: '{{ content() }}',
+  hostDirectives: [NgpTooltip],
+  host: {
+    ngpTooltip: '',
+  },
+})
+export class NgpTooltipTextContentComponent {
+  /**
+   * The string content to display
+   */
+  readonly content = injectOverlayContext();
+}

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render, waitFor } from '@testing-library/angular';
-import { NgpTooltip, NgpTooltipTrigger } from 'ng-primitives/tooltip';
+import { NgpTooltip, NgpTooltipTrigger, provideTooltipConfig } from 'ng-primitives/tooltip';
 
 describe('NgpTooltipTrigger', () => {
   afterEach(() => {
@@ -10,7 +10,7 @@ describe('NgpTooltipTrigger', () => {
   it('should destroy the overlay when the trigger is destroyed', async () => {
     const { fixture, getByRole } = await render(
       `
-        <button [ngpTooltipTrigger]="content"></button>
+        <button [ngpTooltipTrigger]="content" ngpTooltipTriggerUseTextContent="false"></button>
 
         <ng-template #content>
           <div ngpTooltip>
@@ -39,7 +39,7 @@ describe('NgpTooltipTrigger', () => {
   it('should set the data-placement attribute on the tooltip element', async () => {
     const { getByRole } = await render(
       `
-        <button [ngpTooltipTrigger]="content" ngpTooltipTriggerPlacement="top"></button>
+        <button [ngpTooltipTrigger]="content" ngpTooltipTriggerPlacement="top" ngpTooltipTriggerUseTextContent="false"></button>
 
         <ng-template #content>
           <div ngpTooltip>
@@ -68,6 +68,7 @@ describe('NgpTooltipTrigger', () => {
         <button
           [ngpTooltipTrigger]="content"
           ngpTooltipTriggerShowOnOverflow="true"
+          ngpTooltipTriggerUseTextContent="false"
           style="width: 200px; height: 40px; overflow: hidden;"
         >
           Short text
@@ -99,6 +100,7 @@ describe('NgpTooltipTrigger', () => {
         <button
           [ngpTooltipTrigger]="content"
           ngpTooltipTriggerShowOnOverflow="true"
+          ngpTooltipTriggerUseTextContent="false"
           style="width: 50px; height: 20px; overflow: hidden; white-space: nowrap;"
         >
           This is a very long text that will definitely overflow the button width
@@ -124,5 +126,156 @@ describe('NgpTooltipTrigger', () => {
     const tooltip = document.querySelector('[ngpTooltip]');
 
     expect(tooltip).not.toBeInTheDocument();
+  });
+
+  describe('useTextContent', () => {
+    it('should show tooltip with trigger element text content when useTextContent is enabled', async () => {
+      const { getByRole } = await render(`<button ngpTooltipTrigger>Button text</button>`, {
+        imports: [NgpTooltipTrigger, NgpTooltip],
+      });
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        const tooltip = document.querySelector('[role="tooltip"]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Button text');
+      });
+    });
+
+    it('should not show tooltip when useTextContent is enabled but trigger has no text content', async () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      const { getByRole } = await render(
+        `<button ngpTooltipTrigger ngpTooltipTriggerUseTextContent="true"></button>`,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      // Wait a bit to ensure tooltip doesn't show
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(document.querySelector('[role="tooltip"]')).not.toBeInTheDocument();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[ngpTooltipTrigger]: useTextContent is enabled but trigger element has no text content',
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should prioritize useTextContent over tooltip template when both are provided', async () => {
+      const { getByRole } = await render(
+        `
+          <button [ngpTooltipTrigger]="content" ngpTooltipTriggerUseTextContent="true">
+            Button text
+          </button>
+
+          <ng-template #content>
+            <div ngpTooltip>Template content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        const tooltip = document.querySelector('[role="tooltip"]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Button text');
+      });
+    });
+
+    it('should use global config for useTextContent when not specified on element', async () => {
+      const { getByRole } = await render(`<button ngpTooltipTrigger>Button text</button>`, {
+        imports: [NgpTooltipTrigger, NgpTooltip],
+        providers: [
+          provideTooltipConfig({
+            useTextContent: true,
+          }),
+        ],
+      });
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        const tooltip = document.querySelector('[role="tooltip"]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Button text');
+      });
+    });
+
+    it('should override global config when useTextContent is explicitly set to false', async () => {
+      const { getByRole } = await render(
+        `
+          <button [ngpTooltipTrigger]="content" ngpTooltipTriggerUseTextContent="false">
+            Button text
+          </button>
+
+          <ng-template #content>
+            <div ngpTooltip>Template content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+          providers: [
+            provideTooltipConfig({
+              useTextContent: true,
+            }),
+          ],
+        },
+      );
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        const tooltip = document.querySelector('[role="tooltip"]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Template content');
+      });
+    });
+
+    it('should trim whitespace from text content', async () => {
+      const { getByRole } = await render(
+        `<button ngpTooltipTrigger ngpTooltipTriggerUseTextContent="true">   Button text with whitespace   </button>`,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        const tooltip = document.querySelector('[role="tooltip"]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Button text with whitespace');
+      });
+    });
+
+    it('should throw error when no tooltip content provided and useTextContent is false', async () => {
+      const { getByRole } = await render(
+        `<button ngpTooltipTrigger ngpTooltipTriggerUseTextContent="false">Button text</button>`,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      const trigger = getByRole('button');
+
+      expect(() => fireEvent.mouseEnter(trigger)).toThrow(
+        '[ngpTooltipTrigger]: Tooltip must be a string, TemplateRef, or ComponentType. Alternatively, set useTextContent to true if none is provided.',
+      );
+    });
   });
 });


### PR DESCRIPTION
  feat(tooltip): add useTextContent feature for automatic text content tooltips

  - Add useTextContent input to NgpTooltipTrigger (defaults to true)
  - Allow passing strings directly to ngpTooltipTrigger
  - Update documentation with examples and global styles requirement
  - Add test coverage

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Passing a string to a tooltip is a common use case, especially when displaying ellipses for truncated items but still wanting users to see the full content. Currently, this requires extra boilerplate—wrapping the string in a template reference just to display a simple string value.

## Issue

Closes #

## What does this PR implement/fix?

With this update, NgpTooltipTrigger now accepts strings as inputs, in addition to `TemplateRef`s and components.

This PR also introduces the `useTextContent` option, which automatically extracts the trigger’s text content and uses it as the tooltip’s value. Since this is a frequent pattern, the new shorthand reduces boilerplate and results in much cleaner code.

## Does this PR introduce a breaking change?
It depends on whether you consider setting the useTextContent to true by default breaking or not. Since passing values to the trigger takes precedence, it shouldn't affect users.
The bigger question is rather we want to set it to true by default or not. @ashley-hunter your call.

- [ ] Yes
- [ ] No
- [x] Maybe

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
