### PR TITLE
feat(dialog,popover): dismiss guards for closeOnEscape and closeOnOutsideClick

### DIFF
--- a/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.example.ts
@@ -1,0 +1,226 @@
+import { Component, signal } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import {
+  NgpDialog,
+  NgpDialogDescription,
+  NgpDialogOverlay,
+  NgpDialogTitle,
+  NgpDialogTrigger,
+} from 'ng-primitives/dialog';
+
+@Component({
+  selector: 'app-dialog-dismiss-guard',
+  imports: [
+    NgpButton,
+    NgpDialog,
+    NgpDialogOverlay,
+    NgpDialogTitle,
+    NgpDialogDescription,
+    NgpDialogTrigger,
+  ],
+  template: `
+    <button
+      [ngpDialogTrigger]="dialog"
+      [ngpDialogTriggerCloseOnEscape]="canDismiss"
+      [ngpDialogTriggerCloseOnOutsideClick]="canDismiss"
+      ngpButton
+    >
+      Edit Profile
+    </button>
+
+    <ng-template #dialog let-close="close">
+      <div ngpDialogOverlay>
+        <div ngpDialog>
+          <h1 ngpDialogTitle>Edit Profile</h1>
+          <p ngpDialogDescription>Make changes to your profile. Unsaved changes will be lost.</p>
+
+          <div class="form-field">
+            <label for="name">Name</label>
+            <input
+              id="name"
+              type="text"
+              value="John Doe"
+              (input)="dirty.set(true)"
+              placeholder="Enter your name"
+            />
+          </div>
+
+          <div class="dialog-footer">
+            <button (click)="discard(close)" ngpButton>Discard</button>
+            <button (click)="save(close)" ngpButton>Save Changes</button>
+          </div>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    button {
+      padding-left: 1rem;
+      padding-right: 1rem;
+      border-radius: 0.5rem;
+      color: var(--ngp-text-primary);
+      border: none;
+      outline: none;
+      height: 2.5rem;
+      font-weight: 500;
+      background-color: var(--ngp-background);
+      transition: background-color 300ms cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: var(--ngp-button-shadow);
+    }
+
+    button[data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    button[data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    button[data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpDialogOverlay] {
+      background-color: rgba(0, 0, 0, 0.5);
+      backdrop-filter: blur(4px);
+      position: fixed;
+      inset: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      animation: fadeIn 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpDialogOverlay][data-exit] {
+      animation: fadeOut 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpDialog] {
+      background-color: var(--ngp-background);
+      padding: 24px;
+      border-radius: 8px;
+      box-shadow: var(--ngp-shadow);
+      min-width: 340px;
+      animation: slideIn 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpDialog][data-exit] {
+      animation: slideOut 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpDialogTitle] {
+      font-size: 18px;
+      line-height: 28px;
+      font-weight: 600;
+      color: var(--ngp-text-primary);
+      margin: 0 0 4px;
+    }
+
+    [ngpDialogDescription] {
+      font-size: 14px;
+      line-height: 20px;
+      color: var(--ngp-text-secondary);
+      margin: 0;
+    }
+
+    .form-field {
+      margin-top: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .form-field label {
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--ngp-text-primary);
+    }
+
+    .form-field input {
+      height: 2.25rem;
+      padding: 0 0.75rem;
+      border-radius: 0.375rem;
+      border: 1px solid var(--ngp-border);
+      background-color: var(--ngp-background);
+      color: var(--ngp-text-primary);
+      font-size: 14px;
+      outline: none;
+    }
+
+    .form-field input:focus {
+      border-color: var(--ngp-focus-ring);
+      box-shadow: 0 0 0 1px var(--ngp-focus-ring);
+    }
+
+    .dialog-footer {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 24px;
+      column-gap: 8px;
+    }
+
+    .dialog-footer [ngpButton]:last-of-type {
+      color: var(--ngp-text-blue);
+    }
+
+    @keyframes fadeIn {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+
+    @keyframes fadeOut {
+      0% {
+        opacity: 1;
+      }
+      100% {
+        opacity: 0;
+      }
+    }
+
+    @keyframes slideIn {
+      0% {
+        transform: translateY(-20px);
+        opacity: 0;
+      }
+      100% {
+        transform: translateY(0);
+        opacity: 1;
+      }
+    }
+    @keyframes slideOut {
+      0% {
+        transform: translateY(0);
+        opacity: 1;
+      }
+      100% {
+        transform: translateY(-20px);
+        opacity: 0;
+      }
+    }
+  `,
+})
+export default class DialogDismissGuardExample {
+  readonly dirty = signal(false);
+
+  readonly canDismiss = () => {
+    if (!this.dirty()) {
+      return true;
+    }
+    return confirm('You have unsaved changes. Discard them?');
+  };
+
+  discard(close: () => void) {
+    this.dirty.set(false);
+    close();
+  }
+
+  save(close: () => void) {
+    this.dirty.set(false);
+    close();
+  }
+}

--- a/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.example.ts
@@ -38,9 +38,9 @@ import {
             <label for="name">Name</label>
             <input
               id="name"
+              (input)="dirty.set(true)"
               type="text"
               value="John Doe"
-              (input)="dirty.set(true)"
               placeholder="Enter your name"
             />
           </div>

--- a/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.example.ts
@@ -211,7 +211,11 @@ export default class DialogDismissGuardExample {
     if (!this.dirty()) {
       return true;
     }
-    return confirm('You have unsaved changes. Discard them?');
+    const confirmed = confirm('You have unsaved changes. Discard them?');
+    if (confirmed) {
+      this.dirty.set(false);
+    }
+    return confirmed;
   };
 
   discard(close: () => void) {

--- a/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.tailwind.example.ts
@@ -144,7 +144,11 @@ export default class DialogDismissGuardExample {
     if (!this.dirty()) {
       return true;
     }
-    return confirm('You have unsaved changes. Discard them?');
+    const confirmed = confirm('You have unsaved changes. Discard them?');
+    if (confirmed) {
+      this.dirty.set(false);
+    }
+    return confirmed;
   };
 
   discard(close: () => void) {

--- a/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.tailwind.example.ts
@@ -52,9 +52,9 @@ import {
             <input
               class="h-9 rounded-md border border-zinc-300 bg-white px-3 text-sm text-zinc-900 outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100"
               id="name"
+              (input)="dirty.set(true)"
               type="text"
               value="John Doe"
-              (input)="dirty.set(true)"
               placeholder="Enter your name"
             />
           </div>

--- a/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/dialog/dialog-dismiss-guard.tailwind.example.ts
@@ -1,0 +1,159 @@
+import { Component, signal } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import {
+  NgpDialog,
+  NgpDialogDescription,
+  NgpDialogOverlay,
+  NgpDialogTitle,
+  NgpDialogTrigger,
+} from 'ng-primitives/dialog';
+
+@Component({
+  selector: 'app-dialog-dismiss-guard',
+  imports: [
+    NgpButton,
+    NgpDialog,
+    NgpDialogOverlay,
+    NgpDialogTitle,
+    NgpDialogDescription,
+    NgpDialogTrigger,
+  ],
+  template: `
+    <button
+      class="h-10 rounded-lg border-none bg-white px-4 font-medium text-zinc-900 shadow-sm ring-1 ring-black/5 transition-colors duration-300 ease-in-out data-focus-visible:outline-2 data-focus-visible:outline-offset-2 data-focus-visible:outline-blue-500 data-hover:bg-zinc-50 data-press:bg-zinc-100 dark:bg-zinc-950 dark:text-zinc-100 dark:ring-white/10 dark:data-hover:bg-zinc-900 dark:data-press:bg-zinc-800"
+      [ngpDialogTrigger]="dialog"
+      [ngpDialogTriggerCloseOnEscape]="canDismiss"
+      [ngpDialogTriggerCloseOnOutsideClick]="canDismiss"
+      ngpButton
+    >
+      Edit Profile
+    </button>
+
+    <ng-template #dialog let-close="close">
+      <div
+        class="animate-fade fixed inset-0 z-40 flex items-center justify-center bg-black/50 backdrop-blur-xs"
+        ngpDialogOverlay
+      >
+        <div
+          class="animate-slide w-full max-w-md rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-950"
+          ngpDialog
+        >
+          <h1 class="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-100" ngpDialogTitle>
+            Edit Profile
+          </h1>
+          <p class="text-sm text-zinc-600 dark:text-zinc-400" ngpDialogDescription>
+            Make changes to your profile. Unsaved changes will be lost.
+          </p>
+
+          <div class="mt-4 flex flex-col gap-1">
+            <label class="text-sm font-medium text-zinc-900 dark:text-zinc-100" for="name">
+              Name
+            </label>
+            <input
+              class="h-9 rounded-md border border-zinc-300 bg-white px-3 text-sm text-zinc-900 outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-950 dark:text-zinc-100"
+              id="name"
+              type="text"
+              value="John Doe"
+              (input)="dirty.set(true)"
+              placeholder="Enter your name"
+            />
+          </div>
+
+          <div class="mt-6 flex justify-end gap-2">
+            <button
+              class="h-10 rounded-lg border-none bg-white px-4 font-medium text-zinc-900 shadow-sm ring-1 ring-black/5 transition-colors duration-300 ease-in-out data-focus-visible:outline-2 data-focus-visible:outline-offset-2 data-focus-visible:outline-blue-500 data-hover:bg-zinc-50 data-press:bg-zinc-100 dark:bg-zinc-950 dark:text-zinc-100 dark:ring-white/10 dark:data-hover:bg-zinc-900 dark:data-press:bg-zinc-800"
+              (click)="discard(close)"
+              ngpButton
+            >
+              Discard
+            </button>
+            <button
+              class="h-10 rounded-lg border-none bg-white px-4 font-medium text-blue-600 shadow-sm ring-1 ring-black/5 transition-colors duration-300 ease-in-out data-focus-visible:outline-2 data-focus-visible:outline-offset-2 data-focus-visible:outline-blue-500 data-hover:bg-zinc-50 data-press:bg-blue-100 dark:bg-zinc-950 dark:text-blue-400 dark:ring-white/10 dark:data-hover:bg-zinc-900 dark:data-press:bg-zinc-800"
+              (click)="save(close)"
+              ngpButton
+            >
+              Save Changes
+            </button>
+          </div>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    @keyframes fadeIn {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+
+    @keyframes fadeOut {
+      0% {
+        opacity: 1;
+      }
+      100% {
+        opacity: 0;
+      }
+    }
+
+    @keyframes slideIn {
+      0% {
+        transform: translateY(-20px);
+        opacity: 0;
+      }
+      100% {
+        transform: translateY(0);
+        opacity: 1;
+      }
+    }
+
+    @keyframes slideOut {
+      0% {
+        transform: translateY(0);
+        opacity: 1;
+      }
+      100% {
+        transform: translateY(-20px);
+        opacity: 0;
+      }
+    }
+
+    .animate-fade {
+      animation: fadeIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .animate-fade[data-exit] {
+      animation: fadeOut 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .animate-slide {
+      animation: slideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .animate-slide[data-exit] {
+      animation: slideOut 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+  `,
+})
+export default class DialogDismissGuardExample {
+  readonly dirty = signal(false);
+
+  readonly canDismiss = () => {
+    if (!this.dirty()) {
+      return true;
+    }
+    return confirm('You have unsaved changes. Discard them?');
+  };
+
+  discard(close: () => void) {
+    this.dirty.set(false);
+    close();
+  }
+
+  save(close: () => void) {
+    this.dirty.set(false);
+    close();
+  }
+}

--- a/apps/documentation/src/app/examples/popover/popover-dismiss-guard.example.ts
+++ b/apps/documentation/src/app/examples/popover/popover-dismiss-guard.example.ts
@@ -155,7 +155,7 @@ export default class PopoverDismissGuardExample {
         closeOnEscape: false,
         closeOnOutsideClick: false,
       });
-      ref.afterClosed.subscribe(result => resolve(result === true));
+      ref.closed.subscribe(({ result }) => resolve(result === true));
     });
   };
 }

--- a/apps/documentation/src/app/examples/popover/popover-dismiss-guard.example.ts
+++ b/apps/documentation/src/app/examples/popover/popover-dismiss-guard.example.ts
@@ -1,0 +1,305 @@
+import { Component, inject, signal } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import {
+  NgpDialog,
+  NgpDialogDescription,
+  NgpDialogManager,
+  NgpDialogOverlay,
+  NgpDialogTitle,
+  injectDialogRef,
+} from 'ng-primitives/dialog';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+
+@Component({
+  selector: 'app-popover-dismiss-guard',
+  imports: [NgpPopoverTrigger, NgpPopover, NgpButton],
+  template: `
+    <button
+      [ngpPopoverTrigger]="popover"
+      [ngpPopoverTriggerCloseOnOutsideClick]="canDismiss"
+      [ngpPopoverTriggerCloseOnEscape]="canDismiss"
+      ngpButton
+      type="button"
+    >
+      Quick Note
+    </button>
+
+    <ng-template #popover>
+      <div ngpPopover>
+        <h3>Quick Note</h3>
+        <textarea
+          rows="3"
+          placeholder="Type something..."
+          (input)="dirty.set(true)"
+        ></textarea>
+        <div class="popover-footer">
+          <button (click)="dirty.set(false)" ngpButton type="button">Save</button>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    button {
+      padding-left: 1rem;
+      padding-right: 1rem;
+      border-radius: 0.5rem;
+      color: var(--ngp-text-primary);
+      outline: none;
+      height: 2.5rem;
+      font-weight: 500;
+      background-color: var(--ngp-background);
+      transition: background-color 300ms cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: var(--ngp-button-shadow);
+    }
+
+    button[data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    button[data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+    }
+
+    button[data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpPopover] {
+      position: absolute;
+      display: flex;
+      flex-direction: column;
+      row-gap: 8px;
+      width: 260px;
+      border-radius: 0.75rem;
+      background: var(--ngp-background);
+      padding: 0.75rem 1rem;
+      box-shadow: var(--ngp-shadow);
+      border: 1px solid var(--ngp-border);
+      outline: none;
+      animation: popover-show 0.1s ease-out;
+      transform-origin: var(--ngp-popover-transform-origin);
+    }
+
+    [ngpPopover][data-exit] {
+      animation: popover-hide 0.1s ease-out;
+    }
+
+    [ngpPopover] h3 {
+      font-size: 13px;
+      font-weight: 500;
+      margin: 0;
+      color: var(--ngp-text-primary);
+    }
+
+    [ngpPopover] textarea {
+      font-size: 13px;
+      border-radius: 0.375rem;
+      border: 1px solid var(--ngp-border);
+      background-color: var(--ngp-background);
+      color: var(--ngp-text-primary);
+      padding: 0.5rem;
+      resize: none;
+      outline: none;
+      font-family: inherit;
+    }
+
+    [ngpPopover] textarea:focus {
+      border-color: var(--ngp-focus-ring);
+      box-shadow: 0 0 0 1px var(--ngp-focus-ring);
+    }
+
+    .popover-footer {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .popover-footer button {
+      height: 1.75rem;
+      font-size: 12px;
+      padding-left: 0.75rem;
+      padding-right: 0.75rem;
+      color: var(--ngp-text-blue);
+    }
+
+    @keyframes popover-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes popover-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+  `,
+})
+export default class PopoverDismissGuardExample {
+  private readonly dialogManager = inject(NgpDialogManager);
+
+  readonly dirty = signal(false);
+
+  readonly canDismiss = () => {
+    if (!this.dirty()) {
+      return true;
+    }
+
+    return new Promise<boolean>(resolve => {
+      const ref = this.dialogManager.open(DiscardConfirmDialog, {
+        closeOnEscape: false,
+        closeOnOutsideClick: false,
+      });
+      ref.afterClosed.subscribe(result => resolve(result === true));
+    });
+  };
+}
+
+@Component({
+  imports: [NgpButton, NgpDialog, NgpDialogOverlay, NgpDialogTitle, NgpDialogDescription],
+  template: `
+    <div ngpDialogOverlay>
+      <div ngpDialog>
+        <h1 ngpDialogTitle>Discard changes?</h1>
+        <p ngpDialogDescription>You have unsaved changes that will be lost.</p>
+        <div class="dialog-footer">
+          <button (click)="dialogRef.close(false)" ngpButton>Keep Editing</button>
+          <button (click)="dialogRef.close(true)" ngpButton>Discard</button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    button {
+      padding-left: 1rem;
+      padding-right: 1rem;
+      border-radius: 0.5rem;
+      color: var(--ngp-text-primary);
+      border: none;
+      outline: none;
+      height: 2.5rem;
+      font-weight: 500;
+      background-color: var(--ngp-background);
+      transition: background-color 300ms cubic-bezier(0.4, 0, 0.2, 1);
+      box-shadow: var(--ngp-button-shadow);
+    }
+
+    button[data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    button[data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    button[data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpDialogOverlay] {
+      background-color: rgba(0, 0, 0, 0.5);
+      backdrop-filter: blur(4px);
+      position: fixed;
+      inset: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      animation: fadeIn 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpDialogOverlay][data-exit] {
+      animation: fadeOut 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpDialog] {
+      background-color: var(--ngp-background);
+      padding: 24px;
+      border-radius: 8px;
+      box-shadow: var(--ngp-shadow);
+      animation: slideIn 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpDialog][data-exit] {
+      animation: slideOut 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpDialogTitle] {
+      font-size: 18px;
+      line-height: 28px;
+      font-weight: 600;
+      color: var(--ngp-text-primary);
+      margin: 0 0 4px;
+    }
+
+    [ngpDialogDescription] {
+      font-size: 14px;
+      line-height: 20px;
+      color: var(--ngp-text-secondary);
+      margin: 0;
+    }
+
+    .dialog-footer {
+      display: flex;
+      justify-content: flex-end;
+      margin-top: 24px;
+      column-gap: 8px;
+    }
+
+    .dialog-footer [ngpButton]:last-of-type {
+      color: var(--ngp-text-red, #dc2626);
+    }
+
+    @keyframes fadeIn {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+
+    @keyframes fadeOut {
+      0% {
+        opacity: 1;
+      }
+      100% {
+        opacity: 0;
+      }
+    }
+
+    @keyframes slideIn {
+      0% {
+        transform: translateY(-20px);
+        opacity: 0;
+      }
+      100% {
+        transform: translateY(0);
+        opacity: 1;
+      }
+    }
+
+    @keyframes slideOut {
+      0% {
+        transform: translateY(0);
+        opacity: 1;
+      }
+      100% {
+        transform: translateY(-20px);
+        opacity: 0;
+      }
+    }
+  `,
+})
+class DiscardConfirmDialog {
+  protected readonly dialogRef = injectDialogRef<void, boolean>();
+}

--- a/apps/documentation/src/app/examples/popover/popover-dismiss-guard.example.ts
+++ b/apps/documentation/src/app/examples/popover/popover-dismiss-guard.example.ts
@@ -155,7 +155,12 @@ export default class PopoverDismissGuardExample {
         closeOnEscape: false,
         closeOnOutsideClick: false,
       });
-      ref.closed.subscribe(({ result }) => resolve(result === true));
+      ref.closed.subscribe(({ result }) => {
+        if (result === true) {
+          this.dirty.set(false);
+        }
+        resolve(result === true);
+      });
     });
   };
 }

--- a/apps/documentation/src/app/examples/popover/popover-dismiss-guard.example.ts
+++ b/apps/documentation/src/app/examples/popover/popover-dismiss-guard.example.ts
@@ -27,11 +27,7 @@ import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
     <ng-template #popover>
       <div ngpPopover>
         <h3>Quick Note</h3>
-        <textarea
-          rows="3"
-          placeholder="Type something..."
-          (input)="dirty.set(true)"
-        ></textarea>
+        <textarea (input)="dirty.set(true)" rows="3" placeholder="Type something..."></textarea>
         <div class="popover-footer">
           <button (click)="dirty.set(false)" ngpButton type="button">Save</button>
         </div>

--- a/apps/documentation/src/app/examples/popover/popover-dismiss-guard.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/popover/popover-dismiss-guard.tailwind.example.ts
@@ -33,9 +33,9 @@ import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
         <h3 class="m-0 text-[13px] font-medium text-gray-900 dark:text-gray-100">Quick Note</h3>
         <textarea
           class="resize-none rounded-md border border-gray-300 bg-white p-2 font-[inherit] text-[13px] text-gray-900 outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-black dark:text-gray-100"
+          (input)="dirty.set(true)"
           rows="3"
           placeholder="Type something..."
-          (input)="dirty.set(true)"
         ></textarea>
         <div class="flex justify-end">
           <button

--- a/apps/documentation/src/app/examples/popover/popover-dismiss-guard.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/popover/popover-dismiss-guard.tailwind.example.ts
@@ -89,7 +89,12 @@ export default class PopoverDismissGuardExample {
         closeOnEscape: false,
         closeOnOutsideClick: false,
       });
-      ref.closed.subscribe(({ result }) => resolve(result === true));
+      ref.closed.subscribe(({ result }) => {
+        if (result === true) {
+          this.dirty.set(false);
+        }
+        resolve(result === true);
+      });
     });
   };
 }

--- a/apps/documentation/src/app/examples/popover/popover-dismiss-guard.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/popover/popover-dismiss-guard.tailwind.example.ts
@@ -1,0 +1,193 @@
+import { Component, inject, signal } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import {
+  NgpDialog,
+  NgpDialogDescription,
+  NgpDialogManager,
+  NgpDialogOverlay,
+  NgpDialogTitle,
+  injectDialogRef,
+} from 'ng-primitives/dialog';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+
+@Component({
+  selector: 'app-popover-dismiss-guard',
+  imports: [NgpPopoverTrigger, NgpPopover, NgpButton],
+  template: `
+    <button
+      class="h-10 rounded-lg bg-white px-4 font-medium text-gray-900 shadow-sm ring-1 ring-black/5 transition-colors duration-300 ease-in-out data-focus-visible:outline-2 data-focus-visible:outline-offset-2 data-focus-visible:outline-blue-500 data-hover:bg-gray-50 data-press:bg-gray-100 dark:bg-transparent dark:text-gray-100 dark:shadow-sm dark:ring-white/10 dark:data-hover:bg-black dark:data-press:bg-black"
+      [ngpPopoverTrigger]="popover"
+      [ngpPopoverTriggerCloseOnOutsideClick]="canDismiss"
+      [ngpPopoverTriggerCloseOnEscape]="canDismiss"
+      ngpButton
+      type="button"
+    >
+      Quick Note
+    </button>
+
+    <ng-template #popover>
+      <div
+        class="animate-in absolute flex w-[260px] flex-col gap-2 rounded-xl border border-gray-200 bg-white p-3 shadow-lg outline-hidden dark:border-zinc-800 dark:bg-black"
+        ngpPopover
+      >
+        <h3 class="m-0 text-[13px] font-medium text-gray-900 dark:text-gray-100">Quick Note</h3>
+        <textarea
+          class="resize-none rounded-md border border-gray-300 bg-white p-2 font-[inherit] text-[13px] text-gray-900 outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-zinc-700 dark:bg-black dark:text-gray-100"
+          rows="3"
+          placeholder="Type something..."
+          (input)="dirty.set(true)"
+        ></textarea>
+        <div class="flex justify-end">
+          <button
+            class="h-7 rounded-lg bg-white px-3 text-xs font-medium text-blue-600 shadow-sm ring-1 ring-black/5 transition-colors data-hover:bg-gray-50 dark:bg-transparent dark:text-blue-400 dark:ring-white/10 dark:data-hover:bg-black"
+            (click)="dirty.set(false)"
+            ngpButton
+            type="button"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    @keyframes fade-in {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+    @keyframes scale-in {
+      0% {
+        transform: scale(0.9);
+      }
+      100% {
+        transform: scale(1);
+      }
+    }
+    .animate-in {
+      animation:
+        fade-in 0.1s ease-out,
+        scale-in 0.1s ease-out;
+    }
+  `,
+})
+export default class PopoverDismissGuardExample {
+  private readonly dialogManager = inject(NgpDialogManager);
+
+  readonly dirty = signal(false);
+
+  readonly canDismiss = () => {
+    if (!this.dirty()) {
+      return true;
+    }
+
+    return new Promise<boolean>(resolve => {
+      const ref = this.dialogManager.open(DiscardConfirmDialog, {
+        closeOnEscape: false,
+        closeOnOutsideClick: false,
+      });
+      ref.afterClosed.subscribe(result => resolve(result === true));
+    });
+  };
+}
+
+@Component({
+  imports: [NgpButton, NgpDialog, NgpDialogOverlay, NgpDialogTitle, NgpDialogDescription],
+  template: `
+    <div
+      class="animate-fade fixed inset-0 z-40 flex items-center justify-center bg-black/50 backdrop-blur-xs"
+      ngpDialogOverlay
+    >
+      <div
+        class="animate-slide w-full max-w-sm rounded-xl bg-white p-6 shadow-xl dark:bg-zinc-950"
+        ngpDialog
+      >
+        <h1 class="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-100" ngpDialogTitle>
+          Discard changes?
+        </h1>
+        <p class="text-sm text-zinc-600 dark:text-zinc-400" ngpDialogDescription>
+          You have unsaved changes that will be lost.
+        </p>
+        <div class="mt-6 flex justify-end gap-2">
+          <button
+            class="h-10 rounded-lg border-none bg-white px-4 font-medium text-zinc-900 shadow-sm ring-1 ring-black/5 transition-colors duration-300 ease-in-out data-focus-visible:outline-2 data-focus-visible:outline-offset-2 data-focus-visible:outline-blue-500 data-hover:bg-zinc-50 data-press:bg-zinc-100 dark:bg-zinc-950 dark:text-zinc-100 dark:ring-white/10 dark:data-hover:bg-zinc-900 dark:data-press:bg-zinc-800"
+            (click)="dialogRef.close(false)"
+            ngpButton
+          >
+            Keep Editing
+          </button>
+          <button
+            class="h-10 rounded-lg border-none bg-white px-4 font-medium text-red-600 shadow-sm ring-1 ring-black/5 transition-colors duration-300 ease-in-out data-focus-visible:outline-2 data-focus-visible:outline-offset-2 data-focus-visible:outline-blue-500 data-hover:bg-zinc-50 data-press:bg-red-100 dark:bg-zinc-950 dark:text-red-400 dark:ring-white/10 dark:data-hover:bg-zinc-900 dark:data-press:bg-zinc-800"
+            (click)="dialogRef.close(true)"
+            ngpButton
+          >
+            Discard
+          </button>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    @keyframes fadeIn {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+      }
+    }
+
+    @keyframes fadeOut {
+      0% {
+        opacity: 1;
+      }
+      100% {
+        opacity: 0;
+      }
+    }
+
+    @keyframes slideIn {
+      0% {
+        transform: translateY(-20px);
+        opacity: 0;
+      }
+      100% {
+        transform: translateY(0);
+        opacity: 1;
+      }
+    }
+
+    @keyframes slideOut {
+      0% {
+        transform: translateY(0);
+        opacity: 1;
+      }
+      100% {
+        transform: translateY(-20px);
+        opacity: 0;
+      }
+    }
+
+    .animate-fade {
+      animation: fadeIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .animate-fade[data-exit] {
+      animation: fadeOut 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .animate-slide {
+      animation: slideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .animate-slide[data-exit] {
+      animation: slideOut 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    }
+  `,
+})
+class DiscardConfirmDialog {
+  protected readonly dialogRef = injectDialogRef<void, boolean>();
+}

--- a/apps/documentation/src/app/examples/popover/popover-dismiss-guard.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/popover/popover-dismiss-guard.tailwind.example.ts
@@ -89,7 +89,7 @@ export default class PopoverDismissGuardExample {
         closeOnEscape: false,
         closeOnOutsideClick: false,
       });
-      ref.afterClosed.subscribe(result => resolve(result === true));
+      ref.closed.subscribe(({ result }) => resolve(result === true));
     });
   };
 }

--- a/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
@@ -136,18 +136,53 @@ The manager provides methods to open, close, and query dialogs, and accepts a co
 
 Reference returned by `NgpDialogManager.open()`. Provides methods to interact with the opened dialog.
 
-<api-reference-config>
-  <api-config-prop name="close" type="(result?: R, focusOrigin?: FocusOrigin) => Promise<void>" description="Closes the dialog, optionally returning a result value." />
-  <api-config-prop name="afterClosed" type="Observable<R | undefined>" description="Observable that emits the dialog result when the dialog is closed." />
-  <api-config-prop name="data" type="T" description="The data passed to the dialog via NgpDialogConfig.data." />
-  <api-config-prop name="id" type="string" description="The unique ID for the dialog." />
-  <api-config-prop name="disableClose" type="boolean | undefined" description="Whether the user is allowed to close the dialog." />
-  <api-config-prop name="keydownEvents" type="Observable<KeyboardEvent>" description="Observable that emits keyboard events dispatched within the dialog." />
-  <api-config-prop name="outsidePointerEvents" type="Observable<MouseEvent>" description="Observable that emits pointer events dispatched outside of the dialog." />
-  <api-config-prop name="updatePosition" type="() => NgpDialogRef" description="Updates the position of the dialog. Currently a no-op as dialogs are CSS-centered." />
-</api-reference-config>
+<prop-details name="close" type="(result?: R, focusOrigin?: FocusOrigin) => Promise<void>">
+  Closes the dialog, optionally returning a result value.
+</prop-details>
+
+<prop-details name="afterClosed" type="Observable<R | undefined>">
+  Observable that emits the dialog result when the dialog is closed.
+</prop-details>
+
+<prop-details name="data" type="T">
+  The data passed to the dialog via `NgpDialogConfig.data`.
+</prop-details>
+
+<prop-details name="id" type="string">
+  The unique ID for the dialog.
+</prop-details>
+
+<prop-details name="disableClose" type="boolean | undefined">
+  Whether the user is allowed to close the dialog.
+</prop-details>
+
+<prop-details name="closeOnEscape" type="NgpDismissGuard<KeyboardEvent> | undefined">
+  Whether the escape key is allowed to close the dialog, or a guard function. When a function is provided, it receives the keyboard event and should return a boolean or `Promise<boolean>`.
+</prop-details>
+
+<prop-details name="closeOnOutsideClick" type="NgpDismissGuard<Element> | undefined">
+  Whether clicking outside (on the overlay) is allowed to close the dialog, or a guard function. When a function is provided, it receives the target element and should return a boolean or `Promise<boolean>`.
+</prop-details>
+
+<prop-details name="keydownEvents" type="Observable<KeyboardEvent>">
+  Observable that emits keyboard events dispatched within the dialog.
+</prop-details>
+
+<prop-details name="outsidePointerEvents" type="Observable<MouseEvent>">
+  Observable that emits pointer events dispatched outside of the dialog.
+</prop-details>
+
+<prop-details name="updatePosition" type="() => NgpDialogRef">
+  Updates the position of the dialog. Currently a no-op as dialogs are CSS-centered.
+</prop-details>
 
 ## Examples
+
+### Dismiss Guard
+
+Use dismiss guards to prevent a dialog from closing when there are unsaved changes. The `closeOnEscape` and `closeOnOutsideClick` options accept a guard function that returns a boolean or a `Promise<boolean>`.
+
+<docs-example name="dialog-dismiss-guard"></docs-example>
 
 ### Dialog with external data
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
@@ -140,8 +140,12 @@ Reference returned by `NgpDialogManager.open()`. Provides methods to interact wi
   Closes the dialog, optionally returning a result value.
 </prop-details>
 
-<prop-details name="afterClosed" type="Observable<R | undefined>">
-  Observable that emits the dialog result when the dialog is closed.
+<prop-details name="closed" type="Observable<{ focusOrigin?: FocusOrigin; result?: R }>">
+  Observable that emits immediately when `close()` is called, before exit animations run.
+</prop-details>
+
+<prop-details name="afterClosed" type="Observable<{ focusOrigin?: FocusOrigin; result?: R }>">
+  Observable that emits after exit animations have completed.
 </prop-details>
 
 <prop-details name="data" type="T">

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -98,6 +98,12 @@ The popover can be anchored to a different element than the trigger.
 
 <docs-example name="popover-anchor"></docs-example>
 
+### Dismiss Guard
+
+Use dismiss guards to prevent a popover from closing when there are unsaved changes. The `closeOnOutsideClick` and `closeOnEscape` options accept a guard function that returns a boolean or a `Promise<boolean>`.
+
+<docs-example name="popover-dismiss-guard"></docs-example>
+
 ## API Reference
 
 The following directives are available to import from the `ng-primitives/popover` package:

--- a/packages/ng-primitives/dialog/src/config/dialog-config.ts
+++ b/packages/ng-primitives/dialog/src/config/dialog-config.ts
@@ -1,5 +1,5 @@
 import { InjectionToken, Injector, Provider, ViewContainerRef, inject } from '@angular/core';
-import { ScrollStrategy } from 'ng-primitives/portal';
+import { NgpDismissGuard, ScrollStrategy } from 'ng-primitives/portal';
 
 /** Valid ARIA roles for a dialog. */
 export type NgpDialogRole = 'dialog' | 'alertdialog';
@@ -26,10 +26,18 @@ export interface NgpDialogConfig<T = any> {
    */
   closeOnNavigation?: boolean;
 
-  /** Whether the dialog should close when the user presses the escape key. */
-  closeOnEscape?: boolean;
+  /** Whether the dialog should close when the user presses the escape key, or a guard function. */
+  closeOnEscape?: NgpDismissGuard<KeyboardEvent>;
 
-  /** Whether the dialog should close when the user clicks the overlay. */
+  /**
+   * Whether the dialog should close when clicking outside (on the overlay), or a guard function.
+   */
+  closeOnOutsideClick?: NgpDismissGuard<Element>;
+
+  /**
+   * Whether the dialog should close when the user clicks the overlay.
+   * @deprecated Use `closeOnOutsideClick` instead.
+   */
   closeOnClick?: boolean;
 
   /** Scroll strategy to be used for the dialog. */

--- a/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay.ts
+++ b/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay.ts
@@ -31,8 +31,7 @@ export class NgpDialogOverlay {
   }
 
   protected onClick(event: Event): void {
-    const isOverlayClick =
-      this.startedPointerDownOnOverlay && event.target === event.currentTarget;
+    const isOverlayClick = this.startedPointerDownOnOverlay && event.target === event.currentTarget;
 
     this.resetPointerOrigin();
 

--- a/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay.ts
+++ b/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay.ts
@@ -1,5 +1,6 @@
 import { booleanAttribute, Directive, input } from '@angular/core';
 import { NgpExitAnimation } from 'ng-primitives/internal';
+import { NgpDismissGuard } from 'ng-primitives/portal';
 import { injectDialogRef } from '../dialog/dialog-ref';
 
 @Directive({
@@ -30,16 +31,53 @@ export class NgpDialogOverlay {
   }
 
   protected onClick(event: Event): void {
-    const shouldClose =
-      this.startedPointerDownOnOverlay &&
-      event.target === event.currentTarget &&
-      this.closeOnClick() &&
-      !this.dialogRef.disableClose;
+    const isOverlayClick =
+      this.startedPointerDownOnOverlay && event.target === event.currentTarget;
 
     this.resetPointerOrigin();
 
-    if (shouldClose) {
+    if (!isOverlayClick || this.dialogRef.disableClose) {
+      return;
+    }
+
+    const guard: NgpDismissGuard<Element> =
+      this.dialogRef.closeOnOutsideClick ?? this.closeOnClick() ?? true;
+    this.evaluateGuard(guard, event.target as Element);
+  }
+
+  private evaluateGuard(guard: NgpDismissGuard<Element>, target: Element): void {
+    if (guard === true) {
       this.dialogRef.close(undefined, 'mouse');
+      return;
+    }
+
+    if (guard === false) {
+      return;
+    }
+
+    // Function guard — evaluate sync or async
+    let result: boolean | Promise<boolean>;
+    try {
+      result = guard(target);
+    } catch (error) {
+      console.error('NgpDialogOverlay: dismiss guard threw', error);
+      return;
+    }
+
+    if (typeof result === 'boolean') {
+      if (result) {
+        this.dialogRef.close(undefined, 'mouse');
+      }
+    } else {
+      result
+        .then(shouldClose => {
+          if (shouldClose) {
+            this.dialogRef.close(undefined, 'mouse');
+          }
+        })
+        .catch(error => {
+          console.error('NgpDialogOverlay: dismiss guard rejected', error);
+        });
     }
   }
 

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
@@ -1,9 +1,5 @@
 import { Directive, HostListener, inject, input, output, TemplateRef } from '@angular/core';
-import {
-  dismissGuardAttribute,
-  NgpDismissGuard,
-  NgpDismissGuardInput,
-} from 'ng-primitives/portal';
+import { dismissGuardAttribute, NgpDismissGuard, NgpDismissGuardInput } from 'ng-primitives/portal';
 import { injectDialogConfig } from '../config/dialog-config';
 import { NgpDialogRef } from '../dialog/dialog-ref';
 import { NgpDialogContext, NgpDialogManager } from '../dialog/dialog.service';
@@ -31,13 +27,13 @@ export class NgpDialogTrigger<T = unknown> {
    * Whether the dialog should close on escape, or a guard function.
    * @default `true`
    */
-  readonly closeOnEscape = input<NgpDismissGuard<KeyboardEvent>, NgpDismissGuardInput<KeyboardEvent>>(
-    this.config.closeOnEscape ?? true,
-    {
-      alias: 'ngpDialogTriggerCloseOnEscape',
-      transform: dismissGuardAttribute,
-    },
-  );
+  readonly closeOnEscape = input<
+    NgpDismissGuard<KeyboardEvent>,
+    NgpDismissGuardInput<KeyboardEvent>
+  >(this.config.closeOnEscape ?? true, {
+    alias: 'ngpDialogTriggerCloseOnEscape',
+    transform: dismissGuardAttribute,
+  });
 
   /**
    * Whether the dialog should close on outside click, or a guard function.

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
@@ -1,4 +1,5 @@
 import { Directive, HostListener, inject, input, output, TemplateRef } from '@angular/core';
+import { NgpDismissGuard } from 'ng-primitives/portal';
 import { injectDialogConfig } from '../config/dialog-config';
 import { NgpDialogRef } from '../dialog/dialog-ref';
 import { NgpDialogContext, NgpDialogManager } from '../dialog/dialog.service';
@@ -23,10 +24,10 @@ export class NgpDialogTrigger<T = unknown> {
   readonly closed = output<T>({ alias: 'ngpDialogTriggerClosed' });
 
   /**
-   * Whether the dialog should close on escape.
+   * Whether the dialog should close on escape, or a guard function.
    * @default `true`
    */
-  readonly closeOnEscape = input(this.config.closeOnEscape, {
+  readonly closeOnEscape = input<NgpDismissGuard<KeyboardEvent>>(this.config.closeOnEscape ?? true, {
     alias: 'ngpDialogTriggerCloseOnEscape',
   });
 

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
@@ -1,5 +1,9 @@
 import { Directive, HostListener, inject, input, output, TemplateRef } from '@angular/core';
-import { NgpDismissGuard } from 'ng-primitives/portal';
+import {
+  dismissGuardAttribute,
+  NgpDismissGuard,
+  NgpDismissGuardInput,
+} from 'ng-primitives/portal';
 import { injectDialogConfig } from '../config/dialog-config';
 import { NgpDialogRef } from '../dialog/dialog-ref';
 import { NgpDialogContext, NgpDialogManager } from '../dialog/dialog.service';
@@ -27,10 +31,11 @@ export class NgpDialogTrigger<T = unknown> {
    * Whether the dialog should close on escape, or a guard function.
    * @default `true`
    */
-  readonly closeOnEscape = input<NgpDismissGuard<KeyboardEvent>>(
+  readonly closeOnEscape = input<NgpDismissGuard<KeyboardEvent>, NgpDismissGuardInput<KeyboardEvent>>(
     this.config.closeOnEscape ?? true,
     {
       alias: 'ngpDialogTriggerCloseOnEscape',
+      transform: dismissGuardAttribute,
     },
   );
 
@@ -38,10 +43,11 @@ export class NgpDialogTrigger<T = unknown> {
    * Whether the dialog should close on outside click, or a guard function.
    * @default `true`
    */
-  readonly closeOnOutsideClick = input<NgpDismissGuard<Element>>(
+  readonly closeOnOutsideClick = input<NgpDismissGuard<Element>, NgpDismissGuardInput<Element>>(
     this.config.closeOnOutsideClick ?? true,
     {
       alias: 'ngpDialogTriggerCloseOnOutsideClick',
+      transform: dismissGuardAttribute,
     },
   );
 

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
@@ -27,9 +27,12 @@ export class NgpDialogTrigger<T = unknown> {
    * Whether the dialog should close on escape, or a guard function.
    * @default `true`
    */
-  readonly closeOnEscape = input<NgpDismissGuard<KeyboardEvent>>(this.config.closeOnEscape ?? true, {
-    alias: 'ngpDialogTriggerCloseOnEscape',
-  });
+  readonly closeOnEscape = input<NgpDismissGuard<KeyboardEvent>>(
+    this.config.closeOnEscape ?? true,
+    {
+      alias: 'ngpDialogTriggerCloseOnEscape',
+    },
+  );
 
   /**
    * Store the dialog ref.

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
@@ -35,6 +35,17 @@ export class NgpDialogTrigger<T = unknown> {
   );
 
   /**
+   * Whether the dialog should close on outside click, or a guard function.
+   * @default `true`
+   */
+  readonly closeOnOutsideClick = input<NgpDismissGuard<Element>>(
+    this.config.closeOnOutsideClick ?? true,
+    {
+      alias: 'ngpDialogTriggerCloseOnOutsideClick',
+    },
+  );
+
+  /**
    * Store the dialog ref.
    * @internal
    */
@@ -44,6 +55,7 @@ export class NgpDialogTrigger<T = unknown> {
   protected launch(): void {
     this.dialogRef = this.dialogManager.open(this.template(), {
       closeOnEscape: this.closeOnEscape(),
+      closeOnOutsideClick: this.closeOnOutsideClick(),
     });
     this.dialogRef.closed.subscribe(({ result }) => {
       this.closed.emit(result as T);

--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -3,7 +3,7 @@ import { inject, Injector } from '@angular/core';
 import { NgpExitAnimationManager } from 'ng-primitives/internal';
 import { NgpDismissGuard, NgpOverlayRef } from 'ng-primitives/portal';
 import { defer, EMPTY, fromEvent, Observable, Subject } from 'rxjs';
-import { filter, takeUntil } from 'rxjs/operators';
+import { filter, map, takeUntil } from 'rxjs/operators';
 import { NgpDialogConfig } from '../config/dialog-config';
 
 /** Minimal portal interface needed by the dialog ref. */
@@ -29,13 +29,14 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
   readonly closed = new Subject<{ focusOrigin?: FocusOrigin; result?: R }>();
 
   /** @internal */
-  private readonly afterClosed$ = new Subject<{ focusOrigin?: FocusOrigin; result?: R }>();
+  readonly afterClosed$ = new Subject<{ focusOrigin?: FocusOrigin; result?: R }>();
 
   /**
    * Observable that emits the dialog result after exit animations have completed.
    */
-  readonly afterClosed: Observable<{ focusOrigin?: FocusOrigin; result?: R }> =
-    this.afterClosed$.asObservable();
+  readonly afterClosed: Observable<R | undefined> = this.afterClosed$.pipe(
+    map(event => event.result),
+  );
 
   /** Data passed from the dialog opener. */
   readonly data: T;

--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -3,7 +3,7 @@ import { inject, Injector } from '@angular/core';
 import { NgpExitAnimationManager } from 'ng-primitives/internal';
 import { NgpDismissGuard, NgpOverlayRef } from 'ng-primitives/portal';
 import { defer, EMPTY, fromEvent, Observable, Subject } from 'rxjs';
-import { filter, map, takeUntil } from 'rxjs/operators';
+import { filter, takeUntil } from 'rxjs/operators';
 import { NgpDialogConfig } from '../config/dialog-config';
 
 /** Minimal portal interface needed by the dialog ref. */
@@ -28,10 +28,14 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
   /** Emits when the dialog has been closed. */
   readonly closed = new Subject<{ focusOrigin?: FocusOrigin; result?: R }>();
 
+  /** @internal */
+  private readonly afterClosed$ = new Subject<{ focusOrigin?: FocusOrigin; result?: R }>();
+
   /**
-   * Observable that emits the dialog result when closed.
+   * Observable that emits the dialog result after exit animations have completed.
    */
-  readonly afterClosed: Observable<R | undefined> = this.closed.pipe(map(event => event.result));
+  readonly afterClosed: Observable<{ focusOrigin?: FocusOrigin; result?: R }> =
+    this.afterClosed$.asObservable();
 
   /** Data passed from the dialog opener. */
   readonly data: T;
@@ -109,14 +113,17 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
 
     this.closing = true;
 
+    this.closed.next({});
+    this.closed.complete();
+
     // Detach the portal immediately — no exit animation
     if (this.portal) {
       await this.portal.detach(true);
       this.portal = null;
     }
 
-    this.closed.next({});
-    this.closed.complete();
+    this.afterClosed$.next({});
+    this.afterClosed$.complete();
   }
 
   /**
@@ -132,6 +139,10 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
 
     this.closing = true;
 
+    // Emit immediately so consumers can react before exit animations run.
+    this.closed.next({ focusOrigin, result });
+    this.closed.complete();
+
     const exitAnimationManager = this.injector?.get(NgpExitAnimationManager, undefined, {
       optional: true,
     });
@@ -145,8 +156,8 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
       this.portal = null;
     }
 
-    this.closed.next({ focusOrigin, result });
-    this.closed.complete();
+    this.afterClosed$.next({ focusOrigin, result });
+    this.afterClosed$.complete();
   }
 
   /**

--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -1,7 +1,7 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { inject, Injector } from '@angular/core';
 import { NgpExitAnimationManager } from 'ng-primitives/internal';
-import { NgpOverlayRef } from 'ng-primitives/portal';
+import { NgpDismissGuard, NgpOverlayRef } from 'ng-primitives/portal';
 import { defer, EMPTY, fromEvent, Observable, Subject } from 'rxjs';
 import { filter, map, takeUntil } from 'rxjs/operators';
 import { NgpDialogConfig } from '../config/dialog-config';
@@ -19,8 +19,11 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
   /** Whether the user is allowed to close the dialog. */
   disableClose: boolean | undefined;
 
-  /** Whether the escape key is allowed to close the dialog. */
-  closeOnEscape: boolean | undefined;
+  /** Whether the escape key is allowed to close the dialog, or a guard function. */
+  closeOnEscape: NgpDismissGuard<KeyboardEvent> | undefined;
+
+  /** Whether clicking outside (on the overlay) is allowed to close the dialog, or a guard function. */
+  closeOnOutsideClick: NgpDismissGuard<Element> | undefined;
 
   /** Emits when the dialog has been closed. */
   readonly closed = new Subject<{ focusOrigin?: FocusOrigin; result?: R }>();
@@ -65,6 +68,7 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
     this.data = config.data as T;
     this.id = config.id!; // By the time the dialog is created we are guaranteed to have an ID.
     this.closeOnEscape = config.closeOnEscape ?? true;
+    this.closeOnOutsideClick = config.closeOnOutsideClick;
 
     // Use defer() so the observable is created on subscribe — by then the portal will be set.
     this.keydownEvents = defer(() => {

--- a/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
@@ -201,7 +201,7 @@ export class NgpDialogManager implements OnDestroy {
       this.removeOpenDialog(dialogRef as NgpDialogRef<any, any>, true);
     });
 
-    dialogRef.afterClosed.subscribe(({ focusOrigin }) => {
+    dialogRef.afterClosed$.subscribe(({ focusOrigin }) => {
       // Focus the trigger element after exit animations complete.
       if (activeElement instanceof HTMLElement && this.document.body.contains(activeElement)) {
         // Its not great that we are relying on an internal API here, but we need to in order to

--- a/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
@@ -201,12 +201,15 @@ export class NgpDialogManager implements OnDestroy {
       this.removeOpenDialog(dialogRef as NgpDialogRef<any, any>, true);
     });
 
-    dialogRef.afterClosed.subscribe(() => {
+    dialogRef.afterClosed.subscribe(({ focusOrigin }) => {
       // Focus the trigger element after exit animations complete.
       if (activeElement instanceof HTMLElement && this.document.body.contains(activeElement)) {
         // Its not great that we are relying on an internal API here, but we need to in order to
         // try and best determine the focus origin when it is programmatically closed by the user.
-        this.focusMonitor.focusVia(activeElement, (this.focusMonitor as any)._lastFocusOrigin);
+        this.focusMonitor.focusVia(
+          activeElement,
+          focusOrigin ?? (this.focusMonitor as any)._lastFocusOrigin,
+        );
       }
     });
 

--- a/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
@@ -195,18 +195,18 @@ export class NgpDialogManager implements OnDestroy {
     this.afterOpened.next(dialogRef as NgpDialogRef<any, any>);
     this.subscribeToRouterEvents();
 
-    dialogRef.closed.subscribe(closeResult => {
-      // Deregister from the overlay registry
+    dialogRef.closed.subscribe(() => {
+      // Deregister from the overlay registry immediately so stacking order is updated.
       this.registry.deregister(dialogRef.id);
       this.removeOpenDialog(dialogRef as NgpDialogRef<any, any>, true);
-      // Focus the trigger element after the dialog closes.
+    });
+
+    dialogRef.afterClosed.subscribe(() => {
+      // Focus the trigger element after exit animations complete.
       if (activeElement instanceof HTMLElement && this.document.body.contains(activeElement)) {
         // Its not great that we are relying on an internal API here, but we need to in order to
         // try and best determine the focus origin when it is programmatically closed by the user.
-        this.focusMonitor.focusVia(
-          activeElement,
-          closeResult.focusOrigin ?? (this.focusMonitor as any)._lastFocusOrigin,
-        );
+        this.focusMonitor.focusVia(activeElement, (this.focusMonitor as any)._lastFocusOrigin);
       }
     });
 

--- a/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
@@ -208,6 +208,74 @@ describe('NgpDialog', () => {
     expect(closedSpy).not.toHaveBeenCalled();
   }));
 
+  it('should NOT close on overlay click when closeOnOutsideClick is false', async () => {
+    const { ref } = openDialog({ closeOnOutsideClick: false });
+    const closedSpy = vi.fn();
+    ref.closed.subscribe(closedSpy);
+
+    const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
+    overlay.click();
+
+    await new Promise(r => setTimeout(r, 0));
+    expect(closedSpy).not.toHaveBeenCalled();
+  });
+
+  it('should support async dismiss guard on closeOnOutsideClick', async () => {
+    const { ref } = openDialog({
+      closeOnOutsideClick: () => Promise.resolve(false),
+    });
+    const closedSpy = vi.fn();
+    ref.closed.subscribe(closedSpy);
+
+    const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
+    overlay.click();
+
+    await new Promise(r => setTimeout(r, 0));
+    expect(closedSpy).not.toHaveBeenCalled();
+  });
+
+  it('should close when async dismiss guard resolves true', async () => {
+    const { ref } = openDialog({
+      closeOnOutsideClick: () => Promise.resolve(true),
+    });
+    const closedSpy = vi.fn();
+    ref.closed.subscribe(closedSpy);
+
+    const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
+    overlay.click();
+
+    await waitFor(() => {
+      expect(closedSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('should support sync dismiss guard function on closeOnOutsideClick', async () => {
+    const { ref } = openDialog({
+      closeOnOutsideClick: () => false,
+    });
+    const closedSpy = vi.fn();
+    ref.closed.subscribe(closedSpy);
+
+    const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
+    overlay.click();
+
+    await new Promise(r => setTimeout(r, 0));
+    expect(closedSpy).not.toHaveBeenCalled();
+  });
+
+  it('should support dismiss guard on closeOnEscape', async () => {
+    const { ref } = openDialog({
+      closeOnEscape: () => false,
+    });
+    const closedSpy = vi.fn();
+    ref.closed.subscribe(closedSpy);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    await new Promise(r => setTimeout(r, 0));
+    expect(closedSpy).not.toHaveBeenCalled();
+  });
+
   it('should generate unique dialog id', () => {
     openDialog();
     const dialog = document.querySelector('[data-testid="dialog"]');

--- a/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
@@ -1,6 +1,6 @@
 import { Component, TemplateRef, ViewContainerRef, inject, viewChild } from '@angular/core';
 import { TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
-import { fireEvent } from '@testing-library/angular';
+import { fireEvent, waitFor } from '@testing-library/angular';
 import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from 'ng-primitives/menu';
 import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
 import { NgpOverlayRegistry } from 'ng-primitives/portal';

--- a/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
@@ -214,7 +214,7 @@ describe('NgpDialog', () => {
     ref.closed.subscribe(closedSpy);
 
     const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
-    overlay.click();
+    dispatchOverlayClick(overlay);
 
     await new Promise(r => setTimeout(r, 0));
     expect(closedSpy).not.toHaveBeenCalled();
@@ -228,7 +228,7 @@ describe('NgpDialog', () => {
     ref.closed.subscribe(closedSpy);
 
     const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
-    overlay.click();
+    dispatchOverlayClick(overlay);
 
     await new Promise(r => setTimeout(r, 0));
     expect(closedSpy).not.toHaveBeenCalled();
@@ -242,7 +242,7 @@ describe('NgpDialog', () => {
     ref.closed.subscribe(closedSpy);
 
     const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
-    overlay.click();
+    dispatchOverlayClick(overlay);
 
     await waitFor(() => {
       expect(closedSpy).toHaveBeenCalled();
@@ -257,7 +257,7 @@ describe('NgpDialog', () => {
     ref.closed.subscribe(closedSpy);
 
     const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
-    overlay.click();
+    dispatchOverlayClick(overlay);
 
     await new Promise(r => setTimeout(r, 0));
     expect(closedSpy).not.toHaveBeenCalled();

--- a/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
@@ -210,7 +210,7 @@ describe('NgpDialog', () => {
 
   it('should NOT close on overlay click when closeOnOutsideClick is false', async () => {
     const { ref } = openDialog({ closeOnOutsideClick: false });
-    const closedSpy = vi.fn();
+    const closedSpy = jest.fn();
     ref.closed.subscribe(closedSpy);
 
     const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
@@ -224,7 +224,7 @@ describe('NgpDialog', () => {
     const { ref } = openDialog({
       closeOnOutsideClick: () => Promise.resolve(false),
     });
-    const closedSpy = vi.fn();
+    const closedSpy = jest.fn();
     ref.closed.subscribe(closedSpy);
 
     const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
@@ -238,7 +238,7 @@ describe('NgpDialog', () => {
     const { ref } = openDialog({
       closeOnOutsideClick: () => Promise.resolve(true),
     });
-    const closedSpy = vi.fn();
+    const closedSpy = jest.fn();
     ref.closed.subscribe(closedSpy);
 
     const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
@@ -253,7 +253,7 @@ describe('NgpDialog', () => {
     const { ref } = openDialog({
       closeOnOutsideClick: () => false,
     });
-    const closedSpy = vi.fn();
+    const closedSpy = jest.fn();
     ref.closed.subscribe(closedSpy);
 
     const overlay = document.querySelector('[data-testid="overlay"]') as HTMLElement;
@@ -267,7 +267,7 @@ describe('NgpDialog', () => {
     const { ref } = openDialog({
       closeOnEscape: () => false,
     });
-    const closedSpy = vi.fn();
+    const closedSpy = jest.fn();
     ref.closed.subscribe(closedSpy);
 
     document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));

--- a/packages/ng-primitives/popover/src/config/popover-config.ts
+++ b/packages/ng-primitives/popover/src/config/popover-config.ts
@@ -1,6 +1,6 @@
 import { InjectionToken, Provider, inject } from '@angular/core';
 import { type Placement } from '@floating-ui/dom';
-import { NgpFlip, NgpOffset, NgpShift } from 'ng-primitives/portal';
+import { NgpDismissGuard, NgpFlip, NgpOffset, NgpShift } from 'ng-primitives/portal';
 
 export interface NgpPopoverConfig {
   /**
@@ -42,16 +42,16 @@ export interface NgpPopoverConfig {
   container: HTMLElement | string | null;
 
   /**
-   * Define whether the popover should close when clicking outside of it.
+   * Define whether the popover should close when clicking outside of it, or a guard function.
    * @default true
    */
-  closeOnOutsideClick: boolean;
+  closeOnOutsideClick: NgpDismissGuard<Element>;
 
   /**
-   * Define whether the popover should close when the escape key is pressed.
+   * Define whether the popover should close when the escape key is pressed, or a guard function.
    * @default true
    */
-  closeOnEscape: boolean;
+  closeOnEscape: NgpDismissGuard<KeyboardEvent>;
 
   /**
    * Defines how the popover behaves when the window is scrolled.

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
@@ -17,7 +17,9 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   createOverlay,
   coerceFlip,
+  dismissGuardAttribute,
   NgpDismissGuard,
+  NgpDismissGuardInput,
   NgpFlip,
   NgpFlipInput,
   NgpOverlay,
@@ -154,17 +156,25 @@ export class NgpPopoverTrigger<T = null> implements OnDestroy {
    * Define whether the popover should close when clicking outside of it, or a guard function.
    * @default true
    */
-  readonly closeOnOutsideClick = input<NgpDismissGuard<Element>>(this.config.closeOnOutsideClick, {
-    alias: 'ngpPopoverTriggerCloseOnOutsideClick',
-  });
+  readonly closeOnOutsideClick = input<NgpDismissGuard<Element>, NgpDismissGuardInput<Element>>(
+    this.config.closeOnOutsideClick,
+    {
+      alias: 'ngpPopoverTriggerCloseOnOutsideClick',
+      transform: dismissGuardAttribute,
+    },
+  );
 
   /**
    * Define whether the popover should close when the escape key is pressed, or a guard function.
    * @default true
    */
-  readonly closeOnEscape = input<NgpDismissGuard<KeyboardEvent>>(this.config.closeOnEscape, {
-    alias: 'ngpPopoverTriggerCloseOnEscape',
-  });
+  readonly closeOnEscape = input<NgpDismissGuard<KeyboardEvent>, NgpDismissGuardInput<KeyboardEvent>>(
+    this.config.closeOnEscape,
+    {
+      alias: 'ngpPopoverTriggerCloseOnEscape',
+      transform: dismissGuardAttribute,
+    },
+  );
 
   /**
    * Defines how the popover behaves when the window is scrolled.

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
@@ -168,13 +168,13 @@ export class NgpPopoverTrigger<T = null> implements OnDestroy {
    * Define whether the popover should close when the escape key is pressed, or a guard function.
    * @default true
    */
-  readonly closeOnEscape = input<NgpDismissGuard<KeyboardEvent>, NgpDismissGuardInput<KeyboardEvent>>(
-    this.config.closeOnEscape,
-    {
-      alias: 'ngpPopoverTriggerCloseOnEscape',
-      transform: dismissGuardAttribute,
-    },
-  );
+  readonly closeOnEscape = input<
+    NgpDismissGuard<KeyboardEvent>,
+    NgpDismissGuardInput<KeyboardEvent>
+  >(this.config.closeOnEscape, {
+    alias: 'ngpPopoverTriggerCloseOnEscape',
+    transform: dismissGuardAttribute,
+  });
 
   /**
    * Defines how the popover behaves when the window is scrolled.

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
@@ -17,6 +17,7 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   createOverlay,
   coerceFlip,
+  NgpDismissGuard,
   NgpFlip,
   NgpFlipInput,
   NgpOverlay,
@@ -150,21 +151,19 @@ export class NgpPopoverTrigger<T = null> implements OnDestroy {
   });
 
   /**
-   * Define whether the popover should close when clicking outside of it.
+   * Define whether the popover should close when clicking outside of it, or a guard function.
    * @default true
    */
-  readonly closeOnOutsideClick = input<boolean, BooleanInput>(this.config.closeOnOutsideClick, {
+  readonly closeOnOutsideClick = input<NgpDismissGuard<Element>>(this.config.closeOnOutsideClick, {
     alias: 'ngpPopoverTriggerCloseOnOutsideClick',
-    transform: booleanAttribute,
   });
 
   /**
-   * Define whether the popover should close when the escape key is pressed.
+   * Define whether the popover should close when the escape key is pressed, or a guard function.
    * @default true
    */
-  readonly closeOnEscape = input<boolean, BooleanInput>(this.config.closeOnEscape, {
+  readonly closeOnEscape = input<NgpDismissGuard<KeyboardEvent>>(this.config.closeOnEscape, {
     alias: 'ngpPopoverTriggerCloseOnEscape',
-    transform: booleanAttribute,
   });
 
   /**

--- a/packages/ng-primitives/portal/src/index.ts
+++ b/packages/ng-primitives/portal/src/index.ts
@@ -10,7 +10,9 @@ export {
 } from './overlay';
 export { NgpOverlayCooldownManager } from './overlay-cooldown';
 export {
+  dismissGuardAttribute,
   NgpDismissGuard,
+  NgpDismissGuardInput,
   NgpDismissPolicy,
   NgpOverlayEntry,
   NgpOverlayRef,

--- a/packages/ng-primitives/portal/src/overlay-registry.ts
+++ b/packages/ng-primitives/portal/src/overlay-registry.ts
@@ -12,6 +12,27 @@ import { Subject } from 'rxjs';
 export type NgpDismissGuard<T = Element> = boolean | ((target: T) => boolean | Promise<boolean>);
 
 /**
+ * Input type for dismiss guard inputs, accepting booleans, string booleans, or guard functions.
+ */
+export type NgpDismissGuardInput<T = Element> = NgpDismissGuard<T> | string;
+
+/**
+ * Transform function for dismiss guard inputs.
+ * Coerces string boolean values ('', 'true', 'false') while passing through
+ * actual booleans and guard functions unchanged.
+ */
+export function dismissGuardAttribute<T>(value: NgpDismissGuardInput<T>): NgpDismissGuard<T> {
+  if (typeof value === 'function') {
+    return value;
+  }
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  // String coercion: '' (attribute present) and 'true' → true, 'false' → false
+  return value !== 'false';
+}
+
+/**
  * Dismiss policy for an overlay entry.
  * Determines how the overlay responds to outside clicks and escape key presses.
  * @internal

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -34,7 +34,7 @@ import { Subject } from 'rxjs';
 import { NgpFlip } from './flip';
 import { NgpOffset } from './offset';
 import { CooldownOverlay, NgpOverlayCooldownManager } from './overlay-cooldown';
-import { NgpOverlayRegistry } from './overlay-registry';
+import { NgpDismissGuard, NgpOverlayRegistry } from './overlay-registry';
 import { provideOverlayContext } from './overlay-token';
 import { NgpPortal, createPortal } from './portal';
 import { NgpPosition } from './position';
@@ -161,10 +161,10 @@ export interface NgpOverlayConfig<T = unknown> {
 
   /** The scroll strategy to use for the overlay */
   scrollBehaviour?: 'reposition' | 'block' | 'close';
-  /** Whether to close the overlay when clicking outside */
-  closeOnOutsideClick?: boolean;
-  /** Whether to close the overlay when pressing escape */
-  closeOnEscape?: boolean;
+  /** Whether to close the overlay when clicking outside, or a guard function */
+  closeOnOutsideClick?: NgpDismissGuard<Element>;
+  /** Whether to close the overlay when pressing escape, or a guard function */
+  closeOnEscape?: NgpDismissGuard<KeyboardEvent>;
   /**
    * Whether to restore focus to the trigger element when hiding the overlay.
    * Can be a boolean or a signal that returns a boolean.


### PR DESCRIPTION
## Summary
- Add dismiss guard support (`closeOnEscape`, `closeOnOutsideClick`) to dialog and popover, allowing sync or async guard functions (including Promises) to conditionally prevent dismissal
- Add missing `closeOnOutsideClick` input to `NgpDialogTrigger`
- Split `closed` (emits immediately) and `afterClosed` (emits after exit animations) on `NgpDialogRef`, aligned to same `{ focusOrigin?, result? }` shape
- Popover dismiss guard examples now close in parallel with confirmation dialog instead of sequentially

## Test plan
- [ ] Dialog dismiss guard example: escape and outside click respect the guard
- [ ] Popover dismiss guard example: popover closes simultaneously with confirmation dialog
- [ ] Dialog examples without guards still work as before
- [ ] `afterClosed` emits after exit animations complete
- [ ] `closed` emits immediately when `close()` is called

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dismiss guards to `ng-primitives/dialog` and `ng-primitives/popover` so `closeOnEscape` and `closeOnOutsideClick` accept booleans or guard functions (sync or async). Also adds `[ngpDialogTriggerCloseOnOutsideClick]`, splits `NgpDialogRef.closed` (immediate) from `afterClosed` (post-animation), updates docs/examples, and restores focus after exit.

- **New Features**
  - `closeOnEscape`/`closeOnOutsideClick` accept `NgpDismissGuard` (`boolean | (event) => boolean | Promise<boolean>`); string boolean attributes are coerced via `dismissGuardAttribute` from `ng-primitives/portal`.
  - `NgpDialogTrigger` supports `[ngpDialogTriggerCloseOnEscape]` and `[ngpDialogTriggerCloseOnOutsideClick]` with guard functions; overlay respects deprecated `closeOnClick` when no guard is set.
  - `NgpDialogRef` exposes `closed` (emits immediately) and keeps `afterClosed: Observable<R | undefined>` (emits after exit); focus restores after exit using `focusOrigin`.
  - Docs and examples updated for `ng-primitives/dialog` and `ng-primitives/popover`; popover guard closes in parallel with the confirm dialog and resets dirty state on discard; tests use `jest.fn()`, add `waitFor`, and use `dispatchOverlayClick`.

- **Migration**
  - Replace deprecated `closeOnClick` with `closeOnOutsideClick` in dialog config.
  - Use `closed` to react immediately; keep using `afterClosed` for results after animations.
  - For conditional closes, pass a function to `closeOnEscape`/`closeOnOutsideClick` that returns `boolean | Promise<boolean>`.

<sup>Written for commit ce04150ce5e7b65a70bd30128168397c3f975dd7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

