### PR TITLE
fix(resize): isPlatformServer check before 'window' access

### DIFF
--- a/packages/ng-primitives/internal/src/utilities/resize.ts
+++ b/packages/ng-primitives/internal/src/utilities/resize.ts
@@ -1,4 +1,14 @@
-import { DestroyRef, effect, inject, Injector, signal, Signal, untracked } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import {
+  DestroyRef,
+  effect,
+  inject,
+  Injector,
+  PLATFORM_ID,
+  signal,
+  Signal,
+  untracked,
+} from '@angular/core';
 import { isUndefined, safeTakeUntilDestroyed } from 'ng-primitives/utils';
 import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -26,9 +36,11 @@ export function fromResizeEvent(
   element: HTMLElement,
   { disabled = signal(false), injector }: NgpResizeObserverOptions = {},
 ): Observable<Dimensions> {
+  const platformId = injector?.get(PLATFORM_ID) ?? inject(PLATFORM_ID);
+
   return new Observable(observable => {
     // ResizeObserver may not be available in all environments, so check for its existence
-    if (isUndefined(window?.ResizeObserver)) {
+    if (isPlatformServer(platformId) || isUndefined(window?.ResizeObserver)) {
       // ResizeObserver is not available (SSR or unsupported browser)
       // Complete the observable without emitting any values
       observable.complete();


### PR DESCRIPTION
# fix(resize): isPlatformServer check before 'window' access

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #597

## What does this PR implement/fix?

Fixes `ReferenceError: window is not defined` error when using ng-primitives components that rely on `fromResizeEvent` (such as `NgpResize` and `NgpTooltip`) in Angular applications with Server-Side Rendering (SSR).

### The Problem

In `packages/ng-primitives/internal/src/utilities/resize.ts`, the current code checks:

```ts
if (isUndefined(window?.ResizeObserver)) {
```

While optional chaining (`?.`) prevents errors when accessing properties on `undefined`, the `window` identifier itself must exist in scope. In Node.js/SSR environments, `window` is completely undefined, so just referencing it throws a `ReferenceError` before the optional chaining can take effect.

### The Solution

Use Angular's `PLATFORM_ID` and `isPlatformServer` to properly detect the SSR environment before attempting to access `window`:

```ts
const platformId = injector?.get(PLATFORM_ID) ?? inject(PLATFORM_ID);

return new Observable(observable => {
  if (isPlatformServer(platformId) || isUndefined(window?.ResizeObserver)) {
    observable.complete();
    return;
  }
  // ...
});
```

This approach:
1. Uses Angular's built-in platform detection which is the recommended way to handle SSR
2. Checks for server platform first, avoiding any reference to `window` on the server
3. Falls back to the existing `ResizeObserver` check for unsupported browsers

### Reproduction Repository

https://github.com/jczacharia/from-resize-window-undefined-ng-primitives

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
