### PR TITLE
fix(portal): block scroll on ancestor containers and add options to NgpFlipOptions and NgpShiftOptions (#455, #689)

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -279,8 +279,21 @@ bootstrapApplication(AppComponent, {
   Define the container element for the combobox dropdown. This is useful for rendering the dropdown in a specific part of the DOM.
 </prop-details>
 
-<prop-details name="flip" type="boolean" default="true">
-  Define whether the dropdown should flip to the opposite side when there is not enough space.
+<prop-details name="flip" type="boolean | NgpFlipOptions" default="true">
+  Define whether the dropdown should flip to the opposite side when there is not enough space. Can be a boolean to enable/disable, or an object with detailed options.
+
+**Object format:**
+
+```ts
+flip: {
+  padding: 8,                          // Minimum padding from viewport edges (default: 0)
+  fallbackPlacements: ['top', 'left'], // Placements to try if preferred doesn't fit
+  boundary: element,                   // Clipping boundary area (default: 'clippingAncestors')
+  rootBoundary: 'viewport',            // Root clipping area: 'viewport' or 'document' (default: 'viewport')
+  crossAxis: true,                     // Whether to check overflow on the cross axis (default: true)
+}
+```
+
 </prop-details>
 
 ## Accessibility

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -281,27 +281,47 @@ bootstrapApplication(AppComponent, {
 
 <prop-details name="shift" type="boolean | NgpShiftOptions" default="true">
   Define the shift behavior to keep the menu in view. When enabled (default), the menu will shift along its axis to stay visible when it would otherwise overflow the viewport. Set to `false` to disable.
-  
-  **Boolean format:** `shift: false` - Disables shift behavior
-  
-  **Object format:** 
-  ```ts
-  shift: {
-    padding: 8,     // Minimum padding between menu and viewport edges
-    limiter: {      // Optional limiter to control shifting behavior
-      fn: limitShift,
-      options: { /* limiter options */ }
-    }
-  }
-  ```
+
+**Boolean format:** `shift: false` - Disables shift behavior
+
+**Object format:**
+
+```ts
+shift: {
+  padding: 8,           // Minimum padding between menu and viewport edges
+  limiter: {            // Optional limiter to control shifting behavior
+    fn: limitShift,
+    options: { /* limiter options */ }
+  },
+  boundary: element,    // Clipping boundary area (default: 'clippingAncestors')
+  rootBoundary: 'viewport', // Root clipping area: 'viewport' or 'document' (default: 'viewport')
+  crossAxis: true,      // Whether to also shift along the cross axis (default: false)
+}
+```
+
 </prop-details>
 
 <prop-details name="placement" type="'top' | 'right' | 'bottom' | 'left'">
   Define the placement of the menu.
 </prop-details>
 
-<prop-details name="flip" type="boolean">
-  Define if the menu should flip when it reaches the edge of the viewport.
+<prop-details name="flip" type="boolean | NgpFlipOptions">
+  Define if the menu should flip when it reaches the edge of the viewport. Can be a boolean to enable/disable, or an object with detailed options.
+
+**Boolean format:** `flip: false` - Disables flip behavior
+
+**Object format:**
+
+```ts
+flip: {
+  padding: 8,                          // Minimum padding from viewport edges (default: 0)
+  fallbackPlacements: ['top', 'left'], // Placements to try if preferred doesn't fit
+  boundary: element,                   // Clipping boundary area (default: 'clippingAncestors')
+  rootBoundary: 'viewport',            // Root clipping area: 'viewport' or 'document' (default: 'viewport')
+  crossAxis: true,                     // Whether to check overflow on the cross axis (default: true)
+}
+```
+
 </prop-details>
 
 <prop-details name="container" type="HTMLElement">

--- a/apps/documentation/src/app/pages/(documentation)/primitives/navigation-menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/navigation-menu.md
@@ -251,8 +251,21 @@ Define the placement of the content relative to the trigger.
 Define the offset from the trigger element.
 </prop-details>
 
-<prop-details name="flip" type="boolean" default="true">
-Define if the content should flip when it reaches the edge of the viewport.
+<prop-details name="flip" type="boolean | NgpFlipOptions" default="true">
+Define if the content should flip when it reaches the edge of the viewport. Can be a boolean to enable/disable, or an object with detailed options.
+
+**Object format:**
+
+```ts
+flip: {
+  padding: 8,                          // Minimum padding from viewport edges (default: 0)
+  fallbackPlacements: ['top', 'left'], // Placements to try if preferred doesn't fit
+  boundary: element,                   // Clipping boundary area (default: 'clippingAncestors')
+  rootBoundary: 'viewport',            // Root clipping area: 'viewport' or 'document' (default: 'viewport')
+  crossAxis: true,                     // Whether to check overflow on the cross axis (default: true)
+}
+```
+
 </prop-details>
 
 <prop-details name="wrap" type="boolean" default="true">
@@ -261,6 +274,22 @@ Define if focus should wrap around when navigating with arrow keys.
 
 <prop-details name="shift" type="boolean | NgpShiftOptions" default="undefined">
 Configure shift behavior to keep the content in view when it would overflow the viewport.
+
+**Object format:**
+
+```ts
+shift: {
+  padding: 8,           // Minimum padding between content and viewport edges
+  limiter: {            // Optional limiter to control shifting behavior
+    fn: limitShift,
+    options: { /* limiter options */ }
+  },
+  boundary: element,    // Clipping boundary area (default: 'clippingAncestors')
+  rootBoundary: 'viewport', // Root clipping area: 'viewport' or 'document' (default: 'viewport')
+  crossAxis: true,      // Whether to also shift along the cross axis (default: false)
+}
+```
+
 </prop-details>
 
 <prop-details name="cooldown" type="number" default="300">

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -227,19 +227,24 @@ bootstrapApplication(AppComponent, {
 
 <prop-details name="shift" type="boolean | NgpShiftOptions" default="true">
   Define the shift behavior to keep the popover in view. When enabled (default), the popover will shift along its axis to stay visible when it would otherwise overflow the viewport. Set to `false` to disable.
-  
-  **Boolean format:** `shift: false` - Disables shift behavior
-  
-  **Object format:** 
-  ```ts
-  shift: {
-    padding: 8,     // Minimum padding between popover and viewport edges
-    limiter: {      // Optional limiter to control shifting behavior
-      fn: limitShift,
-      options: { /* limiter options */ }
-    }
-  }
-  ```
+
+**Boolean format:** `shift: false` - Disables shift behavior
+
+**Object format:**
+
+```ts
+shift: {
+  padding: 8,           // Minimum padding between popover and viewport edges
+  limiter: {            // Optional limiter to control shifting behavior
+    fn: limitShift,
+    options: { /* limiter options */ }
+  },
+  boundary: element,    // Clipping boundary area (default: 'clippingAncestors')
+  rootBoundary: 'viewport', // Root clipping area: 'viewport' or 'document' (default: 'viewport')
+  crossAxis: true,      // Whether to also shift along the cross axis (default: false)
+}
+```
+
 </prop-details>
 
 <prop-details name="placement" type="'top' | 'right' | 'bottom' | 'left'">
@@ -254,8 +259,23 @@ bootstrapApplication(AppComponent, {
   Define the delay before the popover hides.
 </prop-details>
 
-<prop-details name="flip" type="boolean">
-  Define if the popover should flip when it reaches the edge of the viewport.
+<prop-details name="flip" type="boolean | NgpFlipOptions">
+  Define if the popover should flip when it reaches the edge of the viewport. Can be a boolean to enable/disable, or an object with detailed options.
+
+**Boolean format:** `flip: false` - Disables flip behavior
+
+**Object format:**
+
+```ts
+flip: {
+  padding: 8,                          // Minimum padding from viewport edges (default: 0)
+  fallbackPlacements: ['top', 'left'], // Placements to try if preferred doesn't fit
+  boundary: element,                   // Clipping boundary area (default: 'clippingAncestors')
+  rootBoundary: 'viewport',            // Root clipping area: 'viewport' or 'document' (default: 'viewport')
+  crossAxis: true,                     // Whether to check overflow on the cross axis (default: true)
+}
+```
+
 </prop-details>
 
 <prop-details name="container" type="HTMLElement">

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -162,8 +162,21 @@ bootstrapApplication(AppComponent, {
   Define the container element for the select dropdown. This is useful for rendering the dropdown in a specific part of the DOM.
 </prop-details>
 
-<prop-details name="flip" type="boolean" default="true">
-  Define whether the dropdown should flip to the opposite side when there is not enough space.
+<prop-details name="flip" type="boolean | NgpFlipOptions" default="true">
+  Define whether the dropdown should flip to the opposite side when there is not enough space. Can be a boolean to enable/disable, or an object with detailed options.
+
+**Object format:**
+
+```ts
+flip: {
+  padding: 8,                          // Minimum padding from viewport edges (default: 0)
+  fallbackPlacements: ['top', 'left'], // Placements to try if preferred doesn't fit
+  boundary: element,                   // Clipping boundary area (default: 'clippingAncestors')
+  rootBoundary: 'viewport',            // Root clipping area: 'viewport' or 'document' (default: 'viewport')
+  crossAxis: true,                     // Whether to check overflow on the cross axis (default: true)
+}
+```
+
 </prop-details>
 
 ## Accessibility

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -287,11 +287,14 @@ Define the shift behavior to keep the tooltip in view. When enabled (default), t
 
 ```ts
 shift: {
-  padding: 8,     // Minimum padding between tooltip and viewport edges
-  limiter: {      // Optional limiter to control shifting behavior
+  padding: 8,           // Minimum padding between tooltip and viewport edges
+  limiter: {            // Optional limiter to control shifting behavior
     fn: limitShift,
     options: { /* limiter options */ }
-  }
+  },
+  boundary: element,    // Clipping boundary area (default: 'clippingAncestors')
+  rootBoundary: 'viewport', // Root clipping area: 'viewport' or 'document' (default: 'viewport')
+  crossAxis: true,      // Whether to also shift along the cross axis (default: false)
 }
 ```
 
@@ -309,8 +312,23 @@ shift: {
   Define the delay before the tooltip hides.
 </prop-details>
 
-<prop-details name="flip" type="boolean" default="true">
-  Define if the tooltip should flip when it reaches the edge of the viewport.
+<prop-details name="flip" type="boolean | NgpFlipOptions" default="true">
+Define if the tooltip should flip when it reaches the edge of the viewport. Can be a boolean to enable/disable, or an object with detailed options.
+
+**Boolean format:** `flip: false` - Disables flip behavior
+
+**Object format:**
+
+```ts
+flip: {
+  padding: 8,                          // Minimum padding from viewport edges (default: 0)
+  fallbackPlacements: ['top', 'left'], // Placements to try if preferred doesn't fit
+  boundary: element,                   // Clipping boundary area (default: 'clippingAncestors')
+  rootBoundary: 'viewport',            // Root clipping area: 'viewport' or 'document' (default: 'viewport')
+  crossAxis: true,                     // Whether to check overflow on the cross axis (default: true)
+}
+```
+
 </prop-details>
 
 <prop-details name="container" type="HTMLElement" default="document.body">

--- a/packages/ng-primitives/portal/src/flip.ts
+++ b/packages/ng-primitives/portal/src/flip.ts
@@ -1,5 +1,5 @@
 import { coerceNumberProperty } from '@angular/cdk/coercion';
-import { type Placement } from '@floating-ui/dom';
+import { type Boundary, type Placement, type RootBoundary } from '@floating-ui/dom';
 import { isNil, isObject } from 'ng-primitives/utils';
 
 /**
@@ -20,6 +20,24 @@ export interface NgpFlipOptions {
    * @default [oppositePlacement] (computed)
    */
   fallbackPlacements?: Placement[];
+
+  /**
+   * The clipping boundary area of the floating element.
+   * @default 'clippingAncestors'
+   */
+  boundary?: Boundary;
+
+  /**
+   * The root clipping area of the floating element.
+   * @default 'viewport'
+   */
+  rootBoundary?: RootBoundary;
+
+  /**
+   * Whether to also check for overflow on the cross axis.
+   * @default true
+   */
+  crossAxis?: boolean;
 }
 
 /**

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -1,5 +1,4 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { ViewportRuler } from '@angular/cdk/overlay';
 import { DOCUMENT } from '@angular/common';
 import {
   DestroyRef,
@@ -228,7 +227,6 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   private readonly document = inject(DOCUMENT);
   private readonly destroyRef = inject(DestroyRef);
   private readonly viewContainerRef: ViewContainerRef;
-  private readonly viewportRuler = inject(ViewportRuler);
   private readonly focusMonitor = inject(FocusMonitor);
   private readonly cooldownManager = inject(NgpOverlayCooldownManager);
   /** Access any parent overlays */
@@ -715,7 +713,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   private createScrollStrategy(): ScrollStrategy {
     switch (this.config.scrollBehaviour) {
       case 'block':
-        return new BlockScrollStrategy(this.viewportRuler, this.document);
+        return new BlockScrollStrategy(this.document, this.config.triggerElement);
       case 'close':
         return new CloseScrollStrategy(
           this.config.anchorElement || this.config.triggerElement,

--- a/packages/ng-primitives/portal/src/scroll-strategy.spec.ts
+++ b/packages/ng-primitives/portal/src/scroll-strategy.spec.ts
@@ -1,4 +1,191 @@
-import { CloseScrollStrategy } from './scroll-strategy';
+import { BlockScrollStrategy, CloseScrollStrategy } from './scroll-strategy';
+
+describe('BlockScrollStrategy', () => {
+  let root: HTMLElement;
+
+  beforeEach(() => {
+    root = document.documentElement;
+    root.style.cssText = '';
+    root.removeAttribute('data-scrollblock');
+
+    // Make the document scrollable
+    Object.defineProperty(root, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(root, 'scrollWidth', { value: 1024, configurable: true });
+    Object.defineProperty(root, 'clientHeight', { value: 768, configurable: true });
+    Object.defineProperty(root, 'clientWidth', { value: 1024, configurable: true });
+  });
+
+  afterEach(() => {
+    root.style.cssText = '';
+    root.removeAttribute('data-scrollblock');
+  });
+
+  describe('document-level blocking', () => {
+    it('should block scrolling on the document when enabled', () => {
+      const strategy = new BlockScrollStrategy(document);
+      strategy.enable();
+
+      expect(root.style.overflow).toBe('hidden');
+      expect(root.style.scrollbarGutter).toBe('stable');
+      expect(root.hasAttribute('data-scrollblock')).toBe(true);
+
+      strategy.disable();
+    });
+
+    it('should restore original styles when disabled', () => {
+      root.style.overflow = 'visible';
+      root.style.scrollbarGutter = '';
+
+      const strategy = new BlockScrollStrategy(document);
+      strategy.enable();
+      strategy.disable();
+
+      expect(root.style.overflow).toBe('visible');
+      expect(root.style.scrollbarGutter).toBe('');
+      expect(root.hasAttribute('data-scrollblock')).toBe(false);
+    });
+
+    it('should not enable if already has data-scrollblock', () => {
+      root.setAttribute('data-scrollblock', '');
+
+      const strategy = new BlockScrollStrategy(document);
+      strategy.enable();
+      strategy.disable();
+
+      // Should still have the attribute since we didn't set didBlockDocument
+      expect(root.hasAttribute('data-scrollblock')).toBe(true);
+    });
+
+    it('should not block when the document is not scrollable', () => {
+      Object.defineProperty(root, 'scrollHeight', { value: 768, configurable: true });
+      Object.defineProperty(root, 'scrollWidth', { value: 1024, configurable: true });
+
+      const strategy = new BlockScrollStrategy(document);
+      strategy.enable();
+
+      expect(root.style.overflow).not.toBe('hidden');
+      expect(root.hasAttribute('data-scrollblock')).toBe(false);
+
+      strategy.disable();
+    });
+  });
+
+  describe('scrollable ancestor blocking', () => {
+    let scrollableContainer: HTMLDivElement;
+    let triggerElement: HTMLButtonElement;
+
+    beforeEach(() => {
+      scrollableContainer = document.createElement('div');
+      scrollableContainer.style.overflow = 'auto';
+      scrollableContainer.style.height = '200px';
+      Object.defineProperty(scrollableContainer, 'scrollHeight', {
+        value: 500,
+        configurable: true,
+      });
+      Object.defineProperty(scrollableContainer, 'clientHeight', {
+        value: 200,
+        configurable: true,
+      });
+
+      triggerElement = document.createElement('button');
+      triggerElement.textContent = 'Trigger';
+
+      scrollableContainer.appendChild(triggerElement);
+      document.body.appendChild(scrollableContainer);
+    });
+
+    afterEach(() => {
+      scrollableContainer.remove();
+    });
+
+    it('should block scroll on the scrollable ancestor when a trigger element is provided', () => {
+      const strategy = new BlockScrollStrategy(document, triggerElement);
+      strategy.enable();
+
+      expect(scrollableContainer.style.overflow).toBe('hidden');
+
+      strategy.disable();
+    });
+
+    it('should restore original overflow styles on the scrollable ancestor when disabled', () => {
+      scrollableContainer.style.overflow = 'auto';
+      scrollableContainer.style.overflowX = '';
+      scrollableContainer.style.overflowY = '';
+
+      const strategy = new BlockScrollStrategy(document, triggerElement);
+      strategy.enable();
+
+      expect(scrollableContainer.style.overflow).toBe('hidden');
+
+      strategy.disable();
+
+      expect(scrollableContainer.style.overflow).toBe('auto');
+    });
+
+    it('should set scrollbarGutter to stable when the ancestor has scroll content', () => {
+      const strategy = new BlockScrollStrategy(document, triggerElement);
+      strategy.enable();
+
+      expect(scrollableContainer.style.scrollbarGutter).toBe('stable');
+
+      strategy.disable();
+
+      expect(scrollableContainer.style.scrollbarGutter).toBe('');
+    });
+
+    it('should not set scrollbarGutter if ancestor has overflow auto but no scroll content', () => {
+      Object.defineProperty(scrollableContainer, 'scrollHeight', {
+        value: 200,
+        configurable: true,
+      });
+
+      const strategy = new BlockScrollStrategy(document, triggerElement);
+      strategy.enable();
+
+      expect(scrollableContainer.style.scrollbarGutter).not.toBe('stable');
+
+      strategy.disable();
+    });
+
+    it('should still block the document when a trigger element is provided', () => {
+      const strategy = new BlockScrollStrategy(document, triggerElement);
+      strategy.enable();
+
+      expect(root.style.overflow).toBe('hidden');
+      expect(root.hasAttribute('data-scrollblock')).toBe(true);
+
+      strategy.disable();
+    });
+
+    it('should work without a trigger element (backwards compatible)', () => {
+      const strategy = new BlockScrollStrategy(document);
+      strategy.enable();
+
+      expect(root.style.overflow).toBe('hidden');
+
+      strategy.disable();
+    });
+
+    it('should lock and unlock ancestor even when the document is not scrollable', () => {
+      Object.defineProperty(root, 'scrollHeight', { value: 768, configurable: true });
+      Object.defineProperty(root, 'scrollWidth', { value: 1024, configurable: true });
+
+      const strategy = new BlockScrollStrategy(document, triggerElement);
+      strategy.enable();
+
+      // Ancestor should still be locked
+      expect(scrollableContainer.style.overflow).toBe('hidden');
+      // Document should NOT be blocked
+      expect(root.style.overflow).not.toBe('hidden');
+      expect(root.hasAttribute('data-scrollblock')).toBe(false);
+
+      strategy.disable();
+
+      // Ancestor should be restored
+      expect(scrollableContainer.style.overflow).toBe('auto');
+    });
+  });
+});
 
 describe('CloseScrollStrategy', () => {
   let strategy: CloseScrollStrategy;
@@ -63,8 +250,6 @@ describe('CloseScrollStrategy', () => {
     overlayElement.appendChild(innerElement);
 
     // Simulate a scroll event on the inner element that is part of the overlay
-    // The ancestors listener won't fire for overlay-internal scrolls since the
-    // overlay is not an ancestor of the trigger. This test verifies the filter logic.
     const scrollEvent = new Event('scroll');
     Object.defineProperty(scrollEvent, 'target', { value: innerElement });
 

--- a/packages/ng-primitives/portal/src/scroll-strategy.ts
+++ b/packages/ng-primitives/portal/src/scroll-strategy.ts
@@ -1,105 +1,68 @@
 /**
- * This code is largely based on the CDK Overlay's scroll strategy implementation, however it
- * has been modified so that it does not rely on the CDK's global overlay styles.
+ * Scroll blocking inspired by react-aria's usePreventScroll.
+ * Uses `overflow: hidden` + `scrollbar-gutter: stable` instead of the CDK's
+ * `position: fixed` approach, avoiding the need to save/restore scroll position.
+ *
+ * @see https://github.com/adobe/react-spectrum/blob/main/packages/@react-aria/overlays/src/usePreventScroll.ts
  */
-import { coerceCssPixelValue } from '@angular/cdk/coercion';
-import { ViewportRuler } from '@angular/cdk/overlay';
 import { getOverflowAncestors } from '@floating-ui/dom';
-import { isFunction, isObject } from 'ng-primitives/utils';
 
 export interface ScrollStrategy {
   enable(): void;
   disable(): void;
 }
 
-/** Cached result of the check that indicates whether the browser supports scroll behaviors. */
-let scrollBehaviorSupported: boolean | undefined;
-
-export function supportsScrollBehavior(): boolean {
-  if (scrollBehaviorSupported != null) {
-    return scrollBehaviorSupported;
-  }
-
-  // If we're not in the browser, it can't be supported. Also check for `Element`, because
-  // some projects stub out the global `document` during SSR which can throw us off.
-  if (!isObject(document) || !document || !isFunction(Element) || !Element) {
-    return (scrollBehaviorSupported = false);
-  }
-
-  // If the element can have a `scrollBehavior` style, we can be sure that it's supported.
-  if ('scrollBehavior' in document.documentElement!.style) {
-    return (scrollBehaviorSupported = true);
-  }
-
-  // Check if scrollTo is supported and if it's been polyfilled
-  const scrollToFunction = Element.prototype.scrollTo;
-  if (!scrollToFunction) {
-    return (scrollBehaviorSupported = false);
-  }
-
-  // We can detect if the function has been polyfilled by calling `toString` on it. Native
-  // functions are obfuscated using `[native code]`, whereas if it was overwritten we'd get
-  // the actual function source. Via https://davidwalsh.name/detect-native-function. Consider
-  // polyfilled functions as supporting scroll behavior.
-  return (scrollBehaviorSupported = !/\{\s*\[native code\]\s*\}/.test(scrollToFunction.toString()));
-}
-
-interface HTMLStyles {
-  top: string;
-  left: string;
-  position: string;
+interface SavedOverflowState {
+  element: HTMLElement;
+  overflow: string;
+  overflowX: string;
   overflowY: string;
-  width: string;
+  scrollbarGutter: string;
 }
 
 export class BlockScrollStrategy implements ScrollStrategy {
-  private readonly previousHTMLStyles: HTMLStyles = {
-    top: '',
-    left: '',
-    position: '',
-    overflowY: '',
-    width: '',
-  };
-  private previousScrollPosition = { top: 0, left: 0 };
   private isEnabled = false;
+  private didBlockDocument = false;
+  private previousOverflow = '';
+  private previousScrollbarGutter = '';
+  private readonly savedAncestorStates: SavedOverflowState[] = [];
 
   constructor(
-    private readonly viewportRuler: ViewportRuler,
     private readonly document: Document,
+    private readonly triggerElement?: HTMLElement,
   ) {}
 
   /** Blocks page-level scroll while the attached overlay is open. */
   enable() {
-    if (this.canBeEnabled()) {
-      const root = this.document.documentElement!;
+    const root = this.document.documentElement!;
 
-      this.previousScrollPosition = this.viewportRuler.getViewportScrollPosition();
+    // Don't enable if already enabled or if another strategy (ours or CDK's) has blocked scrolling.
+    if (
+      this.isEnabled ||
+      root.hasAttribute('data-scrollblock') ||
+      root.classList.contains('cdk-global-scrollblock')
+    ) {
+      return;
+    }
 
-      // Cache the previous inline styles in case the user had set them.
-      this.previousHTMLStyles.left = root.style.left || '';
-      this.previousHTMLStyles.top = root.style.top || '';
-      this.previousHTMLStyles.position = root.style.position || '';
-      this.previousHTMLStyles.overflowY = root.style.overflowY || '';
-      this.previousHTMLStyles.width = root.style.width || '';
+    // Block scrollable ancestors of the trigger element regardless of document scrollability.
+    if (this.triggerElement) {
+      this.blockScrollableAncestors(this.triggerElement);
+    }
 
-      // Set the styles to block scrolling.
-      root.style.position = 'fixed';
+    // Block document scroll if the document itself is scrollable.
+    if (root.scrollHeight > root.clientHeight || root.scrollWidth > root.clientWidth) {
+      this.previousOverflow = root.style.overflow;
+      this.previousScrollbarGutter = root.style.scrollbarGutter;
 
-      // Necessary for the content not to lose its width. Note that we're using 100%, instead of
-      // 100vw, because 100vw includes the width plus the scrollbar, whereas 100% is the width
-      // that the element had before we made it `fixed`.
-      root.style.width = '100%';
-
-      // Note: this will always add a scrollbar to whatever element it is on, which can
-      // potentially result in double scrollbars. It shouldn't be an issue, because we won't
-      // block scrolling on a page that doesn't have a scrollbar in the first place.
-      root.style.overflowY = 'scroll';
-
-      // Note: we're using the `html` node, instead of the `body`, because the `body` may
-      // have the user agent margin, whereas the `html` is guaranteed not to have one.
-      root.style.left = coerceCssPixelValue(-this.previousScrollPosition.left);
-      root.style.top = coerceCssPixelValue(-this.previousScrollPosition.top);
+      root.style.overflow = 'hidden';
+      root.style.scrollbarGutter = 'stable';
       root.setAttribute('data-scrollblock', '');
+      this.didBlockDocument = true;
+    }
+
+    // Mark as enabled if we blocked the document or any ancestors.
+    if (root.hasAttribute('data-scrollblock') || this.savedAncestorStates.length > 0) {
       this.isEnabled = true;
     }
   }
@@ -107,52 +70,64 @@ export class BlockScrollStrategy implements ScrollStrategy {
   /** Unblocks page-level scroll while the attached overlay is open. */
   disable(): void {
     if (this.isEnabled) {
-      const html = this.document.documentElement!;
-      const body = this.document.body!;
-      const htmlStyle = html.style;
-      const bodyStyle = body.style;
-      const previousHtmlScrollBehavior = htmlStyle.scrollBehavior || '';
-      const previousBodyScrollBehavior = bodyStyle.scrollBehavior || '';
+      const root = this.document.documentElement!;
 
-      this.isEnabled = false;
-
-      htmlStyle.left = this.previousHTMLStyles.left;
-      htmlStyle.top = this.previousHTMLStyles.top;
-      htmlStyle.position = this.previousHTMLStyles.position;
-      htmlStyle.overflowY = this.previousHTMLStyles.overflowY;
-      htmlStyle.width = this.previousHTMLStyles.width;
-      html.removeAttribute('data-scrollblock');
-
-      // Disable user-defined smooth scrolling temporarily while we restore the scroll position.
-      // See https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-behavior
-      // Note that we don't mutate the property if the browser doesn't support `scroll-behavior`,
-      // because it can throw off feature detections in `supportsScrollBehavior` which
-      // checks for `'scrollBehavior' in documentElement.style`.
-      if (scrollBehaviorSupported) {
-        htmlStyle.scrollBehavior = bodyStyle.scrollBehavior = 'auto';
+      // Only restore document styles if this instance actually blocked document scrolling.
+      if (this.didBlockDocument && root.hasAttribute('data-scrollblock')) {
+        root.style.overflow = this.previousOverflow;
+        root.style.scrollbarGutter = this.previousScrollbarGutter;
+        root.removeAttribute('data-scrollblock');
       }
 
-      window.scroll(this.previousScrollPosition.left, this.previousScrollPosition.top);
+      this.didBlockDocument = false;
 
-      if (scrollBehaviorSupported) {
-        htmlStyle.scrollBehavior = previousHtmlScrollBehavior;
-        bodyStyle.scrollBehavior = previousBodyScrollBehavior;
+      // Restore scrollable ancestors
+      this.restoreScrollableAncestors();
+      this.isEnabled = false;
+    }
+  }
+
+  private blockScrollableAncestors(element: HTMLElement): void {
+    const ancestors = getOverflowAncestors(element);
+
+    for (const ancestor of ancestors) {
+      // Skip non-HTML elements (Window, VisualViewport) and document-level elements
+      // (document scrolling is handled separately above).
+      if (
+        !(ancestor instanceof HTMLElement) ||
+        ancestor === this.document.documentElement ||
+        ancestor === this.document.body
+      ) {
+        continue;
+      }
+
+      const hasScrollContent =
+        ancestor.scrollHeight > ancestor.clientHeight ||
+        ancestor.scrollWidth > ancestor.clientWidth;
+
+      this.savedAncestorStates.push({
+        element: ancestor,
+        overflow: ancestor.style.overflow,
+        overflowX: ancestor.style.overflowX,
+        overflowY: ancestor.style.overflowY,
+        scrollbarGutter: ancestor.style.scrollbarGutter,
+      });
+
+      ancestor.style.overflow = 'hidden';
+      if (hasScrollContent) {
+        ancestor.style.scrollbarGutter = 'stable';
       }
     }
   }
 
-  private canBeEnabled(): boolean {
-    // Since the scroll strategies can't be singletons, we have to use a global CSS class
-    // (`cdk-global-scrollblock`) to make sure that we don't try to disable global
-    // scrolling multiple times.
-    const html = this.document.documentElement!;
-
-    if (html.classList.contains('cdk-global-scrollblock') || this.isEnabled) {
-      return false;
+  private restoreScrollableAncestors(): void {
+    for (const state of this.savedAncestorStates) {
+      state.element.style.overflow = state.overflow;
+      state.element.style.overflowX = state.overflowX;
+      state.element.style.overflowY = state.overflowY;
+      state.element.style.scrollbarGutter = state.scrollbarGutter;
     }
-
-    const viewport = this.viewportRuler.getViewportSize();
-    return html.scrollHeight > viewport.height || html.scrollWidth > viewport.width;
+    this.savedAncestorStates.length = 0;
   }
 }
 

--- a/packages/ng-primitives/portal/src/shift.ts
+++ b/packages/ng-primitives/portal/src/shift.ts
@@ -1,4 +1,5 @@
 import { coerceNumberProperty } from '@angular/cdk/coercion';
+import { type Boundary, type RootBoundary } from '@floating-ui/dom';
 import { isNil, isObject } from 'ng-primitives/utils';
 
 /**
@@ -24,6 +25,24 @@ export interface NgpShiftOptions {
     fn: (state: unknown) => { x: number; y: number };
     options?: unknown;
   };
+
+  /**
+   * The clipping boundary area of the floating element.
+   * @default 'clippingAncestors'
+   */
+  boundary?: Boundary;
+
+  /**
+   * The root clipping area of the floating element.
+   * @default 'viewport'
+   */
+  rootBoundary?: RootBoundary;
+
+  /**
+   * Whether to also shift along the cross axis to keep the floating element in view.
+   * @default false
+   */
+  crossAxis?: boolean;
 }
 
 /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #455
Closes #689

## What does this PR implement/fix?

### Scroll blocking on ancestor containers (#455)

Rewrites `BlockScrollStrategy` to also block scrolling on ancestor scrollable containers, not just the document. Uses `overflow: hidden` + `scrollbarGutter: stable` instead of the CDK's `position: fixed` approach, which avoids the need to save/restore scroll position and prevents layout shift when the scrollbar disappears. Original inline styles are restored on disable.

### Flip and shift boundary options (#689)

Adds `boundary`, `rootBoundary`, and `crossAxis` options to `NgpFlipOptions` and `NgpShiftOptions`. The `flip` input type changes from `boolean` to `boolean | NgpFlipOptions` on primitives that previously only accepted a boolean (combobox, navigation-menu, popover, select, tooltip). This allows consumers to configure how Floating UI's flip and shift middleware detect overflow boundaries.

Updated documentation for combobox, menu, navigation-menu, popover, select, and tooltip.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No