### PR TITLE
fix(favicon): use svg as type

### DIFF
--- a/apps/documentation/index.html
+++ b/apps/documentation/index.html
@@ -35,7 +35,7 @@
     />
     <meta property="twitter:image" content="https://i.postimg.cc/0jZ1hKt2/Mac-Book-Pro-16-23.png" />
 
-    <link rel="icon" type="image/x-icon" href="/src/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <link rel="preconnect" href="https://rsms.me/" />
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Currently the favicon uses the type used for `.ico`. 

```html
<link rel="icon" type="image/x-icon" href="/src/favicon.svg" />
```

Modern browsers are able to display the favicon anyways, but maybe thats why the favicon is not showing up in the google search.

<img width="611" height="138" alt="CleanShot 2025-08-08 at 10 52 44" src="https://github.com/user-attachments/assets/47266d73-e330-4edb-bf6a-a9f63a5abdce" />

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

Updates the type to match the file extension `.svg`

```html
<link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
