### PR TITLE
feat(toast): Expose NgpToastOptions type

### DIFF
--- a/packages/ng-primitives/toast/src/index.ts
+++ b/packages/ng-primitives/toast/src/index.ts
@@ -1,4 +1,4 @@
 export { NgpToastConfig, provideToastConfig } from './config/toast-config';
 export { NgpToast } from './toast/toast';
 export { injectToastContext } from './toast/toast-context';
-export { NgpToastManager, NgpToastRef } from './toast/toast-manager';
+export { NgpToastManager, type NgpToastRef, type NgpToastOptions } from './toast/toast-manager';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes N/A

## What does this PR implement/fix?

This PR exposes the `NgpToastOptions` type interfaces as part of the public API, improving TypeScript support for toast functionality.

**Changes:**

- Export `NgpToastOptions` as type-only exports from `toast/index.ts`
- Use `type` keyword to ensure these are type-only exports

**Benefits:**

- Enables proper TypeScript typing when storing toast references
- Allows consumers to type toast options when creating reusable toast configurations
- Provides access to the `dismiss()` method type
- Improves developer experience with better autocomplete and type safety

**Usage examples:**

```typescript
import { NgpToastOptions } from 'ng-primitives/toast';

// Type toast options
const options: NgpToastOptions = {
  placement: 'top-right',
  duration: 5000,
  dismissible: true,
};
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
