### PR TITLE
feat: enhance offset control with axis-specific configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.81.1 (2025-09-23)
+
+### 🩹 Fixes
+
+- **combobox:** open dropdown for Android virtual keyboard 'Unidentified' key ([#467](https://github.com/ng-primitives/ng-primitives/pull/467), [#476](https://github.com/ng-primitives/ng-primitives/pull/476))
+
+### ❤️ Thank You
+
+- BennyPLS
+
 ## 0.81.0 (2025-09-23)
 
 ### 🚀 Features

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -64,6 +64,23 @@ The menu can contain submenus, which are nested menus that can be opened by hove
 
 <docs-example name="submenu"></docs-example>
 
+### Custom Offset
+
+You can customize the offset using either a simple number or an object for more precise control:
+
+```html
+<!-- Simple number offset -->
+<button [ngpMenuTrigger]="menu" ngpMenuTriggerOffset="12">Menu with 12px offset</button>
+
+<!-- Object offset for precise control -->
+<button
+  [ngpMenuTrigger]="menu"
+  [ngpMenuTriggerOffset]="{mainAxis: 8, crossAxis: 4, alignmentAxis: 2}"
+>
+  Menu with custom offset
+</button>
+```
+
 ## API Reference
 
 The following directives are available to import from the `ng-primitives/menu` package:
@@ -173,8 +190,19 @@ bootstrapApplication(AppComponent, {
 
 ### NgpMenuConfig
 
-<prop-details name="offset" type="number">
-  Define the offset from the trigger element.
+<prop-details name="offset" type="number | NgpOffsetOptions">
+  Define the offset from the trigger element. Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis properties.
+  
+  **Number format:** `offset: 8` - Applies to mainAxis (distance from trigger)
+  
+  **Object format:** 
+  ```ts
+  offset: {
+    mainAxis: 8,     // Distance between menu and trigger element
+    crossAxis: 4,    // Skidding along the alignment axis  
+    alignmentAxis: 2 // Same as crossAxis but for aligned placements
+  }
+  ```
 </prop-details>
 
 <prop-details name="placement" type="'top' | 'right' | 'bottom' | 'left'">

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -32,6 +32,25 @@ Assemble the popover directives in your template.
 
 You can listen to the `ngpPopoverTriggerOpenChange` event to perform actions when the popover state changes. The event emits a boolean value indicating whether the popover is open or closed:
 
+## Examples
+
+### Custom Offset
+
+You can customize the offset using either a simple number or an object for more precise control:
+
+```html
+<!-- Simple number offset -->
+<button [ngpPopoverTrigger]="popover" ngpPopoverTriggerOffset="12">Popover with 12px offset</button>
+
+<!-- Object offset for precise control -->
+<button
+  [ngpPopoverTrigger]="popover"
+  [ngpPopoverTriggerOffset]="{mainAxis: 8, crossAxis: 4, alignmentAxis: 2}"
+>
+  Popover with custom offset
+</button>
+```
+
 ## Reusable Component
 
 Create a popover component that uses the `NgpPopover` directive.
@@ -147,8 +166,19 @@ bootstrapApplication(AppComponent, {
 
 ### NgpPopoverConfig
 
-<prop-details name="offset" type="number">
-  Define the offset from the trigger element.
+<prop-details name="offset" type="number | NgpOffsetOptions">
+  Define the offset from the trigger element. Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis properties.
+  
+  **Number format:** `offset: 8` - Applies to mainAxis (distance from trigger)
+  
+  **Object format:** 
+  ```ts
+  offset: {
+    mainAxis: 8,     // Distance between popover and trigger element
+    crossAxis: 4,    // Skidding along the alignment axis  
+    alignmentAxis: 2 // Same as crossAxis but for aligned placements
+  }
+  ```
 </prop-details>
 
 <prop-details name="placement" type="'top' | 'right' | 'bottom' | 'left'">

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -58,6 +58,23 @@ The tooltip can be rendered inside a custom container. You can open DevTools and
 
 <docs-example name="tooltip-custom-container"></docs-example>
 
+### Custom Offset
+
+You can customize the offset using either a simple number or an object for more precise control:
+
+```html
+<!-- Simple number offset -->
+<button [ngpTooltipTrigger]="tooltip" ngpTooltipTriggerOffset="12">Tooltip with 12px offset</button>
+
+<!-- Object offset for precise control -->
+<button
+  [ngpTooltipTrigger]="tooltip"
+  [ngpTooltipTriggerOffset]="{mainAxis: 8, crossAxis: 4, alignmentAxis: 2}"
+>
+  Tooltip with custom offset
+</button>
+```
+
 ## API Reference
 
 The following directives are available to import from the `ng-primitives/tooltip` package:
@@ -218,8 +235,21 @@ bootstrapApplication(AppComponent, {
 
 ### NgpTooltipConfig
 
-<prop-details name="offset" type="number" default="4">
-Define the offset from the trigger element.
+<prop-details name="offset" type="number | NgpOffsetOptions" default="4">
+Define the offset from the trigger element. Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis properties.
+
+**Number format:** `offset: 8` - Applies to mainAxis (distance from trigger)
+
+**Object format:**
+
+```ts
+offset: {
+  mainAxis: 8,     // Distance between tooltip and trigger element
+  crossAxis: 4,    // Skidding along the alignment axis
+  alignmentAxis: 2 // Same as crossAxis but for aligned placements
+}
+```
+
 </prop-details>
 
 <prop-details name="placement" type="'top' | 'right' | 'bottom' | 'left'" default="top">

--- a/apps/documentation/src/styles.css
+++ b/apps/documentation/src/styles.css
@@ -37,6 +37,10 @@
   --docsearch-key-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   --docsearch-logo-color: white;
   --docsearch-muted-color: theme('colors.zinc.400');
+
+  .prose-zinc {
+    --tw-prose-bold: theme('colors.zinc.100');
+  }
 }
 
 html,

--- a/packages/ng-primitives/menu/src/config/menu-config.ts
+++ b/packages/ng-primitives/menu/src/config/menu-config.ts
@@ -1,12 +1,14 @@
 import { InjectionToken, Provider, inject } from '@angular/core';
+import { NgpOffset } from 'ng-primitives/portal';
 import type { NgpMenuPlacement } from '../menu-trigger/menu-trigger';
 
 export interface NgpMenuConfig {
   /**
    * Define the offset of the menu relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
    * @default 4
    */
-  offset: number;
+  offset: NgpOffset;
 
   /**
    * Define the placement of the menu relative to the trigger.

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
@@ -1,5 +1,5 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
+import { BooleanInput } from '@angular/cdk/coercion';
 import {
   booleanAttribute,
   computed,
@@ -7,7 +7,6 @@ import {
   inject,
   Injector,
   input,
-  numberAttribute,
   OnDestroy,
   signal,
   ViewContainerRef,
@@ -18,6 +17,9 @@ import {
   NgpOverlay,
   NgpOverlayConfig,
   NgpOverlayContent,
+  coerceOffset,
+  NgpOffset,
+  NgpOffsetInput,
 } from 'ng-primitives/portal';
 import { injectMenuConfig } from '../config/menu-config';
 import { menuTriggerState, provideMenuTriggerState } from './menu-trigger-state';
@@ -84,11 +86,12 @@ export class NgpMenuTrigger<T = unknown> implements OnDestroy {
 
   /**
    * Define the offset of the menu relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
    * @default 4
    */
-  readonly offset = input<number, NumberInput>(this.config.offset, {
+  readonly offset = input<NgpOffset, NgpOffsetInput>(this.config.offset, {
     alias: 'ngpMenuTriggerOffset',
-    transform: numberAttribute,
+    transform: coerceOffset,
   });
 
   /**

--- a/packages/ng-primitives/menu/src/submenu-trigger/submenu-trigger.ts
+++ b/packages/ng-primitives/menu/src/submenu-trigger/submenu-trigger.ts
@@ -1,5 +1,5 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
+import { BooleanInput } from '@angular/cdk/coercion';
 import {
   booleanAttribute,
   computed,
@@ -8,7 +8,6 @@ import {
   inject,
   Injector,
   input,
-  numberAttribute,
   signal,
   ViewContainerRef,
 } from '@angular/core';
@@ -18,6 +17,9 @@ import {
   NgpOverlay,
   NgpOverlayConfig,
   NgpOverlayContent,
+  coerceOffset,
+  NgpOffset,
+  NgpOffsetInput,
 } from 'ng-primitives/portal';
 import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
 import { NgpMenuPlacement } from '../menu-trigger/menu-trigger';
@@ -80,11 +82,12 @@ export class NgpSubmenuTrigger<T = unknown> {
 
   /**
    * Define the offset of the menu relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
    * @default 0
    */
-  readonly offset = input<number, NumberInput>(0, {
+  readonly offset = input<NgpOffset, NgpOffsetInput>(0, {
     alias: 'ngpSubmenuTriggerOffset',
-    transform: numberAttribute,
+    transform: coerceOffset,
   });
 
   /**

--- a/packages/ng-primitives/package.json
+++ b/packages/ng-primitives/package.json
@@ -2,7 +2,7 @@
   "name": "ng-primitives",
   "description": "Angular Primitives is a low-level headless UI component library with a focus on accessibility, customization, and developer experience. ",
   "license": "Apache-2.0",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "keywords": [
     "angular",
     "primitives",

--- a/packages/ng-primitives/popover/src/config/popover-config.ts
+++ b/packages/ng-primitives/popover/src/config/popover-config.ts
@@ -1,12 +1,14 @@
 import { InjectionToken, Provider, inject } from '@angular/core';
 import { type Placement } from '@floating-ui/dom';
+import { NgpOffset } from 'ng-primitives/portal';
 
 export interface NgpPopoverConfig {
   /**
    * Define the offset of the popover relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
    * @default 4
    */
-  offset: number;
+  offset: NgpOffset;
 
   /**
    * Define the placement of the popover relative to the trigger.

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
@@ -19,6 +19,9 @@ import {
   NgpOverlay,
   NgpOverlayConfig,
   NgpOverlayContent,
+  coerceOffset,
+  NgpOffset,
+  NgpOffsetInput,
 } from 'ng-primitives/portal';
 import { injectPopoverConfig } from '../config/popover-config';
 import { popoverTriggerState, providePopoverTriggerState } from './popover-trigger-state';
@@ -86,11 +89,12 @@ export class NgpPopoverTrigger<T = null> implements OnDestroy {
 
   /**
    * Define the offset of the popover relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
    * @default 0
    */
-  readonly offset = input<number, NumberInput>(this.config.offset, {
+  readonly offset = input<NgpOffset, NgpOffsetInput>(this.config.offset, {
     alias: 'ngpPopoverTriggerOffset',
-    transform: numberAttribute,
+    transform: coerceOffset,
   });
 
   /**

--- a/packages/ng-primitives/portal/src/index.ts
+++ b/packages/ng-primitives/portal/src/index.ts
@@ -10,3 +10,4 @@ export { setupOverlayArrow } from './overlay-arrow';
 export { injectOverlayContext, provideOverlayContext } from './overlay-token';
 export { createPortal, NgpComponentPortal, NgpPortal, NgpTemplatePortal } from './portal';
 export { BlockScrollStrategy, NoopScrollStrategy, ScrollStrategy } from './scroll-strategy';
+export { NgpOffset, NgpOffsetInput, NgpOffsetOptions, coerceOffset } from './offset';

--- a/packages/ng-primitives/portal/src/offset.spec.ts
+++ b/packages/ng-primitives/portal/src/offset.spec.ts
@@ -1,0 +1,41 @@
+import { coerceOffset } from './offset';
+
+describe('coerceOffset', () => {
+  it('should handle number inputs', () => {
+    expect(coerceOffset(10)).toBe(10);
+    expect(coerceOffset(0)).toBe(0);
+    expect(coerceOffset(-5)).toBe(-5);
+  });
+
+  it('should handle string number inputs', () => {
+    expect(coerceOffset('10')).toBe(10);
+    expect(coerceOffset('0')).toBe(0);
+    expect(coerceOffset('-5')).toBe(-5);
+    expect(coerceOffset('3.14')).toBe(3.14);
+  });
+
+  it('should handle invalid string inputs', () => {
+    expect(coerceOffset('invalid')).toBe(0);
+    expect(coerceOffset('')).toBe(0);
+    expect(coerceOffset('abc123')).toBe(0);
+  });
+
+  it('should handle object inputs', () => {
+    const offsetObj = { mainAxis: 10, crossAxis: 5 };
+    expect(coerceOffset(offsetObj)).toBe(offsetObj);
+  });
+
+  it('should handle null and undefined inputs', () => {
+    expect(coerceOffset(null)).toBe(0);
+    expect(coerceOffset(undefined)).toBe(0);
+  });
+
+  it('should handle complex object inputs', () => {
+    const complexOffset = {
+      mainAxis: 10,
+      crossAxis: 5,
+      alignmentAxis: 2,
+    };
+    expect(coerceOffset(complexOffset)).toBe(complexOffset);
+  });
+});

--- a/packages/ng-primitives/portal/src/offset.ts
+++ b/packages/ng-primitives/portal/src/offset.ts
@@ -1,0 +1,59 @@
+import { coerceNumberProperty } from '@angular/cdk/coercion';
+import { isObject, isNil } from 'ng-primitives/utils';
+
+/**
+ * Options for configuring offset between a floating element and its reference element.
+ * Can be a single number for uniform offset or an object for axis-specific control.
+ */
+export interface NgpOffsetOptions {
+  /**
+   * The offset along the main axis (the axis that runs along the side of the floating element).
+   * Represents the distance between the floating element and the reference element.
+   * @default 0
+   */
+  mainAxis?: number;
+
+  /**
+   * The offset along the cross axis (the axis that runs along the alignment of the floating element).
+   * Represents the skidding between the floating element and the reference element.
+   * @default 0
+   */
+  crossAxis?: number;
+
+  /**
+   * Same axis as crossAxis but applies only to aligned placements and inverts the end alignment.
+   * When set to a number, it overrides the crossAxis value.
+   * @default null
+   */
+  alignmentAxis?: number | null;
+}
+
+/**
+ * Type representing all valid offset values.
+ * Can be a number (applies to mainAxis) or an object with axis-specific offsets.
+ */
+export type NgpOffset = number | NgpOffsetOptions;
+
+/**
+ * Input type for offset that also accepts string representations of numbers
+ */
+export type NgpOffsetInput = NgpOffset | string;
+
+/**
+ * Transform function to coerce offset input values to the correct type
+ * @param value The input value to coerce
+ * @returns The coerced offset value
+ */
+export function coerceOffset(value: NgpOffsetInput | null | undefined): NgpOffset {
+  if (isNil(value)) {
+    return 0;
+  }
+
+  if (isObject(value)) {
+    return value;
+  }
+
+  // Use CDK's coerceNumberProperty for consistent number coercion
+  // This handles strings, numbers, and other input types just like Angular CDK inputs
+  return coerceNumberProperty(value, 0);
+}

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -28,6 +28,7 @@ import {
 import { explicitEffect, fromResizeEvent } from 'ng-primitives/internal';
 import { injectDisposables, safeTakeUntilDestroyed, uniqueId } from 'ng-primitives/utils';
 import { Subject, fromEvent } from 'rxjs';
+import { NgpOffset } from './offset';
 import { provideOverlayContext } from './overlay-token';
 import { NgpPortal, createPortal } from './portal';
 import { BlockScrollStrategy, NoopScrollStrategy } from './scroll-strategy';
@@ -57,8 +58,8 @@ export interface NgpOverlayConfig<T = unknown> {
   /** Preferred placement of the overlay relative to the trigger. */
   placement?: Signal<Placement>;
 
-  /** Offset distance between the overlay and trigger in pixels */
-  offset?: number;
+  /** Offset distance between the overlay and trigger. Can be a number or an object with axis-specific offsets */
+  offset?: NgpOffset;
 
   /** Whether to enable flip behavior when space is limited */
   flip?: boolean;
@@ -469,7 +470,7 @@ export class NgpOverlay<T = unknown> {
     strategy: Strategy = 'absolute',
   ): Promise<void> {
     // Create middleware array
-    const middleware: Middleware[] = [offset(this.config.offset || 0), shift()];
+    const middleware: Middleware[] = [offset(this.config.offset ?? 0), shift()];
 
     // Add flip middleware if requested
     if (this.config.flip !== false) {

--- a/packages/ng-primitives/tooltip/src/config/tooltip-config.ts
+++ b/packages/ng-primitives/tooltip/src/config/tooltip-config.ts
@@ -1,12 +1,14 @@
 import { InjectionToken, Provider, inject } from '@angular/core';
 import { type Placement } from '@floating-ui/dom';
+import { NgpOffset } from 'ng-primitives/portal';
 
 export interface NgpTooltipConfig {
   /**
    * Define the offset of the tooltip relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
    * @default 4
    */
-  offset: number;
+  offset: NgpOffset;
 
   /**
    * Define the placement of the tooltip relative to the trigger.

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -19,6 +19,9 @@ import {
   NgpOverlay,
   NgpOverlayConfig,
   NgpOverlayContent,
+  coerceOffset,
+  NgpOffset,
+  NgpOffsetInput,
 } from 'ng-primitives/portal';
 import { isString } from 'ng-primitives/utils';
 import { injectTooltipConfig } from '../config/tooltip-config';
@@ -92,11 +95,12 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
 
   /**
    * Define the offset of the tooltip relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
    * @default 0
    */
-  readonly offset = input<number, NumberInput>(this.config.offset, {
+  readonly offset = input<NgpOffset, NgpOffsetInput>(this.config.offset, {
     alias: 'ngpTooltipTriggerOffset',
-    transform: numberAttribute,
+    transform: coerceOffset,
   });
 
   /**

--- a/packages/ng-primitives/utils/src/helpers/validators.ts
+++ b/packages/ng-primitives/utils/src/helpers/validators.ts
@@ -55,3 +55,21 @@ export function isObject(value: unknown): value is Record<string, unknown> {
 export function isUndefined(value: unknown): value is undefined {
   return typeof value === 'undefined';
 }
+
+/**
+ * Checks if a value is null or undefined
+ * @param value - The value to check
+ * @returns true if the value is null or undefined, false otherwise
+ */
+export function isNil(value: unknown): value is null | undefined {
+  return isUndefined(value) || value === null;
+}
+
+/**
+ * Checks if a value is not null and not undefined
+ * @param value - The value to check
+ * @returns true if the value is not null and not undefined, false otherwise
+ */
+export function notNil<T>(value: T | null | undefined): value is T {
+  return !isNil(value);
+}

--- a/packages/ng-primitives/utils/src/index.ts
+++ b/packages/ng-primitives/utils/src/index.ts
@@ -11,6 +11,8 @@ export {
   isObject,
   isString,
   isUndefined,
+  isNil,
+  notNil,
 } from './helpers/validators';
 export { safeTakeUntilDestroyed } from './observables/take-until-destroyed';
 export { onBooleanChange, onChange } from './signals';

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -2,7 +2,7 @@
   "name": "@ng-primitives/state",
   "description": "Angular Primitives State is a low-level state library with a focus on developer experience.",
   "license": "Apache-2.0",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "keywords": [
     "angular",
     "primitives",
@@ -29,7 +29,7 @@
     "@angular/core": ">=19.0.0"
   },
   "dependencies": {
-    "ng-primitives": "0.81.0"
+    "ng-primitives": "0.81.1"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
# PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Current Behavior

Currently, the offset property in overlay-based components (menu, tooltip, popover, submenu) only accepts a simple number value that applies uniformly to both x and y axes. This limits positioning control when you need different offsets for different axes.

**Current limitations:**
- Only supports `offset: number` (e.g., `offset: 8`)
- The number applies to both mainAxis (distance from trigger) and crossAxis (skidding)
- No way to control individual axes separately
- No support for alignmentAxis positioning

## Issue

Closes # (No specific issue - enhancement request)

## What does this PR implement/fix?

This PR enhances the offset control functionality across all overlay-based components (menu, tooltip, popover, submenu) by adding support for axis-specific configuration.

**Key Changes:**

1. **Enhanced Offset API**: Added support for object-based offset configuration with `mainAxis`, `crossAxis`, and `alignmentAxis` properties
2. **Backward Compatibility**: Maintains full compatibility with existing number-based offset usage
3. **Type Safety**: Added explicit generic types to all offset inputs for better TypeScript support
4. **CDK Integration**: Uses Angular CDK's `coerceNumberProperty` for consistent number coercion
5. **Documentation**: Updated all component documentation with examples and explanations
6. **Utilities**: Added `isNil` and `notNil` helper functions to the validators module

**Components Updated:**
- NgpMenuTrigger
- NgpSubmenuTrigger
- NgpTooltipTrigger
- NgpPopoverTrigger

**Usage Examples:**
```typescript
// Simple number (existing usage - still works)
offset: 8

// New object format for precise control
offset: {
  mainAxis: 8,     // Distance between element and trigger
  crossAxis: 4,    // Skidding along alignment axis  
  alignmentAxis: 2 // For aligned placements
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- No breaking changes - fully backward compatible with existing number-based offset usage -->