### PR TITLE
feat(dialog)!: replace CDK overlay with standalone portal

### DIFF
--- a/apps/documentation/src/app/examples/dialog/dialog-data.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-data.example.ts
@@ -112,6 +112,7 @@ export default class DialogDataExample {
       backdrop-filter: blur(4px);
       position: fixed;
       inset: 0;
+      z-index: 1000;
       display: flex;
       justify-content: center;
       align-items: center;

--- a/apps/documentation/src/app/examples/dialog/dialog-data.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-data.tailwind.example.ts
@@ -36,7 +36,7 @@ export default class DialogDataExample {
   imports: [NgpButton, NgpDialog, NgpDialogOverlay, NgpDialogTitle, NgpDialogDescription],
   template: `
     <div
-      class="animate-fade fixed inset-0 z-40 flex items-center justify-center bg-black/50 backdrop-blur-xs"
+      class="animate-fade fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 backdrop-blur-xs"
       ngpDialogOverlay
     >
       <div

--- a/apps/documentation/src/app/examples/dialog/dialog-drawer.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-drawer.example.ts
@@ -67,6 +67,7 @@ import {
       backdrop-filter: blur(4px);
       position: fixed;
       inset: 0;
+      z-index: 1000;
       display: flex;
       justify-content: flex-end;
       align-items: stretch;

--- a/apps/documentation/src/app/examples/dialog/dialog-drawer.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-drawer.tailwind.example.ts
@@ -29,7 +29,7 @@ import {
 
     <ng-template #drawer let-close="close">
       <div
-        class="animate-fade fixed inset-0 flex items-stretch justify-end bg-black/50 backdrop-blur-sm"
+        class="animate-fade fixed inset-0 z-[1000] flex items-stretch justify-end bg-black/50 backdrop-blur-sm"
         ngpDialogOverlay
       >
         <div class="animate-drawer h-full w-80 max-w-full bg-white p-6 dark:bg-zinc-950" ngpDialog>

--- a/apps/documentation/src/app/examples/dialog/dialog.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog.example.ts
@@ -69,6 +69,7 @@ import {
       backdrop-filter: blur(4px);
       position: fixed;
       inset: 0;
+      z-index: 1000;
       display: flex;
       justify-content: center;
       align-items: center;

--- a/apps/documentation/src/app/examples/dialog/dialog.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog.tailwind.example.ts
@@ -29,7 +29,7 @@ import {
 
     <ng-template #dialog let-close="close">
       <div
-        class="animate-fade fixed inset-0 z-40 flex items-center justify-center bg-black/50 backdrop-blur-xs"
+        class="animate-fade fixed inset-0 z-[1000] flex items-center justify-center bg-black/50 backdrop-blur-xs"
         ngpDialogOverlay
       >
         <div

--- a/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
@@ -111,7 +111,7 @@ The following directives are available to import from the `ng-primitives/dialog`
 
 The `NgpDialogManager` can be used as an alternative to the `NgpDialogTrigger` directive for programmatically opening dialogs.
 
-The manager provides a method to open or close all dialogs and accepts a component or template reference to display.
+The manager provides methods to open, close, and query dialogs, and accepts a component or template reference to display.
 
 <prop-details name="open" type="(component: Type | TemplateRef, options?: NgpDialogConfig) => NgpDialogRef">
   Opens a dialog with the specified component or template reference.
@@ -119,6 +119,58 @@ The manager provides a method to open or close all dialogs and accepts a compone
 
 <prop-details name="closeAll" type="() => void">
   Closes all open dialogs.
+</prop-details>
+
+<prop-details name="getDialogById" type="(id: string) => NgpDialogRef | undefined">
+  Finds an open dialog by its ID.
+</prop-details>
+
+<prop-details name="openDialogs" type="readonly NgpDialogRef[]">
+  The list of currently open dialogs.
+</prop-details>
+
+<prop-details name="afterOpened" type="Subject<NgpDialogRef>">
+  Stream that emits when a dialog has been opened.
+</prop-details>
+
+<prop-details name="afterAllClosed" type="Observable<void>">
+  Stream that emits when all open dialogs have finished closing. Emits on subscribe if there are no open dialogs.
+</prop-details>
+
+### NgpDialogRef
+
+Reference returned by `NgpDialogManager.open()`. Provides methods to interact with the opened dialog.
+
+<prop-details name="close" type="(result?: R, focusOrigin?: FocusOrigin) => Promise<void>">
+  Closes the dialog, optionally returning a result value.
+</prop-details>
+
+<prop-details name="afterClosed" type="Observable<R | undefined>">
+  Observable that emits the dialog result when the dialog is closed.
+</prop-details>
+
+<prop-details name="data" type="T">
+  The data passed to the dialog via `NgpDialogConfig.data`.
+</prop-details>
+
+<prop-details name="id" type="string">
+  The unique ID for the dialog.
+</prop-details>
+
+<prop-details name="disableClose" type="boolean | undefined">
+  Whether the user is allowed to close the dialog.
+</prop-details>
+
+<prop-details name="keydownEvents" type="Observable<KeyboardEvent>">
+  Observable that emits keyboard events dispatched within the dialog.
+</prop-details>
+
+<prop-details name="outsidePointerEvents" type="Observable<MouseEvent>">
+  Observable that emits pointer events dispatched outside of the dialog.
+</prop-details>
+
+<prop-details name="updatePosition" type="() => NgpDialogRef">
+  Updates the position of the dialog. Currently a no-op as dialogs are CSS-centered.
 </prop-details>
 
 ## Examples

--- a/packages/ng-primitives/dialog/src/config/dialog-config.ts
+++ b/packages/ng-primitives/dialog/src/config/dialog-config.ts
@@ -1,5 +1,5 @@
-import { ScrollStrategy } from '@angular/cdk/overlay';
 import { InjectionToken, Injector, Provider, ViewContainerRef, inject } from '@angular/core';
+import { ScrollStrategy } from 'ng-primitives/portal';
 
 /** Valid ARIA roles for a dialog. */
 export type NgpDialogRole = 'dialog' | 'alertdialog';
@@ -20,9 +20,6 @@ export interface NgpDialogConfig<T = any> {
   /** Whether this is a modal dialog. Used to set the `aria-modal` attribute. */
   modal?: boolean;
 
-  /** Scroll strategy to be used for the dialog. This determines how the dialog responds to scrolling underneath the panel element. */
-  scrollStrategy?: ScrollStrategy;
-
   /**
    * Whether the dialog should close when the user navigates. This includes both browser history
    * navigation (back/forward) and programmatic route changes (e.g. router.navigate()).
@@ -32,8 +29,11 @@ export interface NgpDialogConfig<T = any> {
   /** Whether the dialog should close when the user presses the escape key. */
   closeOnEscape?: boolean;
 
-  /** Whether the dialog should close when the user click the overlay. */
+  /** Whether the dialog should close when the user clicks the overlay. */
   closeOnClick?: boolean;
+
+  /** Scroll strategy to be used for the dialog. */
+  scrollStrategy?: ScrollStrategy;
 
   data?: T;
 }

--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -48,8 +48,15 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
   /** Emits on keyboard events within the dialog. */
   readonly keydownEvents: Observable<KeyboardEvent>;
 
+  /**
+   * Emits pointer events (click, auxclick, contextmenu) that happen outside of the dialog.
+   * Fed by the NgpOverlayRegistry with CDK-compatible stacking awareness.
+   * @internal
+   */
+  readonly outsidePointerEvents$ = new Subject<MouseEvent>();
+
   /** Emits on pointer events that happen outside of the dialog. */
-  readonly outsidePointerEvents: Observable<MouseEvent>;
+  readonly outsidePointerEvents: Observable<MouseEvent> = this.outsidePointerEvents$.asObservable();
 
   constructor(
     readonly config: NgpDialogConfig<T>,
@@ -69,14 +76,6 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
       );
     });
 
-    this.outsidePointerEvents = defer(() => {
-      const elements = this.getElements();
-      if (!elements.length) return EMPTY;
-      return fromEvent<MouseEvent>(this.document, 'mouseup').pipe(
-        filter(event => !elements.some(el => el.contains(event.target as Node))),
-        takeUntil(this.closed),
-      );
-    });
   }
 
   /**

--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -1,15 +1,21 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { hasModifierKey } from '@angular/cdk/keycodes';
-import { OverlayRef } from '@angular/cdk/overlay';
 import { inject, Injector } from '@angular/core';
 import { NgpExitAnimationManager } from 'ng-primitives/internal';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { NgpOverlayRef } from 'ng-primitives/portal';
+import { defer, EMPTY, fromEvent, Observable, Subject } from 'rxjs';
+import { filter, map, takeUntil } from 'rxjs/operators';
 import { NgpDialogConfig } from '../config/dialog-config';
+
+/** Minimal portal interface needed by the dialog ref. */
+export interface NgpDialogPortalRef {
+  getElements(): HTMLElement[];
+  detach(immediate?: boolean): Promise<void>;
+}
 
 /**
  * Reference to a dialog opened via the Dialog service.
  */
-export class NgpDialogRef<T = unknown, R = unknown> {
+export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
   /** Whether the user is allowed to close the dialog. */
   disableClose: boolean | undefined;
 
@@ -19,11 +25,10 @@ export class NgpDialogRef<T = unknown, R = unknown> {
   /** Emits when the dialog has been closed. */
   readonly closed = new Subject<{ focusOrigin?: FocusOrigin; result?: R }>();
 
-  /** Emits when on keyboard events within the dialog. */
-  readonly keydownEvents: Observable<KeyboardEvent>;
-
-  /** Emits on pointer events that happen outside of the dialog. */
-  readonly outsidePointerEvents: Observable<MouseEvent>;
+  /**
+   * Observable that emits the dialog result when closed.
+   */
+  readonly afterClosed: Observable<R | undefined> = this.closed.pipe(map(event => event.result));
 
   /** Data passed from the dialog opener. */
   readonly data: T;
@@ -31,44 +36,91 @@ export class NgpDialogRef<T = unknown, R = unknown> {
   /** Unique ID for the dialog. */
   readonly id: string;
 
-  /** Subscription to external detachments of the dialog. */
-  private detachSubscription: Subscription;
-
   /** @internal Store the injector */
   injector: Injector | undefined;
 
   /** Whether the dialog is closing. */
   private closing = false;
 
+  /** @internal Portal reference for element access and detach. */
+  portal: NgpDialogPortalRef | null = null;
+
+  /** Emits on keyboard events within the dialog. */
+  readonly keydownEvents: Observable<KeyboardEvent>;
+
+  /** Emits on pointer events that happen outside of the dialog. */
+  readonly outsidePointerEvents: Observable<MouseEvent>;
+
   constructor(
-    readonly overlayRef: OverlayRef,
     readonly config: NgpDialogConfig<T>,
+    private readonly document: Document,
   ) {
     this.data = config.data as T;
-    this.keydownEvents = overlayRef.keydownEvents();
-    this.outsidePointerEvents = overlayRef.outsidePointerEvents();
     this.id = config.id!; // By the time the dialog is created we are guaranteed to have an ID.
     this.closeOnEscape = config.closeOnEscape ?? true;
 
-    this.keydownEvents.subscribe(event => {
-      if (
-        event.key === 'Escape' &&
-        !this.disableClose &&
-        this.closeOnEscape !== false &&
-        !hasModifierKey(event)
-      ) {
-        event.preventDefault();
-        this.close(undefined, 'keyboard');
-      }
+    // Use defer() so the observable is created on subscribe — by then the portal will be set.
+    this.keydownEvents = defer(() => {
+      const elements = this.getElements();
+      if (!elements.length) return EMPTY;
+      return fromEvent<KeyboardEvent>(this.document, 'keydown').pipe(
+        filter(event => elements.some(el => el.contains(event.target as Node))),
+        takeUntil(this.closed),
+      );
     });
 
-    this.detachSubscription = overlayRef.detachments().subscribe(() => this.close());
+    this.outsidePointerEvents = defer(() => {
+      const elements = this.getElements();
+      if (!elements.length) return EMPTY;
+      return fromEvent<MouseEvent>(this.document, 'mouseup').pipe(
+        filter(event => !elements.some(el => el.contains(event.target as Node))),
+        takeUntil(this.closed),
+      );
+    });
+  }
+
+  /**
+   * Updates the position of the dialog. No-op since dialogs are CSS-centered.
+   */
+  updatePosition(): this {
+    return this;
+  }
+
+  /**
+   * NgpOverlayRef implementation — called by the registry for escape-key dismiss.
+   */
+  hide(options?: { immediate?: boolean; origin?: FocusOrigin }): void {
+    if (this.disableClose) {
+      return;
+    }
+    this.close(undefined, options?.origin);
+  }
+
+  /**
+   * NgpOverlayRef implementation — called by the registry for descendant cascade.
+   * Skips exit animations and tears down immediately.
+   */
+  async hideImmediate(): Promise<void> {
+    if (this.disableClose || this.closing) {
+      return;
+    }
+
+    this.closing = true;
+
+    // Detach the portal immediately — no exit animation
+    if (this.portal) {
+      await this.portal.detach(true);
+      this.portal = null;
+    }
+
+    this.closed.next({});
+    this.closed.complete();
   }
 
   /**
    * Close the dialog.
    * @param result Optional result to return to the dialog opener.
-   * @param options Additional options to customize the closing behavior.
+   * @param focusOrigin The origin of the focus event that triggered the close.
    */
   async close(result?: R, focusOrigin?: FocusOrigin): Promise<void> {
     // If the dialog is already closed, do nothing.
@@ -85,16 +137,44 @@ export class NgpDialogRef<T = unknown, R = unknown> {
       await exitAnimationManager.exit();
     }
 
-    this.overlayRef.dispose();
-    this.detachSubscription.unsubscribe();
+    // Detach the portal (immediate since exit animation already ran)
+    if (this.portal) {
+      await this.portal.detach(true);
+      this.portal = null;
+    }
+
     this.closed.next({ focusOrigin, result });
     this.closed.complete();
   }
 
-  /** Updates the position of the dialog based on the current position strategy. */
-  updatePosition(): this {
-    this.overlayRef.updatePosition();
-    return this;
+  /**
+   * @deprecated Access dialog methods directly instead (keydownEvents, outsidePointerEvents,
+   * updatePosition, close). This shim will be removed in the next major version.
+   */
+  get overlayRef(): {
+    keydownEvents: () => Observable<KeyboardEvent>;
+    outsidePointerEvents: () => Observable<MouseEvent>;
+    updatePosition: () => NgpDialogRef<T, R>;
+    dispose: () => Promise<void>;
+    detachments: () => Observable<{ focusOrigin?: FocusOrigin; result?: R }>;
+    overlayElement: HTMLElement | undefined;
+  } {
+    return {
+      keydownEvents: () => this.keydownEvents,
+      outsidePointerEvents: () => this.outsidePointerEvents,
+      updatePosition: () => this.updatePosition(),
+      dispose: () => this.close(),
+      detachments: () => this.closed.asObservable(),
+      overlayElement: this.getElements()[0] as HTMLElement | undefined,
+    };
+  }
+
+  /**
+   * Get the portal elements.
+   * @internal
+   */
+  getElements(): HTMLElement[] {
+    return this.portal?.getElements() ?? [];
   }
 }
 

--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -75,7 +75,6 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
         takeUntil(this.closed),
       );
     });
-
   }
 
   /**

--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -101,7 +101,7 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
    * Skips exit animations and tears down immediately.
    */
   async hideImmediate(): Promise<void> {
-    if (this.disableClose || this.closing) {
+    if (this.closing) {
       return;
     }
 

--- a/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
@@ -319,7 +319,8 @@ export class NgpDialogManager implements OnDestroy {
    */
   private enableScrollBlocking(config?: NgpDialogConfig): void {
     if (!this.scrollStrategy) {
-      this.scrollStrategy = config?.scrollStrategy ?? new BlockScrollStrategy(this.viewportRuler, this.document);
+      this.scrollStrategy =
+        config?.scrollStrategy ?? new BlockScrollStrategy(this.viewportRuler, this.document);
     }
     this.scrollStrategy.enable();
   }

--- a/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
@@ -1,4 +1,5 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
+import { ViewportRuler } from '@angular/cdk/scrolling';
 import { DOCUMENT } from '@angular/common';
 import {
   ApplicationRef,
@@ -39,6 +40,7 @@ export class NgpDialogManager implements OnDestroy {
   private readonly injector = inject(Injector);
   private readonly document = inject<Document>(DOCUMENT);
   private readonly focusMonitor = inject(FocusMonitor);
+  private readonly viewportRuler = inject(ViewportRuler);
   private readonly registry = inject(NgpOverlayRegistry);
   private readonly defaultOptions = injectDialogConfig();
   private readonly parentDialogManager = inject(NgpDialogManager, {
@@ -317,7 +319,7 @@ export class NgpDialogManager implements OnDestroy {
    */
   private enableScrollBlocking(config?: NgpDialogConfig): void {
     if (!this.scrollStrategy) {
-      this.scrollStrategy = config?.scrollStrategy ?? new BlockScrollStrategy(this.document);
+      this.scrollStrategy = config?.scrollStrategy ?? new BlockScrollStrategy(this.viewportRuler, this.document);
     }
     this.scrollStrategy.enable();
   }

--- a/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
@@ -327,6 +327,7 @@ export class NgpDialogManager implements OnDestroy {
    */
   private disableScrollBlocking(): void {
     this.scrollStrategy?.disable();
+    this.scrollStrategy = null;
   }
 
   /**

--- a/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
@@ -182,6 +182,7 @@ export class NgpDialogManager implements OnDestroy {
         outsidePress: false,
         escapeKey: config.closeOnEscape ?? true,
       },
+      outsidePointerEvents$: dialogRef.outsidePointerEvents$,
     });
 
     (this.openDialogs as NgpDialogRef[]).push(dialogRef as NgpDialogRef<any, any>);

--- a/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
@@ -1,6 +1,4 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
-import { Overlay, OverlayConfig, OverlayContainer, ScrollStrategy } from '@angular/cdk/overlay';
-import { ComponentPortal, TemplatePortal } from '@angular/cdk/portal';
 import { DOCUMENT } from '@angular/common';
 import {
   ApplicationRef,
@@ -16,6 +14,12 @@ import {
 } from '@angular/core';
 import { NavigationStart, Router } from '@angular/router';
 import { NgpExitAnimationManager } from 'ng-primitives/internal';
+import {
+  BlockScrollStrategy,
+  NgpOverlayRegistry,
+  ScrollStrategy,
+  createPortal,
+} from 'ng-primitives/portal';
 import { uniqueId } from 'ng-primitives/utils';
 import { Observable, Subject, Subscription, defer } from 'rxjs';
 import { startWith } from 'rxjs/operators';
@@ -23,8 +27,8 @@ import { NgpDialogConfig, injectDialogConfig } from '../config/dialog-config';
 import { NgpDialogRef } from './dialog-ref';
 
 /**
- * This is based on the Angular CDK Dialog service.
- * https://github.com/angular/components/blob/main/src/cdk/dialog/dialog.ts
+ * Originally based on Angular CDK Dialog service.
+ * Re-implemented to use ng-primitives/portal instead of @angular/cdk/overlay.
  */
 
 @Injectable({
@@ -32,24 +36,25 @@ import { NgpDialogRef } from './dialog-ref';
 })
 export class NgpDialogManager implements OnDestroy {
   private readonly applicationRef = inject(ApplicationRef);
+  private readonly injector = inject(Injector);
   private readonly document = inject<Document>(DOCUMENT);
-  private readonly overlay = inject(Overlay);
   private readonly focusMonitor = inject(FocusMonitor);
+  private readonly registry = inject(NgpOverlayRegistry);
   private readonly defaultOptions = injectDialogConfig();
   private readonly parentDialogManager = inject(NgpDialogManager, {
     optional: true,
     skipSelf: true,
   });
-  private readonly overlayContainer = inject(OverlayContainer);
   private readonly router = inject(Router, { optional: true });
-  private readonly scrollStrategy: ScrollStrategy =
-    this.defaultOptions.scrollStrategy ?? this.overlay.scrollStrategies.block();
 
   private openDialogsAtThisLevel: NgpDialogRef[] = [];
   private readonly afterAllClosedAtThisLevel = new Subject<void>();
   private readonly afterOpenedAtThisLevel = new Subject<NgpDialogRef>();
   private ariaHiddenElements = new Map<Element, string | null>();
   private routerSubscription: Subscription | undefined;
+
+  /** Scroll blocking strategy — shared across all dialogs. */
+  private scrollStrategy: ScrollStrategy | null = null;
 
   /** Keeps track of the currently-open dialogs. */
   get openDialogs(): readonly NgpDialogRef[] {
@@ -123,10 +128,8 @@ export class NgpDialogManager implements OnDestroy {
       throw Error(`Dialog with id "${config.id}" exists already. The dialog id must be unique.`);
     }
 
-    const overlayConfig = this.getOverlayConfig(config);
-    const overlayRef = this.overlay.create(overlayConfig);
-    const dialogRef = new NgpDialogRef(overlayRef, config);
-    const injector = this.createInjector(config, dialogRef, undefined);
+    const dialogRef = new NgpDialogRef(config, this.document);
+    const injector = this.createInjector(config, dialogRef);
 
     // store the injector in the dialog ref - this is so we can access the exit animation manager
     dialogRef.injector = injector;
@@ -136,26 +139,56 @@ export class NgpDialogManager implements OnDestroy {
       close: dialogRef.close.bind(dialogRef),
     };
 
-    if (templateRefOrComponentType instanceof TemplateRef) {
-      overlayRef.attach(
-        new TemplatePortal(templateRefOrComponentType, config.viewContainerRef!, context, injector),
-      );
-    } else {
-      overlayRef.attach(
-        new ComponentPortal(templateRefOrComponentType, config.viewContainerRef!, injector),
-      );
+    // Create the portal using our portal system
+    const portal = createPortal(
+      templateRefOrComponentType,
+      config.viewContainerRef!,
+      injector,
+      context,
+    );
+
+    // Attach the portal to document.body
+    portal.attach(this.document.body);
+
+    // Store the portal reference on the dialog ref for element access and cleanup
+    dialogRef.portal = portal;
+
+    // If this is the first dialog that we're opening, hide all the non-overlay content
+    // and enable scroll blocking.
+    if (!this.openDialogs.length) {
+      this.hideNonDialogContentFromAssistiveTechnology(portal.getElements());
+      this.enableScrollBlocking(config);
     }
 
-    // If this is the first dialog that we're opening, hide all the non-overlay content.
-    if (!this.openDialogs.length) {
-      this.hideNonDialogContentFromAssistiveTechnology();
-    }
+    // Auto-detect parent overlay: if the trigger element lives inside an existing overlay
+    // (e.g. a dialog opened from a popover), register as its child so that clicks inside
+    // the dialog don't dismiss the parent overlay.
+    const parentId =
+      activeElement instanceof HTMLElement
+        ? this.registry.findContainingOverlay(activeElement)
+        : null;
+
+    // Register with the overlay registry for centralized escape-key routing.
+    // outsidePress is false because the NgpDialogOverlay directive handles its own backdrop clicks.
+    this.registry.register({
+      id: dialogRef.id,
+      parentId,
+      overlay: dialogRef,
+      getElements: () => dialogRef.getElements(),
+      triggerElement: (activeElement as HTMLElement) ?? this.document.body,
+      dismissPolicy: {
+        outsidePress: false,
+        escapeKey: config.closeOnEscape ?? true,
+      },
+    });
 
     (this.openDialogs as NgpDialogRef[]).push(dialogRef as NgpDialogRef<any, any>);
     this.afterOpened.next(dialogRef as NgpDialogRef<any, any>);
     this.subscribeToRouterEvents();
 
     dialogRef.closed.subscribe(closeResult => {
+      // Deregister from the overlay registry
+      this.registry.deregister(dialogRef.id);
       this.removeOpenDialog(dialogRef as NgpDialogRef<any, any>, true);
       // Focus the trigger element after the dialog closes.
       if (activeElement instanceof HTMLElement && this.document.body.contains(activeElement)) {
@@ -188,8 +221,8 @@ export class NgpDialogManager implements OnDestroy {
 
   /**
    * Subscribe to router navigation events so that dialogs with `closeOnNavigation`
-   * are closed when the user navigates programmatically (e.g. router.navigate()).
-   * CDK's `disposeOnNavigation` only handles browser popstate events.
+   * are closed when the user navigates. This handles both browser popstate events
+   * and programmatic route changes (e.g. router.navigate()).
    */
   private subscribeToRouterEvents(): void {
     if (this.routerSubscription || !this.router) {
@@ -231,31 +264,12 @@ export class NgpDialogManager implements OnDestroy {
   }
 
   /**
-   * Creates an overlay config from a dialog config.
-   */
-  private getOverlayConfig(config: NgpDialogConfig): OverlayConfig {
-    const state = new OverlayConfig({
-      positionStrategy: this.overlay.position().global().centerHorizontally().centerVertically(),
-      scrollStrategy: config.scrollStrategy || this.scrollStrategy,
-      hasBackdrop: false,
-      disposeOnNavigation: config.closeOnNavigation,
-      // required for v21 - the CDK launches overlays using the popover api which means any other overlays
-      // such as select dropdowns, or tooltips will appear behind the dialog, regardless of z-index
-      // this disables the use of popovers
-      usePopover: false,
-    } as any);
-
-    return state;
-  }
-
-  /**
    * Creates a custom injector to be used inside the dialog. This allows a component loaded inside
    * of a dialog to close itself and, optionally, to return a value.
    */
   private createInjector<T, R>(
     config: NgpDialogConfig<T>,
     dialogRef: NgpDialogRef<T, R>,
-    fallbackInjector: Injector | undefined,
   ): Injector {
     const userInjector = config.injector || config.viewContainerRef?.injector;
     const providers: StaticProvider[] = [
@@ -263,7 +277,9 @@ export class NgpDialogManager implements OnDestroy {
       { provide: NgpExitAnimationManager, useClass: NgpExitAnimationManager },
     ];
 
-    return Injector.create({ parent: userInjector || fallbackInjector, providers });
+    // Fall back to the service's own injector (root injector) to ensure
+    // ApplicationRef and other platform providers are available.
+    return Injector.create({ parent: userInjector || this.injector, providers });
   }
 
   /**
@@ -287,6 +303,7 @@ export class NgpDialogManager implements OnDestroy {
         });
 
         this.ariaHiddenElements.clear();
+        this.disableScrollBlocking();
 
         if (emitEvent) {
           this.getAfterAllClosed().next();
@@ -295,26 +312,41 @@ export class NgpDialogManager implements OnDestroy {
     }
   }
 
-  /** Hides all of the content that isn't an overlay from assistive technology. */
-  private hideNonDialogContentFromAssistiveTechnology() {
-    const overlayContainer = this.overlayContainer.getContainerElement();
+  /**
+   * Enable scroll blocking when the first dialog opens.
+   */
+  private enableScrollBlocking(config?: NgpDialogConfig): void {
+    if (!this.scrollStrategy) {
+      this.scrollStrategy = config?.scrollStrategy ?? new BlockScrollStrategy(this.document);
+    }
+    this.scrollStrategy.enable();
+  }
 
-    // Ensure that the overlay container is attached to the DOM.
-    if (overlayContainer.parentElement) {
-      const siblings = overlayContainer.parentElement.children;
+  /**
+   * Disable scroll blocking when the last dialog closes.
+   */
+  private disableScrollBlocking(): void {
+    this.scrollStrategy?.disable();
+  }
 
-      for (let i = siblings.length - 1; i > -1; i--) {
-        const sibling = siblings[i];
+  /**
+   * Hides all of the content that isn't a dialog portal from assistive technology.
+   */
+  private hideNonDialogContentFromAssistiveTechnology(portalElements: HTMLElement[]) {
+    const body = this.document.body;
+    const bodyChildren = body.children;
 
-        if (
-          sibling !== overlayContainer &&
-          sibling.nodeName !== 'SCRIPT' &&
-          sibling.nodeName !== 'STYLE' &&
-          !sibling.hasAttribute('aria-live')
-        ) {
-          this.ariaHiddenElements.set(sibling, sibling.getAttribute('aria-hidden'));
-          sibling.setAttribute('aria-hidden', 'true');
-        }
+    for (let i = bodyChildren.length - 1; i > -1; i--) {
+      const sibling = bodyChildren[i];
+
+      if (
+        !portalElements.includes(sibling as HTMLElement) &&
+        sibling.nodeName !== 'SCRIPT' &&
+        sibling.nodeName !== 'STYLE' &&
+        !sibling.hasAttribute('aria-live')
+      ) {
+        this.ariaHiddenElements.set(sibling, sibling.getAttribute('aria-hidden'));
+        sibling.setAttribute('aria-hidden', 'true');
       }
     }
   }

--- a/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
@@ -131,14 +131,13 @@ describe('NgpDialog', () => {
     expect(closedSpy).not.toHaveBeenCalled();
   }));
 
-  it('should close dialog on Escape key via overlay keydown events', fakeAsync(() => {
+  it('should close dialog on Escape key via registry', fakeAsync(() => {
     const { ref } = openDialog();
     const closedSpy = jest.fn();
     ref.closed.subscribe(closedSpy);
 
-    // The CDK overlay captures keydown events on the overlay host element
-    const overlayHost = ref.overlayRef.overlayElement;
-    overlayHost.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    // The registry captures keydown events on the document
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     flush();
 
     expect(closedSpy).toHaveBeenCalled();
@@ -149,8 +148,7 @@ describe('NgpDialog', () => {
     const closedSpy = jest.fn();
     ref.closed.subscribe(closedSpy);
 
-    const overlayHost = ref.overlayRef.overlayElement;
-    overlayHost.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     flush();
 
     expect(closedSpy).not.toHaveBeenCalled();

--- a/packages/ng-primitives/portal/src/index.ts
+++ b/packages/ng-primitives/portal/src/index.ts
@@ -10,6 +10,13 @@ export {
 } from './overlay';
 export { NgpOverlayCooldownManager } from './overlay-cooldown';
 export {
+  NgpDismissGuard,
+  NgpDismissPolicy,
+  NgpOverlayEntry,
+  NgpOverlayRef,
+  NgpOverlayRegistry,
+} from './overlay-registry';
+export {
   injectOverlayArrowState,
   NgpOverlayArrowProps,
   NgpOverlayArrowState,

--- a/packages/ng-primitives/portal/src/overlay-registry.ts
+++ b/packages/ng-primitives/portal/src/overlay-registry.ts
@@ -1,0 +1,332 @@
+import { FocusOrigin } from '@angular/cdk/a11y';
+import { DOCUMENT } from '@angular/common';
+import { inject, Injectable, NgZone } from '@angular/core';
+
+/**
+ * A dismiss guard can be a boolean or a callback that returns a boolean (sync or async).
+ * - `true` → always dismiss
+ * - `false` → never dismiss
+ * - `(target) => boolean | Promise<boolean>` → custom logic per interaction
+ */
+export type NgpDismissGuard<T = Element> = boolean | ((target: T) => boolean | Promise<boolean>);
+
+/**
+ * Dismiss policy for an overlay entry.
+ * Determines how the overlay responds to outside clicks and escape key presses.
+ * @internal
+ */
+export interface NgpDismissPolicy {
+  /** Whether clicking outside should close this overlay, or a guard function */
+  outsidePress: NgpDismissGuard<Element>;
+  /** Whether pressing Escape should close this overlay, or a guard function */
+  escapeKey: NgpDismissGuard<KeyboardEvent>;
+}
+
+/**
+ * An entry in the overlay registry representing a single visible overlay.
+ * @internal
+ */
+export interface NgpOverlayEntry {
+  /** Unique overlay ID */
+  id: string;
+  /** Parent overlay ID, null for root overlays */
+  parentId: string | null;
+  /** Reference to the overlay instance for calling hide()/hideImmediate() */
+  overlay: NgpOverlayRef;
+  /** Function that returns the portal DOM elements */
+  getElements: () => HTMLElement[];
+  /** The trigger element */
+  triggerElement: HTMLElement;
+  /** Optional anchor element */
+  anchorElement?: HTMLElement | null;
+  /** Per-instance dismiss configuration */
+  dismissPolicy: NgpDismissPolicy;
+}
+
+/**
+ * Minimal overlay reference needed by the registry.
+ * This avoids a circular dependency with NgpOverlay.
+ * @internal
+ */
+export interface NgpOverlayRef {
+  hide(options?: { immediate?: boolean; origin?: FocusOrigin }): void;
+  hideImmediate(): void;
+}
+
+/**
+ * Singleton registry that tracks all visible overlays in open order and
+ * provides centralized dismiss routing (outside-click and escape-key).
+ *
+ * Document listeners are attached when the first overlay registers and
+ * detached when the last deregisters, avoiding permanent global listeners.
+ * @internal
+ */
+@Injectable({ providedIn: 'root' })
+export class NgpOverlayRegistry {
+  private readonly document = inject(DOCUMENT);
+  private readonly ngZone = inject(NgZone);
+
+  /** Ordered list of visible overlay entries (oldest first, newest/topmost last) */
+  private readonly entries: NgpOverlayEntry[] = [];
+
+  /** Set of overlay IDs currently evaluating an async dismiss guard */
+  private readonly pendingGuardIds = new Set<string>();
+
+  /** Cleanup functions for the centralized document listeners */
+  private removeOutsideClickListener?: () => void;
+  private removeEscapeKeyListener?: () => void;
+
+  /**
+   * Register an overlay as visible. The entry is appended to the end of the list
+   * (making it the topmost overlay). Attaches document listeners if this is the
+   * first entry.
+   */
+  register(entry: NgpOverlayEntry): void {
+    // Avoid double-registration
+    if (this.entries.some(e => e.id === entry.id)) {
+      return;
+    }
+    this.entries.push(entry);
+
+    // Attach listeners when the first overlay registers
+    if (this.entries.length === 1) {
+      this.attachListeners();
+    }
+  }
+
+  /**
+   * Remove an overlay from the registry.
+   * Detaches document listeners if no entries remain.
+   */
+  deregister(id: string): void {
+    const index = this.entries.findIndex(e => e.id === id);
+    if (index !== -1) {
+      this.entries.splice(index, 1);
+      this.pendingGuardIds.delete(id);
+    }
+
+    // Detach listeners when the last overlay deregisters
+    if (this.entries.length === 0) {
+      this.detachListeners();
+    }
+  }
+
+  /**
+   * Close all descendants of the given overlay.
+   * Called by NgpOverlay when it hides to cascade the close to children.
+   */
+  closeDescendants(id: string): void {
+    const descendants = this.getDescendants(id);
+    // Close deepest first to avoid re-entrant issues
+    for (let i = descendants.length - 1; i >= 0; i--) {
+      descendants[i].overlay.hideImmediate();
+    }
+  }
+
+  /**
+   * Get all registered entries.
+   */
+  getEntries(): readonly NgpOverlayEntry[] {
+    return this.entries;
+  }
+
+  /**
+   * Get the topmost (most recently opened) overlay entry, or null if none.
+   */
+  getTopmost(): NgpOverlayEntry | null {
+    return this.entries.length > 0 ? this.entries[this.entries.length - 1] : null;
+  }
+
+  /**
+   * Find the overlay whose elements contain the given DOM element.
+   * Returns the ID of the most recently opened (topmost) containing overlay, or null.
+   */
+  findContainingOverlay(element: HTMLElement): string | null {
+    // Walk from topmost to oldest so we find the nearest containing overlay
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      const entry = this.entries[i];
+      const elements = entry.getElements();
+      if (elements.some(el => el.contains(element))) {
+        return entry.id;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Check whether overlay `ancestorId` is an ancestor of overlay `descendantId`
+   * by walking the parentId chain.
+   */
+  isAncestorOf(ancestorId: string, descendantId: string): boolean {
+    let currentId: string | null = descendantId;
+
+    while (currentId !== null) {
+      const entry = this.entries.find(e => e.id === currentId);
+      if (!entry) {
+        return false;
+      }
+      if (entry.parentId === ancestorId) {
+        return true;
+      }
+      currentId = entry.parentId;
+    }
+
+    return false;
+  }
+
+  /**
+   * Get all descendants of the given overlay (children, grandchildren, etc.)
+   * by walking parentId chains of all entries.
+   */
+  getDescendants(id: string): NgpOverlayEntry[] {
+    const descendants: NgpOverlayEntry[] = [];
+    const ancestorIds = new Set<string>([id]);
+
+    // Walk the list and collect entries whose parentId is in the ancestor set.
+    // Because entries are ordered by open time, a child always appears after its parent.
+    for (const entry of this.entries) {
+      if (entry.parentId !== null && ancestorIds.has(entry.parentId)) {
+        descendants.push(entry);
+        ancestorIds.add(entry.id);
+      }
+    }
+
+    return descendants;
+  }
+
+  /**
+   * Attach centralized document listeners for outside-click and escape-key.
+   * Runs outside Angular zone to avoid unnecessary change detection on every
+   * mouse/keyboard event.
+   */
+  private attachListeners(): void {
+    this.ngZone.runOutsideAngular(() => {
+      const onMouseUp = (event: MouseEvent) => this.handleOutsideClick(event);
+      const onKeyDown = (event: KeyboardEvent) => this.handleEscapeKey(event);
+
+      this.document.addEventListener('mouseup', onMouseUp, true);
+      this.document.addEventListener('keydown', onKeyDown, true);
+
+      this.removeOutsideClickListener = () =>
+        this.document.removeEventListener('mouseup', onMouseUp, true);
+      this.removeEscapeKeyListener = () =>
+        this.document.removeEventListener('keydown', onKeyDown, true);
+    });
+  }
+
+  /**
+   * Detach centralized document listeners.
+   */
+  private detachListeners(): void {
+    this.removeOutsideClickListener?.();
+    this.removeOutsideClickListener = undefined;
+    this.removeEscapeKeyListener?.();
+    this.removeEscapeKeyListener = undefined;
+  }
+
+  /**
+   * Outside-click dismiss: only the topmost overlay responds.
+   */
+  private handleOutsideClick(event: MouseEvent): void {
+    const topmost = this.getTopmost();
+    if (!topmost || this.pendingGuardIds.has(topmost.id)) {
+      return;
+    }
+
+    // Ignore scrollbar clicks — the click lands outside the viewport's client area.
+    const { clientWidth, clientHeight } = this.document.documentElement;
+    if (
+      clientWidth > 0 &&
+      clientHeight > 0 &&
+      (event.clientX >= clientWidth || event.clientY >= clientHeight)
+    ) {
+      return;
+    }
+
+    // Check if the click is inside the topmost overlay
+    const path = event.composedPath();
+    const isInsideElements = topmost.getElements().some(el => path.includes(el));
+    const isInsideTrigger = path.includes(topmost.triggerElement);
+    const isInsideAnchor = topmost.anchorElement ? path.includes(topmost.anchorElement) : false;
+
+    if (isInsideElements || isInsideTrigger || isInsideAnchor) {
+      return;
+    }
+
+    // Derive a proper Element from the composed path
+    const target =
+      (path.find((node): node is Element => node instanceof Element) as Element) ??
+      this.document.documentElement;
+    this.evaluateGuardAndDismiss(topmost.id, topmost.dismissPolicy.outsidePress, target, () =>
+      this.ngZone.run(() => topmost.overlay.hide()),
+    );
+  }
+
+  /**
+   * Escape-key dismiss: only the topmost overlay responds.
+   */
+  private handleEscapeKey(event: KeyboardEvent): void {
+    if (event.key !== 'Escape' || event.isComposing) {
+      return;
+    }
+
+    const topmost = this.getTopmost();
+    if (!topmost || this.pendingGuardIds.has(topmost.id)) {
+      return;
+    }
+
+    this.evaluateGuardAndDismiss(topmost.id, topmost.dismissPolicy.escapeKey, event, () =>
+      this.ngZone.run(() => topmost.overlay.hide({ origin: 'keyboard', immediate: true })),
+    );
+  }
+
+  /**
+   * Evaluate a dismiss guard and call the dismiss function if allowed.
+   * Supports boolean values and sync/async guard functions.
+   */
+  private evaluateGuardAndDismiss<T>(
+    overlayId: string,
+    guard: NgpDismissGuard<T>,
+    target: T,
+    dismiss: () => void,
+  ): void {
+    if (guard === true || guard === undefined) {
+      dismiss();
+      return;
+    }
+
+    if (guard === false) {
+      return;
+    }
+
+    // Function guard → evaluate
+    let result: boolean | Promise<boolean>;
+    try {
+      result = guard(target);
+    } catch (error) {
+      console.error('NgpOverlayRegistry: dismiss guard threw', error);
+      return;
+    }
+
+    if (typeof result === 'boolean') {
+      if (result) {
+        dismiss();
+      }
+    } else {
+      // Promise — track as pending to prevent re-triggering
+      this.pendingGuardIds.add(overlayId);
+      result
+        .then(shouldDismiss => {
+          if (shouldDismiss) {
+            dismiss();
+          }
+        })
+        .catch(error => {
+          console.error('NgpOverlayRegistry: dismiss guard rejected', error);
+        })
+        .finally(() => {
+          this.pendingGuardIds.delete(overlayId);
+        });
+    }
+  }
+}

--- a/packages/ng-primitives/portal/src/overlay-registry.ts
+++ b/packages/ng-primitives/portal/src/overlay-registry.ts
@@ -226,8 +226,7 @@ export class NgpOverlayRegistry {
         this.pointerDownTarget = this.getComposedTarget(event);
       };
 
-      const onPointerEvent = (event: MouseEvent) =>
-        this.handleOutsidePointerEvent(event);
+      const onPointerEvent = (event: MouseEvent) => this.handleOutsidePointerEvent(event);
 
       this.document.addEventListener('pointerdown', onPointerDown, true);
       this.document.addEventListener('click', onPointerEvent, true);
@@ -335,10 +334,7 @@ export class NgpOverlayRegistry {
       }
 
       const elements = entry.getElements();
-      if (
-        this.containsElement(elements, target) ||
-        this.containsElement(elements, origin)
-      ) {
+      if (this.containsElement(elements, target) || this.containsElement(elements, origin)) {
         break;
       }
 
@@ -356,10 +352,7 @@ export class NgpOverlayRegistry {
   /**
    * Check whether any of the given elements contain the target, piercing shadow DOM.
    */
-  private containsElement(
-    elements: HTMLElement[],
-    target: EventTarget | null,
-  ): boolean {
+  private containsElement(elements: HTMLElement[], target: EventTarget | null): boolean {
     if (!target || !(target instanceof Node)) {
       return false;
     }

--- a/packages/ng-primitives/portal/src/overlay-registry.ts
+++ b/packages/ng-primitives/portal/src/overlay-registry.ts
@@ -1,6 +1,7 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { DOCUMENT } from '@angular/common';
 import { inject, Injectable, NgZone } from '@angular/core';
+import { Subject } from 'rxjs';
 
 /**
  * A dismiss guard can be a boolean or a callback that returns a boolean (sync or async).
@@ -41,6 +42,8 @@ export interface NgpOverlayEntry {
   anchorElement?: HTMLElement | null;
   /** Per-instance dismiss configuration */
   dismissPolicy: NgpDismissPolicy;
+  /** Optional subject that receives pointer events that occur outside the overlay */
+  outsidePointerEvents$?: Subject<MouseEvent>;
 }
 
 /**
@@ -75,6 +78,10 @@ export class NgpOverlayRegistry {
   /** Cleanup functions for the centralized document listeners */
   private removeOutsideClickListener?: () => void;
   private removeEscapeKeyListener?: () => void;
+  private removeOutsidePointerListeners?: () => void;
+
+  /** Tracks the pointerdown target for CDK-compatible outside pointer event dispatch */
+  private pointerDownTarget: EventTarget | null = null;
 
   /**
    * Register an overlay as visible. The entry is appended to the end of the list
@@ -211,6 +218,28 @@ export class NgpOverlayRegistry {
         this.document.removeEventListener('mouseup', onMouseUp, true);
       this.removeEscapeKeyListener = () =>
         this.document.removeEventListener('keydown', onKeyDown, true);
+
+      // CDK-compatible outside pointer event dispatch:
+      // Track pointerdown origin, then emit click/auxclick/contextmenu events
+      // to entries that have an outsidePointerEvents$ subject.
+      const onPointerDown = (event: PointerEvent) => {
+        this.pointerDownTarget = this.getComposedTarget(event);
+      };
+
+      const onPointerEvent = (event: MouseEvent) =>
+        this.handleOutsidePointerEvent(event);
+
+      this.document.addEventListener('pointerdown', onPointerDown, true);
+      this.document.addEventListener('click', onPointerEvent, true);
+      this.document.addEventListener('auxclick', onPointerEvent, true);
+      this.document.addEventListener('contextmenu', onPointerEvent, true);
+
+      this.removeOutsidePointerListeners = () => {
+        this.document.removeEventListener('pointerdown', onPointerDown, true);
+        this.document.removeEventListener('click', onPointerEvent, true);
+        this.document.removeEventListener('auxclick', onPointerEvent, true);
+        this.document.removeEventListener('contextmenu', onPointerEvent, true);
+      };
     });
   }
 
@@ -222,6 +251,9 @@ export class NgpOverlayRegistry {
     this.removeOutsideClickListener = undefined;
     this.removeEscapeKeyListener?.();
     this.removeEscapeKeyListener = undefined;
+    this.removeOutsidePointerListeners?.();
+    this.removeOutsidePointerListeners = undefined;
+    this.pointerDownTarget = null;
   }
 
   /**
@@ -278,6 +310,70 @@ export class NgpOverlayRegistry {
     this.evaluateGuardAndDismiss(topmost.id, topmost.dismissPolicy.escapeKey, event, () =>
       this.ngZone.run(() => topmost.overlay.hide({ origin: 'keyboard', immediate: true })),
     );
+  }
+
+  /**
+   * CDK-compatible outside pointer event dispatch.
+   * Iterates overlays from topmost to oldest (like CDK's OverlayOutsideClickDispatcher).
+   * For each overlay with an outsidePointerEvents$ subject, emits the event if the
+   * click was outside its elements. Stops iterating when an overlay contains the click.
+   */
+  private handleOutsidePointerEvent(event: MouseEvent): void {
+    const target = this.getComposedTarget(event);
+    // For click events, use the pointerdown origin to handle drag scenarios
+    const origin =
+      event.type === 'click' && this.pointerDownTarget ? this.pointerDownTarget : target;
+    this.pointerDownTarget = null;
+
+    // Iterate from topmost to oldest (like CDK)
+    const overlays = this.entries.slice();
+    for (let i = overlays.length - 1; i >= 0; i--) {
+      const entry = overlays[i];
+
+      if (!entry.outsidePointerEvents$?.observers.length) {
+        continue;
+      }
+
+      const elements = entry.getElements();
+      if (
+        this.containsElement(elements, target) ||
+        this.containsElement(elements, origin)
+      ) {
+        break;
+      }
+
+      this.ngZone.run(() => entry.outsidePointerEvents$!.next(event));
+    }
+  }
+
+  /**
+   * Get the composed event target, piercing shadow DOM boundaries.
+   */
+  private getComposedTarget(event: Event): EventTarget | null {
+    return event.composedPath?.()?.[0] ?? event.target;
+  }
+
+  /**
+   * Check whether any of the given elements contain the target, piercing shadow DOM.
+   */
+  private containsElement(
+    elements: HTMLElement[],
+    target: EventTarget | null,
+  ): boolean {
+    if (!target || !(target instanceof Node)) {
+      return false;
+    }
+    return elements.some(el => {
+      let current: Node | null = target;
+      while (current) {
+        if (current === el) return true;
+        current =
+          typeof ShadowRoot !== 'undefined' && current instanceof ShadowRoot
+            ? current.host
+            : current.parentNode;
+      }
+      return false;
+    });
   }
 
   /**

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -1,4 +1,5 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
+import { ViewportRuler } from '@angular/cdk/scrolling';
 import { DOCUMENT } from '@angular/common';
 import {
   DestroyRef,
@@ -225,6 +226,7 @@ export type NgpOverlayTemplateContext<T> = {
 export class NgpOverlay<T = unknown> implements CooldownOverlay {
   private readonly disposables = injectDisposables();
   private readonly document = inject(DOCUMENT);
+  private readonly viewportRuler = inject(ViewportRuler);
   private readonly destroyRef = inject(DestroyRef);
   private readonly viewContainerRef: ViewContainerRef;
   private readonly focusMonitor = inject(FocusMonitor);
@@ -769,7 +771,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   private createScrollStrategy(): ScrollStrategy {
     switch (this.config.scrollBehaviour) {
       case 'block':
-        return new BlockScrollStrategy(this.document);
+        return new BlockScrollStrategy(this.viewportRuler, this.document);
       case 'close':
         return new CloseScrollStrategy(
           this.config.anchorElement || this.config.triggerElement,

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -1,5 +1,4 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { ViewportRuler } from '@angular/cdk/overlay';
 import { DOCUMENT } from '@angular/common';
 import {
   DestroyRef,
@@ -30,11 +29,11 @@ import {
 } from '@floating-ui/dom';
 import { explicitEffect, fromResizeEvent } from 'ng-primitives/internal';
 import { injectDisposables, safeTakeUntilDestroyed, uniqueId } from 'ng-primitives/utils';
-import { Subject, fromEvent } from 'rxjs';
-import { debounceTime } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 import { NgpFlip } from './flip';
 import { NgpOffset } from './offset';
 import { CooldownOverlay, NgpOverlayCooldownManager } from './overlay-cooldown';
+import { NgpOverlayRegistry } from './overlay-registry';
 import { provideOverlayContext } from './overlay-token';
 import { NgpPortal, createPortal } from './portal';
 import { NgpPosition } from './position';
@@ -228,9 +227,9 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   private readonly document = inject(DOCUMENT);
   private readonly destroyRef = inject(DestroyRef);
   private readonly viewContainerRef: ViewContainerRef;
-  private readonly viewportRuler = inject(ViewportRuler);
   private readonly focusMonitor = inject(FocusMonitor);
   private readonly cooldownManager = inject(NgpOverlayCooldownManager);
+  private readonly registry = inject(NgpOverlayRegistry);
   /** Access any parent overlays */
   private readonly parentOverlay = inject(NgpOverlay, { optional: true });
   /** Track child overlays for outside click detection */
@@ -354,65 +353,8 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
         }
       });
 
-    // Register with parent overlay for outside click detection
-    if (this.parentOverlay) {
-      this.parentOverlay.registerChildOverlay(this);
-    }
-
-    // if there is a parent overlay and it is closed, close this overlay
-    this.parentOverlay?.closing
-      // we add a debounce here to ensure any dom events like clicks are processed first
-      .pipe(debounceTime(0), safeTakeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        if (this.isOpen()) {
-          this.hideImmediate();
-        }
-      });
-
-    // If closeOnOutsideClick is enabled, set up a click listener
-    fromEvent<MouseEvent>(this.document, 'mouseup', { capture: true })
-      .pipe(safeTakeUntilDestroyed(this.destroyRef))
-      .subscribe(event => {
-        if (!this.config.closeOnOutsideClick) {
-          return;
-        }
-
-        const overlay = this.portal();
-
-        if (!overlay || !this.isOpen()) {
-          return;
-        }
-
-        const path = event.composedPath();
-        const isInsideOverlay = overlay.getElements().some(el => path.includes(el));
-        const isInsideTrigger = path.includes(this.config.triggerElement);
-        const isInsideAnchor = this.config.anchorElement
-          ? path.includes(this.config.anchorElement)
-          : false;
-
-        if (
-          !isInsideOverlay &&
-          !isInsideTrigger &&
-          !isInsideAnchor &&
-          !this.isInsideChildOverlay(path)
-        ) {
-          this.hide();
-        }
-      });
-
-    // If closeOnEscape is enabled, set up a keydown listener
-    fromEvent<KeyboardEvent>(this.document, 'keydown', { capture: true })
-      .pipe(safeTakeUntilDestroyed(this.destroyRef))
-      .subscribe(event => {
-        if (!this.config.closeOnEscape) return;
-        if (event.key === 'Escape' && this.isOpen()) {
-          this.hide({ origin: 'keyboard', immediate: true });
-        }
-      });
-
     // Ensure cleanup on destroy
     this.destroyRef.onDestroy(() => {
-      this.parentOverlay?.unregisterChildOverlay(this);
       this.destroy();
     });
   }
@@ -798,6 +740,20 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     // Mark as open
     this.isOpen.set(true);
 
+    // Register with the overlay registry for centralized dismiss routing
+    this.registry.register({
+      id: this.id(),
+      parentId: this.parentOverlay?.id() ?? null,
+      overlay: this,
+      getElements: () => this.getElements(),
+      triggerElement: this.config.triggerElement,
+      anchorElement: this.config.anchorElement,
+      dismissPolicy: {
+        outsidePress: this.config.closeOnOutsideClick ?? false,
+        escapeKey: this.config.closeOnEscape ?? false,
+      },
+    });
+
     // Register as active overlay for this type (skip when cooldown is bypassed)
     if (this.config.overlayType && !skipCooldown) {
       this.cooldownManager.registerActive(this.config.overlayType, this, this.config.cooldown ?? 0);
@@ -813,7 +769,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   private createScrollStrategy(): ScrollStrategy {
     switch (this.config.scrollBehaviour) {
       case 'block':
-        return new BlockScrollStrategy(this.viewportRuler, this.document);
+        return new BlockScrollStrategy(this.document);
       case 'close':
         return new CloseScrollStrategy(
           this.config.anchorElement || this.config.triggerElement,
@@ -954,6 +910,12 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     if (!portal) {
       return;
     }
+
+    // Close any descendant overlays before destroying this one
+    this.registry.closeDescendants(this.id());
+
+    // Deregister from the overlay registry
+    this.registry.deregister(this.id());
 
     // Unregister from active overlays
     if (this.config.overlayType) {

--- a/packages/ng-primitives/portal/src/scroll-strategy.ts
+++ b/packages/ng-primitives/portal/src/scroll-strategy.ts
@@ -3,6 +3,7 @@
  * Modified to be fully standalone with no CDK overlay dependency.
  */
 import { coerceCssPixelValue } from '@angular/cdk/coercion';
+import { ViewportRuler } from '@angular/cdk/scrolling';
 import { getOverflowAncestors } from '@floating-ui/dom';
 import { isFunction, isObject } from 'ng-primitives/utils';
 
@@ -62,14 +63,17 @@ export class BlockScrollStrategy implements ScrollStrategy {
   private previousScrollPosition = { top: 0, left: 0 };
   private isEnabled = false;
 
-  constructor(private readonly document: Document) {}
+  constructor(
+    private readonly viewportRuler: ViewportRuler,
+    private readonly document: Document,
+  ) {}
 
   /** Blocks page-level scroll while the attached overlay is open. */
   enable() {
     if (this.canBeEnabled()) {
       const root = this.document.documentElement!;
 
-      this.previousScrollPosition = { top: window.scrollY ?? 0, left: window.scrollX ?? 0 };
+      this.previousScrollPosition = this.viewportRuler.getViewportScrollPosition();
 
       // Cache the previous inline styles in case the user had set them.
       this.previousHTMLStyles.left = root.style.left || '';
@@ -140,11 +144,12 @@ export class BlockScrollStrategy implements ScrollStrategy {
   private canBeEnabled(): boolean {
     const html = this.document.documentElement!;
 
-    if (html.hasAttribute('data-scrollblock') || this.isEnabled) {
+    if (html.classList.contains('cdk-global-scrollblock') || html.hasAttribute('data-scrollblock') || this.isEnabled) {
       return false;
     }
 
-    return html.scrollHeight > html.clientHeight || html.scrollWidth > html.clientWidth;
+    const viewport = this.viewportRuler.getViewportSize();
+    return html.scrollHeight > viewport.height || html.scrollWidth > viewport.width;
   }
 }
 

--- a/packages/ng-primitives/portal/src/scroll-strategy.ts
+++ b/packages/ng-primitives/portal/src/scroll-strategy.ts
@@ -144,7 +144,11 @@ export class BlockScrollStrategy implements ScrollStrategy {
   private canBeEnabled(): boolean {
     const html = this.document.documentElement!;
 
-    if (html.classList.contains('cdk-global-scrollblock') || html.hasAttribute('data-scrollblock') || this.isEnabled) {
+    if (
+      html.classList.contains('cdk-global-scrollblock') ||
+      html.hasAttribute('data-scrollblock') ||
+      this.isEnabled
+    ) {
       return false;
     }
 

--- a/packages/ng-primitives/portal/src/scroll-strategy.ts
+++ b/packages/ng-primitives/portal/src/scroll-strategy.ts
@@ -144,9 +144,7 @@ export class BlockScrollStrategy implements ScrollStrategy {
       return false;
     }
 
-    return (
-      html.scrollHeight > html.clientHeight || html.scrollWidth > html.clientWidth
-    );
+    return html.scrollHeight > html.clientHeight || html.scrollWidth > html.clientWidth;
   }
 }
 

--- a/packages/ng-primitives/portal/src/scroll-strategy.ts
+++ b/packages/ng-primitives/portal/src/scroll-strategy.ts
@@ -1,9 +1,8 @@
 /**
- * This code is largely based on the CDK Overlay's scroll strategy implementation, however it
- * has been modified so that it does not rely on the CDK's global overlay styles.
+ * Originally based on Angular CDK's scroll strategy.
+ * Modified to be fully standalone with no CDK overlay dependency.
  */
 import { coerceCssPixelValue } from '@angular/cdk/coercion';
-import { ViewportRuler } from '@angular/cdk/overlay';
 import { getOverflowAncestors } from '@floating-ui/dom';
 import { isFunction, isObject } from 'ng-primitives/utils';
 
@@ -63,17 +62,14 @@ export class BlockScrollStrategy implements ScrollStrategy {
   private previousScrollPosition = { top: 0, left: 0 };
   private isEnabled = false;
 
-  constructor(
-    private readonly viewportRuler: ViewportRuler,
-    private readonly document: Document,
-  ) {}
+  constructor(private readonly document: Document) {}
 
   /** Blocks page-level scroll while the attached overlay is open. */
   enable() {
     if (this.canBeEnabled()) {
       const root = this.document.documentElement!;
 
-      this.previousScrollPosition = this.viewportRuler.getViewportScrollPosition();
+      this.previousScrollPosition = { top: window.scrollY ?? 0, left: window.scrollX ?? 0 };
 
       // Cache the previous inline styles in case the user had set them.
       this.previousHTMLStyles.left = root.style.left || '';
@@ -128,13 +124,13 @@ export class BlockScrollStrategy implements ScrollStrategy {
       // Note that we don't mutate the property if the browser doesn't support `scroll-behavior`,
       // because it can throw off feature detections in `supportsScrollBehavior` which
       // checks for `'scrollBehavior' in documentElement.style`.
-      if (scrollBehaviorSupported) {
+      if (supportsScrollBehavior()) {
         htmlStyle.scrollBehavior = bodyStyle.scrollBehavior = 'auto';
       }
 
       window.scroll(this.previousScrollPosition.left, this.previousScrollPosition.top);
 
-      if (scrollBehaviorSupported) {
+      if (supportsScrollBehavior()) {
         htmlStyle.scrollBehavior = previousHtmlScrollBehavior;
         bodyStyle.scrollBehavior = previousBodyScrollBehavior;
       }
@@ -142,17 +138,15 @@ export class BlockScrollStrategy implements ScrollStrategy {
   }
 
   private canBeEnabled(): boolean {
-    // Since the scroll strategies can't be singletons, we have to use a global CSS class
-    // (`cdk-global-scrollblock`) to make sure that we don't try to disable global
-    // scrolling multiple times.
     const html = this.document.documentElement!;
 
-    if (html.classList.contains('cdk-global-scrollblock') || this.isEnabled) {
+    if (html.hasAttribute('data-scrollblock') || this.isEnabled) {
       return false;
     }
 
-    const viewport = this.viewportRuler.getViewportSize();
-    return html.scrollHeight > viewport.height || html.scrollWidth > viewport.width;
+    return (
+      html.scrollHeight > html.clientHeight || html.scrollWidth > html.clientWidth
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- Re-implement dialog overlay using `ng-primitives/portal` instead of `@angular/cdk/overlay`
- Introduce `NgpOverlayRegistry` for centralized escape-key routing and parent-child overlay tracking
- Update dialog documentation with full `NgpDialogManager` and `NgpDialogRef` API reference
- Clean up stale CDK references in comments and fix minor typo

## Test plan

- [x] `pnpm build` passes
- [x] `nx test ng-primitives` — all 1120 tests pass
- [ ] Visual check: `pnpm start` → navigate to dialog docs page, verify rendering
- [ ] Verify dialog open/close, escape key, overlay click, and navigation close behaviors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the dialog overlay with a standalone portal from `ng-primitives/portal`, removing `@angular/cdk/overlay`. Added a centralized overlay registry, expanded dialog APIs, and CDK-compatible outside click/Escape behavior.

- **New Features**
  - Central `NgpOverlayRegistry` for Escape routing, topmost-only dismiss, and parent–child cascade close; auto-detects parent overlays; exports `NgpOverlayRef` and registry types.
  - `NgpDialogRef` now implements `NgpOverlayRef`; adds `afterClosed`, `keydownEvents`, and `outsidePointerEvents` (via registry), plus a deprecated `overlayRef` shim. `NgpDialogManager` adds `getDialogById`, `openDialogs`, `afterOpened`, `afterAllClosed`.
  - Standalone `BlockScrollStrategy` using `@angular/cdk/scrolling`’s `ViewportRuler`, honoring both `data-scrollblock` and `cdk-global-scrollblock`; hides non-dialog content from AT; dialogs close on browser and programmatic navigation.

- **Bug Fixes**
  - Reset scroll blocking after the last dialog closes so each open uses the correct strategy.
  - Cascade teardown ignores `disableClose`, preventing orphaned child dialogs when a parent closes.
  - `outsidePointerEvents` now comes from the registry using CDK’s pointerdown+click pattern with stacking and Shadow DOM support; examples set `z-index: 1000` to avoid overlay ordering issues.

<sup>Written for commit 82fcc5f80535b0669fed0efee6cadbe20d7e7fcd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

