### PR TITLE
fix(overlay): close previous overlay of same type regardless of cooldown (#728)

### DIFF
--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.spec.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.spec.ts
@@ -1,5 +1,7 @@
+import { Component } from '@angular/core';
 import { fakeAsync, flush } from '@angular/core/testing';
 import { fireEvent, render, screen } from '@testing-library/angular';
+import { NgpTooltip, NgpTooltipTrigger } from 'ng-primitives/tooltip';
 import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from '../index';
 
 describe('NgpMenuTrigger', () => {
@@ -25,5 +27,61 @@ describe('NgpMenuTrigger', () => {
 
     const menu = screen.getByTestId('ngp-menu');
     expect(menu).toBeInTheDocument();
+  }));
+
+  it('should close previous menu when combining tooltip with menu on buttons (fixes #728)', fakeAsync(async () => {
+    @Component({
+      template: `
+        <!-- Button A with tooltip + menu -->
+        <button [ngpTooltipTrigger]="tooltipA" [ngpMenuTrigger]="menuA" data-testid="button-a">
+          Button A
+        </button>
+        <ng-template #tooltipA>
+          <div ngpTooltip>Tooltip A</div>
+        </ng-template>
+        <ng-template #menuA>
+          <div ngpMenu data-testid="menu-a">
+            <button ngpMenuItem>Item A1</button>
+            <button ngpMenuItem>Item A2</button>
+          </div>
+        </ng-template>
+
+        <!-- Button B with tooltip + menu -->
+        <button [ngpTooltipTrigger]="tooltipB" [ngpMenuTrigger]="menuB" data-testid="button-b">
+          Button B
+        </button>
+        <ng-template #tooltipB>
+          <div ngpTooltip>Tooltip B</div>
+        </ng-template>
+        <ng-template #menuB>
+          <div ngpMenu data-testid="menu-b">
+            <button ngpMenuItem>Item B1</button>
+            <button ngpMenuItem>Item B2</button>
+          </div>
+        </ng-template>
+      `,
+      imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem, NgpTooltipTrigger, NgpTooltip],
+    })
+    class TooltipWithMenuComponent {}
+
+    const { getByTestId } = await render(TooltipWithMenuComponent);
+
+    const buttonA = getByTestId('button-a');
+    const buttonB = getByTestId('button-b');
+
+    // Click Button A → opens Menu A
+    fireEvent.click(buttonA);
+    flush();
+
+    expect(screen.getByTestId('menu-a')).toBeInTheDocument();
+
+    // Click Button B → should close Menu A and open Menu B
+    fireEvent.click(buttonB);
+    flush();
+
+    // Menu A should be closed
+    expect(screen.queryByTestId('menu-a')).not.toBeInTheDocument();
+    // Only Menu B should be open
+    expect(screen.getByTestId('menu-b')).toBeInTheDocument();
   }));
 });

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.spec.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.spec.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
 import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+import { NgpTooltip, NgpTooltipTrigger } from 'ng-primitives/tooltip';
 
 describe('NgpPopoverTrigger', () => {
   it('should destroy the overlay when the trigger is destroyed', async () => {
@@ -401,6 +402,65 @@ describe('NgpPopoverTrigger', () => {
 
     await waitFor(() => {
       expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+    });
+  });
+
+  it('should close previous popover when combining tooltip with popover on buttons (fixes #728)', async () => {
+    @Component({
+      template: `
+        <!-- Button A with tooltip + popover -->
+        <button
+          [ngpTooltipTrigger]="tooltipA"
+          [ngpPopoverTrigger]="popoverA"
+          data-testid="button-a"
+        >
+          Button A
+        </button>
+        <ng-template #tooltipA>
+          <div ngpTooltip>Tooltip A</div>
+        </ng-template>
+        <ng-template #popoverA>
+          <div ngpPopover data-testid="popover-a">Popover A</div>
+        </ng-template>
+
+        <!-- Button B with tooltip + popover -->
+        <button
+          [ngpTooltipTrigger]="tooltipB"
+          [ngpPopoverTrigger]="popoverB"
+          data-testid="button-b"
+        >
+          Button B
+        </button>
+        <ng-template #tooltipB>
+          <div ngpTooltip>Tooltip B</div>
+        </ng-template>
+        <ng-template #popoverB>
+          <div ngpPopover data-testid="popover-b">Popover B</div>
+        </ng-template>
+      `,
+      imports: [NgpPopoverTrigger, NgpPopover, NgpTooltipTrigger, NgpTooltip],
+    })
+    class TooltipWithPopoverComponent {}
+
+    const { getByTestId } = await render(TooltipWithPopoverComponent);
+    const buttonA = getByTestId('button-a');
+    const buttonB = getByTestId('button-b');
+
+    // Click Button A → opens Popover A
+    fireEvent.click(buttonA);
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-testid="popover-a"]')).toBeInTheDocument();
+    });
+
+    // Click Button B → should close Popover A and open Popover B
+    fireEvent.click(buttonB);
+
+    await waitFor(() => {
+      // Popover A should be closed
+      expect(document.querySelector('[data-testid="popover-a"]')).not.toBeInTheDocument();
+      // Only Popover B should be open
+      expect(document.querySelector('[data-testid="popover-b"]')).toBeInTheDocument();
     });
   });
 });

--- a/packages/ng-primitives/portal/src/overlay-cooldown.ts
+++ b/packages/ng-primitives/portal/src/overlay-cooldown.ts
@@ -51,10 +51,13 @@ export class NgpOverlayCooldownManager {
   registerActive(overlayType: string, overlay: CooldownOverlay, cooldown: number): void {
     const existing = this.activeOverlays.get(overlayType);
 
-    // If there's an existing overlay and cooldown is enabled, close it immediately.
-    // This ensures instant DOM swap when hovering between items of the same type.
-    if (existing && existing !== overlay && cooldown > 0) {
-      existing.instantTransition?.set(true);
+    // If there's an existing overlay of the same type, close it immediately.
+    // This ensures only one overlay of each type is open at a time.
+    if (existing && existing !== overlay) {
+      // Enable instant transition only if cooldown is active
+      if (cooldown > 0) {
+        existing.instantTransition?.set(true);
+      }
       existing.hideImmediate();
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #728

## What does this PR implement/fix?

### Problem

The bug was in `overlay-cooldown.ts` where closing the previous overlay was conditioned by `cooldown > 0`. This caused multiple overlays of the same type (popover/menu) to remain open simultaneously when cooldown was disabled.

When combining tooltips with popovers or menus on different buttons:
- Clicking Button A opened Popover/Menu A
- Clicking Button B opened Popover/Menu B but **did not close** Popover/Menu A
- Both overlays remained visible at the same time

### Solution

- **Always close** the previous overlay of the same type in `registerActive()`, regardless of cooldown value
- Use `cooldown` **only** for UX optimizations (instant transitions, skip delays)
- Added tests for tooltip+popover and tooltip+menu combinations to prevent regression

### Changes

- Modified `packages/ng-primitives/portal/src/overlay-cooldown.ts`:
  - Remove `cooldown > 0` condition from closing logic
  - Separate overlay closing (always) from instant transition flag (only when cooldown > 0)
- Added regression tests in:
  - `packages/ng-primitives/popover/src/popover-trigger/popover-trigger.spec.ts`
  - `packages/ng-primitives/menu/src/menu-trigger/menu-trigger.spec.ts`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always close the previous overlay of the same type when a new one opens, regardless of cooldown, so only one menu or popover is visible at a time. Fixes #728 where tooltip + popover/menu combos left multiple overlays open with cooldown off.

- **Bug Fixes**
  - Updated `packages/ng-primitives/portal/src/overlay-cooldown.ts` to always close the existing overlay; use `cooldown` only to enable instant transitions.
  - Added regression tests for tooltip+popover and tooltip+menu in `packages/ng-primitives/popover/src/popover-trigger/popover-trigger.spec.ts` and `packages/ng-primitives/menu/src/menu-trigger/menu-trigger.spec.ts`.

<sup>Written for commit f45d52e0dbff3b1acc07daea7fed3dd5ebc10fd0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

