### PR TITLE
fix(focus-trap): use isTabbable and allow focus to CDK overlays ( #682, #687 )

### DIFF
--- a/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap-state.ts
+++ b/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap-state.ts
@@ -190,6 +190,8 @@ export const [NgpFocusTrapStateToken, ngpFocusTrap, injectFocusTrapState, provid
 
         if (element.nativeElement.contains(target)) {
           lastFocusedElement = target;
+        } else if (isAllowedExternalTarget(target)) {
+          // Don't interfere — see `isAllowedExternalTarget` for details.
         } else {
           focus(lastFocusedElement);
         }
@@ -205,9 +207,29 @@ export const [NgpFocusTrapStateToken, ngpFocusTrap, injectFocusTrapState, provid
 
         const relatedTarget = event.relatedTarget as HTMLElement;
 
-        if (!element.nativeElement.contains(relatedTarget)) {
+        if (
+          !element.nativeElement.contains(relatedTarget) &&
+          !isAllowedExternalTarget(relatedTarget)
+        ) {
           focus(lastFocusedElement);
         }
+      }
+
+      /**
+       * Whether the given element belongs to another focus trap or a CDK overlay container.
+       *
+       * When focus moves to these elements we must not redirect it back, because they
+       * manage their own focus trapping. Without this check, opening a CDK overlay
+       * (e.g. a select dropdown) from inside a focus-trapped dialog would immediately
+       * yank focus back into the dialog, making the overlay unusable.
+       *
+       * See https://github.com/nicecod3r/ng-primitives/issues/682
+       * and https://github.com/nicecod3r/ng-primitives/issues/687
+       */
+      function isAllowedExternalTarget(target: HTMLElement | null): boolean {
+        return !!(
+          target?.closest?.('[data-focus-trap]') || target?.closest?.('.cdk-overlay-container')
+        );
       }
 
       /**
@@ -283,7 +305,7 @@ export const [NgpFocusTrapStateToken, ngpFocusTrap, injectFocusTrapState, provid
         const nodes: HTMLElement[] = [];
         const walker = document.createTreeWalker(container, NodeFilter.SHOW_ELEMENT, {
           acceptNode: (node: HTMLElement) =>
-            interactivityChecker.isFocusable(node)
+            interactivityChecker.isTabbable(node)
               ? NodeFilter.FILTER_ACCEPT
               : NodeFilter.FILTER_SKIP,
         });

--- a/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap.spec.ts
+++ b/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap.spec.ts
@@ -1,5 +1,6 @@
+import { FocusMonitor, InteractivityChecker } from '@angular/cdk/a11y';
 import { Component, signal } from '@angular/core';
-import { fakeAsync, flush, tick } from '@angular/core/testing';
+import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { fireEvent, render } from '@testing-library/angular';
 import { NgpFocusTrap } from './focus-trap';
 
@@ -62,6 +63,49 @@ class TestNestedFocusTrapsComponent {
   showSecond = signal(false);
   showThird = signal(false);
 }
+
+@Component({
+  selector: 'test-focus-trap-negative-tabindex',
+  imports: [NgpFocusTrap],
+  template: `
+    <div ngpFocusTrap data-testid="focus-trap">
+      <button data-testid="btn1" tabindex="0">Button 1</button>
+      <div data-testid="negative-tabindex" tabindex="-1">Not tabbable</div>
+      <button data-testid="btn2" tabindex="0">Button 2</button>
+    </div>
+  `,
+})
+class TestFocusTrapWithNegativeTabIndexComponent {}
+
+@Component({
+  selector: 'test-focus-trap-cdk-overlay',
+  imports: [NgpFocusTrap],
+  template: `
+    <div ngpFocusTrap data-testid="focus-trap">
+      <button data-testid="trap-btn" tabindex="0">Trap Button</button>
+    </div>
+    <div class="cdk-overlay-container" data-testid="overlay-container">
+      <button data-testid="overlay-btn" tabindex="0">Overlay Button</button>
+    </div>
+    <button data-testid="outside-btn" tabindex="0">Outside Button</button>
+  `,
+})
+class TestFocusTrapWithCdkOverlayComponent {}
+
+@Component({
+  selector: 'test-focus-trap-external-trap',
+  imports: [NgpFocusTrap],
+  template: `
+    <div ngpFocusTrap data-testid="focus-trap">
+      <button data-testid="trap-btn" tabindex="0">Trap Button</button>
+    </div>
+    <div data-focus-trap data-testid="external-trap">
+      <button data-testid="external-trap-btn" tabindex="0">External Trap Button</button>
+    </div>
+    <button data-testid="outside-btn" tabindex="0">Outside Button</button>
+  `,
+})
+class TestFocusTrapWithExternalTrapComponent {}
 
 describe('NgpFocusTrap', () => {
   describe('Host Bindings', () => {
@@ -440,5 +484,180 @@ describe('FocusTrapStack behavior', () => {
     // First trap should still work
     fireEvent.focus(trap1Button);
     expect(document.activeElement).toBeTruthy();
+  }));
+});
+
+describe('Tabbable candidate filtering', () => {
+  it('should use isTabbable to exclude tabindex="-1" elements from tabbable candidates', fakeAsync(async () => {
+    const { getByTestId } = await render(TestFocusTrapWithNegativeTabIndexComponent);
+    tick();
+    flush();
+
+    const interactivityChecker = TestBed.inject(InteractivityChecker);
+    const isTabbableSpy = jest.spyOn(interactivityChecker, 'isTabbable');
+
+    const focusTrap = getByTestId('focus-trap');
+    const negativeTabIndexEl = getByTestId('negative-tabindex');
+    const btn1 = getByTestId('btn1');
+
+    // Focus an element inside the trap to set document.activeElement
+    btn1.focus();
+    isTabbableSpy.mockClear();
+
+    // Trigger Tab key which calls getTabbableCandidates -> isTabbable
+    fireEvent.keyDown(focusTrap, { key: 'Tab' });
+
+    // Verify isTabbable was called during Tab handling
+    expect(isTabbableSpy).toHaveBeenCalled();
+
+    // Verify isTabbable was called with and returned false for the tabindex="-1" element
+    const callIndex = isTabbableSpy.mock.calls.findIndex(call => call[0] === negativeTabIndexEl);
+    expect(callIndex).toBeGreaterThanOrEqual(0);
+    expect(isTabbableSpy.mock.results[callIndex].value).toBe(false);
+  }));
+
+  it('should call isTabbable for standard tabbable elements during Tab navigation', fakeAsync(async () => {
+    const { getByTestId } = await render(TestFocusTrapWithNegativeTabIndexComponent);
+    tick();
+    flush();
+
+    const interactivityChecker = TestBed.inject(InteractivityChecker);
+    const isTabbableSpy = jest.spyOn(interactivityChecker, 'isTabbable');
+
+    const focusTrap = getByTestId('focus-trap');
+    const btn1 = getByTestId('btn1');
+    const btn2 = getByTestId('btn2');
+
+    btn1.focus();
+    isTabbableSpy.mockClear();
+
+    fireEvent.keyDown(focusTrap, { key: 'Tab' });
+
+    // Verify isTabbable was called with both buttons
+    expect(isTabbableSpy.mock.calls.some(call => call[0] === btn1)).toBe(true);
+    expect(isTabbableSpy.mock.calls.some(call => call[0] === btn2)).toBe(true);
+  }));
+});
+
+describe('Focus-in with CDK overlays and external traps', () => {
+  it('should not redirect focus when it moves to a [data-focus-trap] element', fakeAsync(async () => {
+    const { getByTestId } = await render(TestFocusTrapWithExternalTrapComponent);
+    tick();
+    flush();
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    // Establish lastFocusedElement by focusing inside the trap
+    fireEvent.focusIn(getByTestId('trap-btn'));
+    focusViaSpy.mockClear();
+
+    // Focus moves to an element inside an external [data-focus-trap]
+    fireEvent.focusIn(getByTestId('external-trap-btn'));
+
+    expect(focusViaSpy).not.toHaveBeenCalled();
+  }));
+
+  it('should not redirect focus when it moves to a .cdk-overlay-container element', fakeAsync(async () => {
+    const { getByTestId } = await render(TestFocusTrapWithCdkOverlayComponent);
+    tick();
+    flush();
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    // Establish lastFocusedElement by focusing inside the trap
+    fireEvent.focusIn(getByTestId('trap-btn'));
+    focusViaSpy.mockClear();
+
+    // Focus moves to an element inside .cdk-overlay-container
+    fireEvent.focusIn(getByTestId('overlay-btn'));
+
+    expect(focusViaSpy).not.toHaveBeenCalled();
+  }));
+
+  it('should redirect focus back when it moves to a plain outside element', fakeAsync(async () => {
+    const { getByTestId } = await render(TestFocusTrapWithCdkOverlayComponent);
+    tick();
+    flush();
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    const trapBtn = getByTestId('trap-btn');
+
+    // Establish lastFocusedElement by focusing inside the trap
+    fireEvent.focusIn(trapBtn);
+    focusViaSpy.mockClear();
+
+    // Focus moves to a plain outside element (not overlay or external trap)
+    fireEvent.focusIn(getByTestId('outside-btn'));
+
+    expect(focusViaSpy).toHaveBeenCalledWith(trapBtn, expect.anything(), expect.anything());
+  }));
+});
+
+describe('Focus-out with CDK overlays and external traps', () => {
+  it('should not redirect focus when it leaves to a [data-focus-trap] element', fakeAsync(async () => {
+    const { getByTestId } = await render(TestFocusTrapWithExternalTrapComponent);
+    tick();
+    flush();
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    const trapBtn = getByTestId('trap-btn');
+    const externalTrapBtn = getByTestId('external-trap-btn');
+
+    // Establish lastFocusedElement by focusing inside the trap
+    fireEvent.focusIn(trapBtn);
+    focusViaSpy.mockClear();
+
+    // Focus leaves to an element inside an external [data-focus-trap]
+    fireEvent.focusOut(trapBtn, { relatedTarget: externalTrapBtn });
+
+    expect(focusViaSpy).not.toHaveBeenCalled();
+  }));
+
+  it('should not redirect focus when it leaves to a .cdk-overlay-container element', fakeAsync(async () => {
+    const { getByTestId } = await render(TestFocusTrapWithCdkOverlayComponent);
+    tick();
+    flush();
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    const trapBtn = getByTestId('trap-btn');
+    const overlayBtn = getByTestId('overlay-btn');
+
+    // Establish lastFocusedElement by focusing inside the trap
+    fireEvent.focusIn(trapBtn);
+    focusViaSpy.mockClear();
+
+    // Focus leaves to an element inside .cdk-overlay-container
+    fireEvent.focusOut(trapBtn, { relatedTarget: overlayBtn });
+
+    expect(focusViaSpy).not.toHaveBeenCalled();
+  }));
+
+  it('should redirect focus back when it leaves to a plain outside element', fakeAsync(async () => {
+    const { getByTestId } = await render(TestFocusTrapWithCdkOverlayComponent);
+    tick();
+    flush();
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    const trapBtn = getByTestId('trap-btn');
+    const outsideBtn = getByTestId('outside-btn');
+
+    // Establish lastFocusedElement by focusing inside the trap
+    fireEvent.focusIn(trapBtn);
+    focusViaSpy.mockClear();
+
+    // Focus leaves to a plain outside element
+    fireEvent.focusOut(trapBtn, { relatedTarget: outsideBtn });
+
+    expect(focusViaSpy).toHaveBeenCalledWith(trapBtn, expect.anything(), expect.anything());
   }));
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- #682: isFocusable() used instead of isTabbable(), causing wrong elements to receive focus                                                                                                                         
- #687: focus incorrectly redirected away from CDK overlays                                                                                                                                                         
                                                                                                                                                                                                                      
No new features, no API changes, just correcting existing behavior. 

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #682 #687

## What does this PR implement/fix?

**#682** - **Focus** **trap** **incorrectly** **focuses** **tabindex="-1" elements:**

getTabbableCandidates() used InteractivityChecker.isFocusable() which includes elements with tabindex="-1". Switched to isTabbable() so only keyboard-reachable elements are part of the tab cycle. This fixes incorrect initial focus and broken tab wrapping in dialogs.

**#687** - **Focus** **trap** **blocks** **focus** **to** **CDK** **overlay** **panes:**

When a CDK overlay (e.g. select dropdown) opens from within a focus-trapped container, the overlay renders in .cdk-overlay-container at the document root — outside the trap's DOM. The trap's handleFocusIn and handleFocusOut would forcibly redirect focus back. Added checks to allow focus to move to elements inside another [data-focus-trap] or .cdk-overlay-container without interference.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Focus-trap now ignores focus moves into other traps or overlay containers, preventing unwanted redirection.
  * Tabbable detection refined to exclude elements with negative tabindex, improving keyboard navigation.

* **Tests**
  * Expanded coverage for tabbable filtering and focus interactions involving overlay containers and separate focus traps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->