### PR TITLE
feat(snippet): add copy confirmation feedback to code snippet and exa…

### DIFF
--- a/apps/documentation/src/app/components/example/example.html
+++ b/apps/documentation/src/app/components/example/example.html
@@ -61,7 +61,11 @@
         class="inline-flex size-8 items-center justify-center rounded-lg bg-white p-2 shadow-sm ring-1 ring-black/5 transition-colors hover:bg-zinc-50 active:bg-zinc-100 dark:bg-zinc-900 dark:ring-white/5 dark:hover:bg-zinc-950 dark:active:bg-zinc-800"
         (click)="copyCode()"
       >
+        @if (isCopied()) {
+        <ng-icon name="lucideCheck" />
+        } @else {
         <ng-icon name="lucideClipboard" />
+        }
       </button>
 
       <button

--- a/apps/documentation/src/app/components/example/example.ts
+++ b/apps/documentation/src/app/components/example/example.ts
@@ -16,7 +16,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { lucideClipboard } from '@ng-icons/lucide';
+import { lucideClipboard, lucideCheck } from '@ng-icons/lucide';
 import { phosphorLightning } from '@ng-icons/phosphor-icons/regular';
 import sdk from '@stackblitz/sdk';
 import { isString } from 'ng-primitives/utils';
@@ -31,7 +31,7 @@ const GLOBAL_STORAGE_STYLE_KEY = 'ngp-example-style';
   imports: [NgComponentOutlet, NgClass, NgIcon, FormsModule],
   templateUrl: './example.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [provideIcons({ phosphorLightning, lucideClipboard })],
+  providers: [provideIcons({ phosphorLightning, lucideClipboard, lucideCheck })],
 })
 export class Example {
   private readonly clipboard = inject(Clipboard);
@@ -56,6 +56,7 @@ export class Example {
   readonly component = signal<Type<unknown> | null>(null);
   readonly mode = signal<'preview' | 'source'>('preview');
   readonly code = signal<string>('');
+  readonly isCopied = signal<boolean>(false);
   // Private properties
   private raw: string | null = null; // Raw source code for copying and StackBlitz
 
@@ -582,5 +583,13 @@ module.exports = {
     }
 
     this.clipboard.copy(this.raw); // Copies the content of this.raw
+    // Set copied state to true
+    this.isCopied.set(true);
+
+    // Reset after 2 seconds
+    setTimeout(() => {
+      this.isCopied.set(false);
+      this.changeDetector.detectChanges();
+    }, 2000);
   }
 }

--- a/apps/documentation/src/app/components/snippet/snippet.html
+++ b/apps/documentation/src/app/components/snippet/snippet.html
@@ -24,12 +24,18 @@
         }
 
         <button
-          class="relative -mb-px ml-auto flex size-7 items-center justify-center whitespace-nowrap rounded-md text-base font-medium text-white outline-none hover:bg-zinc-700/60 hover:text-white"
+          class="relative -mb-px ml-auto flex items-center justify-center whitespace-nowrap rounded-md px-2 py-1 text-base font-medium text-white outline-none hover:bg-zinc-700/60 hover:text-white"
+          [class.min-w-[80px]]="isCopied()"
           (click)="copyToClipboard()"
           type="button"
           tabindex="0"
         >
+          @if (isCopied()) {
+          <ng-icon class="mr-1" name="heroCheck" />
+          <span class="text-xs">Copied</span>
+          } @else {
           <ng-icon name="heroSquare2Stack" />
+          }
         </button>
       </div>
 

--- a/apps/documentation/src/app/components/snippet/snippet.ts
+++ b/apps/documentation/src/app/components/snippet/snippet.ts
@@ -10,7 +10,7 @@ import {
   signal,
 } from '@angular/core';
 import { NgIcon, provideIcons } from '@ng-icons/core';
-import { heroSquare2Stack } from '@ng-icons/heroicons/outline';
+import { heroSquare2Stack, heroCheck } from '@ng-icons/heroicons/outline';
 import * as prismjs from 'prismjs';
 
 const { highlight, languages } = prismjs;
@@ -18,7 +18,7 @@ const { highlight, languages } = prismjs;
 @Component({
   selector: 'docs-snippet',
   imports: [NgIcon],
-  providers: [provideIcons({ heroSquare2Stack })],
+  providers: [provideIcons({ heroSquare2Stack, heroCheck })],
   templateUrl: './snippet.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -34,8 +34,8 @@ export class Snippet {
   );
 
   readonly files = signal<Tab[]>([]);
-
   readonly selectedFile = signal<string | null>(null);
+  readonly isCopied = signal<boolean>(false);
 
   readonly code = computed(() => {
     const files = this.files();
@@ -126,6 +126,13 @@ export class Snippet {
     }
     const code = this.files().find(file => file.label === this.selectedFile())!.value;
     this.clipboard.copy(code);
+
+    this.isCopied.set(true);
+
+    setTimeout(() => {
+      this.isCopied.set(false);
+      this.changeDetector.detectChanges();
+    }, 2000);
   }
 }
 

--- a/apps/documentation/src/app/pages/index.page.ts
+++ b/apps/documentation/src/app/pages/index.page.ts
@@ -10,8 +10,11 @@ import {
   heroMagnifyingGlass,
   heroSquares2x2,
   heroUsers,
+  heroSquare2Stack,
+  heroCheck,
 } from '@ng-icons/heroicons/outline';
 import { ThemeToggle } from '../components/theme-toggle/theme-toggle';
+import { Clipboard } from '@angular/cdk/clipboard';
 
 @Component({
   selector: 'docs-navbar',
@@ -121,6 +124,8 @@ export class DocsNavbar implements OnInit {
       heroBolt,
       heroSquares2x2,
       heroUsers,
+      heroSquare2Stack,
+      heroCheck,
       coralogix: `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M8 2C4.68874 2 2 4.69011 2 8C2 11.3099 4.68874 14 8 14C11.3113 14 14 11.3099 14 8C14 4.69011 11.3113 2 8 2Z" fill="white"/>
 <path opacity="0.4" d="M8 1.60563C4.46643 1.60563 1.59717 4.47887 1.59717 8.01408C1.59717 11.5493 4.46643 14.4225 8 14.4225C11.5336 14.4225 14.4028 11.5493 14.4028 8.01408C14.417 4.47887 11.5336 1.60563 8 1.60563ZM8 16C3.59011 16 0 12.4085 0 8C0 3.59155 3.59011 0 8 0C12.4099 0 16 3.59155 16 8C16 12.4225 12.4099 16 8 16Z" fill="white"/>
@@ -262,10 +267,26 @@ export class DocsNavbar implements OnInit {
 
           <div class="w-full max-w-sm overflow-hidden rounded-lg bg-zinc-950 text-white/90">
             <div class="mt-0 flex flex-1 flex-col outline-none">
-              <div class="flex h-8 items-center border-b border-b-zinc-800 px-4">
-                <div class="mr-2 h-3 w-3 rounded-full bg-red-500"></div>
-                <div class="mr-2 h-3 w-3 rounded-full bg-yellow-500"></div>
-                <div class="h-3 w-3 rounded-full bg-green-500"></div>
+              <div class="flex h-8 items-center justify-between border-b border-b-zinc-800 ps-4 pe-2">
+                <div class="flex items-center">
+                  <div class="mr-2 h-3 w-3 rounded-full bg-red-500"></div>
+                  <div class="mr-2 h-3 w-3 rounded-full bg-yellow-500"></div>
+                  <div class="h-3 w-3 rounded-full bg-green-500"></div>
+                </div>
+                <button
+                  class="flex items-center justify-center rounded-md p-1 text-white hover:bg-zinc-700/60 "
+                  [class.min-w-[60px]]="isCopied()"
+                  (click)="copyCommand()"
+                  type="button"
+                  aria-label="Copy command"
+                >
+                  @if (isCopied()) {
+                    <ng-icon name="heroCheck" class="mr-1 text-xs" />
+                    <span class="text-[10px]">Copied</span>
+                  } @else {
+                    <ng-icon name="heroSquare2Stack" class="text-md" />
+                  }
+                </button>
               </div>
               <pre
                 class="px-4 py-3.5"
@@ -302,7 +323,7 @@ export class DocsNavbar implements OnInit {
             class="flex flex-col justify-between rounded-xl bg-white p-8 shadow-sm ring-1 ring-zinc-200 dark:bg-zinc-800 dark:ring-zinc-700"
           >
             <p class="mb-6 text-sm leading-loose text-zinc-600 dark:text-zinc-300">
-              “{{ testimonial.quote }}”
+              "{{ testimonial.quote }}"
             </p>
             <div class="flex items-center gap-4 pt-4">
               <img
@@ -377,7 +398,11 @@ export class DocsNavbar implements OnInit {
   `,
 })
 export default class IndexPage {
+  private readonly clipboard = inject(Clipboard);
+  
   readonly year = new Date().getFullYear();
+  readonly isCopied = signal<boolean>(false);
+  
   readonly features = [
     {
       icon: 'heroCodeBracket',
@@ -446,4 +471,16 @@ export default class IndexPage {
       image: '/assets/testimonials/kedevked.jpg',
     },
   ];
+
+  protected copyCommand(): void {
+    this.clipboard.copy('ng add ng-primitives');
+    
+    // Set copied state to true
+    this.isCopied.set(true);
+    
+    // Reset after 2 seconds
+    setTimeout(() => {
+      this.isCopied.set(false);
+    }, 2000);
+  }
 }

--- a/apps/documentation/src/app/pages/index.page.ts
+++ b/apps/documentation/src/app/pages/index.page.ts
@@ -1,3 +1,4 @@
+import { Clipboard } from '@angular/cdk/clipboard';
 import { isPlatformBrowser } from '@angular/common';
 import { Component, HostListener, inject, OnInit, PLATFORM_ID, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
@@ -14,7 +15,6 @@ import {
   heroCheck,
 } from '@ng-icons/heroicons/outline';
 import { ThemeToggle } from '../components/theme-toggle/theme-toggle';
-import { Clipboard } from '@angular/cdk/clipboard';
 
 @Component({
   selector: 'docs-navbar',
@@ -267,24 +267,26 @@ export class DocsNavbar implements OnInit {
 
           <div class="w-full max-w-sm overflow-hidden rounded-lg bg-zinc-950 text-white/90">
             <div class="mt-0 flex flex-1 flex-col outline-none">
-              <div class="flex h-8 items-center justify-between border-b border-b-zinc-800 ps-4 pe-2">
+              <div
+                class="flex h-8 items-center justify-between border-b border-b-zinc-800 pe-2 ps-4"
+              >
                 <div class="flex items-center">
                   <div class="mr-2 h-3 w-3 rounded-full bg-red-500"></div>
                   <div class="mr-2 h-3 w-3 rounded-full bg-yellow-500"></div>
                   <div class="h-3 w-3 rounded-full bg-green-500"></div>
                 </div>
                 <button
-                  class="flex items-center justify-center rounded-md p-1 text-white hover:bg-zinc-700/60 "
+                  class="flex items-center justify-center rounded-md p-1 text-white hover:bg-zinc-700/60"
                   [class.min-w-[60px]]="isCopied()"
                   (click)="copyCommand()"
                   type="button"
                   aria-label="Copy command"
                 >
                   @if (isCopied()) {
-                    <ng-icon name="heroCheck" class="mr-1 text-xs" />
+                    <ng-icon class="mr-1 text-xs" name="heroCheck" />
                     <span class="text-[10px]">Copied</span>
                   } @else {
-                    <ng-icon name="heroSquare2Stack" class="text-md" />
+                    <ng-icon class="text-md" name="heroSquare2Stack" />
                   }
                 </button>
               </div>
@@ -399,10 +401,10 @@ export class DocsNavbar implements OnInit {
 })
 export default class IndexPage {
   private readonly clipboard = inject(Clipboard);
-  
+
   readonly year = new Date().getFullYear();
   readonly isCopied = signal<boolean>(false);
-  
+
   readonly features = [
     {
       icon: 'heroCodeBracket',
@@ -474,10 +476,10 @@ export default class IndexPage {
 
   protected copyCommand(): void {
     this.clipboard.copy('ng add ng-primitives');
-    
+
     // Set copied state to true
     this.isCopied.set(true);
-    
+
     // Reset after 2 seconds
     setTimeout(() => {
       this.isCopied.set(false);


### PR DESCRIPTION
# Add copy confirmation feedback to code snippet and example components

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Closes #[issue_number_if_applicable]

Currently, when users click the copy button in code snippets, there's no visual feedback to confirm the action was successful. This can lead to uncertainty about whether the code was actually copied to the clipboard.

## What does this PR implement/fix?

This PR adds visual confirmation feedback to the copy button in code snippet and example components:

- **Visual Feedback**: When the copy button is clicked, it temporarily changes to show a check icon with "Copied" text
- **Auto-reset**: After 2 seconds, the button automatically returns to its original state (copy icon only)
- **Smooth Transitions**: Uses Angular signals for reactive state management ensuring smooth UI updates
- **Layout Stability**: Button maintains consistent dimensions during state changes to prevent layout shifts
- **Accessibility**: Maintains proper button semantics and interactions

### Technical Implementation:
- Added `isCopied` signal to track the copied state
- Imported `heroCheck` icon from heroicons/outline
- Enhanced `copyToClipboard()` method with temporary state management
- Updated template with conditional rendering for copy states
- Used `setTimeout` with manual change detection for state reset

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

This is a purely additive feature that enhances the existing copy functionality without changing any APIs or breaking existing behavior.