### PR TITLE
fix(file-upload): hide native input to prevent visible injection (#501)

### DIFF
--- a/packages/ng-primitives/file-upload/src/file-upload/file-upload.ts
+++ b/packages/ng-primitives/file-upload/src/file-upload/file-upload.ts
@@ -129,6 +129,7 @@ export class NgpFileUpload {
       disabled: this.state.disabled,
     });
     this.input.type = 'file';
+    this.input.style.display = 'none';
     this.input.addEventListener('change', () => {
       this.selected.emit(this.input.files);
       // clear the input value to allow re-uploading the same file


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?



- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## Issue

Closes #501 

## What does this PR implement/fix?
This PR hides the native `<input type="file">` element to prevent it from becoming visible when injected into the DOM by certain environments or security tools.

By setting display: none right after the input creation, we ensure it remains hidden without impacting the expected file picker behavior.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

