### PR TITLE
fix(focus-visible): use focus origin as data-focus-visible value (#526)

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/interactions/focus-visible.md
+++ b/apps/documentation/src/app/pages/(documentation)/interactions/focus-visible.md
@@ -4,7 +4,8 @@ name: 'Focus Visible'
 
 # Focus Visible
 
-Determine whether focus should be visible based on user interaction. This is useful for accessibility and user experience, as it allows you to provide visual feedback when an element is focused using keyboard navigation, while not showing the focus outline when the user is using a mouse or touch device.
+Determine whether an element should display a visible focus indicator and exposes the origin of that focus (keyboard, mouse, touch, program).
+This is useful for accessibility and user experience, as it allows you to provides accessible visual feedback aligned with the `:focus-visible` standard.
 
 <docs-example name="focus-visible"></docs-example>
 
@@ -36,9 +37,9 @@ The following directives are available to import from the `ng-primitives/interac
 
 The following data attributes are applied to the `ngpFocusVisible` directive:
 
-| Attribute            | Description                                                  |
-| -------------------- | ------------------------------------------------------------ |
-| `data-focus-visible` | Applied when the element is focused via keyboard navigation. |
+| Attribute            | Description                                                        | Value                                   |
+| -------------------- | ------------------------------------------------------------------ | --------------------------------------- |
+| `data-focus-visible` | Applied when the element should display a visible focus indicator. | `keyboard \| mouse \| touch \| program` |
 
 ### Disabling Focus Visible Interaction
 

--- a/packages/ng-primitives/button/src/button/button.spec.ts
+++ b/packages/ng-primitives/button/src/button/button.spec.ts
@@ -95,7 +95,7 @@ describe('NgpButton', () => {
 
     const button = container.getByRole('button');
     focusMonitor.focusVia(button, 'keyboard');
-    expect(button).toHaveAttribute('data-focus-visible', '');
+    expect(button).toHaveAttribute('data-focus-visible');
   });
 
   it('should remove the data-focus attribute when not focused', async () => {
@@ -107,7 +107,7 @@ describe('NgpButton', () => {
 
     const button = container.getByRole('button');
     focusMonitor.focusVia(button, 'keyboard');
-    expect(button).toHaveAttribute('data-focus-visible', '');
+    expect(button).toHaveAttribute('data-focus-visible');
     fireEvent.blur(button);
     expect(button).not.toHaveAttribute('data-focus-visible');
   });

--- a/packages/ng-primitives/interactions/src/focus-visible/focus-visible-interaction.ts
+++ b/packages/ng-primitives/interactions/src/focus-visible/focus-visible-interaction.ts
@@ -51,13 +51,13 @@ export function ngpFocusVisibleInteraction({
 
     // for some elements the focus visible state should always appear on focus
     if (alwaysShowFocus()) {
-      focus(true);
+      focus(true, origin);
       return;
     }
 
     // if the focus origin is keyboard or program(focused programmatically), then the focus is visible
     if (origin === 'keyboard') {
-      focus(true);
+      focus(true, 'keyboard');
       return;
     }
   }
@@ -73,7 +73,7 @@ export function ngpFocusVisibleInteraction({
   /**
    * Trigger the focus signal along with the focusChange event.
    */
-  function focus(value: boolean) {
+  function focus(value: boolean, origin?: FocusOrigin) {
     if (isFocused() === value) {
       return;
     }
@@ -82,7 +82,7 @@ export function ngpFocusVisibleInteraction({
     focusChange?.(value);
 
     if (value) {
-      renderer.setAttribute(elementRef.nativeElement, 'data-focus-visible', '');
+      renderer.setAttribute(elementRef.nativeElement, 'data-focus-visible', origin ?? '');
     } else {
       renderer.removeAttribute(elementRef.nativeElement, 'data-focus-visible');
     }

--- a/packages/ng-primitives/interactions/src/focus-visible/focus-visible.spec.ts
+++ b/packages/ng-primitives/interactions/src/focus-visible/focus-visible.spec.ts
@@ -53,7 +53,7 @@ describe('NgpFocusVisible', () => {
     focusMonitor.focusVia(trigger, 'keyboard');
     container.detectChanges();
 
-    expect(trigger).toHaveAttribute('data-focus-visible');
+    expect(trigger).toHaveAttribute('data-focus-visible', 'keyboard');
     expect(focusChange).toHaveBeenCalledWith(true);
   });
 
@@ -100,6 +100,29 @@ describe('NgpFocusVisible', () => {
     container.detectChanges();
 
     expect(trigger).toHaveAttribute('data-focus-visible');
+    expect(focusChange).toHaveBeenCalledWith(true);
+  });
+
+  it('should always show focus on an input element when focused programmatically', async () => {
+    const container = await render(
+      `<input data-testid="trigger" (ngpFocusVisible)="focusChange($event)" />`,
+      {
+        imports: [NgpFocusVisible],
+        componentProperties: {
+          focusChange,
+        },
+      },
+    );
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+
+    const trigger = container.getByTestId('trigger');
+    expect(trigger).not.toHaveAttribute('data-focus-visible');
+
+    focusMonitor.focusVia(trigger, 'program');
+    container.detectChanges();
+
+    expect(trigger).toHaveAttribute('data-focus-visible', 'program');
     expect(focusChange).toHaveBeenCalledWith(true);
   });
 
@@ -174,7 +197,7 @@ describe('NgpFocusVisible', () => {
     focusMonitor.focusVia(trigger, 'mouse');
     container.detectChanges();
 
-    expect(trigger).toHaveAttribute('data-focus-visible');
+    expect(trigger).toHaveAttribute('data-focus-visible', 'mouse');
     expect(focusChange).toHaveBeenCalledWith(true);
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #526

## What does this PR implement/fix?

This PR extends the `ngpFocusVisible` directive by adding an origin value to the `data-focus-visible` attribute (`keyboard`, `mouse`, `touch` or `program`). This allows consumers to distinguish how the element received focus while keeping behavior aligned with the `:focus-visible` standard.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


@ashley-hunter I also updated the README because the following sentences were misleading:

> When an element is focused using keyboard navigation

> Applied when the element is focused via keyboard navigation.

It’s not limited to keyboard navigation. It also applies to elements like inputs or textareas that always show focus visibly, regardless of the input method.
I’m still not 100 percent convinced the README wording is perfect. I think it could be even clearer, but I haven’t found a better formulation yet without making the text too long.
