### PR TITLE
fix: add compatibility for @angular/cdk@20 caused by removed deprecations in DomPortalOutlet

### DIFF
--- a/packages/ng-primitives/portal/src/portal.ts
+++ b/packages/ng-primitives/portal/src/portal.ts
@@ -1,3 +1,4 @@
+import { VERSION } from '@angular/cdk';
 import { ComponentPortal, DomPortalOutlet, TemplatePortal } from '@angular/cdk/portal';
 import {
   type ApplicationRef,
@@ -42,13 +43,20 @@ export abstract class NgpPortal {
    */
   abstract detach(): Promise<void>;
 
-  // todo: remove this temp workaround once base repo migrates to v20
-  // this temp fix prevents several issues when consuming in a v20 app
+  /**
+   * Angular v20 removes `_unusedComponentFactoryResolver` and `_document` from DomPortalOutlet's
+   * constructor signature as they have been deprecated since v18, and replaced with optional
+   * `_appRef` and `_defaultInjector` params.
+   * This temporary change ensures consistent behaviour for consumers using ng v20+.
+   * @see {@link https://github.com/angular/components/pull/24504 The implementing PR} for the new implementation.
+   * @see {@link https://github.com/angular/components/blob/732a0d7ab69ec25925cc06a0fb17b0fb16a4b0ae/src/cdk/portal/dom-portal-outlet.ts#L27 The latest v20 version comments}
+   * describe the importance of passing the `_appRef` and `_defaultInjector` when it comes to component portals
+   */
+  // todo: remove this compat fix once support for v19 is dropped when v21 is released
+  //  - should aim to add appRef also to prevent unforeseen issues in certain edge cases
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   protected _getDomPortalOutletCtorParamsCompat(): (ApplicationRef | Injector | undefined | any)[] {
-    return DomPortalOutlet.prototype.constructor.length > 3
-      ? [undefined, this.injector]
-      : [this.injector];
+    return Number(VERSION.major) >= 20 ? [this.injector] : [undefined, this.injector];
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Currently in NgpPortal, [DomPortalOutlets are constructed like so](https://github.com/ng-primitives/ng-primitives/blob/8a77b2811093d61b23b02a28c8847ef02984920c/packages/ng-primitives/portal/src/portal.ts#L61):
```ts
const domOutlet = new DomPortalOutlet(container, undefined, undefined, this.injector);
```

However, since [this PR in @angular/cdk](https://github.com/angular/components/pull/30569) which was released in v20, DomPortalOutlets now has the following constructor signature: 
```ts
  constructor(
    /** Element into which the content is projected. */
    public outletElement: Element,
    private _appRef?: ApplicationRef,
    private _defaultInjector?: Injector,
  ) {
    super();
  }
  ```
as opposed to v19 (currently used as ng-primitives peerDep)
```ts
constructor(
    /** Element into which the content is projected. */
    public outletElement: Element,
    /**
     * @deprecated No longer in use. To be removed.
     * @breaking-change 18.0.0
     */
    _unusedComponentFactoryResolver?: any,
    private _appRef?: ApplicationRef,
    private _defaultInjector?: Injector,

    /**
     * @deprecated `_document` Parameter to be made required.
     * @breaking-change 10.0.0
     */
    _document?: any,
  ) {
    super();
    this._document = _document;
  }
```

The deprecated and unused `_unusedComponentFactoryResolver` param has been removed, and also `_document` is no longer in the constructor signature as they get the reference to what the need via the outlet element instead ie. `this.outletElement.ownerDocument`.

As you can see, the new constructor only has 3 params, so anyone using v20 (this package has @angular/cdk as peer dep with >=19.0.0 range) - will have no injector passed at all.

Closes #

## What does this PR implement/fix?

I just added a horrible little compatibility fix, which checked constructor length of DomPortalOutlet at runtime and puts the injector in the correct place..

Now it works exactly the same for consumers using cdk v19, but also works for consumers using v20+. Took me a while to root this bug out; hard to identify with very vague error messages related to 'provider not found', which is common enough so as to suspect an issue with my own code. At first I just worked around it entirely until I saw the reason. Figured it was best to fix (or at least make you aware), so that v20 users don't waste time debugging and creating workarounds.


I'm of a few minds here - because I personally hate hacky patch fixes like this - you could:
1. either merge this temporary ugly hacky fix so it works as expected for v20
2. constrain peerDeps to cdk < 20
3. release a version based on angular cdk v20, but I think you previously mentioned you wanted to stay compatible with v18+? Can't remember specifically - but this is just one instance. A lot of long deprecated dead code is finally being culled (personally a big fan of them finally removing references to long redundant ComponentFactoryResolvers), so who knows where else these types of cases popup. Just trying to say that maintaining compatibility across versions with breaking changes adds a lot of maintenance overhead - compatibility fixes & tests - which I should note I did not add any tests here because I am time constrained and making tests for multiple versions of angular is a pain, and not sure how you'd want to approach it.

It's also worth noting that the DomPortalOutlet does accept an ApplicationRef, which is set explicitly as undefined here. But as commented in the code:
```
/**
   * @param outletElement Element into which the content is projected.
   * @param _appRef Reference to the application. Only used in component portals when there
   *   is no `ViewContainerRef` available.
   * @param _defaultInjector Injector to use as a fallback when the portal being attached doesn't
   *   have one. Only used for component portals.
   */
```
- so it COULD potentially cause issues for people using MFEs and app shells? That, and other edge cases - but possible.
And since these are primitives designed to be composable as you please, I feel as if it should definitely be added here.
I didn't add that in this PR, because not sure how you'd prefer to go about it - if at all, plus this PR is a a simple fix, as far as I am aware, not passing an ApplicationRef will not cause issues in 99% of cases, and maybe you had a reason behind not adding it in the first place - all I know is that the missing injector definitely caused me some hassle.

Personally - I WOULD NOT merge this right now.. even though it leaves ng-primitives in a broken state, I'd take a minute to think about the above:
- maybe add tests? would need to run all existing tests on ng@20, and potentially add more
- maybe add appRef too? maybe there was a reason to leave it out because it was only ever supposed to be used internally? But I kind of don't like the idea of having too many internals in primitives because when consumed, the primitives ARE the internals, which should be fully configurable.
  - one case I saw of the impact of that is [in the CreatedState interface](https://github.com/ng-primitives/ng-primitives/blob/8a77b2811093d61b23b02a28c8847ef02984920c/packages/ng-primitives/state/src/index.ts#L35), which does note it only wants to expose inputs - but this also hides computed signals too (which actually causes a bunch of `TS2349: This expression is not callable. Type never has no call signatures.` n your own codebase implementations which was surprising when I cloned it; and in practice I need to be able to react to those - introducing complexities of either Proxys or losing type safety with type casts eg. `SomeState & Signal<R>` or `as any`, neither are nice solutions to problems that ideally shouldn't be present - the properties are still there, just not exposed via interface rather arbitrarily. (Should it be up to the consumer what to expose from their own components / directives composed from these primitives?)
- decide how you want to balance maintaining compatibility

Again - sorry for long posts.. sometimes need to cover a lot of ground. And since you mentioned some company with a large codebase uses this package, it leaves you less flexible in what you can/can't do - however, I'm sure if they upgrade to ng20 (if not already), they'd appreciate no unexpected behaviour.

Anyway, regardless of whether this gets merged or not, a broader decision regarding the above still remains.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
