### PR TITLE
fix(date-picker): clear viewRefs for weeks on destroy

### DIFF
--- a/packages/ng-primitives/date-picker/src/date-picker-row-render/date-picker-row-render.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-row-render/date-picker-row-render.ts
@@ -155,6 +155,7 @@ export class NgpDatePickerRowRender<T> implements OnDestroy {
     for (const viewRef of this.viewRefs) {
       viewRef.destroy();
     }
+    this.viewRefs.length = 0;
   }
 
   /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue


## What does this PR implement/fix?

Ensure viewRefs array is cleared when the destroyRows() is called in the NgpDatePickerRowRender. This ensures that all references can be properly disposed of.

Just a small fix - I skipped adding tests for this one 🙈 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
