### PR TITLE
fix(portal): prevent ControlContainer leak for SkipSelf directives (#677)

### DIFF
--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.spec.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.spec.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { FormsModule, ReactiveFormsModule, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
 import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
 
@@ -251,6 +251,126 @@ describe('NgpPopoverTrigger', () => {
     const trigger = getByRole('button');
 
     // This would throw NG01350 if ControlContainer leaked into the overlay
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      expect(document.querySelector('input')).toBeInTheDocument();
+    });
+  });
+
+  it('should not leak ControlContainer into overlay content (template inside form, ngModel)', async () => {
+    @Component({
+      template: `
+        <form [formGroup]="form">
+          <button [ngpPopoverTrigger]="content">Open</button>
+
+          <ng-template #content>
+            <div ngpPopover>
+              <input [(ngModel)]="value" />
+            </div>
+          </ng-template>
+        </form>
+      `,
+      imports: [NgpPopoverTrigger, NgpPopover, ReactiveFormsModule, FormsModule],
+    })
+    class FormLeakInsideFormNgModelComponent {
+      form = new FormGroup({});
+      value = '';
+    }
+
+    const { getByRole } = await render(FormLeakInsideFormNgModelComponent);
+    const trigger = getByRole('button');
+
+    // NG01350 would be thrown if ControlContainer leaked from the parent form
+    // into the overlay when the template is declared inside the form.
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      expect(document.querySelector('input')).toBeInTheDocument();
+    });
+  });
+
+  it('should not leak ControlContainer into overlay content (template inside form, formControlName)', async () => {
+    @Component({
+      template: `
+        <form [formGroup]="outerForm">
+          <input formControlName="outerField" />
+          <button [ngpPopoverTrigger]="content">Open</button>
+
+          <ng-template #content>
+            <div ngpPopover>
+              <form [formGroup]="innerForm">
+                <input formControlName="innerField" />
+              </form>
+            </div>
+          </ng-template>
+        </form>
+      `,
+      imports: [NgpPopoverTrigger, NgpPopover, ReactiveFormsModule],
+    })
+    class FormLeakInsideFormControlNameComponent {
+      outerForm = new FormGroup({
+        outerField: new FormControl('outer'),
+      });
+      innerForm = new FormGroup({
+        innerField: new FormControl('inner'),
+      });
+    }
+
+    const { getByRole } = await render(FormLeakInsideFormControlNameComponent);
+    const trigger = getByRole('button');
+
+    // The inner formControlName should bind to innerForm, not the outer form
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      const inputs = document.querySelectorAll('[ngpPopover] input');
+      expect(inputs.length).toBe(1);
+    });
+  });
+
+  it('should not leak ControlContainer to child components with formControlName', async () => {
+    @Component({
+      selector: 'test-child-form',
+      template: `
+        <form [formGroup]="innerForm">
+          <input formControlName="name" />
+        </form>
+      `,
+      imports: [ReactiveFormsModule],
+    })
+    class TestChildFormComponent {
+      readonly innerForm = new FormGroup({
+        name: new FormControl('test-value'),
+      });
+    }
+
+    @Component({
+      template: `
+        <form [formGroup]="outerForm">
+          <button [ngpPopoverTrigger]="content">Open</button>
+
+          <ng-template #content>
+            <div ngpPopover>
+              <test-child-form />
+            </div>
+          </ng-template>
+        </form>
+      `,
+      imports: [NgpPopoverTrigger, NgpPopover, ReactiveFormsModule, TestChildFormComponent],
+    })
+    class FormControlNameLeakComponent {
+      outerForm = new FormGroup({});
+    }
+
+    const { getByRole } = await render(FormControlNameLeakComponent);
+    const trigger = getByRole('button');
+
+    // The child component's formControlName should resolve against its own form,
+    // not the outer form from the host component
     fireEvent.click(trigger);
 
     await waitFor(() => {

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -41,6 +41,73 @@ import { BlockScrollStrategy, NoopScrollStrategy } from './scroll-strategy';
 import { NgpShift } from './shift';
 
 /**
+ * Bit value of the internal `SkipSelf` inject flag used by Angular's DI system.
+ * This value is part of Angular's ABI and is stable across versions 19+.
+ * @see InjectFlags.SkipSelf / InternalInjectFlags.SkipSelf
+ */
+const SKIP_SELF_FLAG = 4;
+
+/** Check whether the given inject flags include `SkipSelf`. */
+function hasSkipSelfFlag(flags: unknown): boolean {
+  if (typeof flags === 'number') {
+    return (flags & SKIP_SELF_FLAG) !== 0;
+  }
+  if (flags != null && typeof flags === 'object' && 'skipSelf' in flags) {
+    return !!(flags as { skipSelf: unknown }).skipSelf;
+  }
+  return false;
+}
+
+/**
+ * An injector wrapper that intercepts `ControlContainer` lookups carrying the
+ * `SkipSelf` flag and short-circuits them to `notFoundValue`.
+ *
+ * ## Why this is needed
+ *
+ * Angular's `lookupTokenUsingEmbeddedInjector` passes the original inject flags
+ * to the embedded view injector's `.get()` call. For directives that use
+ * `@Host() @SkipSelf()` (e.g. `FormControlName`, `FormGroupName`):
+ *
+ * - **Without this wrapper**: `R3Injector.get()` honors `SkipSelf` by skipping
+ *   its own `ControlContainer: null` record and delegates to the parent injector
+ *   (the trigger element's injector), which may find the **outer** form's
+ *   `ControlContainer` — leaking the wrong form context into child components.
+ *
+ * - **If we stripped SkipSelf entirely**: `R3Injector` would find its own
+ *   `ControlContainer: null` and return `null`. But this `null` is returned
+ *   for ALL `ControlContainer` lookups within the portaled view, killing child
+ *   components' own `FormGroupDirective` resolution (NG01050).
+ *
+ * ## The fix
+ *
+ * For `ControlContainer` + `SkipSelf`, return `notFoundValue` directly. This
+ * causes `lookupTokenUsingEmbeddedInjector` to skip this boundary and eventually
+ * return `NOT_FOUND`, letting `lookupTokenUsingNodeInjector` run — which correctly
+ * finds the child component's own `FormGroupDirective` via the element injector chain.
+ *
+ * For `ControlContainer` without `SkipSelf` (e.g. `NgModel` uses `@Host()` only),
+ * delegation proceeds normally and finds `ControlContainer: null`, preventing the
+ * outer form from leaking.
+ *
+ * @see https://github.com/angular/angular/issues/57390
+ * @see https://github.com/ng-primitives/ng-primitives/issues/677
+ * @internal
+ */
+class EmbeddedViewInjector extends Injector {
+  constructor(private readonly delegate: Injector) {
+    super();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  get(token: any, notFoundValue?: any, flags?: any): any {
+    if (token === ControlContainer && hasSkipSelfFlag(flags)) {
+      return notFoundValue;
+    }
+    return this.delegate.get(token, notFoundValue, flags);
+  }
+}
+
+/**
  * Configuration options for creating an overlay
  * @internal
  */
@@ -571,19 +638,24 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       throw new Error('Overlay content must be provided');
     }
 
-    // Create a new portal with context
+    // Create a new portal with context.
+    // The injector is wrapped in EmbeddedViewInjector to work around an Angular 19 bug
+    // where @SkipSelf() causes the embedded view injector's ControlContainer: null to be
+    // bypassed. See https://github.com/angular/angular/issues/57390
     const portal = createPortal(
       this.config.content,
       this.viewContainerRef,
-      Injector.create({
-        parent: this.config.injector,
-        providers: [
-          ...(this.config.providers || []),
-          { provide: NgpOverlay, useValue: this },
-          provideOverlayContext<T>(this.config.context),
-          { provide: ControlContainer, useValue: null },
-        ],
-      }),
+      new EmbeddedViewInjector(
+        Injector.create({
+          parent: this.config.injector,
+          providers: [
+            ...(this.config.providers || []),
+            { provide: NgpOverlay, useValue: this },
+            provideOverlayContext<T>(this.config.context),
+            { provide: ControlContainer, useValue: null },
+          ],
+        }),
+      ),
       { $implicit: this.config.context } as NgpOverlayTemplateContext<T>,
     );
 


### PR DESCRIPTION
## PR Checklist                             
                                          
  - [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
  - [x] Tests for the changes have been added (for bug fixes / features)                                                                                                                                              
  - [ ] Docs have been added / updated (for bug fixes / features)
                                                                                                                                                                                                                      
  ## PR Type                                                                                                                                                                                                        

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update (formatting, local variables)
  - [ ] Refactoring (no functional changes, no api changes)
  - [ ] Build related changes
  - [ ] CI related changes
  - [ ] Documentation changes
  - [ ] Other... Please describe:

  ## Issue

  Closes #677

  ## What does this PR implement/fix?

  The existing `ControlContainer: null` provision in the overlay's embedded view injector (added in #675) prevents form context from leaking into portaled content for `NgModel` (`@Host()`). However, directives
  using `@Host() @SkipSelf()` (e.g. `FormControlName`, `FormGroupName`, `FormArrayName`) bypass this null provision because Angular's `R3Injector.get()` honors `SkipSelf` by skipping its own records, delegating to
  the parent injector — which may find an outer form's `ControlContainer`. This causes NG01050 when a child component inside the portal has its own `<form [formGroup]>` with `formControlName`.

  This PR wraps the portal's `Injector.create()` in an `EmbeddedViewInjector` that intercepts `ControlContainer` lookups carrying the `SkipSelf` flag and returns `notFoundValue` directly. This forces Angular's
  `lookupTokenUsingNodeInjector` to handle the resolution instead, which correctly finds the child component's own `FormGroupDirective` via the element injector chain.

  - **`NgModel`** (`@Host()`, no `SkipSelf`): finds `ControlContainer: null` → outer form blocked ✓
  - **`FormControlName`** (`@Host() @SkipSelf()`): gets `NOT_FOUND` → node injector finds inner form ✓
  - **`FormGroupName` / `FormArrayName`** (`@Host() @SkipSelf()`): same behavior ✓

  This is a workaround for [angular/angular#57390](https://github.com/angular/angular/issues/57390), which was incidentally fixed in Angular 20 but remains broken in Angular 19.

  ## Does this PR introduce a breaking change?

  - [ ] Yes
  - [x] No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form control lookup in overlays and portalled content so nested forms and embedded controls resolve correctly when using popovers and overlays.

* **Tests**
  * Expanded test coverage for popover triggers and overlay scenarios, validating form control behaviour across templates, reactive and template-driven forms, and nested component boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->