### PR TITLE
feat(combobox): add keyboard navigation support without input

### DIFF
--- a/apps/documentation/src/app/examples/combobox/combobox-button.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-button.example.ts
@@ -1,0 +1,188 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDown } from '@ng-icons/heroicons/outline';
+import {
+  NgpCombobox,
+  NgpComboboxButton,
+  NgpComboboxDropdown,
+  NgpComboboxOption,
+  NgpComboboxPortal,
+} from 'ng-primitives/combobox';
+
+@Component({
+  selector: 'app-combobox-button',
+  imports: [
+    NgpCombobox,
+    NgpComboboxDropdown,
+    NgpComboboxOption,
+    NgpComboboxPortal,
+    NgpComboboxButton,
+    NgIcon,
+  ],
+  providers: [provideIcons({ heroChevronDown })],
+  template: `
+    <div [(ngpComboboxValue)]="value" ngpCombobox>
+      <button ngpComboboxButton>
+        {{ value() || 'Select a character' }}
+        <ng-icon name="heroChevronDown" />
+      </button>
+
+      <div *ngpComboboxPortal ngpComboboxDropdown>
+        @for (option of options; track option) {
+          <div [ngpComboboxOptionValue]="option" ngpComboboxOption>
+            {{ option }}
+          </div>
+        }
+      </div>
+    </div>
+  `,
+  styles: `
+    [ngpCombobox] {
+      display: inline-block;
+      width: 300px;
+    }
+
+    [ngpCombobox]:focus-within {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+      border-radius: 8px;
+    }
+
+    [ngpComboboxButton] {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+      height: 36px;
+      padding: 0 16px;
+      border-radius: 8px;
+      border: none;
+      background-color: var(--ngp-background);
+      box-shadow: var(--ngp-input-shadow);
+      color: var(--ngp-text);
+      font-family: inherit;
+      font-size: 14px;
+      cursor: pointer;
+      box-sizing: border-box;
+      transition: all 0.2s ease;
+    }
+
+    [ngpComboboxButton]:hover {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpComboboxButton][aria-expanded='true'] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpComboboxButton] ng-icon {
+      transition: transform 0.2s ease;
+      width: 16px;
+      height: 16px;
+    }
+
+    [ngpComboboxButton][aria-expanded='true'] ng-icon {
+      transform: rotate(180deg);
+    }
+
+    [ngpComboboxDropdown] {
+      background-color: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      padding: 0.25rem;
+      border-radius: 0.75rem;
+      outline: none;
+      position: absolute;
+      width: var(--ngp-combobox-width);
+      box-shadow: var(--ngp-shadow-lg);
+      box-sizing: border-box;
+      margin-top: 4px;
+      max-height: 240px;
+      overflow-y: auto;
+      z-index: 1001;
+      transform-origin: var(--ngp-combobox-transform-origin);
+    }
+
+    [ngpComboboxDropdown][data-enter] {
+      animation: dropdown-show 0.15s ease-out;
+    }
+
+    [ngpComboboxDropdown][data-exit] {
+      animation: dropdown-hide 0.15s ease-in;
+    }
+
+    [ngpComboboxOption] {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.375rem 0.75rem;
+      cursor: pointer;
+      border-radius: 0.5rem;
+      width: 100%;
+      height: 36px;
+      font-size: 14px;
+      color: var(--ngp-text-primary);
+      box-sizing: border-box;
+      transition: background-color 0.1s ease;
+    }
+
+    [ngpComboboxOption][data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpComboboxOption][data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpComboboxOption][data-active] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpComboboxOption][data-selected] {
+      background-color: var(--ngp-primary);
+      color: var(--ngp-primary-contrast);
+    }
+
+    @keyframes dropdown-show {
+      0% {
+        opacity: 0;
+        transform: translateY(-10px) scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    @keyframes dropdown-hide {
+      0% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: translateY(-10px) scale(0.9);
+      }
+    }
+  `,
+})
+export default class ComboboxButtonExample {
+  /** The options for the combobox. */
+  readonly options: string[] = [
+    'Marty McFly',
+    'Doc Brown',
+    'Biff Tannen',
+    'George McFly',
+    'Jennifer Parker',
+    'Emmett Brown',
+    'Einstein',
+    'Clara Clayton',
+    'Needles',
+    'Goldie Wilson',
+    'Marvin Berry',
+    'Lorraine Baines',
+    'Strickland',
+  ];
+
+  /** The selected value. */
+  readonly value = signal<string | undefined>(undefined);
+}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -39,11 +39,34 @@ Assemble the combobox directives in your template.
 </div>
 ```
 
+### Without Input Field
+
+You can also create a combobox without an input field, which is useful for select-like behavior with keyboard navigation:
+
+```html
+<div ngpCombobox>
+  <button ngpComboboxButton>{{ selectedOption || 'Select an option' }} ▼</button>
+  <div ngpComboboxDropdown>
+    @for (option of options; track option) {
+    <div ngpComboboxOption [ngpComboboxOptionValue]="option">{{ option }}</div>
+    }
+  </div>
+</div>
+```
+
+When no input is present, the combobox element itself becomes focusable and supports full keyboard navigation.
+
 ## Reusable Component
 
 Create a reusable component that uses the `NgpCombobox` directive.
 
 <docs-snippet name="combobox"></docs-snippet>
+
+## Button-only Combobox
+
+This example demonstrates a combobox without an input field. The combobox element itself becomes focusable.
+
+<docs-example name="combobox-button"></docs-example>
 
 ## Multiple Selection with chips
 
@@ -94,6 +117,14 @@ The following data attributes are applied to the `ngpCombobox` directive:
 | `data-dirty`    | Applied when the combobox has been modified.                   |
 | `data-pending`  | Applied when the combobox is pending (e.g., async validation). |
 | `data-disabled` | Applied when the combobox is disabled.                         |
+
+#### Focus Management
+
+When no `ngpComboboxInput` is present, the combobox element itself receives:
+
+- `tabindex="0"` to make it focusable via keyboard navigation
+- `tabindex="-1"` when disabled or when an input is present
+- Full keyboard navigation support
 
 ### NgpComboboxButton
 
@@ -217,7 +248,26 @@ Adheres to the [WAI-ARIA](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) gu
 
 ### Keyboard Interactions
 
+The combobox supports comprehensive keyboard navigation whether or not an input field is present:
+
+#### With Input Field
+
 - <kbd>ArrowDown</kbd>: Open the dropdown and focus the first option. If the dropdown is already open, move focus to the next option.
-- <kbd>ArrowUp</kbd>: Move focus to the previous option.
-- <kbd>Enter</kbd>: Toggle the selection state of the focused option. In single selection mode, this will select the option and close the dropdown. In multiple selection mode, this will toggle the option without closing the dropdown. When `ngpComboboxAllowDeselect` is enabled on single selection comboboxes, pressing Enter on an already selected option will deselect it.
+- <kbd>ArrowUp</kbd>: Open the dropdown and focus the last option. If the dropdown is already open, move focus to the previous option.
+- <kbd>Home</kbd>: Move focus to the first option (when dropdown is open).
+- <kbd>End</kbd>: Move focus to the last option (when dropdown is open).
+- <kbd>Enter</kbd>: Toggle the selection state of the focused option. In single selection mode, this will select the option and close the dropdown. In multiple selection mode, this will toggle the option without closing the dropdown.
+- <kbd>Escape</kbd>: Close the dropdown without selecting an option.
+- <kbd>Any character key</kbd>: Open the dropdown and filter options based on typed text.
+
+#### Without Input Field
+
+When no `ngpComboboxInput` is present, the combobox container becomes focusable and supports:
+
+- <kbd>Tab</kbd>: Focus the combobox container.
+- <kbd>ArrowDown</kbd>: Open the dropdown and focus the first option. If already open, move to the next option.
+- <kbd>ArrowUp</kbd>: Open the dropdown and focus the last option. If already open, move to the previous option.
+- <kbd>Home</kbd>: Move focus to the first option (when dropdown is open).
+- <kbd>End</kbd>: Move focus to the last option (when dropdown is open).
+- <kbd>Enter</kbd>: Select the focused option and close the dropdown.
 - <kbd>Escape</kbd>: Close the dropdown without selecting an option.

--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -62,13 +62,15 @@ Create a reusable component that uses the `NgpCombobox` directive.
 
 <docs-snippet name="combobox"></docs-snippet>
 
-## Button-only Combobox
+## Examples
+
+### Button-only Combobox
 
 This example demonstrates a combobox without an input field. The combobox element itself becomes focusable.
 
 <docs-example name="combobox-button"></docs-example>
 
-## Multiple Selection with chips
+### Multiple Selection with chips
 
 <docs-example name="combobox-multiple"></docs-example>
 

--- a/packages/ng-primitives/combobox/src/combobox/combobox.spec.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.spec.ts
@@ -767,12 +767,18 @@ describe('NgpCombobox without input', () => {
 
   it('should have tabindex -1 when disabled', async () => {
     @Component({
-      imports: [NgpCombobox, NgpComboboxButton, NgpComboboxDropdown, NgpComboboxOption, NgpComboboxPortal],
+      imports: [
+        NgpCombobox,
+        NgpComboboxButton,
+        NgpComboboxDropdown,
+        NgpComboboxOption,
+        NgpComboboxPortal,
+      ],
       template: `
-        <div ngpCombobox [ngpComboboxDisabled]="true" data-testid="disabled-combobox">
+        <div [ngpComboboxDisabled]="true" ngpCombobox data-testid="disabled-combobox">
           <button ngpComboboxButton>Select</button>
           <div *ngpComboboxPortal ngpComboboxDropdown>
-            <div ngpComboboxOption [ngpComboboxOptionValue]="'test'">Test</div>
+            <div [ngpComboboxOptionValue]="'test'" ngpComboboxOption>Test</div>
           </div>
         </div>
       `,

--- a/packages/ng-primitives/combobox/src/combobox/combobox.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.ts
@@ -575,10 +575,7 @@ export class NgpCombobox {
     const relatedTarget = event.relatedTarget as HTMLElement;
 
     // if the blur was caused by focus moving to the dropdown, don't close
-    if (
-      relatedTarget &&
-      this.dropdown()?.elementRef.nativeElement.contains(relatedTarget)
-    ) {
+    if (relatedTarget && this.dropdown()?.elementRef.nativeElement.contains(relatedTarget)) {
       return;
     }
 

--- a/packages/tools/src/executors/api-extraction/api-extraction.ts
+++ b/packages/tools/src/executors/api-extraction/api-extraction.ts
@@ -120,7 +120,7 @@ function mapToInputDefinition(entry: PropertyEntry): InputDefinition {
     type: (() => {
       const match = entry.type.match(/^(InputSignal|InputSignalWithTransform|ModelSignal)<(.+)>$/);
       if (!match) return entry.type;
-      let typeParam = match[2];
+      const typeParam = match[2];
       // For InputSignalWithTransform<T, U>, only extract T (but avoid splitting inside parens)
       // Find the first comma not inside parentheses
       let depth = 0;

--- a/packages/tools/src/executors/api-extraction/api-extraction.ts
+++ b/packages/tools/src/executors/api-extraction/api-extraction.ts
@@ -116,11 +116,23 @@ function isOutput(entry: MemberEntry): entry is PropertyEntry {
 function mapToInputDefinition(entry: PropertyEntry): InputDefinition {
   return {
     name: entry.inputAlias,
-    // the type will be InputSignal<T>, InputSignalWithTransform<T> or ModelSignal<T>, we want to extract the T
-    // in the case of InputSignalWithTransform<T, U>, we only want the T
-    type: entry.type
-      .replace(/^(InputSignal|InputSignalWithTransform|ModelSignal)<(.*)>$/, '$2')
-      .split(',')[0],
+    // Extract the type parameter, handling nested generics and function types with commas
+    type: (() => {
+      const match = entry.type.match(/^(InputSignal|InputSignalWithTransform|ModelSignal)<(.+)>$/);
+      if (!match) return entry.type;
+      let typeParam = match[2];
+      // For InputSignalWithTransform<T, U>, only extract T (but avoid splitting inside parens)
+      // Find the first comma not inside parentheses
+      let depth = 0;
+      for (let i = 0; i < typeParam.length; i++) {
+        if (typeParam[i] === '(') depth++;
+        else if (typeParam[i] === ')') depth--;
+        else if (typeParam[i] === ',' && depth === 0) {
+          return typeParam.slice(0, i).trim();
+        }
+      }
+      return typeParam.trim();
+    })(),
     description: entry.description,
     isRequired: entry.isRequiredInput || entry.jsdocTags.some(tag => tag.name === 'required'),
     defaultValue: entry.jsdocTags.find(tag => tag.name === 'default')?.comment,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What does this PR implement/fix?

 Added full keyboard navigation support to the combobox component,
  enabling it to work without an input element. Users can now
  navigate options using arrow keys, select with Enter, close with
  Escape, and jump to first/last items with Home/End keys. The
  component intelligently manages focus and blur events to ensure the
   dropdown behaves correctly when focus moves between related
  elements.

  Key changes:
  - Keyboard event handlers for navigation and selection
  - Dynamic tabindex management based on input presence and disabled
  state
  - Smart blur handling that keeps dropdown open when appropriate
  - Complete test suite covering all new functionality

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No