### PR TITLE
Prevent screen from scrolling when combobox input receives focus

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox-input/combobox-input.ts
+++ b/packages/ng-primitives/combobox/src/combobox-input/combobox-input.ts
@@ -157,7 +157,7 @@ export class NgpComboboxInput {
    * @internal
    */
   focus(): void {
-    this.elementRef.nativeElement.focus();
+    this.elementRef.nativeElement.focus({preventScroll: true});
   }
 
   @HostListener('focus', ['$event'])

--- a/packages/ng-primitives/combobox/src/combobox-input/combobox-input.ts
+++ b/packages/ng-primitives/combobox/src/combobox-input/combobox-input.ts
@@ -157,7 +157,7 @@ export class NgpComboboxInput {
    * @internal
    */
   focus(): void {
-    this.elementRef.nativeElement.focus({preventScroll: true});
+    this.elementRef.nativeElement.focus({ preventScroll: true });
   }
 
   @HostListener('focus', ['$event'])


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

## What does this PR implement/fix?

Prevents the screen from scrolling on the initial opening of the combobox dropdown in cases the input is placed inside the dropdown

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
