### PR TITLE
fix(date-picker): missing last day of week offset calculation for calendars using firstDayOfWeek

### DIFF
--- a/packages/ng-primitives/date-picker/src/date-picker-row-render/date-picker-row-render.spec.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-row-render/date-picker-row-render.spec.ts
@@ -7,6 +7,7 @@ import {
   viewChild,
 } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NgpNativeDateAdapter } from 'ng-primitives/date-time';
 import { defaultDatePickerConfig } from '../config/date-picker-config';
 import { NgpDatePicker } from '../date-picker/date-picker';
 import {
@@ -20,7 +21,10 @@ import {
 import { NgpDatePickerRowRender } from './date-picker-row-render';
 
 describe('NgpDatePickerRowRender', () => {
-  const firstOfAugust2025 = new Date(2025, 7, 1);
+  const adapter = new NgpNativeDateAdapter();
+  const firstOfAugust2025 = adapter.create({ year: 2025, month: 8, day: 1 });
+  const lastOfAugust2025 = adapter.create({ year: 2025, month: 8, day: 31 });
+
   let fixture: ComponentFixture<TestHost>;
   let host: TestHost;
 
@@ -42,25 +46,32 @@ describe('NgpDatePickerRowRender', () => {
     );
 
     expect(host.rowRender().getFirstDayOfWeekOffset(firstOfAugust2025)).toBe(5);
+    expect(host.rowRender().getLastDayOfWeekOffset(lastOfAugust2025)).toBe(6);
 
     firstDayOfWeek.set(1);
 
     expect(host.rowRender().getFirstDayOfWeekOffset(firstOfAugust2025)).toBe(4);
+    expect(host.rowRender().getLastDayOfWeekOffset(lastOfAugust2025)).toBe(0);
 
     firstDayOfWeek.set(2);
     expect(host.rowRender().getFirstDayOfWeekOffset(firstOfAugust2025)).toBe(3);
+    expect(host.rowRender().getLastDayOfWeekOffset(lastOfAugust2025)).toBe(1);
 
     firstDayOfWeek.set(3);
     expect(host.rowRender().getFirstDayOfWeekOffset(firstOfAugust2025)).toBe(2);
+    expect(host.rowRender().getLastDayOfWeekOffset(lastOfAugust2025)).toBe(2);
 
     firstDayOfWeek.set(4);
     expect(host.rowRender().getFirstDayOfWeekOffset(firstOfAugust2025)).toBe(1);
+    expect(host.rowRender().getLastDayOfWeekOffset(lastOfAugust2025)).toBe(3);
 
     firstDayOfWeek.set(5);
     expect(host.rowRender().getFirstDayOfWeekOffset(firstOfAugust2025)).toBe(0);
+    expect(host.rowRender().getLastDayOfWeekOffset(lastOfAugust2025)).toBe(4);
 
     firstDayOfWeek.set(6);
     expect(host.rowRender().getFirstDayOfWeekOffset(firstOfAugust2025)).toBe(6);
+    expect(host.rowRender().getLastDayOfWeekOffset(lastOfAugust2025)).toBe(5);
   });
 
   it('should calculate the days and first week', () => {
@@ -79,7 +90,23 @@ describe('NgpDatePickerRowRender', () => {
     );
   });
 
-  it('should calculate the days and first week with the first day of the week offset', () => {
+  it('should calculate the days and last week', () => {
+    expect(host.rowRender()['weeks']()).toEqual(
+      expect.arrayContaining([
+        [
+          new Date(2025, 7, 31),
+          new Date(2025, 8, 1),
+          new Date(2025, 8, 2),
+          new Date(2025, 8, 3),
+          new Date(2025, 8, 4),
+          new Date(2025, 8, 5),
+          new Date(2025, 8, 6),
+        ],
+      ]),
+    );
+  });
+
+  it('should calculate the days and last week with the first day of the week offset', () => {
     const firstDayOfWeek = TestBed.runInInjectionContext(
       () => injectDateControllerState()().firstDayOfWeek,
     );
@@ -95,6 +122,27 @@ describe('NgpDatePickerRowRender', () => {
           new Date(2025, 7, 1),
           new Date(2025, 7, 2),
           new Date(2025, 7, 3),
+        ],
+      ]),
+    );
+  });
+
+  it('should calculate the days and last week with the first day of the week offset', () => {
+    const firstDayOfWeek = TestBed.runInInjectionContext(
+      () => injectDateControllerState()().firstDayOfWeek,
+    );
+
+    firstDayOfWeek.set(1);
+    expect(host.rowRender()['weeks']()).toEqual(
+      expect.arrayContaining([
+        [
+          new Date(2025, 7, 25),
+          new Date(2025, 7, 26),
+          new Date(2025, 7, 27),
+          new Date(2025, 7, 28),
+          new Date(2025, 7, 29),
+          new Date(2025, 7, 30),
+          new Date(2025, 7, 31),
         ],
       ]),
     );

--- a/packages/ng-primitives/date-picker/src/date-picker-row-render/date-picker-row-render.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-row-render/date-picker-row-render.ts
@@ -65,13 +65,14 @@ export class NgpDatePickerRowRender<T> implements OnDestroy {
 
     // calculate the offset of the first day of the week.
     const firstDayOfWeekOffset = this.getFirstDayOfWeekOffset(firstDay);
+    const lastDayOfWeekOffset = this.getLastDayOfWeekOffset(lastDay);
 
     // find the first and last day of visible in the grid.
     firstDay = this.dateAdapter.subtract(firstDay, {
       days: firstDayOfWeekOffset,
     });
     lastDay = this.dateAdapter.add(lastDay, {
-      days: 6 - this.dateAdapter.getDay(lastDay),
+      days: lastDayOfWeekOffset,
     });
 
     // collect all the days to display.
@@ -170,5 +171,19 @@ export class NgpDatePickerRowRender<T> implements OnDestroy {
       (DAYS_PER_WEEK + this.dateAdapter.getDay(firstCalendarDay) - this.state().firstDayOfWeek()) %
       DAYS_PER_WEEK
     );
+  }
+
+  /**
+   * Get the offset of the last day of the week.
+   * @param lastCalendarDay The last day of the calendar without the offset.
+   * @returns The offset of the last day of the week.
+   *
+   * @internal
+   */
+  getLastDayOfWeekOffset(lastCalendarDay: T): number {
+    const lastDay = this.dateAdapter.getDay(lastCalendarDay);
+    const firstDay = this.state().firstDayOfWeek();
+
+    return (DAYS_PER_WEEK + firstDay + DAYS_PER_WEEK - 1 - lastDay) % DAYS_PER_WEEK;
   }
 }

--- a/packages/ng-primitives/date-time-luxon/src/luxon-date-adapter/luxon-date-adapter.spec.ts
+++ b/packages/ng-primitives/date-time-luxon/src/luxon-date-adapter/luxon-date-adapter.spec.ts
@@ -1,0 +1,4 @@
+import { dateAdapterTests } from 'ng-primitives/date-time/testing';
+import { NgpLuxonDateAdapter } from './luxon-date-adapter';
+
+dateAdapterTests(NgpLuxonDateAdapter);

--- a/packages/ng-primitives/date-time/src/date-adapter/date-adapter.ts
+++ b/packages/ng-primitives/date-time/src/date-adapter/date-adapter.ts
@@ -79,7 +79,14 @@ export interface NgpDateAdapter<T> {
   getDate(date: T): number;
 
   /**
-   * Get the day.
+   * Get the day of the week as a number (1-7).
+   * - `1` = Monday
+   * - `2` = Tuesday
+   * - `3` = Wednesday
+   * - `4` = Thursday
+   * - `5` = Friday
+   * - `6` = Saturday
+   * - `7` = Sunday
    */
   getDay(date: T): number;
 
@@ -131,7 +138,7 @@ export interface NgpDateUnits {
   year?: number;
 
   /**
-   * The month.
+   * The month 1-12.
    */
   month?: number;
 

--- a/packages/ng-primitives/date-time/src/index.ts
+++ b/packages/ng-primitives/date-time/src/index.ts
@@ -1,2 +1,3 @@
 export { NgpDateAdapter, NgpDateUnits, NgpDuration } from './date-adapter/date-adapter';
 export { injectDateAdapter, provideDateAdapter } from './date-adapter/date-adapter-token';
+export { NgpNativeDateAdapter } from './native-date-adapter/native-date-adapter';

--- a/packages/ng-primitives/date-time/src/native-date-adapter/native-date-adapter.spec.ts
+++ b/packages/ng-primitives/date-time/src/native-date-adapter/native-date-adapter.spec.ts
@@ -1,0 +1,4 @@
+import { dateAdapterTests } from 'ng-primitives/date-time/testing';
+import { NgpNativeDateAdapter } from './native-date-adapter';
+
+dateAdapterTests(NgpNativeDateAdapter);

--- a/packages/ng-primitives/date-time/src/native-date-adapter/native-date-adapter.ts
+++ b/packages/ng-primitives/date-time/src/native-date-adapter/native-date-adapter.ts
@@ -9,7 +9,7 @@ export class NgpNativeDateAdapter implements NgpDateAdapter<Date> {
 
     return new Date(
       year ?? now.getFullYear(),
-      month ?? now.getMonth(),
+      month ? month - 1 : now.getMonth(),
       day ?? now.getDate(),
       hour ?? now.getHours(),
       minute ?? now.getMinutes(),
@@ -135,10 +135,17 @@ export class NgpNativeDateAdapter implements NgpDateAdapter<Date> {
   }
 
   /**
-   * Get the day.
+   * Get the day of the week as a number (1-7).
+   * - `1` = Monday
+   * - `2` = Tuesday
+   * - `3` = Wednesday
+   * - `4` = Thursday
+   * - `5` = Friday
+   * - `6` = Saturday
+   * - `7` = Sunday
    */
   getDay(date: Date): number {
-    return date.getDay();
+    return date.getDay() === 0 ? 7 : date.getDay();
   }
 
   /**

--- a/packages/ng-primitives/date-time/testing/date-adapter-tests.ts
+++ b/packages/ng-primitives/date-time/testing/date-adapter-tests.ts
@@ -1,0 +1,19 @@
+import type { NgpDateAdapter } from 'ng-primitives/date-time';
+
+export function dateAdapterTests<T>(adapterClass: new () => NgpDateAdapter<T>) {
+  describe('NgpDateAdapter via ' + adapterClass.name, () => {
+    const adapter = new adapterClass();
+
+    it('should get the day of the week (1-7)', () => {
+      const lastOfAugust2025 = adapter.create({ year: 2025, month: 8, day: 31 }); // Aug 31st, 2025 is a Sunday
+      expect(adapter.getDay(lastOfAugust2025)).toBe(7);
+      expect(adapter.getDay(adapter.add(lastOfAugust2025, { days: 1 }))).toBe(1);
+      expect(adapter.getDay(adapter.add(lastOfAugust2025, { days: 2 }))).toBe(2);
+      expect(adapter.getDay(adapter.add(lastOfAugust2025, { days: 3 }))).toBe(3);
+      expect(adapter.getDay(adapter.add(lastOfAugust2025, { days: 4 }))).toBe(4);
+      expect(adapter.getDay(adapter.add(lastOfAugust2025, { days: 5 }))).toBe(5);
+      expect(adapter.getDay(adapter.add(lastOfAugust2025, { days: 6 }))).toBe(6);
+      expect(adapter.getDay(adapter.add(lastOfAugust2025, { days: 7 }))).toBe(7);
+    });
+  });
+}

--- a/packages/ng-primitives/date-time/testing/index.ts
+++ b/packages/ng-primitives/date-time/testing/index.ts
@@ -1,0 +1,1 @@
+export * from './date-adapter-tests';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,7 @@
       "ng-primitives/date-picker": ["packages/ng-primitives/date-picker/src/index.ts"],
       "ng-primitives/date-time": ["packages/ng-primitives/date-time/src/index.ts"],
       "ng-primitives/date-time-luxon": ["packages/ng-primitives/date-time-luxon/src/index.ts"],
+      "ng-primitives/date-time/testing": ["packages/ng-primitives/date-time/testing/index.ts"],
       "ng-primitives/dialog": ["packages/ng-primitives/dialog/src/index.ts"],
       "ng-primitives/file-upload": ["packages/ng-primitives/file-upload/src/index.ts"],
       "ng-primitives/focus-trap": ["packages/ng-primitives/focus-trap/src/index.ts"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What does this PR implement/fix?

The `NgpNativeDateAdapter` and the `NgpLuxonDateAdapter` do behave differently for the `create(...)` and `getDay(...)` methods. This will align the behavior and is a precursor for the fix of the calendar. When using the firstDayOfWeek and the `NgpLuxonDateAdapter`, the last week of the month was cut off.

Fore more details please see the commit descriptions

## Does this PR introduce a breaking change?

Potentially, yes. If Someone is using the `NgpNativeDateAdapter` create and getDay methods, the behavior changes.

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
