### PR TITLE
fix(interactions): prevent stuck hover state on iOS Safari

### DIFF
--- a/packages/ng-primitives/interactions/src/hover/hover-interaction.ts
+++ b/packages/ng-primitives/interactions/src/hover/hover-interaction.ts
@@ -20,6 +20,12 @@ class GlobalPointerEvents {
   ignoreEmulatedMouseEvents: boolean = false;
 
   /**
+   * Handle to the current ignore timeout, so rapid touches don't clear
+   * the guard prematurely.
+   */
+  private ignoreTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  /**
    * Access the document.
    */
   private readonly document = inject(DOCUMENT);
@@ -43,11 +49,21 @@ class GlobalPointerEvents {
 
   private setGlobalIgnoreEmulatedMouseEvents(): void {
     this.ignoreEmulatedMouseEvents = true;
+
+    // Cancel any pending timeout so rapid successive touches don't
+    // clear the guard prematurely.
+    if (this.ignoreTimeout != null) {
+      clearTimeout(this.ignoreTimeout);
+    }
+
     // Clear globalIgnoreEmulatedMouseEvents after a short timeout. iOS fires onPointerEnter
     // with pointerType="mouse" immediately after onPointerUp and before onFocus. On other
     // devices that don't have this quirk, we don't want to ignore a mouse hover sometime in
     // the distant future because a user previously touched the element.
-    setTimeout(() => (this.ignoreEmulatedMouseEvents = false), 500);
+    this.ignoreTimeout = setTimeout(() => {
+      this.ignoreEmulatedMouseEvents = false;
+      this.ignoreTimeout = null;
+    }, 500);
   }
 
   private handleGlobalPointerEvent(event: PointerEvent): void {

--- a/packages/ng-primitives/interactions/src/hover/hover-interaction.ts
+++ b/packages/ng-primitives/interactions/src/hover/hover-interaction.ts
@@ -39,24 +39,20 @@ class GlobalPointerEvents {
   private setupGlobalTouchEvents(): void {
     this.document.addEventListener('pointerup', this.handleGlobalPointerEvent.bind(this));
     this.document.addEventListener('touchend', this.setGlobalIgnoreEmulatedMouseEvents.bind(this));
-    this.document.addEventListener('pointermove', this.handlePointerMove.bind(this));
   }
 
   private setGlobalIgnoreEmulatedMouseEvents(): void {
     this.ignoreEmulatedMouseEvents = true;
+    // Clear globalIgnoreEmulatedMouseEvents after a short timeout. iOS fires onPointerEnter
+    // with pointerType="mouse" immediately after onPointerUp and before onFocus. On other
+    // devices that don't have this quirk, we don't want to ignore a mouse hover sometime in
+    // the distant future because a user previously touched the element.
+    setTimeout(() => (this.ignoreEmulatedMouseEvents = false), 500);
   }
 
   private handleGlobalPointerEvent(event: PointerEvent): void {
     if (event.pointerType === 'touch') {
       this.setGlobalIgnoreEmulatedMouseEvents();
-    }
-  }
-
-  private handlePointerMove(event: PointerEvent): void {
-    // A real mouse movement proves the user switched to a mouse — emulated events
-    // from touch never produce pointermove with pointerType="mouse".
-    if (event.pointerType === 'mouse') {
-      this.ignoreEmulatedMouseEvents = false;
     }
   }
 }

--- a/packages/ng-primitives/interactions/src/hover/hover-interaction.ts
+++ b/packages/ng-primitives/interactions/src/hover/hover-interaction.ts
@@ -39,20 +39,24 @@ class GlobalPointerEvents {
   private setupGlobalTouchEvents(): void {
     this.document.addEventListener('pointerup', this.handleGlobalPointerEvent.bind(this));
     this.document.addEventListener('touchend', this.setGlobalIgnoreEmulatedMouseEvents.bind(this));
+    this.document.addEventListener('pointermove', this.handlePointerMove.bind(this));
   }
 
   private setGlobalIgnoreEmulatedMouseEvents(): void {
     this.ignoreEmulatedMouseEvents = true;
-    // Clear globalIgnoreEmulatedMouseEvents after a short timeout. iOS fires onPointerEnter
-    // with pointerType="mouse" immediately after onPointerUp and before onFocus. On other
-    // devices that don't have this quirk, we don't want to ignore a mouse hover sometime in
-    // the distant future because a user previously touched the element.
-    setTimeout(() => (this.ignoreEmulatedMouseEvents = false), 50);
   }
 
   private handleGlobalPointerEvent(event: PointerEvent): void {
     if (event.pointerType === 'touch') {
       this.setGlobalIgnoreEmulatedMouseEvents();
+    }
+  }
+
+  private handlePointerMove(event: PointerEvent): void {
+    // A real mouse movement proves the user switched to a mouse — emulated events
+    // from touch never produce pointermove with pointerType="mouse".
+    if (event.pointerType === 'mouse') {
+      this.ignoreEmulatedMouseEvents = false;
     }
   }
 }
@@ -164,7 +168,10 @@ export function ngpHover({
   }
 
   function onPointerEnter(event: PointerEvent): void {
-    if (globalPointerEvents.ignoreEmulatedMouseEvents && event.pointerType === 'mouse') {
+    if (
+      (globalPointerEvents.ignoreEmulatedMouseEvents && event.pointerType === 'mouse') ||
+      (ignoreEmulatedMouseEvents && event.pointerType === 'mouse')
+    ) {
       return;
     }
 
@@ -179,6 +186,9 @@ export function ngpHover({
 
   function onTouchStart(): void {
     ignoreEmulatedMouseEvents = true;
+    if (hovered()) {
+      onHoverFinished('mouse');
+    }
   }
 
   function onMouseEnter(event: MouseEvent): void {

--- a/packages/ng-primitives/interactions/src/hover/hover-interaction.ts
+++ b/packages/ng-primitives/interactions/src/hover/hover-interaction.ts
@@ -1,76 +1,37 @@
-import { isPlatformBrowser } from '@angular/common';
-import { DOCUMENT } from '@angular/common';
-import { ElementRef, inject, Injectable, PLATFORM_ID, Signal, signal } from '@angular/core';
+import { ElementRef, inject, Signal, signal } from '@angular/core';
 import { onDomRemoval } from 'ng-primitives/internal';
 import { dataBinding, listener } from 'ng-primitives/state';
 import { onBooleanChange } from 'ng-primitives/utils';
 import { isHoverEnabled } from '../config/interactions-config';
 
-/**
- * We use a service here as this value is a singleton
- * and allows us to register the dom events once.
- */
-@Injectable({
-  providedIn: 'root',
-})
-class GlobalPointerEvents {
-  /**
-   * Whether global mouse events should be ignored.
-   */
-  ignoreEmulatedMouseEvents: boolean = false;
+// Module-level flag that tracks whether the user's last input was a touch.
+// Kept outside Angular DI so it survives service destruction during SSR
+// hydration, micro-frontend re-bootstrap, or any scenario that re-creates
+// the root injector. A timeout can't cover delayed emulated events — iOS
+// may fire an emulated pointerenter long after the originating touch
+// (e.g. after the user navigates away and then taps browser-back).
+//
+// iOS emulated mouse events never dispatch `pointermove`; only a real
+// pointing device does. So a non-touch pointermove is a reliable signal
+// that the user has returned to a real mouse.
+let hadRecentTouch = false;
 
-  /**
-   * Handle to the current ignore timeout, so rapid touches don't clear
-   * the guard prematurely.
-   */
-  private ignoreTimeout: ReturnType<typeof setTimeout> | null = null;
-
-  /**
-   * Access the document.
-   */
-  private readonly document = inject(DOCUMENT);
-
-  /**
-   * Determine the platform id.
-   */
-  private readonly platformId = inject(PLATFORM_ID);
-
-  constructor() {
-    // we only want to setup events on the client
-    if (isPlatformBrowser(this.platformId)) {
-      this.setupGlobalTouchEvents();
-    }
-  }
-
-  private setupGlobalTouchEvents(): void {
-    this.document.addEventListener('pointerup', this.handleGlobalPointerEvent.bind(this));
-    this.document.addEventListener('touchend', this.setGlobalIgnoreEmulatedMouseEvents.bind(this));
-  }
-
-  private setGlobalIgnoreEmulatedMouseEvents(): void {
-    this.ignoreEmulatedMouseEvents = true;
-
-    // Cancel any pending timeout so rapid successive touches don't
-    // clear the guard prematurely.
-    if (this.ignoreTimeout != null) {
-      clearTimeout(this.ignoreTimeout);
-    }
-
-    // Clear globalIgnoreEmulatedMouseEvents after a short timeout. iOS fires onPointerEnter
-    // with pointerType="mouse" immediately after onPointerUp and before onFocus. On other
-    // devices that don't have this quirk, we don't want to ignore a mouse hover sometime in
-    // the distant future because a user previously touched the element.
-    this.ignoreTimeout = setTimeout(() => {
-      this.ignoreEmulatedMouseEvents = false;
-      this.ignoreTimeout = null;
-    }, 500);
-  }
-
-  private handleGlobalPointerEvent(event: PointerEvent): void {
-    if (event.pointerType === 'touch') {
-      this.setGlobalIgnoreEmulatedMouseEvents();
-    }
-  }
+if (typeof document !== 'undefined') {
+  document.addEventListener('touchend', () => (hadRecentTouch = true), true);
+  document.addEventListener(
+    'pointerup',
+    event => {
+      if ((event as PointerEvent).pointerType === 'touch') hadRecentTouch = true;
+    },
+    true,
+  );
+  document.addEventListener(
+    'pointermove',
+    event => {
+      if ((event as PointerEvent).pointerType !== 'touch') hadRecentTouch = false;
+    },
+    true,
+  );
 }
 
 interface NgpHoverProps {
@@ -104,11 +65,6 @@ export function ngpHover({
    * Access the element.
    */
   const elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
-
-  /**
-   * Access the global pointer events handler.
-   */
-  const globalPointerEvents = inject(GlobalPointerEvents);
 
   /**
    * Store the current hover state.
@@ -180,10 +136,7 @@ export function ngpHover({
   }
 
   function onPointerEnter(event: PointerEvent): void {
-    if (
-      (globalPointerEvents.ignoreEmulatedMouseEvents && event.pointerType === 'mouse') ||
-      (ignoreEmulatedMouseEvents && event.pointerType === 'mouse')
-    ) {
+    if (event.pointerType === 'mouse' && (ignoreEmulatedMouseEvents || hadRecentTouch)) {
       return;
     }
 
@@ -204,7 +157,7 @@ export function ngpHover({
   }
 
   function onMouseEnter(event: MouseEvent): void {
-    if (!ignoreEmulatedMouseEvents && !globalPointerEvents.ignoreEmulatedMouseEvents) {
+    if (!ignoreEmulatedMouseEvents && !hadRecentTouch) {
       onHoverBegin(event, 'mouse');
     }
 

--- a/packages/ng-primitives/interactions/src/hover/hover.spec.ts
+++ b/packages/ng-primitives/interactions/src/hover/hover.spec.ts
@@ -1,8 +1,29 @@
+import { TestBed } from '@angular/core/testing';
 import { fireEvent, render } from '@testing-library/angular';
 import { provideInteractionsConfig } from '../config/interactions-config';
 import { NgpHover } from './hover';
 
 describe('NgpHover', () => {
+  function dispatchPointerEvent(
+    target: Element | Document,
+    type: string,
+    pointerType: string,
+  ): void {
+    const event = new Event(type, {
+      bubbles: type !== 'pointerenter' && type !== 'pointerleave',
+    });
+    (event as any).pointerType = pointerType;
+    target.dispatchEvent(event);
+  }
+
+  // The hover primitive tracks a module-level `hadRecentTouch` flag so that
+  // iOS emulated mouse events stay blocked across navigations. A real
+  // pointermove(mouse) clears it, so we dispatch one before each test to
+  // avoid leaked state between tests.
+  beforeEach(() => {
+    dispatchPointerEvent(document, 'pointermove', 'mouse');
+  });
+
   it('should trigger hover start event when pointerstart occurs', async () => {
     const hoverStart = jest.fn();
     const container = await render(
@@ -139,18 +160,6 @@ describe('NgpHover', () => {
   });
 
   describe('iOS Safari touch emulation', () => {
-    function dispatchPointerEvent(
-      target: Element | Document,
-      type: string,
-      pointerType: string,
-    ): void {
-      const event = new Event(type, {
-        bubbles: type !== 'pointerenter' && type !== 'pointerleave',
-      });
-      (event as any).pointerType = pointerType;
-      target.dispatchEvent(event);
-    }
-
     it('should not activate hover when emulated pointerenter(mouse) fires after touch', async () => {
       const hoverStart = jest.fn();
       const container = await render(
@@ -169,8 +178,7 @@ describe('NgpHover', () => {
       expect(hoverStart).not.toHaveBeenCalled();
     });
 
-    it('should allow real mouse hover after touch once timeout expires', async () => {
-      jest.useFakeTimers();
+    it('should allow real mouse hover after touch once a real pointermove(mouse) occurs', async () => {
       const hoverStart = jest.fn();
       const container = await render(
         `<div data-testid="trigger" ngpHover (ngpHoverStart)="hoverStart()"></div>`,
@@ -194,14 +202,98 @@ describe('NgpHover', () => {
       dispatchPointerEvent(trigger, 'pointerleave', 'mouse');
       fireEvent.mouseLeave(trigger);
 
-      // After the 500ms timeout, the global ignore flag clears
-      jest.advanceTimersByTime(500);
+      // A real mouse produces a pointermove; iOS emulation never does.
+      dispatchPointerEvent(document, 'pointermove', 'mouse');
 
       // Now a real mouse hover should work
       dispatchPointerEvent(trigger, 'pointerenter', 'mouse');
       expect(hoverStart).toHaveBeenCalled();
+    });
+
+    it('blocks emulated pointerenter(mouse) indefinitely until a real pointermove occurs', async () => {
+      jest.useFakeTimers();
+      const hoverStart = jest.fn();
+      const container = await render(
+        `<div data-testid="trigger" ngpHover (ngpHoverStart)="hoverStart()"></div>`,
+        {
+          imports: [NgpHover],
+          componentProperties: {
+            hoverStart,
+          },
+        },
+      );
+
+      // Fire the touch on the document (not the trigger) so only the
+      // module-level flag is set — the per-element local flag stays false.
+      // Simulates a touch on some other part of the page before hovering
+      // this element with an emulated mouse event.
+      fireEvent.touchEnd(document.body);
+
+      // Well past any plausible timeout window — the flag must persist.
+      jest.advanceTimersByTime(10_000);
+
+      const trigger = container.getByTestId('trigger');
+      dispatchPointerEvent(trigger, 'pointerenter', 'mouse');
+      expect(hoverStart).not.toHaveBeenCalled();
 
       jest.useRealTimers();
+    });
+
+    it('does not clear the touch flag on pointermove(touch)', async () => {
+      const hoverStart = jest.fn();
+      const container = await render(
+        `<div data-testid="trigger" ngpHover (ngpHoverStart)="hoverStart()"></div>`,
+        {
+          imports: [NgpHover],
+          componentProperties: {
+            hoverStart,
+          },
+        },
+      );
+
+      const trigger = container.getByTestId('trigger');
+      fireEvent.touchStart(trigger);
+      fireEvent.touchEnd(trigger);
+
+      // A touch pointermove must not be treated as a real mouse signal.
+      dispatchPointerEvent(document, 'pointermove', 'touch');
+
+      dispatchPointerEvent(trigger, 'pointerenter', 'mouse');
+      expect(hoverStart).not.toHaveBeenCalled();
+    });
+
+    it('blocks emulated hover on a freshly mounted directive after a prior touch', async () => {
+      // First directive lifecycle: user touches, then navigates away.
+      const firstHoverStart = jest.fn();
+      const first = await render(
+        `<div data-testid="trigger" ngpHover (ngpHoverStart)="hoverStart()"></div>`,
+        {
+          imports: [NgpHover],
+          componentProperties: { hoverStart: firstHoverStart },
+        },
+      );
+      fireEvent.touchStart(first.getByTestId('trigger'));
+      fireEvent.touchEnd(first.getByTestId('trigger'));
+      first.fixture.destroy();
+
+      // Reset the testing module so the second render can reconfigure
+      // TestBed — this also re-creates any `providedIn: 'root'` services,
+      // which is exactly the scenario we want to prove resilient.
+      TestBed.resetTestingModule();
+
+      // Second directive lifecycle: simulates a fresh mount after navigation.
+      // Any emulated pointerenter iOS fires must still be blocked, even though
+      // Angular may have recreated its services in between.
+      const secondHoverStart = jest.fn();
+      const second = await render(
+        `<div data-testid="trigger" ngpHover (ngpHoverStart)="hoverStart()"></div>`,
+        {
+          imports: [NgpHover],
+          componentProperties: { hoverStart: secondHoverStart },
+        },
+      );
+      dispatchPointerEvent(second.getByTestId('trigger'), 'pointerenter', 'mouse');
+      expect(secondHoverStart).not.toHaveBeenCalled();
     });
 
     it('should reset hover state when touch starts while hovered', async () => {

--- a/packages/ng-primitives/interactions/src/hover/hover.spec.ts
+++ b/packages/ng-primitives/interactions/src/hover/hover.spec.ts
@@ -169,7 +169,8 @@ describe('NgpHover', () => {
       expect(hoverStart).not.toHaveBeenCalled();
     });
 
-    it('should allow real mouse hover after touch followed by mouse movement', async () => {
+    it('should allow real mouse hover after touch once timeout expires', async () => {
+      jest.useFakeTimers();
       const hoverStart = jest.fn();
       const container = await render(
         `<div data-testid="trigger" ngpHover (ngpHoverStart)="hoverStart()"></div>`,
@@ -193,12 +194,14 @@ describe('NgpHover', () => {
       dispatchPointerEvent(trigger, 'pointerleave', 'mouse');
       fireEvent.mouseLeave(trigger);
 
-      // A real mouse pointermove on the document clears the global ignore flag
-      dispatchPointerEvent(document, 'pointermove', 'mouse');
+      // After the 500ms timeout, the global ignore flag clears
+      jest.advanceTimersByTime(500);
 
       // Now a real mouse hover should work
       dispatchPointerEvent(trigger, 'pointerenter', 'mouse');
       expect(hoverStart).toHaveBeenCalled();
+
+      jest.useRealTimers();
     });
 
     it('should reset hover state when touch starts while hovered', async () => {

--- a/packages/ng-primitives/interactions/src/hover/hover.spec.ts
+++ b/packages/ng-primitives/interactions/src/hover/hover.spec.ts
@@ -138,6 +138,110 @@ describe('NgpHover', () => {
     expect(hoverEnd).not.toHaveBeenCalled();
   });
 
+  describe('iOS Safari touch emulation', () => {
+    function dispatchPointerEvent(
+      target: Element | Document,
+      type: string,
+      pointerType: string,
+    ): void {
+      const event = new Event(type, {
+        bubbles: type !== 'pointerenter' && type !== 'pointerleave',
+      });
+      (event as any).pointerType = pointerType;
+      target.dispatchEvent(event);
+    }
+
+    it('should not activate hover when emulated pointerenter(mouse) fires after touch', async () => {
+      const hoverStart = jest.fn();
+      const container = await render(
+        `<div data-testid="trigger" ngpHover (ngpHoverStart)="hoverStart()"></div>`,
+        {
+          imports: [NgpHover],
+          componentProperties: {
+            hoverStart,
+          },
+        },
+      );
+
+      const trigger = container.getByTestId('trigger');
+      fireEvent.touchStart(trigger);
+      dispatchPointerEvent(trigger, 'pointerenter', 'mouse');
+      expect(hoverStart).not.toHaveBeenCalled();
+    });
+
+    it('should allow real mouse hover after touch followed by mouse movement', async () => {
+      const hoverStart = jest.fn();
+      const container = await render(
+        `<div data-testid="trigger" ngpHover (ngpHoverStart)="hoverStart()"></div>`,
+        {
+          imports: [NgpHover],
+          componentProperties: {
+            hoverStart,
+          },
+        },
+      );
+
+      const trigger = container.getByTestId('trigger');
+      // Simulate a full touch + emulated event sequence
+      fireEvent.touchStart(trigger);
+      fireEvent.touchEnd(trigger);
+      dispatchPointerEvent(trigger, 'pointerenter', 'mouse'); // emulated, should be blocked
+      fireEvent.mouseEnter(trigger); // emulated, clears local flag
+      expect(hoverStart).not.toHaveBeenCalled();
+
+      // Leave the element
+      dispatchPointerEvent(trigger, 'pointerleave', 'mouse');
+      fireEvent.mouseLeave(trigger);
+
+      // A real mouse pointermove on the document clears the global ignore flag
+      dispatchPointerEvent(document, 'pointermove', 'mouse');
+
+      // Now a real mouse hover should work
+      dispatchPointerEvent(trigger, 'pointerenter', 'mouse');
+      expect(hoverStart).toHaveBeenCalled();
+    });
+
+    it('should reset hover state when touch starts while hovered', async () => {
+      const hoverEnd = jest.fn();
+      const container = await render(
+        `<div data-testid="trigger" ngpHover (ngpHoverEnd)="hoverEnd()"></div>`,
+        {
+          imports: [NgpHover],
+          componentProperties: {
+            hoverEnd,
+          },
+        },
+      );
+
+      const trigger = container.getByTestId('trigger');
+      // Activate hover via pointerenter
+      dispatchPointerEvent(trigger, 'pointerenter', 'mouse');
+      // Touch starts while hovered - should reset
+      fireEvent.touchStart(trigger);
+      expect(hoverEnd).toHaveBeenCalled();
+    });
+
+    it('should block both emulated pointerenter and mouseenter after touchstart', async () => {
+      const hoverStart = jest.fn();
+      const container = await render(
+        `<div data-testid="trigger" ngpHover (ngpHoverStart)="hoverStart()"></div>`,
+        {
+          imports: [NgpHover],
+          componentProperties: {
+            hoverStart,
+          },
+        },
+      );
+
+      const trigger = container.getByTestId('trigger');
+      fireEvent.touchStart(trigger);
+      dispatchPointerEvent(trigger, 'pointerenter', 'mouse');
+      expect(hoverStart).not.toHaveBeenCalled();
+      fireEvent.mouseEnter(trigger);
+      expect(hoverStart).not.toHaveBeenCalled();
+    });
+  });
+
   describe('global configuration', () => {
     it('should not trigger hover events when all interactions are globally disabled', async () => {
       const hoverStart = jest.fn();


### PR DESCRIPTION
Replace the 50ms timeout in GlobalPointerEvents with pointermove detection to clear the emulated mouse event flag. The timeout was too short for async rendering scenarios (e.g. route navigation), allowing emulated pointerenter events to bypass the guard and permanently activate hover.

Also guard onPointerEnter with the local ignoreEmulatedMouseEvents flag and reset stuck hover state on touchstart.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stuck hover on iOS Safari by blocking emulated mouse events after touch using a persistent module-level flag cleared only by a real `pointermove(mouse)`. Prevents hover from staying active across navigations, async renders, and rapid taps in `ng-primitives` interactions.

- **Bug Fixes**
  - Replace `GlobalPointerEvents` and timeout with a module-level `hadRecentTouch` flag; reset only on non-touch `pointermove`.
  - Guard `pointerenter` with the local ignore flag plus `hadRecentTouch` to block emulated `pointerenter`/`mouseenter`.
  - Reset active hover on `touchstart` when hovered.
  - Add tests for cross-navigation persistence, pointermove reset, iOS emulation, rapid touches, and hover reset on touch.

<sup>Written for commit ba3da7e859f12d708fedda1d19a19cd65c6dcb34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

