### PR TITLE
fix(combobox): resolve multiselect combobox de-select with keypress

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox/combobox.spec.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.spec.ts
@@ -458,6 +458,26 @@ describe('NgpCombobox Multi-select', () => {
       expect(screen.queryByText('Apple')).not.toBeInTheDocument();
     });
   });
+
+  it('should deselect an already selected option when pressing Enter key', async () => {
+    const { fixture } = await render(MultiSelectTestComponent);
+    const component = fixture.componentInstance;
+    const input = screen.getByRole('combobox');
+    input.focus();
+    // Open dropdown with arrow down
+    await userEvent.keyboard('{arrowdown}');
+    // Select first option (Apple) with enter
+    await userEvent.keyboard('{enter}');
+    expect(component.value).toEqual(['Apple']);
+    // Dropdown should remain open
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    // Press Enter again to deselect
+    await userEvent.keyboard('{enter}');
+    // Value should be empty now that Apple is deselected
+    expect(component.value).toEqual([]);
+    // Dropdown should remain open
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+  });
 });
 
 describe('NgpComboboxOption', () => {

--- a/packages/ng-primitives/combobox/src/combobox/combobox.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.ts
@@ -601,7 +601,11 @@ export class NgpCombobox {
         break;
       case 'Enter':
         if (this.open()) {
-          this.selectOption(this.activeDescendantManager.activeItem());
+          const activeItem = this.activeDescendantManager.activeItem();
+
+          if (activeItem) {
+            this.toggleOption(activeItem);
+          }
         }
         event.preventDefault();
         break;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

Currently, pressing the enter key to de-select an option within a multi combobox only functions if using the combobox input. Therefore, if using a button only multi combobox de-selecting with a keypress doesn't work.

## Issue

Closes #502 

## What does this PR implement/fix?

Updated the keypress handler for the "enter" key to _**toggle**_ selected options for multi combobox to allow de-selection. This is similar to what is being done in the combobox input.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
