### PR TITLE
feat(toast): expose NgpToastRef interface

### DIFF
--- a/packages/ng-primitives/toast/src/index.ts
+++ b/packages/ng-primitives/toast/src/index.ts
@@ -1,4 +1,4 @@
 export { NgpToastConfig, provideToastConfig } from './config/toast-config';
 export { NgpToast } from './toast/toast';
 export { injectToastContext } from './toast/toast-context';
-export { NgpToastManager } from './toast/toast-manager';
+export { NgpToastManager, NgpToastRef } from './toast/toast-manager';

--- a/packages/ng-primitives/toast/src/toast/toast-manager.ts
+++ b/packages/ng-primitives/toast/src/toast/toast-manager.ts
@@ -198,6 +198,6 @@ interface NgpToastRecord {
   portal: NgpPortal;
 }
 
-interface NgpToastRef {
+export interface NgpToastRef {
   dismiss(): Promise<void>;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes N/A

## What does this PR implement/fix?

This PR exposes the `NgpToastRef` interface as part of the public API, allowing consumers to properly type the return value from `NgpToastManager.show()`.

**Changes:**

- Export `NgpToastRef` interface from `toast-manager.ts`
- Add `NgpToastRef` to public API exports in `toast/index.ts`

**Benefits:**

- Enables proper TypeScript typing when storing toast references
- Provides access to the `dismiss()` method type
- Improves developer experience with better autocomplete and type safety

**Usage example:**

```typescript
import { NgpToastRef } from 'ng-primitives/toast';

const toastRef: NgpToastRef = this.toastManager.show(myToast);
await toastRef.dismiss();
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
