### PR TITLE
fix(combobox): open dropdown on Space key press when no input is pres…

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox/combobox.spec.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.spec.ts
@@ -1098,4 +1098,25 @@ describe('NgpCombobox without input', () => {
     const combobox = screen.getByTestId('disabled-combobox');
     expect(combobox).toHaveAttribute('tabindex', '-1');
   });
+
+  it('should open the dropdown when pressing Space on focused combobox without input', async () => {
+    await render(NoInputTestComponent);
+
+    const combobox = screen.getByTestId('combobox-without-input');
+    const button = screen.getByTestId('combobox-button');
+
+    combobox.focus();
+    // Open with spacebar - should open dropdown
+    await userEvent.keyboard(' ');
+
+    // Wait for dropdown to open
+    await waitFor(() => {
+      expect(button).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    // Check if options are visible
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(screen.getByText('Banana')).toBeInTheDocument();
+    expect(screen.getByText('Cherry')).toBeInTheDocument();
+  });
 });

--- a/packages/ng-primitives/combobox/src/combobox/combobox.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.ts
@@ -615,6 +615,12 @@ export class NgpCombobox {
         }
         event.preventDefault();
         break;
+      case ' ':
+        if (!this.input()) {
+          this.toggleDropdown();
+          event.preventDefault();
+        }
+        break;
     }
   }
 


### PR DESCRIPTION
…ent (#522)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #522 

## What does this PR implement/fix?

Fixes the Combobox behavior where pressing the space bar didn’t open the dropdown when no input field was present (button-only mode).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

