### PR TITLE
fix(dialog): prevent cascade close when opened from menu or popover

### DIFF
--- a/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.service.ts
@@ -165,10 +165,16 @@ export class NgpDialogManager implements OnDestroy {
     // Auto-detect parent overlay: if the trigger element lives inside an existing overlay
     // (e.g. a dialog opened from a popover), register as its child so that clicks inside
     // the dialog don't dismiss the parent overlay.
-    const parentId =
+    // Only inherit parentId from other dialogs — non-dialog overlays (menus, popovers)
+    // may close after triggering the dialog open, which would cascade-close the dialog.
+    let parentId =
       activeElement instanceof HTMLElement
         ? this.registry.findContainingOverlay(activeElement)
         : null;
+
+    if (parentId !== null && !this.openDialogs.some(d => d.id === parentId)) {
+      parentId = null;
+    }
 
     // Register with the overlay registry for centralized escape-key routing.
     // outsidePress is false because the NgpDialogOverlay directive handles its own backdrop clicks.

--- a/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
@@ -314,7 +314,16 @@ describe('NgpDialog', () => {
       fixture.detectChanges();
       flush();
 
+      // Dialog should not be registered as a descendant of the popover.
+      // Unlike the menu test (where closeOnSelect auto-closes the menu), the popover
+      // stays open here. Verify the dialog's parentId is null (not the popover's ID),
+      // so if the popover closes later it won't cascade-close the dialog.
+      const registry = TestBed.inject(NgpOverlayRegistry);
       expect(document.querySelector('[data-testid="dialog-from-popover"]')).toBeTruthy();
+      const dialogId = dialogManager.openDialogs[0].id;
+      const dialogEntry = registry.getEntries().find(e => e.id === dialogId);
+      expect(dialogEntry).toBeTruthy();
+      expect(dialogEntry!.parentId).toBeNull();
     }));
   });
 });

--- a/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
@@ -1,5 +1,9 @@
 import { Component, TemplateRef, ViewContainerRef, inject, viewChild } from '@angular/core';
-import { TestBed, fakeAsync, flush } from '@angular/core/testing';
+import { TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
+import { fireEvent } from '@testing-library/angular';
+import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from 'ng-primitives/menu';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+import { NgpOverlayRegistry } from 'ng-primitives/portal';
 import { NgpDialogConfig } from '../config/dialog-config';
 import { NgpDialogDescription } from '../dialog-description/dialog-description';
 import { NgpDialogOverlay } from '../dialog-overlay/dialog-overlay';
@@ -31,7 +35,11 @@ describe('NgpDialog', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [DialogHostComponent],
+      imports: [
+        DialogHostComponent,
+        MenuDialogTestComponent,
+        PopoverDialogTestComponent,
+      ],
     });
   });
 
@@ -234,4 +242,164 @@ describe('NgpDialog', () => {
 
     expect(dialogManager.openDialogs.length).toBe(0);
   }));
+
+  describe('Overlay Integration', () => {
+    it('should keep dialog open after menu closes when opened from menu item click', fakeAsync(() => {
+      const fixture = TestBed.createComponent(MenuDialogTestComponent);
+      fixture.detectChanges();
+      dialogManager = TestBed.inject(NgpDialogManager);
+
+      const trigger = document.querySelector('[data-testid="menu-trigger"]') as HTMLElement;
+      fireEvent.click(trigger, { detail: 1 });
+      tick();
+      fixture.detectChanges();
+      flush();
+
+      const dialogItem = document.querySelector('[data-testid="dialog-item"]') as HTMLElement;
+      expect(dialogItem).toBeTruthy();
+      fireEvent.click(dialogItem, { detail: 1 });
+      tick();
+      fixture.detectChanges();
+      flush();
+
+      expect(document.querySelector('[data-testid="dialog-from-menu"]')).toBeTruthy();
+      // Menu should be closed (closeOnSelect default is true)
+      expect(document.querySelector('[data-testid="menu"]')).toBeFalsy();
+    }));
+
+    it('should keep dialog-from-dialog parent relationship', fakeAsync(() => {
+      const registry = TestBed.inject(NgpOverlayRegistry);
+
+      // Open dialog A
+      const { fixture, ref: refA } = openDialog();
+
+      // Focus inside dialog A
+      const dialogElement = document.querySelector('[data-testid="dialog"]') as HTMLElement;
+      dialogElement.focus();
+
+      // Open dialog B while focused inside dialog A
+      const component = fixture.componentInstance;
+      const refB = dialogManager.open(component.dialogTemplate(), {
+        viewContainerRef: component.viewContainerRef,
+      });
+      fixture.detectChanges();
+
+      expect(dialogManager.openDialogs.length).toBe(2);
+
+      // Verify dialog B is registered as a child of dialog A in the registry
+      const entryB = registry.getEntries().find(e => e.id === refB.id);
+      expect(entryB).toBeTruthy();
+      expect(entryB!.parentId).toBe(refA.id);
+
+      // Clean up
+      refB.close();
+      flush();
+      refA.close();
+      flush();
+    }));
+
+    it('should keep dialog open after popover closes when opened from popover content', fakeAsync(() => {
+      const fixture = TestBed.createComponent(PopoverDialogTestComponent);
+      fixture.detectChanges();
+      dialogManager = TestBed.inject(NgpDialogManager);
+
+      // Open popover
+      const trigger = document.querySelector('[data-testid="popover-trigger"]') as HTMLElement;
+      fireEvent.click(trigger, { detail: 1 });
+      tick();
+      fixture.detectChanges();
+      flush();
+
+      // Click button inside popover to open dialog
+      const dialogBtn = document.querySelector('[data-testid="popover-dialog-btn"]') as HTMLElement;
+      expect(dialogBtn).toBeTruthy();
+      fireEvent.click(dialogBtn, { detail: 1 });
+      tick();
+      fixture.detectChanges();
+      flush();
+
+      expect(document.querySelector('[data-testid="dialog-from-popover"]')).toBeTruthy();
+    }));
+
+  });
 });
+
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="menu-trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu">
+        <button ngpMenuItem data-testid="dialog-item" (click)="openDialog()">Open Dialog</button>
+      </div>
+    </ng-template>
+
+    <ng-template #dialogTemplate let-close="close">
+      <div ngpDialogOverlay data-testid="dialog-overlay">
+        <div ngpDialog data-testid="dialog-from-menu">
+          <h2 ngpDialogTitle>Dialog</h2>
+          <button (click)="close()" data-testid="dialog-close-btn">Close</button>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  imports: [
+    NgpMenuTrigger,
+    NgpMenu,
+    NgpMenuItem,
+    NgpDialog,
+    NgpDialogOverlay,
+    NgpDialogTitle,
+  ],
+})
+class MenuDialogTestComponent {
+  readonly dialogTemplate = viewChild.required<TemplateRef<NgpDialogContext>>('dialogTemplate');
+  private readonly dialogManager = inject(NgpDialogManager);
+  readonly viewContainerRef = inject(ViewContainerRef);
+
+  openDialog(): void {
+    this.dialogManager.open(this.dialogTemplate(), {
+      viewContainerRef: this.viewContainerRef,
+    });
+  }
+}
+
+@Component({
+  template: `
+    <button [ngpPopoverTrigger]="popover" data-testid="popover-trigger">Open Popover</button>
+
+    <ng-template #popover>
+      <div ngpPopover data-testid="popover">
+        <button (click)="openDialog()" data-testid="popover-dialog-btn">Open Dialog</button>
+      </div>
+    </ng-template>
+
+    <ng-template #dialogTemplate let-close="close">
+      <div ngpDialogOverlay data-testid="dialog-overlay">
+        <div ngpDialog data-testid="dialog-from-popover">
+          <h2 ngpDialogTitle>Dialog</h2>
+          <button (click)="close()" data-testid="dialog-close-btn">Close</button>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  imports: [
+    NgpPopoverTrigger,
+    NgpPopover,
+    NgpDialog,
+    NgpDialogOverlay,
+    NgpDialogTitle,
+  ],
+})
+class PopoverDialogTestComponent {
+  readonly dialogTemplate = viewChild.required<TemplateRef<NgpDialogContext>>('dialogTemplate');
+  private readonly dialogManager = inject(NgpDialogManager);
+  readonly viewContainerRef = inject(ViewContainerRef);
+
+  openDialog(): void {
+    this.dialogManager.open(this.dialogTemplate(), {
+      viewContainerRef: this.viewContainerRef,
+    });
+  }
+}
+

--- a/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.spec.ts
@@ -35,11 +35,7 @@ describe('NgpDialog', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        DialogHostComponent,
-        MenuDialogTestComponent,
-        PopoverDialogTestComponent,
-      ],
+      imports: [DialogHostComponent, MenuDialogTestComponent, PopoverDialogTestComponent],
     });
   });
 
@@ -320,7 +316,6 @@ describe('NgpDialog', () => {
 
       expect(document.querySelector('[data-testid="dialog-from-popover"]')).toBeTruthy();
     }));
-
   });
 });
 
@@ -330,7 +325,7 @@ describe('NgpDialog', () => {
 
     <ng-template #menu>
       <div ngpMenu data-testid="menu">
-        <button ngpMenuItem data-testid="dialog-item" (click)="openDialog()">Open Dialog</button>
+        <button (click)="openDialog()" ngpMenuItem data-testid="dialog-item">Open Dialog</button>
       </div>
     </ng-template>
 
@@ -343,14 +338,7 @@ describe('NgpDialog', () => {
       </div>
     </ng-template>
   `,
-  imports: [
-    NgpMenuTrigger,
-    NgpMenu,
-    NgpMenuItem,
-    NgpDialog,
-    NgpDialogOverlay,
-    NgpDialogTitle,
-  ],
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem, NgpDialog, NgpDialogOverlay, NgpDialogTitle],
 })
 class MenuDialogTestComponent {
   readonly dialogTemplate = viewChild.required<TemplateRef<NgpDialogContext>>('dialogTemplate');
@@ -383,13 +371,7 @@ class MenuDialogTestComponent {
       </div>
     </ng-template>
   `,
-  imports: [
-    NgpPopoverTrigger,
-    NgpPopover,
-    NgpDialog,
-    NgpDialogOverlay,
-    NgpDialogTitle,
-  ],
+  imports: [NgpPopoverTrigger, NgpPopover, NgpDialog, NgpDialogOverlay, NgpDialogTitle],
 })
 class PopoverDialogTestComponent {
   readonly dialogTemplate = viewChild.required<TemplateRef<NgpDialogContext>>('dialogTemplate');
@@ -402,4 +384,3 @@ class PopoverDialogTestComponent {
     });
   }
 }
-


### PR DESCRIPTION
## Summary

- Dialogs opened from menu item `(click)` handlers were immediately closed because the overlay registry registered the dialog as a child of the menu overlay. When the menu closed, `closeDescendants()` destroyed the dialog.
- Only inherit `parentId` from other open dialogs in `NgpDialogManager.open()`, not from menus or popovers that may close after triggering the dialog.

Closes #724

## Test plan

- [ ] Open a dialog from a menu item click handler — dialog should remain open after the menu closes
- [ ] Open a dialog from another dialog — cascade close should still work (closing parent closes child)
- [ ] Open a dialog from a popover — dialog should remain open if the popover closes
- [ ] Escape key still closes the topmost dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dialog cascade-close when opening from a menu item or popover (closes #724). Adds integration tests and a popover-specific assertion to ensure dialogs opened from menus or popovers stay open, and dialog-to-dialog parenting still cascades.

- **Bug Fixes**
  - Updated `NgpDialogManager.open()` to ignore non-dialog overlays when detecting a parent.
  - Preserves cascade close for dialog → dialog; dialogs opened from menus/popovers are not registered as children (`parentId` is `null`).

- **Refactors**
  - Minor formatting cleanup in dialog spec.

<sup>Written for commit 4ab83f2be7dd83e7431b4a032c13ad4f2a97b679. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

