### PR TITLE
docs(menu): fix offset default value

### DIFF
--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
@@ -85,7 +85,7 @@ export class NgpMenuTrigger<T = unknown> implements OnDestroy {
 
   /**
    * Define the offset of the menu relative to the trigger.
-   * @default 0
+   * @default 4
    */
   readonly offset = input<number, NumberInput>(this.config.offset, {
     alias: 'ngpMenuTriggerOffset',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

Update the meuTrigger offset default value to the correct value from the config.
@ashley-hunter I wonder if a better sync mechanism can be used to sync those, there are other open question like the fact that the default container is document.body but that's managed at the overlay level.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
