### PR TITLE
fix(combobox): open dropdown for Android virtual keyboard 'Unidentified' key (#467)

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox-input/combobox-input.ts
+++ b/packages/ng-primitives/combobox/src/combobox-input/combobox-input.ts
@@ -122,7 +122,10 @@ export class NgpComboboxInput {
       default:
         // Ignore keys with length > 1 (e.g., 'Shift', 'ArrowLeft', 'Enter', etc.)
         // Filter out control/meta key combos (e.g., Ctrl+C)
-        if (event.key.length > 1 || event.ctrlKey || event.metaKey || event.altKey) {
+        if (
+          event.key !== 'Unidentified' &&
+          (event.key.length > 1 || event.ctrlKey || event.metaKey || event.altKey)
+        ) {
           return;
         }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

On some Android devices the virtual keyboard emits KeyboardEvent.key === 'Unidentified'. An existing early-return ignored such events and prevented the combobox dropdown from opening when typing on those keyboards.

Fixes: #467

## What does this PR implement/fix?

Add an exception for the 'Unidentified' key so character input from Android virtual keyboards will open the dropdown as expected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
