### PR TITLE
docs: add heading anchor links with hover effect

### DIFF
--- a/apps/documentation/src/app/app.config.ts
+++ b/apps/documentation/src/app/app.config.ts
@@ -1,7 +1,7 @@
 import { provideContent, withMarkdownRenderer } from '@analogjs/content';
 import { withShikiHighlighter } from '@analogjs/content/shiki-highlighter';
 import { provideFileRouter } from '@analogjs/router';
-import { isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, ViewportScroller } from '@angular/common';
 import {
   ApplicationConfig,
   inject,
@@ -39,6 +39,11 @@ export const appConfig: ApplicationConfig = {
     provideAppInitializer(() => {
       const initializerFn = initializeCustomElements(inject(Injector), inject(PLATFORM_ID));
       return initializerFn();
+    }),
+    provideAppInitializer(() => {
+      const scroller = inject(ViewportScroller);
+      // Set scroll offset for fixed header (64px header + 16px buffer)
+      scroller.setOffset([0, 80]);
     }),
   ],
 };

--- a/apps/documentation/src/app/directives/heading-anchor.directive.ts
+++ b/apps/documentation/src/app/directives/heading-anchor.directive.ts
@@ -1,0 +1,74 @@
+import { isPlatformBrowser } from '@angular/common';
+import {
+  AfterViewInit,
+  Directive,
+  ElementRef,
+  inject,
+  PLATFORM_ID,
+  Renderer2,
+} from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { filter } from 'rxjs/operators';
+
+/**
+ * Directive that adds anchor links to all headings with IDs within the host element.
+ * Clicking the link icon copies the full URL with anchor to clipboard.
+ */
+@Directive({
+  selector: '[docsHeadingAnchor]',
+  standalone: true,
+})
+export class HeadingAnchorDirective implements AfterViewInit {
+  private readonly elementRef = inject(ElementRef);
+  private readonly renderer = inject(Renderer2);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly router = inject(Router);
+
+  ngAfterViewInit(): void {
+    if (isPlatformBrowser(this.platformId)) {
+      // Add anchors to headings initially
+      this.addAnchorsToHeadings();
+
+      // Re-add anchors when navigation changes (for route transitions)
+      this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(() => {
+        // Use setTimeout to ensure content is rendered
+        setTimeout(() => this.addAnchorsToHeadings(), 0);
+      });
+    }
+  }
+
+  private addAnchorsToHeadings(): void {
+    const element = this.elementRef.nativeElement as HTMLElement;
+    const headings = element.querySelectorAll('h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]');
+    const currentPath = this.router.url.split('#')[0]; // Get current path without hash
+
+    headings.forEach(heading => {
+      // Skip if anchor already exists
+      if (heading.querySelector('.heading-anchor')) {
+        return;
+      }
+
+      const id = heading.getAttribute('id');
+      if (!id) {
+        return;
+      }
+
+      // Create anchor link
+      const anchor = this.renderer.createElement('a');
+      this.renderer.setAttribute(anchor, 'href', `${currentPath}#${id}`);
+      this.renderer.setAttribute(anchor, 'aria-label', `Link to ${heading.textContent}`);
+      this.renderer.addClass(anchor, 'heading-anchor');
+
+      // Add link icon (SVG)
+      anchor.innerHTML = `
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+          <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
+        </svg>
+      `;
+
+      // Append anchor to end of heading
+      this.renderer.appendChild(heading, anchor);
+    });
+  }
+}

--- a/apps/documentation/src/app/pages/(documentation)/getting-started.page.ts
+++ b/apps/documentation/src/app/pages/(documentation)/getting-started.page.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { QuickLinks } from '../../components/quick-links/quick-links';
+import { HeadingAnchorDirective } from '../../directives/heading-anchor.directive';
 
 @Component({
   selector: 'docs-getting-started',
@@ -9,6 +10,7 @@ import { QuickLinks } from '../../components/quick-links/quick-links';
       <div
         class="prose prose-sm prose-zinc dark:prose-invert flex-1 overflow-hidden px-px"
         data-page-content
+        docsHeadingAnchor
       >
         <div class="mx-auto w-fit max-w-full">
           <p
@@ -24,7 +26,7 @@ import { QuickLinks } from '../../components/quick-links/quick-links';
       <docs-quick-links />
     </div>
   `,
-  imports: [RouterOutlet, QuickLinks],
+  imports: [RouterOutlet, QuickLinks, HeadingAnchorDirective],
   host: {
     class: 'flex-1 max-w-full',
   },

--- a/apps/documentation/src/app/pages/(documentation)/interactions.page.ts
+++ b/apps/documentation/src/app/pages/(documentation)/interactions.page.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { QuickLinks } from '../../components/quick-links/quick-links';
+import { HeadingAnchorDirective } from '../../directives/heading-anchor.directive';
 
 @Component({
   selector: 'docs-interactions',
@@ -9,6 +10,7 @@ import { QuickLinks } from '../../components/quick-links/quick-links';
       <div
         class="prose prose-sm prose-zinc dark:prose-invert flex-1 overflow-hidden px-px"
         data-page-content
+        docsHeadingAnchor
       >
         <div class="mx-auto w-fit max-w-full">
           <p
@@ -25,7 +27,7 @@ import { QuickLinks } from '../../components/quick-links/quick-links';
       <docs-quick-links />
     </div>
   `,
-  imports: [RouterOutlet, QuickLinks],
+  imports: [RouterOutlet, QuickLinks, HeadingAnchorDirective],
   host: {
     class: 'flex-1 max-w-full',
   },

--- a/apps/documentation/src/app/pages/(documentation)/primitives.page.ts
+++ b/apps/documentation/src/app/pages/(documentation)/primitives.page.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { QuickLinks } from '../../components/quick-links/quick-links';
+import { HeadingAnchorDirective } from '../../directives/heading-anchor.directive';
 
 @Component({
   selector: 'docs-primitives',
@@ -9,6 +10,7 @@ import { QuickLinks } from '../../components/quick-links/quick-links';
       <div
         class="prose prose-sm prose-zinc dark:prose-invert flex-1 overflow-hidden px-px"
         data-page-content
+        docsHeadingAnchor
       >
         <div class="mx-auto w-fit max-w-full">
           <p
@@ -24,7 +26,7 @@ import { QuickLinks } from '../../components/quick-links/quick-links';
       <docs-quick-links />
     </div>
   `,
-  imports: [RouterOutlet, QuickLinks],
+  imports: [RouterOutlet, QuickLinks, HeadingAnchorDirective],
   host: {
     class: 'flex-1 max-w-full',
   },

--- a/apps/documentation/src/app/pages/(documentation)/utilities.page.ts
+++ b/apps/documentation/src/app/pages/(documentation)/utilities.page.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { QuickLinks } from '../../components/quick-links/quick-links';
+import { HeadingAnchorDirective } from '../../directives/heading-anchor.directive';
 
 @Component({
   selector: 'docs-utilites',
@@ -9,6 +10,7 @@ import { QuickLinks } from '../../components/quick-links/quick-links';
       <div
         class="prose prose-sm prose-zinc dark:prose-invert flex-1 overflow-hidden px-px"
         data-page-content
+        docsHeadingAnchor
       >
         <div class="mx-auto w-fit max-w-full">
           <p
@@ -24,7 +26,7 @@ import { QuickLinks } from '../../components/quick-links/quick-links';
       <docs-quick-links />
     </div>
   `,
-  imports: [RouterOutlet, QuickLinks],
+  imports: [RouterOutlet, QuickLinks, HeadingAnchorDirective],
   host: {
     class: 'flex-1 max-w-full',
   },

--- a/apps/documentation/src/styles.css
+++ b/apps/documentation/src/styles.css
@@ -153,6 +153,18 @@ pre.shiki code {
   margin-bottom: 24px;
 }
 
+.prose .heading-anchor {
+  @apply hover:text-primary dark:hover:text-primary ml-2 inline-flex items-center text-zinc-400 no-underline opacity-0 transition-opacity dark:text-zinc-500;
+}
+
+.prose :where(h1, h2, h3, h4, h5, h6):hover .heading-anchor {
+  @apply opacity-100;
+}
+
+.prose .heading-anchor:focus {
+  @apply ring-primary rounded-sm opacity-100 ring-2 outline-hidden;
+}
+
 [data-line-numbers] {
   @apply grid min-w-full border-0 bg-transparent p-0 whitespace-pre;
   counter-reset: line;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes N/A

## What does this PR implement/fix?

This PR adds interactive anchor links to all documentation page headings, making it easier for users to link directly to specific sections of the documentation.

**Changes:**
- Add `HeadingAnchorDirective` that automatically adds anchor links to all headings with IDs
- Display link icon on heading hover for easy section linking
- Apply directive to getting-started, interactions, primitives, and utilities pages
- Configure viewport scroller offset to account for fixed header (80px)
- Style anchor links with opacity transition and focus states

**Behavior:**
- Link icons appear on hover at the end of each heading
- Clicking the link navigates to that section with proper scroll offset
- Includes focus states for keyboard accessibility
- Updates on route navigation to ensure correct path in anchor hrefs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
