### PR TITLE
feat(date-picker): refine date selection logic for the date-range-picker

### DIFF
--- a/packages/ng-primitives/date-picker/src/date-picker-date-button/date-picker-date-button.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-date-button/date-picker-date-button.ts
@@ -136,8 +136,8 @@ export class NgpDatePickerDateButton<T> implements OnDestroy {
   @HostListener('keydown.enter', ['$event'])
   @HostListener('keydown.space', ['$event'])
   protected select(event?: KeyboardEvent): void {
-    // if the button is disabled, or is already selected, do nothing.
-    if (this.disabled() || this.selected()) {
+    // if the button is disabled, do nothing.
+    if (this.disabled()) {
       return;
     }
 

--- a/packages/ng-primitives/date-picker/src/date-range-picker/date-range-picker.spec.ts
+++ b/packages/ng-primitives/date-picker/src/date-range-picker/date-range-picker.spec.ts
@@ -1,0 +1,85 @@
+import { Component, InputSignal, Provider, signal, viewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InjectedState } from 'ng-primitives/state';
+import { NgpDateRangePicker } from './date-range-picker';
+import {
+  injectDateRangePickerState,
+  NgpDateRangePickerStateToken,
+} from './date-range-picker-state';
+
+describe('NgpDatePickerRowRender', () => {
+  let fixture: ComponentFixture<TestHost>;
+  let host: TestHost;
+  let state: InjectedState<NgpDateRangePicker<Date>>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHost],
+      providers: [provideMockDateRangePickerState()],
+    });
+    fixture = TestBed.createComponent(TestHost);
+    fixture.detectChanges();
+    host = fixture.componentInstance;
+    state = TestBed.runInInjectionContext(() => injectDateRangePickerState());
+  });
+
+  it('should create', () => {
+    expect(host.rangePicker()).toBeTruthy();
+  });
+
+  describe('when selecting a date', () => {
+    it('should select a start date when neither a start date nor an end date is selected', () => {
+      const testStartDate = new Date(2025, 7, 1);
+      host.rangePicker().select(testStartDate);
+      expect(state().startDate()).toBe(testStartDate);
+      expect(state().endDate()).toBe(undefined);
+    });
+
+    it('should select an end date when a start date is selected and the selected date is after the start date', () => {
+      const testStartDate = new Date(2025, 7, 1);
+      const testEndDate = new Date(2025, 7, 2);
+      host.rangePicker().select(testStartDate);
+      host.rangePicker().select(testEndDate);
+      expect(state().startDate()).toBe(testStartDate);
+      expect(state().endDate()).toBe(testEndDate);
+    });
+
+    it('should select a start date when a start date is selected and the selected date is before the start date', () => {
+      const testStartDate = new Date(2025, 7, 1);
+      const testEndDate = new Date(2025, 6, 31);
+      host.rangePicker().select(testStartDate);
+      host.rangePicker().select(testEndDate);
+      expect(state().startDate()).toBe(testEndDate);
+      expect(state().endDate()).toBe(testStartDate);
+    });
+
+    it('should select a single date when the selected date is the same as the start date', () => {
+      const testStartDate = new Date(2025, 7, 1);
+      host.rangePicker().select(testStartDate);
+      host.rangePicker().select(testStartDate);
+      expect(state().startDate()).toBe(testStartDate);
+      expect(state().endDate()).toBe(testStartDate);
+    });
+  });
+});
+
+@Component({
+  template: `
+    <div ngpDateRangePicker></div>
+  `,
+  imports: [NgpDateRangePicker],
+})
+class TestHost {
+  public rangePicker = viewChild.required<NgpDateRangePicker<Date>>(NgpDateRangePicker);
+}
+
+/** Provide a partial mock date picker state. */
+function provideMockDateRangePickerState(): Provider {
+  return {
+    provide: NgpDateRangePickerStateToken,
+    useValue: signal({
+      startDate: signal(undefined) as unknown as InputSignal<Date | undefined>,
+      endDate: signal(undefined) as unknown as InputSignal<Date | undefined>,
+    } satisfies Partial<NgpDateRangePicker<Date>>),
+  };
+}

--- a/packages/ng-primitives/date-picker/src/date-range-picker/date-range-picker.ts
+++ b/packages/ng-primitives/date-picker/src/date-range-picker/date-range-picker.ts
@@ -220,7 +220,10 @@ export class NgpDateRangePicker<T> {
    *   - Sets the selected date as the start date.
    * - If a start date is selected but no end date:
    *   - If the selected date is after the start date, sets it as the end date.
-   *   - If the selected date is before or equal to the start date, resets the start date to the selected date.
+   *   - If the selected date is before the start date, sets the selected date as the start date
+   *     and the previous start date as the end date.
+   *   - If the selected date is the same as the start date, sets the selected date as the end date
+   *     to select a single date.
    * - If both start and end dates are already selected:
    *   - Resets the selection, setting the selected date as the new start date and clearing the end date.
    *
@@ -240,9 +243,14 @@ export class NgpDateRangePicker<T> {
       if (this.dateAdapter.isAfter(date, start)) {
         this.state.endDate.set(date);
         this.endDateChange.emit(date);
-      } else {
+      } else if (this.dateAdapter.isBefore(date, start)) {
         this.state.startDate.set(date);
+        this.state.endDate.set(start);
         this.startDateChange.emit(date);
+        this.endDateChange.emit(start);
+      } else if (this.dateAdapter.isSameDay(date, start)) {
+        this.state.endDate.set(date);
+        this.endDateChange.emit(date);
       }
       return;
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #407 

## What does this PR implement/fix?

Updated the date selection logic in the NgpDateRangePicker to handle cases where:
- the selected date is the same as the start date, allowing it to be set as the end date for single date selection
- the selected date is before the start date, sets the selected date as the start date and the previous start date as the end date

(I went with `feat(...)` since it expands the features rather than fixing a previous behavior)

## Does this PR introduce a breaking change?

Maybe yes - unsure: since I needed to remove the selected() check in the NgpDatePickerDateButton.select() it will now always select the date again and run the setFocusedDate() for the regular date picker. I'm unclear if anyone is depending on the previous behavior.

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
