### PR TITLE
fix(overlay): close entire overlay tree on outside click

### DIFF
--- a/packages/ng-primitives/menu/src/menu/menu.spec.ts
+++ b/packages/ng-primitives/menu/src/menu/menu.spec.ts
@@ -336,6 +336,45 @@ describe('NgpMenu', () => {
       expect(document.querySelector('[data-testid="submenu"]')).not.toBeInTheDocument();
     }));
 
+    it('should close both menu and submenu when clicking outside with submenu open', fakeAsync(async () => {
+      const { fixture } = await render(TestMenuWithSubmenuComponent);
+      const trigger = fixture.debugElement.nativeElement.querySelector(
+        '[data-testid="root-trigger"]',
+      );
+
+      // Open root menu via click
+      fireEvent.click(trigger);
+      tick();
+      fixture.detectChanges();
+      flush();
+
+      expect(trigger).toHaveAttribute('data-open');
+
+      // Open submenu via click on the submenu trigger
+      const submenuTrigger = document.querySelector('[data-testid="submenu-trigger"]');
+      expect(submenuTrigger).toBeInTheDocument();
+
+      fireEvent.click(submenuTrigger!);
+      tick();
+      fixture.detectChanges();
+      flush();
+
+      // Verify submenu is open
+      expect(submenuTrigger).toHaveAttribute('data-open');
+      expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
+
+      // Click outside the entire menu tree (on document body)
+      fireEvent.mouseUp(document.body);
+      tick();
+      fixture.detectChanges();
+      flush();
+
+      // Both root menu and submenu should be closed
+      expect(trigger).not.toHaveAttribute('data-open');
+      expect(document.querySelector('[data-testid="root-menu"]')).not.toBeInTheDocument();
+      expect(document.querySelector('[data-testid="submenu"]')).not.toBeInTheDocument();
+    }));
+
     it('should close all menus when Escape is pressed in submenu', fakeAsync(async () => {
       const { fixture } = await render(TestMenuWithSubmenuComponent);
       const trigger = fixture.debugElement.nativeElement.querySelector(

--- a/packages/ng-primitives/portal/src/overlay-registry.ts
+++ b/packages/ng-primitives/portal/src/overlay-registry.ts
@@ -256,7 +256,9 @@ export class NgpOverlayRegistry {
   }
 
   /**
-   * Outside-click dismiss: only the topmost overlay responds.
+   * Outside-click dismiss: walks up the parent chain from the topmost overlay
+   * to find the highest ancestor where the click is also outside, then hides
+   * that ancestor (descendants close automatically via closeDescendants).
    */
   private handleOutsideClick(event: MouseEvent): void {
     const topmost = this.getTopmost();
@@ -274,23 +276,50 @@ export class NgpOverlayRegistry {
       return;
     }
 
-    // Check if the click is inside the topmost overlay
     const path = event.composedPath();
-    const isInsideElements = topmost.getElements().some(el => path.includes(el));
-    const isInsideTrigger = path.includes(topmost.triggerElement);
-    const isInsideAnchor = topmost.anchorElement ? path.includes(topmost.anchorElement) : false;
 
-    if (isInsideElements || isInsideTrigger || isInsideAnchor) {
+    // Check if the click is inside the topmost overlay
+    if (!this.isClickOutsideEntry(topmost, path)) {
       return;
+    }
+
+    // Walk up the parentId chain to find the highest ancestor where the click
+    // is also outside. Stop if a parent contains the click or has outsidePress disabled.
+    let highestOutside = topmost;
+    let currentId = topmost.parentId;
+
+    while (currentId !== null) {
+      const parent = this.entries.find(e => e.id === currentId);
+      if (!parent) break;
+      if (!this.isClickOutsideEntry(parent, path)) break;
+      if (parent.dismissPolicy.outsidePress === false) break;
+      if (this.pendingGuardIds.has(parent.id)) break;
+
+      highestOutside = parent;
+      currentId = parent.parentId;
     }
 
     // Derive a proper Element from the composed path
     const target =
       (path.find((node): node is Element => node instanceof Element) as Element) ??
       this.document.documentElement;
-    this.evaluateGuardAndDismiss(topmost.id, topmost.dismissPolicy.outsidePress, target, () =>
-      this.ngZone.run(() => topmost.overlay.hide()),
+    this.evaluateGuardAndDismiss(
+      highestOutside.id,
+      highestOutside.dismissPolicy.outsidePress,
+      target,
+      () => this.ngZone.run(() => highestOutside.overlay.hide()),
     );
+  }
+
+  /**
+   * Check if a click (represented by its composedPath) is outside an entry's
+   * elements, trigger, and anchor.
+   */
+  private isClickOutsideEntry(entry: NgpOverlayEntry, path: EventTarget[]): boolean {
+    const isInsideElements = entry.getElements().some(el => path.includes(el));
+    const isInsideTrigger = path.includes(entry.triggerElement);
+    const isInsideAnchor = entry.anchorElement ? path.includes(entry.anchorElement) : false;
+    return !(isInsideElements || isInsideTrigger || isInsideAnchor);
   }
 
   /**


### PR DESCRIPTION
## Summary
- When a submenu (or nested popover) is open, clicking outside the entire menu tree now closes all ancestors — not just the topmost overlay
- Modified `handleOutsideClick` in `NgpOverlayRegistry` to walk up the `parentId` chain and find the highest ancestor where the click is also outside, then hide that ancestor (descendants cascade-close automatically)
- Generic overlay-level fix, so nested popovers etc. also benefit

Closes #726

## Test plan
- [x] Added test: "should close both menu and submenu when clicking outside with submenu open"
- [x] Run `nx test ng-primitives --testPathPattern="menu.spec"` — all 1135 tests pass
- [x] Run full test suite (`pnpm test`) — all pass
- [ ] Manual: docs site → menu primitive → open submenu → click outside → both should close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking outside a nested menu or popover now closes the entire overlay tree, not just the topmost overlay. This aligns outside-press behavior across overlays and fixes #726.

- **Bug Fixes**
  - Updated `handleOutsideClick` in `NgpOverlayRegistry` to walk up `parentId` and dismiss the highest ancestor where the click is outside; descendants close automatically.
  - Respects `outsidePress: false` and guard states while traversing; extracted `isClickOutsideEntry` for clarity.
  - Added a test to verify both root menu and submenu close on outside click.

<sup>Written for commit c7238c95fe38a2f0fd73a17ebe9252bb662c97ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

