### PR TITLE
test(tooltip): add failing tests for dynamic tooltip reference changes (#711)

### DIFF
--- a/apps/documentation/src/app/examples/tooltip/tooltip-cursor.example.ts
+++ b/apps/documentation/src/app/examples/tooltip/tooltip-cursor.example.ts
@@ -10,7 +10,7 @@ import { NgpTooltip, NgpTooltipTrigger } from 'ng-primitives/tooltip';
       #tooltipTrigger="ngpTooltipTrigger"
       [ngpTooltipTrigger]="cursorTooltip"
       [ngpTooltipTriggerPosition]="cursorPosition()"
-      (pointerenter)="onPointerEnter()"
+      (pointerenter)="onPointerEnter($event)"
       (pointermove)="onPointerMove($event)"
       (pointerleave)="onPointerLeave()"
       ngpTooltipTriggerTrackPosition="true"
@@ -87,7 +87,10 @@ export default class TooltipCursorExample {
   readonly cursorPosition = signal<{ x: number; y: number } | null>(null);
   readonly tooltipTrigger = viewChild.required<NgpTooltipTrigger>('tooltipTrigger');
 
-  onPointerEnter(): void {
+  onPointerEnter(event: PointerEvent): void {
+    this.mouseX.set(Math.round(event.clientX));
+    this.mouseY.set(Math.round(event.clientY));
+    this.cursorPosition.set({ x: event.clientX, y: event.clientY });
     this.tooltipTrigger().show();
   }
 

--- a/apps/documentation/src/app/examples/tooltip/tooltip-dynamic.example.ts
+++ b/apps/documentation/src/app/examples/tooltip/tooltip-dynamic.example.ts
@@ -8,48 +8,43 @@ import { NgpTooltip, NgpTooltipTrigger } from 'ng-primitives/tooltip';
   template: `
     <div class="scenarios">
       <h3>Scenario 1: Switch template while closed</h3>
-      <p>Hover the button, move away, click "Switch", hover again — should show the other tooltip.</p>
+      <p>
+        Hover the button, move away, click "Switch", hover again — should show the other tooltip.
+      </p>
       <div class="row">
-        <button
-          [ngpTooltipTrigger]="useSecond() ? tooltipB : tooltipA"
-          ngpButton
-          type="button"
-        >
+        <button [ngpTooltipTrigger]="useSecond() ? tooltipB : tooltipA" ngpButton type="button">
           Hover me
         </button>
-        <button ngpButton type="button" (click)="useSecond.set(!useSecond())">
+        <button (click)="useSecond.set(!useSecond())" ngpButton type="button">
           Switch to {{ useSecond() ? 'A' : 'B' }}
         </button>
         <span class="badge">Active: Tooltip {{ useSecond() ? 'B' : 'A' }}</span>
       </div>
 
       <h3>Scenario 2: Switch template while open</h3>
-      <p>Hover the button, then click "Switch" while tooltip is visible — content should update live.</p>
+      <p>
+        Hover the button, then click "Switch" while tooltip is visible — content should update live.
+      </p>
       <div class="row">
-        <button
-          [ngpTooltipTrigger]="useLiveSecond() ? tooltipD : tooltipC"
-          ngpButton
-          type="button"
-        >
+        <button [ngpTooltipTrigger]="useLiveSecond() ? tooltipD : tooltipC" ngpButton type="button">
           Hover me (keep hovering)
         </button>
-        <button ngpButton type="button" (click)="useLiveSecond.set(!useLiveSecond())">
+        <button (click)="useLiveSecond.set(!useLiveSecond())" ngpButton type="button">
           Switch to {{ useLiveSecond() ? 'C' : 'D' }}
         </button>
         <span class="badge">Active: Tooltip {{ useLiveSecond() ? 'D' : 'C' }}</span>
       </div>
 
       <h3>Scenario 3: Toggle between template and null</h3>
-      <p>Hover the button, then click "Disable" — tooltip stays until you leave. Click "Enable" and hover again.</p>
+      <p>
+        Hover the button, then click "Disable" — tooltip stays until you leave. Click "Enable" and
+        hover again.
+      </p>
       <div class="row">
-        <button
-          [ngpTooltipTrigger]="showTooltip() ? tooltipE : null"
-          ngpButton
-          type="button"
-        >
+        <button [ngpTooltipTrigger]="showTooltip() ? tooltipE : null" ngpButton type="button">
           Hover me
         </button>
-        <button ngpButton type="button" (click)="showTooltip.set(!showTooltip())">
+        <button (click)="showTooltip.set(!showTooltip())" ngpButton type="button">
           {{ showTooltip() ? 'Set to null' : 'Set template' }}
         </button>
         <span class="badge">Input: {{ showTooltip() ? 'TemplateRef' : 'null' }}</span>

--- a/apps/documentation/src/app/examples/tooltip/tooltip-dynamic.example.ts
+++ b/apps/documentation/src/app/examples/tooltip/tooltip-dynamic.example.ts
@@ -1,0 +1,188 @@
+import { Component, signal, ViewEncapsulation } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpTooltip, NgpTooltipTrigger } from 'ng-primitives/tooltip';
+
+@Component({
+  selector: 'app-tooltip-dynamic',
+  imports: [NgpTooltipTrigger, NgpTooltip, NgpButton],
+  template: `
+    <div class="scenarios">
+      <h3>Scenario 1: Switch template while closed</h3>
+      <p>Hover the button, move away, click "Switch", hover again — should show the other tooltip.</p>
+      <div class="row">
+        <button
+          [ngpTooltipTrigger]="useSecond() ? tooltipB : tooltipA"
+          ngpButton
+          type="button"
+        >
+          Hover me
+        </button>
+        <button ngpButton type="button" (click)="useSecond.set(!useSecond())">
+          Switch to {{ useSecond() ? 'A' : 'B' }}
+        </button>
+        <span class="badge">Active: Tooltip {{ useSecond() ? 'B' : 'A' }}</span>
+      </div>
+
+      <h3>Scenario 2: Switch template while open</h3>
+      <p>Hover the button, then click "Switch" while tooltip is visible — content should update live.</p>
+      <div class="row">
+        <button
+          [ngpTooltipTrigger]="useLiveSecond() ? tooltipD : tooltipC"
+          ngpButton
+          type="button"
+        >
+          Hover me (keep hovering)
+        </button>
+        <button ngpButton type="button" (click)="useLiveSecond.set(!useLiveSecond())">
+          Switch to {{ useLiveSecond() ? 'C' : 'D' }}
+        </button>
+        <span class="badge">Active: Tooltip {{ useLiveSecond() ? 'D' : 'C' }}</span>
+      </div>
+
+      <h3>Scenario 3: Toggle between template and null</h3>
+      <p>Hover the button, then click "Disable" — tooltip stays until you leave. Click "Enable" and hover again.</p>
+      <div class="row">
+        <button
+          [ngpTooltipTrigger]="showTooltip() ? tooltipE : null"
+          ngpButton
+          type="button"
+        >
+          Hover me
+        </button>
+        <button ngpButton type="button" (click)="showTooltip.set(!showTooltip())">
+          {{ showTooltip() ? 'Set to null' : 'Set template' }}
+        </button>
+        <span class="badge">Input: {{ showTooltip() ? 'TemplateRef' : 'null' }}</span>
+      </div>
+    </div>
+
+    <ng-template #tooltipA>
+      <div ngpTooltip>Tooltip A — I am the first tooltip</div>
+    </ng-template>
+
+    <ng-template #tooltipB>
+      <div ngpTooltip>Tooltip B — I am the second tooltip</div>
+    </ng-template>
+
+    <ng-template #tooltipC>
+      <div ngpTooltip>Tooltip C — Original content</div>
+    </ng-template>
+
+    <ng-template #tooltipD>
+      <div ngpTooltip>Tooltip D — Switched content!</div>
+    </ng-template>
+
+    <ng-template #tooltipE>
+      <div ngpTooltip>I can be toggled on and off</div>
+    </ng-template>
+  `,
+  styles: `
+    app-tooltip-dynamic {
+      .scenarios {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      h3 {
+        margin: 1rem 0 0;
+        font-size: 0.875rem;
+        font-weight: 600;
+        color: var(--ngp-text-primary);
+      }
+
+      p {
+        margin: 0;
+        font-size: 0.75rem;
+        color: var(--ngp-text-secondary);
+      }
+
+      .row {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .badge {
+        font-size: 0.75rem;
+        padding: 0.25rem 0.5rem;
+        border-radius: 0.25rem;
+        background-color: var(--ngp-background-hover);
+        color: var(--ngp-text-secondary);
+        font-family: monospace;
+      }
+
+      button {
+        padding-left: 1rem;
+        padding-right: 1rem;
+        border-radius: 0.5rem;
+        color: var(--ngp-text-primary);
+        outline: none;
+        height: 2.5rem;
+        font-weight: 500;
+        background-color: var(--ngp-background);
+        transition: background-color 300ms cubic-bezier(0.4, 0, 0.2, 1);
+        box-shadow: var(--ngp-button-shadow);
+      }
+
+      button[data-hover] {
+        background-color: var(--ngp-background-hover);
+      }
+
+      button[data-focus-visible] {
+        outline: 2px solid var(--ngp-focus-ring);
+      }
+
+      button[data-press] {
+        background-color: var(--ngp-background-active);
+      }
+    }
+
+    [ngpTooltip] {
+      position: absolute;
+      max-width: 16rem;
+      border-radius: 0.5rem;
+      background-color: var(--ngp-background-inverse);
+      padding: 0.5rem 0.75rem;
+      border: none;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--ngp-text-inverse);
+      animation: tooltip-dynamic-show 200ms ease-in-out;
+      transform-origin: var(--ngp-tooltip-transform-origin);
+    }
+
+    [ngpTooltip][data-exit] {
+      animation: tooltip-dynamic-hide 200ms ease-in-out;
+    }
+
+    @keyframes tooltip-dynamic-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes tooltip-dynamic-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+  `,
+  encapsulation: ViewEncapsulation.None,
+})
+export default class TooltipDynamicExample {
+  readonly useSecond = signal(false);
+  readonly useLiveSecond = signal(false);
+  readonly showTooltip = signal(true);
+}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -65,6 +65,12 @@ You can position a tooltip at specific coordinates using the `ngpTooltipTriggerP
 
 <docs-example name="tooltip-cursor"></docs-example>
 
+### Dynamic Template Switching
+
+This example demonstrates dynamically switching tooltip templates at runtime — switching while closed, switching while open, and toggling between a template and null.
+
+<docs-example name="tooltip-dynamic"></docs-example>
+
 ### Custom Offset
 
 You can customize the offset using either a simple number or an object for more precise control:

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -649,6 +649,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       const wasOpen = this.isOpen();
       this.hideImmediate();
       this.destroyingPortal = null;
+      this.registeredOutletElement = null;
 
       if (wasOpen) {
         // Skip the enter animation — this is a content swap, not a fresh show.

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -632,20 +632,23 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    * destroyed and recreated with the new content. If closed, the config is
    * updated so the next show() uses the new content.
    */
-  async updateContent(
-    content: NgpOverlayContent<T>,
-    context?: Signal<T | undefined>,
-  ): Promise<void> {
+  updateContent(content: NgpOverlayContent<T>, context?: Signal<T | undefined>): void {
     this.config = {
       ...this.config,
       content,
       ...(context !== undefined ? { context } : {}),
     };
 
-    // If the overlay is currently showing, recreate it with the new content
+    // If the overlay is currently showing, recreate it with the new content.
+    // We call hideImmediate() to synchronously tear down the portal, then
+    // null out destroyingPortal so the deferred cleanup inside destroyOverlay
+    // (which sets isOpen=false) is skipped — createOverlay will set isOpen=true.
+    // This avoids a microtask gap where isOpen would briefly become false,
+    // which could cause data-open / aria-describedby to flicker.
     if (this.portal()) {
       const wasOpen = this.isOpen();
-      await this.destroyOverlay(true);
+      this.hideImmediate();
+      this.destroyingPortal = null;
 
       if (wasOpen) {
         this.createOverlay(true);

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -644,6 +644,10 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       const wasOpen = this.isOpen();
       this.hideImmediate();
 
+      // Prevent the async destroyOverlay cleanup from clobbering state
+      // set by the subsequent createOverlay call.
+      this.destroyingPortal = null;
+
       if (wasOpen) {
         this.createOverlay(true);
       }

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -628,6 +628,29 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   }
 
   /**
+   * Update the overlay content. If the overlay is currently open, it will be
+   * destroyed and recreated with the new content. If closed, the config is
+   * updated so the next show() uses the new content.
+   */
+  updateContent(content: NgpOverlayContent<T>, context?: Signal<T | undefined>): void {
+    this.config = {
+      ...this.config,
+      content,
+      ...(context !== undefined ? { context } : {}),
+    };
+
+    // If the overlay is currently showing, recreate it with the new content
+    if (this.portal()) {
+      const wasOpen = this.isOpen();
+      this.hideImmediate();
+
+      if (wasOpen) {
+        this.createOverlay(true);
+      }
+    }
+  }
+
+  /**
    * Completely destroy this overlay instance
    */
   destroy(): void {

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -632,7 +632,10 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    * destroyed and recreated with the new content. If closed, the config is
    * updated so the next show() uses the new content.
    */
-  updateContent(content: NgpOverlayContent<T>, context?: Signal<T | undefined>): void {
+  async updateContent(
+    content: NgpOverlayContent<T>,
+    context?: Signal<T | undefined>,
+  ): Promise<void> {
     this.config = {
       ...this.config,
       content,
@@ -642,11 +645,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     // If the overlay is currently showing, recreate it with the new content
     if (this.portal()) {
       const wasOpen = this.isOpen();
-      this.hideImmediate();
-
-      // Prevent the async destroyOverlay cleanup from clobbering state
-      // set by the subsequent createOverlay call.
-      this.destroyingPortal = null;
+      await this.destroyOverlay(true);
 
       if (wasOpen) {
         this.createOverlay(true);

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -651,6 +651,8 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       this.destroyingPortal = null;
 
       if (wasOpen) {
+        // Skip the enter animation — this is a content swap, not a fresh show.
+        this.instantTransition.set(true);
         this.createOverlay(true);
       }
     }

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
@@ -1268,6 +1268,47 @@ describe('NgpTooltipTrigger', () => {
       });
     });
 
+    it('should preserve data-open on trigger after switching content while open', async () => {
+      const { fixture, getByRole } = await render(
+        `
+          <button [ngpTooltipTrigger]="useSecond ? tooltipB : tooltipA" ngpTooltipTriggerDisabled="true"></button>
+
+          <ng-template #tooltipA>
+            <div ngpTooltip>Tooltip A</div>
+          </ng-template>
+
+          <ng-template #tooltipB>
+            <div ngpTooltip>Tooltip B</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+          componentProperties: {
+            useSecond: false,
+          },
+        },
+      );
+
+      const trigger = getByRole('button');
+      const triggerDirective = fixture.debugElement.children[0].injector.get(NgpTooltipTrigger);
+
+      // Show tooltip A
+      triggerDirective.show();
+      await waitFor(() => {
+        expect(trigger.getAttribute('data-open')).toBe('');
+      });
+
+      // Switch to tooltip B while open
+      (fixture.componentInstance as any).useSecond = true;
+      fixture.detectChanges();
+
+      // data-open should still be present after content switch
+      await waitFor(() => {
+        expect(trigger.getAttribute('data-open')).toBe('');
+        expect(document.querySelector('[ngpTooltip]')?.textContent?.trim()).toBe('Tooltip B');
+      });
+    });
+
     it('should show tooltip after switching from null to a template reference', async () => {
       const { fixture } = await render(
         `

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
@@ -1173,4 +1173,171 @@ describe('NgpTooltipTrigger', () => {
       });
     });
   });
+
+  describe('dynamic tooltip changes (issue #711)', () => {
+    it('should update tooltip content when template reference changes while closed', async () => {
+      const { fixture } = await render(
+        `
+          <button [ngpTooltipTrigger]="useSecond ? tooltipB : tooltipA" ngpTooltipTriggerDisabled="true"></button>
+
+          <ng-template #tooltipA>
+            <div ngpTooltip>Tooltip A</div>
+          </ng-template>
+
+          <ng-template #tooltipB>
+            <div ngpTooltip>Tooltip B</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+          componentProperties: {
+            useSecond: false,
+          },
+        },
+      );
+
+      const triggerDirective = fixture.debugElement.children[0].injector.get(NgpTooltipTrigger);
+
+      // Show tooltip A
+      triggerDirective.show();
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Tooltip A');
+      });
+
+      // Hide tooltip
+      triggerDirective.hide();
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+      });
+
+      // Switch to tooltip B
+      (fixture.componentInstance as any).useSecond = true;
+      fixture.detectChanges();
+
+      // Show tooltip again - should display Tooltip B
+      triggerDirective.show();
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Tooltip B');
+      });
+    });
+
+    it('should update tooltip content when template reference changes while open', async () => {
+      const { fixture } = await render(
+        `
+          <button [ngpTooltipTrigger]="useSecond ? tooltipB : tooltipA" ngpTooltipTriggerDisabled="true"></button>
+
+          <ng-template #tooltipA>
+            <div ngpTooltip>Tooltip A</div>
+          </ng-template>
+
+          <ng-template #tooltipB>
+            <div ngpTooltip>Tooltip B</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+          componentProperties: {
+            useSecond: false,
+          },
+        },
+      );
+
+      const triggerDirective = fixture.debugElement.children[0].injector.get(NgpTooltipTrigger);
+
+      // Show tooltip A
+      triggerDirective.show();
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Tooltip A');
+      });
+
+      // Switch to tooltip B while open
+      (fixture.componentInstance as any).useSecond = true;
+      fixture.detectChanges();
+
+      // Should now display Tooltip B
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Tooltip B');
+      });
+    });
+
+    it('should hide tooltip when template reference changes to null', async () => {
+      const { fixture } = await render(
+        `
+          <button [ngpTooltipTrigger]="showTooltip ? content : null" ngpTooltipTriggerDisabled="true" ngpTooltipTriggerUseTextContent="false"></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+          componentProperties: {
+            showTooltip: true,
+          },
+        },
+      );
+
+      const triggerDirective = fixture.debugElement.children[0].injector.get(NgpTooltipTrigger);
+
+      // Show tooltip
+      triggerDirective.show();
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+
+      // Set tooltip to null
+      (fixture.componentInstance as any).showTooltip = false;
+      fixture.detectChanges();
+
+      // Tooltip should be hidden
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should show tooltip after switching from null to a template reference', async () => {
+      const { fixture } = await render(
+        `
+          <button [ngpTooltipTrigger]="showTooltip ? content : null" ngpTooltipTriggerDisabled="true" ngpTooltipTriggerUseTextContent="false"></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+          componentProperties: {
+            showTooltip: false,
+          },
+        },
+      );
+
+      const triggerDirective = fixture.debugElement.children[0].injector.get(NgpTooltipTrigger);
+
+      // Try to show - should not show since tooltip is null
+      triggerDirective.show();
+      await new Promise(resolve => setTimeout(resolve, 100));
+      expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+
+      // Switch to a template
+      (fixture.componentInstance as any).showTooltip = true;
+      fixture.detectChanges();
+
+      // Now show should work
+      triggerDirective.show();
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Tooltip content');
+      });
+    });
+  });
 });

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
@@ -1268,41 +1268,6 @@ describe('NgpTooltipTrigger', () => {
       });
     });
 
-    it('should hide tooltip when template reference changes to null', async () => {
-      const { fixture } = await render(
-        `
-          <button [ngpTooltipTrigger]="showTooltip ? content : null" ngpTooltipTriggerDisabled="true" ngpTooltipTriggerUseTextContent="false"></button>
-
-          <ng-template #content>
-            <div ngpTooltip>Tooltip content</div>
-          </ng-template>
-        `,
-        {
-          imports: [NgpTooltipTrigger, NgpTooltip],
-          componentProperties: {
-            showTooltip: true,
-          },
-        },
-      );
-
-      const triggerDirective = fixture.debugElement.children[0].injector.get(NgpTooltipTrigger);
-
-      // Show tooltip
-      triggerDirective.show();
-      await waitFor(() => {
-        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
-      });
-
-      // Set tooltip to null
-      (fixture.componentInstance as any).showTooltip = false;
-      fixture.detectChanges();
-
-      // Tooltip should be hidden
-      await waitFor(() => {
-        expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
-      });
-    });
-
     it('should show tooltip after switching from null to a template reference', async () => {
       const { fixture } = await render(
         `

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
@@ -1352,6 +1352,50 @@ describe('NgpTooltipTrigger', () => {
       });
     });
 
+    it('should not play enter animation when switching content while open', async () => {
+      const { fixture } = await render(
+        `
+          <button [ngpTooltipTrigger]="useSecond ? tooltipB : tooltipA" ngpTooltipTriggerDisabled="true"></button>
+
+          <ng-template #tooltipA>
+            <div ngpTooltip>Tooltip A</div>
+          </ng-template>
+
+          <ng-template #tooltipB>
+            <div ngpTooltip>Tooltip B</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+          componentProperties: {
+            useSecond: false,
+          },
+        },
+      );
+
+      const triggerDirective = fixture.debugElement.children[0].injector.get(NgpTooltipTrigger);
+
+      // Show tooltip A
+      triggerDirective.show();
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Tooltip A');
+      });
+
+      // Switch to tooltip B while open
+      (fixture.componentInstance as any).useSecond = true;
+      fixture.detectChanges();
+
+      // The new tooltip should have data-instant (skip animation) instead of animating in
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Tooltip B');
+        expect(tooltip?.hasAttribute('data-instant')).toBe(true);
+      });
+    });
+
     it('should show tooltip after switching from null to a template reference', async () => {
       const { fixture } = await render(
         `

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
@@ -1309,6 +1309,49 @@ describe('NgpTooltipTrigger', () => {
       });
     });
 
+    it('should maintain aria-describedby on trigger after switching content while open', async () => {
+      const { fixture, getByRole } = await render(
+        `
+          <button [ngpTooltipTrigger]="useSecond ? tooltipB : tooltipA" ngpTooltipTriggerDisabled="true"></button>
+
+          <ng-template #tooltipA>
+            <div ngpTooltip>Tooltip A</div>
+          </ng-template>
+
+          <ng-template #tooltipB>
+            <div ngpTooltip>Tooltip B</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+          componentProperties: {
+            useSecond: false,
+          },
+        },
+      );
+
+      const trigger = getByRole('button');
+      const triggerDirective = fixture.debugElement.children[0].injector.get(NgpTooltipTrigger);
+
+      // Show tooltip A
+      triggerDirective.show();
+      await waitFor(() => {
+        expect(trigger.getAttribute('aria-describedby')).toBeTruthy();
+      });
+
+      const originalAriaDescribedBy = trigger.getAttribute('aria-describedby');
+
+      // Switch to tooltip B while open
+      (fixture.componentInstance as any).useSecond = true;
+      fixture.detectChanges();
+
+      // aria-describedby should still be present with the same ID
+      await waitFor(() => {
+        expect(trigger.getAttribute('aria-describedby')).toBe(originalAriaDescribedBy);
+        expect(document.querySelector('[ngpTooltip]')?.textContent?.trim()).toBe('Tooltip B');
+      });
+    });
+
     it('should show tooltip after switching from null to a template reference', async () => {
       const { fixture } = await render(
         `

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
@@ -1396,6 +1396,43 @@ describe('NgpTooltipTrigger', () => {
       });
     });
 
+    it('should hide tooltip when template is switched to null while open', async () => {
+      const { fixture } = await render(
+        `
+          <button [ngpTooltipTrigger]="showTooltip ? content : null" ngpTooltipTriggerDisabled="true" ngpTooltipTriggerUseTextContent="false"></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+          componentProperties: {
+            showTooltip: true,
+          },
+        },
+      );
+
+      const triggerDirective = fixture.debugElement.children[0].injector.get(NgpTooltipTrigger);
+
+      // Show tooltip
+      triggerDirective.show();
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip?.textContent?.trim()).toBe('Tooltip content');
+      });
+
+      // Switch to null while open
+      (fixture.componentInstance as any).showTooltip = false;
+      fixture.detectChanges();
+
+      // Tooltip should be hidden
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+      });
+    });
+
     it('should show tooltip after switching from null to a template reference', async () => {
       const { fixture } = await render(
         `

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -255,7 +255,7 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
       disabled: computed(() => !this.state.showOnOverflow()),
     });
 
-    // Watch for tooltip content changes and invalidate the overlay (#711)
+    // Watch for tooltip content changes and update the overlay (#711)
     let previousTooltip = this.state.tooltip();
     effect(() => {
       const currentTooltip = this.state.tooltip();
@@ -265,12 +265,11 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
       untracked(() => {
         const overlay = this.overlay();
         if (overlay) {
-          const wasOpen = this.open();
-          overlay.destroy();
-          this.overlay.set(null);
-
-          if (wasOpen && currentTooltip) {
-            this.performShow(true);
+          if (currentTooltip && !isString(currentTooltip)) {
+            overlay.updateContent(currentTooltip, this.state.context);
+          } else {
+            overlay.destroy();
+            this.overlay.set(null);
           }
         }
       });

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -3,7 +3,6 @@ import {
   booleanAttribute,
   computed,
   Directive,
-  effect,
   ElementRef,
   inject,
   Injector,
@@ -12,10 +11,9 @@ import {
   OnDestroy,
   Signal,
   signal,
-  untracked,
   ViewContainerRef,
 } from '@angular/core';
-import { setupOverflowListener } from 'ng-primitives/internal';
+import { explicitEffect, setupOverflowListener } from 'ng-primitives/internal';
 import {
   coerceFlip,
   coerceOffset,
@@ -255,24 +253,17 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
       disabled: computed(() => !this.state.showOnOverflow()),
     });
 
-    // Watch for tooltip content changes and update the overlay (#711)
-    let previousTooltip = this.state.tooltip();
-    effect(() => {
-      const currentTooltip = this.state.tooltip();
-      if (currentTooltip === previousTooltip) return;
-      previousTooltip = currentTooltip;
+    // When the tooltip content changes, update or destroy the overlay (#711)
+    explicitEffect([this.state.tooltip], ([currentTooltip]) => {
+      const overlay = this.overlay();
+      if (!overlay) return;
 
-      untracked(() => {
-        const overlay = this.overlay();
-        if (overlay) {
-          if (currentTooltip && !isString(currentTooltip)) {
-            overlay.updateContent(currentTooltip, this.state.context);
-          } else {
-            overlay.destroy();
-            this.overlay.set(null);
-          }
-        }
-      });
+      if (currentTooltip && !isString(currentTooltip)) {
+        overlay.updateContent(currentTooltip, this.state.context);
+      } else {
+        overlay.destroy();
+        this.overlay.set(null);
+      }
     });
   }
 

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -253,17 +253,14 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
       disabled: computed(() => !this.state.showOnOverflow()),
     });
 
-    // When the tooltip content changes, update or destroy the overlay (#711)
+    // When the tooltip template changes, update the overlay content (#711).
+    // Only reacts to TemplateRef/ComponentType changes (strings are
+    // transformed to null by the input and handled via useTextContent).
     explicitEffect([this.state.tooltip], ([currentTooltip]) => {
       const overlay = this.overlay();
-      if (!overlay) return;
+      if (!overlay || !currentTooltip || isString(currentTooltip)) return;
 
-      if (currentTooltip && !isString(currentTooltip)) {
-        overlay.updateContent(currentTooltip, this.state.context);
-      } else {
-        overlay.destroy();
-        this.overlay.set(null);
-      }
+      overlay.updateContent(currentTooltip, this.state.context);
     });
   }
 

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -258,9 +258,14 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
     // transformed to null by the input and handled via useTextContent).
     explicitEffect([this.state.tooltip], ([currentTooltip]) => {
       const overlay = this.overlay();
-      if (!overlay || !currentTooltip || isString(currentTooltip)) return;
+      if (!overlay || isString(currentTooltip)) return;
 
-      overlay.updateContent(currentTooltip, this.state.context);
+      if (currentTooltip) {
+        overlay.updateContent(currentTooltip, this.state.context);
+      } else {
+        // Template was removed — hide the overlay so it doesn't show stale content.
+        overlay.hide();
+      }
     });
   }
 

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -3,6 +3,7 @@ import {
   booleanAttribute,
   computed,
   Directive,
+  effect,
   ElementRef,
   inject,
   Injector,
@@ -11,6 +12,7 @@ import {
   OnDestroy,
   Signal,
   signal,
+  untracked,
   ViewContainerRef,
 } from '@angular/core';
 import { setupOverflowListener } from 'ng-primitives/internal';
@@ -251,6 +253,27 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
   constructor() {
     this.hasOverflow = setupOverflowListener(this.trigger.nativeElement, {
       disabled: computed(() => !this.state.showOnOverflow()),
+    });
+
+    // Watch for tooltip content changes and invalidate the overlay (#711)
+    let previousTooltip = this.state.tooltip();
+    effect(() => {
+      const currentTooltip = this.state.tooltip();
+      if (currentTooltip === previousTooltip) return;
+      previousTooltip = currentTooltip;
+
+      untracked(() => {
+        const overlay = this.overlay();
+        if (overlay) {
+          const wasOpen = this.open();
+          overlay.destroy();
+          this.overlay.set(null);
+
+          if (wasOpen && currentTooltip) {
+            this.performShow(true);
+          }
+        }
+      });
     });
   }
 


### PR DESCRIPTION
Tests verify that the tooltip updates when the ngpTooltipTrigger input
changes dynamically - switching between templates, switching to null,
and switching from null to a template.

https://claude.ai/code/session_01Nrw4fUhwAFK69N3cty5hWQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dynamic tooltip updates: when `ngpTooltipTrigger` switches templates or toggles null, the tooltip swaps content immediately—even while open—with no `data-open`/`aria-describedby` flicker, no re-enter animation, and no stale positioning. Adds docs examples for dynamic switching and improves cursor-position behavior (addresses #711).

- **Bug Fixes**
  - Add `NgpOverlay.updateContent(content, context)` to swap content while open, keep `isOpen` stable, skip the enter animation, and clear the registered outlet to prevent stale positioning.
  - In `NgpTooltipTrigger`, watch `tooltip` via `explicitEffect`; update the overlay on `TemplateRef`/`ComponentType` changes, hide when set to `null`, and ignore strings.
  - Tests cover switching while closed/open, template→null (hide while open) and null→template, stable `data-open`/`aria-describedby`, and no enter animation on swap.

- **New Features**
  - Docs: add `tooltip-dynamic` example (switch while closed/open, toggle null) and update cursor example to set position on `pointerenter` for immediate placement.

<sup>Written for commit d272330a14e63a2a824e1a37c9ec7196a0ce340a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

