### PR TITLE
Dialog overlay close when disableClose is set in dialog state

### DIFF
--- a/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay.ts
+++ b/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay.ts
@@ -26,7 +26,7 @@ export class NgpDialogOverlay {
 
   @HostListener('click')
   protected close(): void {
-    if (this.closeOnClick()) {
+    if (this.closeOnClick() && !this.dialogRef.disableClose) {
       this.dialogRef.close(undefined, 'mouse');
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

## What does this PR implement/fix?

Respect the disableClose flag inside the dialog state when the user clicks the overlay to attempt to close the dialog.

Current behavior:

- Clicking the overlay always attempted to close the dialog regardless of the dialog state's disableClose flag.

New behavior:

- Overlay clicks will only close the dialog when the dialog state's disableClose flag is false.

- When disableClose is true, overlay clicks are ignored (dialog remains open).

Why:

- This ensures dialogs that should not be dismissible by clicking outside (overlay) respect their configured state.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
