### PR TITLE
feat(tooltip): add support for hoverable content

### DIFF
--- a/apps/components-e2e/src/reusable-components/tooltip.spec.ts
+++ b/apps/components-e2e/src/reusable-components/tooltip.spec.ts
@@ -8,7 +8,7 @@ test.describe('Tooltip', () => {
 
   test('should have no detectable accessibility issues', async ({ page }) => {
     const accessibilityScanResults = await new AxeBuilder({ page })
-      .disableRules(['page-has-heading-one'])
+      .disableRules(['page-has-heading-one', 'landmark-one-main'])
       .analyze();
     expect(accessibilityScanResults.violations).toEqual([]);
   });

--- a/apps/components/src/app/pages/reusable-components/tooltip/tooltip-trigger.ts
+++ b/apps/components/src/app/pages/reusable-components/tooltip/tooltip-trigger.ts
@@ -16,6 +16,7 @@ import { Tooltip } from './tooltip';
         'ngpTooltipTriggerFlip:appTooltipTriggerFlip',
         'ngpTooltipTriggerContainer:appTooltipTriggerContainer',
         'ngpTooltipTriggerShowOnOverflow:appTooltipTriggerShowOnOverflow',
+        'ngpTooltipTriggerHoverableContent:appTooltipTriggerHoverableContent',
         'ngpTooltipTriggerContext:appTooltipTrigger',
       ],
     },

--- a/apps/documentation/src/app/examples/tooltip/tooltip-hoverable-content.example.ts
+++ b/apps/documentation/src/app/examples/tooltip/tooltip-hoverable-content.example.ts
@@ -7,7 +7,9 @@ import { NgpTooltip, NgpTooltipArrow, NgpTooltipTrigger } from 'ng-primitives/to
   imports: [NgpTooltipTrigger, NgpTooltip, NgpTooltipArrow, NgpButton],
   template: `
     <div class="examples">
-      <button [ngpTooltipTrigger]="defaultTooltip" ngpButton type="button">Default (Close on Leave)</button>
+      <button [ngpTooltipTrigger]="defaultTooltip" ngpButton type="button">
+        Default (Close on Leave)
+      </button>
 
       <button
         [ngpTooltipTrigger]="hoverableTooltip"

--- a/apps/documentation/src/app/examples/tooltip/tooltip-hoverable-content.example.ts
+++ b/apps/documentation/src/app/examples/tooltip/tooltip-hoverable-content.example.ts
@@ -1,0 +1,132 @@
+import { Component, ViewEncapsulation } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpTooltip, NgpTooltipArrow, NgpTooltipTrigger } from 'ng-primitives/tooltip';
+
+@Component({
+  selector: 'app-tooltip-hoverable-content',
+  imports: [NgpTooltipTrigger, NgpTooltip, NgpTooltipArrow, NgpButton],
+  template: `
+    <div class="examples">
+      <button [ngpTooltipTrigger]="defaultTooltip" ngpButton type="button">Default (Close on Leave)</button>
+
+      <button
+        [ngpTooltipTrigger]="hoverableTooltip"
+        ngpTooltipTriggerHoverableContent="true"
+        ngpTooltipTriggerOffset="12"
+        ngpButton
+        type="button"
+      >
+        Hoverable Content Enabled
+      </button>
+    </div>
+
+    <ng-template #defaultTooltip>
+      <div ngpTooltip>
+        This tooltip closes when pointer leaves the trigger.
+        <div ngpTooltipArrow></div>
+      </div>
+    </ng-template>
+
+    <ng-template #hoverableTooltip>
+      <div ngpTooltip>
+        Move your pointer from the trigger into this tooltip; it stays open while hovered.
+        <div ngpTooltipArrow></div>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    app-tooltip-hoverable-content {
+      .examples {
+        display: flex;
+        gap: 1rem;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      button {
+        padding-left: 1rem;
+        padding-right: 1rem;
+        border-radius: 0.5rem;
+        color: var(--ngp-text-primary);
+        outline: none;
+        height: 2.5rem;
+        font-weight: 500;
+        background-color: var(--ngp-background);
+        transition: background-color 300ms cubic-bezier(0.4, 0, 0.2, 1);
+        box-shadow: var(--ngp-button-shadow);
+      }
+
+      button[data-hover] {
+        background-color: var(--ngp-background-hover);
+      }
+
+      button[data-focus-visible] {
+        outline: 2px solid var(--ngp-focus-ring);
+      }
+
+      button[data-press] {
+        background-color: var(--ngp-background-active);
+      }
+    }
+
+    [ngpTooltip] {
+      position: absolute;
+      max-width: 18rem;
+      border-radius: 0.5rem;
+      background-color: var(--ngp-background-inverse);
+      padding: 0.5rem 0.75rem;
+      border: none;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--ngp-text-inverse);
+      animation: tooltip-show 200ms ease-in-out;
+      transform-origin: var(--ngp-tooltip-transform-origin);
+    }
+
+    [ngpTooltip][data-exit] {
+      animation: tooltip-hide 200ms ease-in-out;
+    }
+
+    [ngpTooltipArrow] {
+      position: absolute;
+      pointer-events: none;
+      background-color: var(--ngp-background-inverse);
+      width: 8px;
+      height: 8px;
+      border-radius: 2px;
+      transform: rotate(45deg);
+    }
+
+    [ngpTooltipArrow][data-placement='top'] {
+      top: calc(100% - 5px);
+    }
+
+    [ngpTooltipArrow][data-placement='bottom'] {
+      bottom: calc(100% - 5px);
+    }
+
+    @keyframes tooltip-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes tooltip-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+  `,
+  encapsulation: ViewEncapsulation.None,
+})
+export default class TooltipHoverableContentExample {}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -152,7 +152,7 @@ The arrow can be styled conditionally based on the popover's final placement usi
 
 <api-docs name="NgpPopoverArrow"></api-docs>
 
-### Data Attributes
+#### Data Attributes
 
 | Attribute        | Description                                  |
 | ---------------- | -------------------------------------------- |

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -152,7 +152,7 @@ The arrow can be styled conditionally based on the tooltip's final placement usi
 
 <api-docs name="NgpTooltipArrow"></api-docs>
 
-### Data Attributes
+#### Data Attributes
 
 | Attribute        | Description                                  |
 | ---------------- | -------------------------------------------- |
@@ -209,6 +209,26 @@ The `showOnOverflow` input allows you to show tooltips only when the trigger ele
 </div>
 ```
 
+## Hoverable Tooltip Content
+
+Tooltips keep strict tooltip semantics (`role="tooltip"`) while supporting pointer movement from trigger to tooltip content.
+
+<docs-example name="tooltip-hoverable-content"></docs-example>
+
+Use `ngpTooltipTriggerHoverableContent` to control whether hovering tooltip content keeps it open:
+
+```html
+<!-- Default: closes when pointer leaves trigger -->
+<button [ngpTooltipTrigger]="tooltip">Default behavior</button>
+
+<!-- Opt in: stays open while pointer moves into tooltip content -->
+<button [ngpTooltipTrigger]="tooltip" ngpTooltipTriggerHoverableContent="true">
+  Hover bridge enabled
+</button>
+```
+
+If tooltip content needs to be interactive or focusable, use [`Popover`](/primitives/popover) instead.
+
 ## Styling
 
 For the tooltip to be positioned correctly relative to the trigger element, it must use absolute or fixed positioning. For example, you can use the following CSS:
@@ -255,6 +275,7 @@ bootstrapApplication(AppComponent, {
       useTextContent: true,
       scrollBehavior: 'reposition',
       cooldown: 300,
+      hoverableContent: false,
     }),
   ],
 });
@@ -332,6 +353,10 @@ shift: {
 
 <prop-details name="cooldown" type="number" default="300">
   Define the cooldown duration in milliseconds. When moving from one tooltip to another within this duration, the showDelay is skipped for the new tooltip. This creates a smoother experience when hovering between multiple tooltips.
+</prop-details>
+
+<prop-details name="hoverableContent" type="boolean" default="false">
+  Define whether hovering the tooltip content keeps it open while moving the pointer from the trigger. When enabled, a pointer grace polygon bridges the trigger and tooltip so users can move their cursor into the tooltip without it closing.
 </prop-details>
 
 ## Accessibility

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.spec.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.spec.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
 import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
-import { NgpTooltip, NgpTooltipTrigger } from 'ng-primitives/tooltip';
+import { NgpTooltip, NgpTooltipTrigger, provideTooltipConfig } from 'ng-primitives/tooltip';
 
 describe('NgpPopoverTrigger', () => {
   it('should destroy the overlay when the trigger is destroyed', async () => {
@@ -461,6 +461,96 @@ describe('NgpPopoverTrigger', () => {
       expect(document.querySelector('[data-testid="popover-a"]')).not.toBeInTheDocument();
       // Only Popover B should be open
       expect(document.querySelector('[data-testid="popover-b"]')).toBeInTheDocument();
+    });
+  });
+
+  it('should close popover A when clicking button B (no tooltips)', async () => {
+    @Component({
+      template: `
+        <button [ngpPopoverTrigger]="contentA">Button A</button>
+        <button [ngpPopoverTrigger]="contentB">Button B</button>
+
+        <ng-template #contentA>
+          <div ngpPopover>Popover A</div>
+        </ng-template>
+        <ng-template #contentB>
+          <div ngpPopover>Popover B</div>
+        </ng-template>
+      `,
+      imports: [NgpPopoverTrigger, NgpPopover],
+    })
+    class TwoPopoversComponent {}
+
+    const { getAllByRole } = await render(TwoPopoversComponent);
+    const [buttonA, buttonB] = getAllByRole('button');
+
+    // Open popover A
+    fireEvent.click(buttonA);
+    await waitFor(() => {
+      expect(document.querySelectorAll('[ngpPopover]').length).toBe(1);
+      expect(document.querySelector('[ngpPopover]')!.textContent).toContain('Popover A');
+    });
+
+    // Click button B — fire mouseUp first (overlay registry listens for mouseup),
+    // then click (popover trigger listens for click)
+    fireEvent.mouseUp(buttonB);
+    fireEvent.click(buttonB);
+    await waitFor(() => {
+      const popovers = document.querySelectorAll('[ngpPopover]');
+      expect(popovers.length).toBe(1);
+      expect(popovers[0].textContent).toContain('Popover B');
+    });
+  });
+
+  it('should close popover A when clicking button B that has a tooltip open', async () => {
+    @Component({
+      template: `
+        <button [ngpPopoverTrigger]="contentA" [ngpTooltipTrigger]="tooltipA">Button A</button>
+        <button [ngpPopoverTrigger]="contentB" [ngpTooltipTrigger]="tooltipB">Button B</button>
+
+        <ng-template #contentA>
+          <div ngpPopover>Popover A</div>
+        </ng-template>
+        <ng-template #contentB>
+          <div ngpPopover>Popover B</div>
+        </ng-template>
+        <ng-template #tooltipA>
+          <div ngpTooltip>Tooltip A</div>
+        </ng-template>
+        <ng-template #tooltipB>
+          <div ngpTooltip>Tooltip B</div>
+        </ng-template>
+      `,
+      imports: [NgpPopoverTrigger, NgpPopover, NgpTooltipTrigger, NgpTooltip],
+    })
+    class TwoPopoversWithTooltipsComponent {}
+
+    const { getAllByRole } = await render(TwoPopoversWithTooltipsComponent, {
+      providers: [provideTooltipConfig({ showDelay: 0, hideDelay: 0 })],
+    });
+    const [buttonA, buttonB] = getAllByRole('button');
+
+    // Open popover A
+    fireEvent.click(buttonA);
+    await waitFor(() => {
+      expect(document.querySelectorAll('[ngpPopover]').length).toBe(1);
+      expect(document.querySelector('[ngpPopover]')!.textContent).toContain('Popover A');
+    });
+
+    // Hover button B to show its tooltip
+    fireEvent.mouseEnter(buttonB);
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+    });
+
+    // Click button B — fire mouseUp first (overlay registry listens for mouseup),
+    // then click (popover trigger listens for click)
+    fireEvent.mouseUp(buttonB);
+    fireEvent.click(buttonB);
+    await waitFor(() => {
+      const popovers = document.querySelectorAll('[ngpPopover]');
+      expect(popovers.length).toBe(1);
+      expect(popovers[0].textContent).toContain('Popover B');
     });
   });
 });

--- a/packages/ng-primitives/portal/src/overlay-registry.ts
+++ b/packages/ng-primitives/portal/src/overlay-registry.ts
@@ -256,13 +256,14 @@ export class NgpOverlayRegistry {
   }
 
   /**
-   * Outside-click dismiss: walks up the parent chain from the topmost overlay
-   * to find the highest ancestor where the click is also outside, then hides
-   * that ancestor (descendants close automatically via closeDescendants).
+   * Outside-click dismiss: checks all overlays (not just the topmost) and
+   * dismisses every overlay tree where the click landed outside.
+   *
+   * This handles the case where a non-dismissable overlay (e.g. a tooltip) is
+   * topmost but other overlays (e.g. a popover) should still be dismissed.
    */
   private handleOutsideClick(event: MouseEvent): void {
-    const topmost = this.getTopmost();
-    if (!topmost || this.pendingGuardIds.has(topmost.id)) {
+    if (this.entries.length === 0) {
       return;
     }
 
@@ -278,37 +279,75 @@ export class NgpOverlayRegistry {
 
     const path = event.composedPath();
 
-    // Check if the click is inside the topmost overlay
-    if (!this.isClickOutsideEntry(topmost, path)) {
-      return;
+    // Step 1: Build a set of overlay IDs where the click is "inside"
+    const insideIds = new Set<string>();
+    for (const entry of this.entries) {
+      if (!this.isClickOutsideEntry(entry, path)) {
+        insideIds.add(entry.id);
+      }
     }
 
-    // Walk up the parentId chain to find the highest ancestor where the click
-    // is also outside. Stop if a parent contains the click or has outsidePress disabled.
-    let highestOutside = topmost;
-    let currentId = topmost.parentId;
-
-    while (currentId !== null) {
-      const parent = this.entries.find(e => e.id === currentId);
-      if (!parent) break;
-      if (!this.isClickOutsideEntry(parent, path)) break;
-      if (parent.dismissPolicy.outsidePress === false) break;
-      if (this.pendingGuardIds.has(parent.id)) break;
-
-      highestOutside = parent;
-      currentId = parent.parentId;
+    // Step 2: Expand insideIds to include all ancestors of inside entries.
+    // If a child contains the click, its entire parent chain is protected.
+    for (const id of insideIds) {
+      let currentId = this.entries.find(e => e.id === id)?.parentId ?? null;
+      while (currentId !== null) {
+        if (insideIds.has(currentId)) break; // already protected
+        insideIds.add(currentId);
+        currentId = this.entries.find(e => e.id === currentId)?.parentId ?? null;
+      }
     }
 
-    // Derive a proper Element from the composed path
+    // Step 3: For each entry that is outside, find the highest dismissable ancestor
+    // and collect unique roots to dismiss.
+    const toDismiss = new Map<string, NgpOverlayEntry>();
+    const coveredIds = new Set<string>(); // entries covered by an ancestor we'll dismiss
+
+    // Walk from topmost to oldest
+    for (let i = this.entries.length - 1; i >= 0; i--) {
+      const entry = this.entries[i];
+
+      // Skip entries where the click was inside
+      if (insideIds.has(entry.id)) continue;
+      // Skip entries with pending guards
+      if (this.pendingGuardIds.has(entry.id)) continue;
+      // Skip entries already covered by an ancestor we're about to dismiss
+      if (coveredIds.has(entry.id)) continue;
+
+      // Walk up parent chain to find the highest dismissable ancestor
+      let highest = entry;
+      let currentId = entry.parentId;
+
+      while (currentId !== null) {
+        const parent = this.entries.find(e => e.id === currentId);
+        if (!parent) break;
+        if (insideIds.has(parent.id)) break;
+        if (parent.dismissPolicy.outsidePress === false) break;
+        if (this.pendingGuardIds.has(parent.id)) break;
+
+        highest = parent;
+        currentId = parent.parentId;
+      }
+
+      toDismiss.set(highest.id, highest);
+
+      // Mark all descendants as covered
+      for (const desc of this.getDescendants(highest.id)) {
+        coveredIds.add(desc.id);
+      }
+    }
+
+    // Derive a proper Element from the composed path for guard evaluation
     const target =
       (path.find((node): node is Element => node instanceof Element) as Element) ??
       this.document.documentElement;
-    this.evaluateGuardAndDismiss(
-      highestOutside.id,
-      highestOutside.dismissPolicy.outsidePress,
-      target,
-      () => this.ngZone.run(() => highestOutside.overlay.hide()),
-    );
+
+    // Step 4: Dismiss each root
+    for (const [id, entry] of toDismiss) {
+      this.evaluateGuardAndDismiss(id, entry.dismissPolicy.outsidePress, target, () =>
+        this.ngZone.run(() => entry.overlay.hide()),
+      );
+    }
   }
 
   /**

--- a/packages/ng-primitives/tooltip/src/config/tooltip-config.spec.ts
+++ b/packages/ng-primitives/tooltip/src/config/tooltip-config.spec.ts
@@ -1,0 +1,28 @@
+import { TestBed } from '@angular/core/testing';
+import { injectTooltipConfig, provideTooltipConfig } from './tooltip-config';
+
+describe('tooltip-config', () => {
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('should include interactive tooltip defaults', () => {
+    const config = TestBed.runInInjectionContext(() => injectTooltipConfig());
+
+    expect(config.hoverableContent).toBe(false);
+  });
+
+  it('should merge interactive tooltip values from provider config', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideTooltipConfig({
+          hoverableContent: true,
+        }),
+      ],
+    });
+
+    const config = TestBed.runInInjectionContext(() => injectTooltipConfig());
+
+    expect(config.hoverableContent).toBe(true);
+  });
+});

--- a/packages/ng-primitives/tooltip/src/config/tooltip-config.ts
+++ b/packages/ng-primitives/tooltip/src/config/tooltip-config.ts
@@ -36,7 +36,7 @@ export interface NgpTooltipConfig {
   flip: NgpFlip;
 
   /**
-   * Define the container element or selector in to which the tooltip should be attached.
+   * Define the container element or selector into which the tooltip should be attached.
    * @default 'body'
    */
   container: HTMLElement | string | null;
@@ -80,6 +80,12 @@ export interface NgpTooltipConfig {
    * @default 300
    */
   cooldown: number;
+
+  /**
+   * Whether hovering the tooltip content keeps it open while moving from the trigger.
+   * @default false
+   */
+  hoverableContent: boolean;
 }
 
 export const defaultTooltipConfig: NgpTooltipConfig = {
@@ -95,6 +101,7 @@ export const defaultTooltipConfig: NgpTooltipConfig = {
   trackPosition: false,
   scrollBehavior: 'reposition',
   cooldown: 300,
+  hoverableContent: false,
 };
 
 export const NgpTooltipConfigToken = new InjectionToken<NgpTooltipConfig>('NgpTooltipConfigToken');

--- a/packages/ng-primitives/tooltip/src/index.ts
+++ b/packages/ng-primitives/tooltip/src/index.ts
@@ -1,5 +1,8 @@
 export { injectOverlayContext as injectTooltipContext } from 'ng-primitives/portal';
-export { NgpTooltipConfig, provideTooltipConfig } from './config/tooltip-config';
+export {
+  NgpTooltipConfig,
+  provideTooltipConfig,
+} from './config/tooltip-config';
 export { NgpTooltipArrow } from './tooltip-arrow/tooltip-arrow';
 export {
   injectTooltipArrowState,

--- a/packages/ng-primitives/tooltip/src/index.ts
+++ b/packages/ng-primitives/tooltip/src/index.ts
@@ -1,8 +1,5 @@
 export { injectOverlayContext as injectTooltipContext } from 'ng-primitives/portal';
-export {
-  NgpTooltipConfig,
-  provideTooltipConfig,
-} from './config/tooltip-config';
+export { NgpTooltipConfig, provideTooltipConfig } from './config/tooltip-config';
 export { NgpTooltipArrow } from './tooltip-arrow/tooltip-arrow';
 export {
   injectTooltipArrowState,

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-hover-bridge.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-hover-bridge.spec.ts
@@ -1,0 +1,62 @@
+import {
+  createTooltipHoverBridgePolygon,
+  isPointInHoverBridgePolygon,
+} from './tooltip-hover-bridge';
+
+describe('tooltip-hover-bridge', () => {
+  it('should return null when trigger rect is missing', () => {
+    const polygon = createTooltipHoverBridgePolygon({
+      triggerRect: null,
+      tooltipRect: new DOMRect(100, 0, 40, 20),
+      exitPoint: { x: 10, y: 10 },
+    });
+
+    expect(polygon).toBeNull();
+  });
+
+  it('should return null when tooltip rect is missing', () => {
+    const polygon = createTooltipHoverBridgePolygon({
+      triggerRect: new DOMRect(0, 0, 40, 20),
+      tooltipRect: null,
+      exitPoint: { x: 10, y: 10 },
+    });
+
+    expect(polygon).toBeNull();
+  });
+
+  it('should include points traveling from trigger toward tooltip to the right', () => {
+    const polygon = createTooltipHoverBridgePolygon({
+      triggerRect: new DOMRect(0, 0, 40, 20),
+      tooltipRect: new DOMRect(120, 0, 80, 40),
+      exitPoint: { x: 40, y: 10 },
+    });
+
+    expect(polygon).not.toBeNull();
+    expect(isPointInHoverBridgePolygon({ x: 80, y: 10 }, polygon!)).toBe(true);
+    expect(isPointInHoverBridgePolygon({ x: 80, y: 80 }, polygon!)).toBe(false);
+  });
+
+  it('should include points traveling from trigger toward tooltip above', () => {
+    const polygon = createTooltipHoverBridgePolygon({
+      triggerRect: new DOMRect(0, 100, 40, 20),
+      tooltipRect: new DOMRect(0, 0, 60, 40),
+      exitPoint: { x: 20, y: 100 },
+    });
+
+    expect(polygon).not.toBeNull();
+    expect(isPointInHoverBridgePolygon({ x: 20, y: 70 }, polygon!)).toBe(true);
+    expect(isPointInHoverBridgePolygon({ x: 120, y: 70 }, polygon!)).toBe(false);
+  });
+
+  it('should handle diagonal movement between trigger and tooltip', () => {
+    const polygon = createTooltipHoverBridgePolygon({
+      triggerRect: new DOMRect(0, 0, 40, 20),
+      tooltipRect: new DOMRect(80, 80, 60, 40),
+      exitPoint: { x: 40, y: 20 },
+    });
+
+    expect(polygon).not.toBeNull();
+    expect(isPointInHoverBridgePolygon({ x: 70, y: 80 }, polygon!)).toBe(true);
+    expect(isPointInHoverBridgePolygon({ x: 20, y: 80 }, polygon!)).toBe(false);
+  });
+});

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-hover-bridge.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-hover-bridge.ts
@@ -1,0 +1,79 @@
+export interface TooltipHoverBridgePoint {
+  x: number;
+  y: number;
+}
+
+interface CreateTooltipHoverBridgePolygonOptions {
+  triggerRect: DOMRect | null;
+  tooltipRect: DOMRect | null;
+  exitPoint: TooltipHoverBridgePoint;
+  corridorHalfSize?: number;
+}
+
+/**
+ * Builds a pointer grace polygon between the trigger exit point and the tooltip.
+ * The polygon is intentionally directional so moving away from the tooltip exits quickly.
+ */
+export function createTooltipHoverBridgePolygon({
+  triggerRect,
+  tooltipRect,
+  exitPoint,
+  corridorHalfSize = 8,
+}: CreateTooltipHoverBridgePolygonOptions): TooltipHoverBridgePoint[] | null {
+  if (!triggerRect || !tooltipRect) {
+    return null;
+  }
+
+  const triggerCenterX = triggerRect.left + triggerRect.width / 2;
+  const triggerCenterY = triggerRect.top + triggerRect.height / 2;
+  const tooltipCenterX = tooltipRect.left + tooltipRect.width / 2;
+  const tooltipCenterY = tooltipRect.top + tooltipRect.height / 2;
+
+  const dx = tooltipCenterX - triggerCenterX;
+  const dy = tooltipCenterY - triggerCenterY;
+  const horizontalDominant = Math.abs(dx) >= Math.abs(dy);
+
+  if (horizontalDominant) {
+    const targetX = dx >= 0 ? tooltipRect.left : tooltipRect.right;
+    return [
+      { x: exitPoint.x, y: exitPoint.y - corridorHalfSize },
+      { x: exitPoint.x, y: exitPoint.y + corridorHalfSize },
+      { x: targetX, y: tooltipRect.bottom + corridorHalfSize },
+      { x: targetX, y: tooltipRect.top - corridorHalfSize },
+    ];
+  }
+
+  const targetY = dy >= 0 ? tooltipRect.top : tooltipRect.bottom;
+  return [
+    { x: exitPoint.x - corridorHalfSize, y: exitPoint.y },
+    { x: exitPoint.x + corridorHalfSize, y: exitPoint.y },
+    { x: tooltipRect.right + corridorHalfSize, y: targetY },
+    { x: tooltipRect.left - corridorHalfSize, y: targetY },
+  ];
+}
+
+/**
+ * Returns true when the point lies inside the provided polygon.
+ */
+export function isPointInHoverBridgePolygon(
+  point: TooltipHoverBridgePoint,
+  polygon: TooltipHoverBridgePoint[],
+): boolean {
+  let inside = false;
+
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const xi = polygon[i].x;
+    const yi = polygon[i].y;
+    const xj = polygon[j].x;
+    const yj = polygon[j].y;
+
+    const intersects =
+      yi > point.y !== yj > point.y &&
+      point.x < ((xj - xi) * (point.y - yi)) / (yj - yi || Number.EPSILON) + xi;
+    if (intersects) {
+      inside = !inside;
+    }
+  }
+
+  return inside;
+}

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-interactive.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-interactive.spec.ts
@@ -1,0 +1,246 @@
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpTooltip, NgpTooltipTrigger, provideTooltipConfig } from 'ng-primitives/tooltip';
+
+describe('NgpTooltipTrigger interactive hover behavior', () => {
+  afterEach(() => {
+    document.querySelectorAll('[ngpTooltip]').forEach(el => el.remove());
+    jest.useRealTimers();
+  });
+
+  it('should keep tooltip open when moving from trigger to content when hoverableContent=true', async () => {
+    jest.useFakeTimers();
+
+    const { getByRole } = await render(
+      `
+        <button
+          [ngpTooltipTrigger]="content"
+          ngpTooltipTriggerHideDelay="80"
+          ngpTooltipTriggerHoverableContent="true"
+        >
+          Trigger
+        </button>
+
+        <ng-template #content>
+          <div ngpTooltip>Tooltip content</div>
+        </ng-template>
+      `,
+      { imports: [NgpTooltipTrigger, NgpTooltip] },
+    );
+
+    const trigger = getByRole('button');
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+    });
+
+    fireEvent.mouseLeave(trigger);
+    const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement;
+    fireEvent.mouseEnter(tooltip);
+    jest.advanceTimersByTime(100);
+
+    expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(tooltip);
+    jest.advanceTimersByTime(100);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should close when hoverableContent=false even if pointer enters tooltip content', async () => {
+    jest.useFakeTimers();
+
+    const { getByRole } = await render(
+      `
+        <button
+          [ngpTooltipTrigger]="content"
+          ngpTooltipTriggerHideDelay="0"
+          ngpTooltipTriggerHoverableContent="false"
+        >
+          Trigger
+        </button>
+
+        <ng-template #content>
+          <div ngpTooltip>Tooltip content</div>
+        </ng-template>
+      `,
+      { imports: [NgpTooltipTrigger, NgpTooltip] },
+    );
+
+    const trigger = getByRole('button');
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+    });
+
+    fireEvent.mouseLeave(trigger);
+    const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement;
+    fireEvent.mouseEnter(tooltip);
+    jest.advanceTimersByTime(1);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should keep open while pointer stays in polygon bridge and close when leaving it', async () => {
+    jest.useFakeTimers();
+
+    const { getByRole } = await render(
+      `
+        <button
+          [ngpTooltipTrigger]="content"
+          ngpTooltipTriggerHideDelay="0"
+          ngpTooltipTriggerHoverableContent="true"
+        >
+          Trigger
+        </button>
+
+        <ng-template #content>
+          <div ngpTooltip>Tooltip content</div>
+        </ng-template>
+      `,
+      { imports: [NgpTooltipTrigger, NgpTooltip] },
+    );
+
+    const trigger = getByRole('button') as HTMLButtonElement;
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+    });
+
+    const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement;
+    jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 40, 20));
+    jest.spyOn(tooltip, 'getBoundingClientRect').mockReturnValue(new DOMRect(120, 0, 80, 40));
+
+    fireEvent.mouseLeave(trigger, { clientX: 40, clientY: 10 });
+    fireEvent.pointerMove(document, { clientX: 80, clientY: 10 });
+    jest.advanceTimersByTime(1);
+    expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+
+    fireEvent.pointerMove(document, { clientX: 80, clientY: 90 });
+    jest.advanceTimersByTime(1);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should close if pointer leaves trigger and does not move', async () => {
+    jest.useFakeTimers();
+
+    const { getByRole } = await render(
+      `
+        <button
+          [ngpTooltipTrigger]="content"
+          ngpTooltipTriggerHideDelay="0"
+          ngpTooltipTriggerHoverableContent="true"
+        >
+          Trigger
+        </button>
+
+        <ng-template #content>
+          <div ngpTooltip>Tooltip content</div>
+        </ng-template>
+      `,
+      { imports: [NgpTooltipTrigger, NgpTooltip] },
+    );
+
+    const trigger = getByRole('button') as HTMLButtonElement;
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+    });
+
+    const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement;
+    jest.spyOn(trigger, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 40, 20));
+    jest.spyOn(tooltip, 'getBoundingClientRect').mockReturnValue(new DOMRect(120, 0, 80, 40));
+
+    fireEvent.mouseLeave(trigger, { clientX: 40, clientY: 10 });
+    jest.advanceTimersByTime(200);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should close on blur even while hovering tooltip content', async () => {
+    jest.useFakeTimers();
+
+    const { getByRole } = await render(
+      `
+        <button
+          [ngpTooltipTrigger]="content"
+          ngpTooltipTriggerHideDelay="0"
+          ngpTooltipTriggerHoverableContent="true"
+        >
+          Trigger
+        </button>
+
+        <ng-template #content>
+          <div ngpTooltip>Tooltip content</div>
+        </ng-template>
+      `,
+      { imports: [NgpTooltipTrigger, NgpTooltip] },
+    );
+
+    const trigger = getByRole('button');
+    fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+    });
+
+    const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement;
+    fireEvent.mouseEnter(tooltip);
+    fireEvent.blur(trigger);
+    jest.advanceTimersByTime(1);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should use provider defaults and allow input override for hoverableContent', async () => {
+    jest.useFakeTimers();
+
+    const { getByRole } = await render(
+      `
+        <button
+          [ngpTooltipTrigger]="content"
+          ngpTooltipTriggerHideDelay="0"
+          ngpTooltipTriggerHoverableContent="true"
+        >
+          Trigger
+        </button>
+
+        <ng-template #content>
+          <div ngpTooltip>Tooltip content</div>
+        </ng-template>
+      `,
+      {
+        imports: [NgpTooltipTrigger, NgpTooltip],
+        providers: [provideTooltipConfig({ hoverableContent: false })],
+      },
+    );
+
+    const trigger = getByRole('button');
+    fireEvent.mouseEnter(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+    });
+
+    fireEvent.mouseLeave(trigger);
+    const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement;
+    fireEvent.mouseEnter(tooltip);
+    jest.advanceTimersByTime(1);
+
+    expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+  });
+});

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.spec.ts
@@ -785,7 +785,11 @@ describe('NgpTooltipTrigger', () => {
       try {
         const { getByRole } = await render(
           `
-            <button [ngpTooltipTrigger]="content" ngpTooltipTriggerHideDelay="0"></button>
+            <button
+              [ngpTooltipTrigger]="content"
+              ngpTooltipTriggerHideDelay="0"
+              ngpTooltipTriggerHoverableContent="false"
+            ></button>
             <ng-template #content>
               <div ngpTooltip>Tooltip content</div>
             </ng-template>
@@ -857,7 +861,11 @@ describe('NgpTooltipTrigger', () => {
       try {
         const { getByRole } = await render(
           `
-            <button [ngpTooltipTrigger]="content" ngpTooltipTriggerHideDelay="0"></button>
+            <button
+              [ngpTooltipTrigger]="content"
+              ngpTooltipTriggerHideDelay="0"
+              ngpTooltipTriggerHoverableContent="false"
+            ></button>
             <ng-template #content>
               <div ngpTooltip>Tooltip content</div>
             </ng-template>
@@ -919,7 +927,11 @@ describe('NgpTooltipTrigger', () => {
       try {
         const { getByRole } = await render(
           `
-            <button [ngpTooltipTrigger]="content" ngpTooltipTriggerHideDelay="0"></button>
+            <button
+              [ngpTooltipTrigger]="content"
+              ngpTooltipTriggerHideDelay="0"
+              ngpTooltipTriggerHoverableContent="false"
+            ></button>
             <ng-template #content>
               <div ngpTooltip>Tooltip content</div>
             </ng-template>
@@ -982,7 +994,11 @@ describe('NgpTooltipTrigger', () => {
       try {
         const { getByRole } = await render(
           `
-            <button [ngpTooltipTrigger]="content" ngpTooltipTriggerHideDelay="0"></button>
+            <button
+              [ngpTooltipTrigger]="content"
+              ngpTooltipTriggerHideDelay="0"
+              ngpTooltipTriggerHoverableContent="false"
+            ></button>
             <ng-template #content>
               <div ngpTooltip>Tooltip content</div>
             </ng-template>

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -30,9 +30,14 @@ import {
   NgpShift,
   NgpShiftInput,
 } from 'ng-primitives/portal';
-import { isString } from 'ng-primitives/utils';
+import { injectDisposables, isString } from 'ng-primitives/utils';
 import { injectTooltipConfig } from '../config/tooltip-config';
 import { NgpTooltipTextContentComponent } from '../tooltip-text-content/tooltip-text-content.component';
+import {
+  createTooltipHoverBridgePolygon,
+  isPointInHoverBridgePolygon,
+  TooltipHoverBridgePoint,
+} from './tooltip-hover-bridge';
 import { provideTooltipTriggerState, tooltipTriggerState } from './tooltip-trigger-state';
 
 type TooltipInput<T> = NgpOverlayContent<T> | string | null | undefined;
@@ -49,12 +54,17 @@ type TooltipInput<T> = NgpOverlayContent<T> | string | null | undefined;
     '[attr.data-disabled]': 'state.disabled() ? "" : null',
     '[attr.aria-describedby]': 'overlay()?.ariaDescribedBy()',
     '(mouseenter)': 'showFromInteraction()',
-    '(mouseleave)': 'hideFromInteraction()',
+    '(mouseleave)': 'hideFromInteraction($event)',
     '(focus)': 'showFromInteraction()',
     '(blur)': 'hideFromInteraction()',
   },
 })
 export class NgpTooltipTrigger<T = null> implements OnDestroy {
+  /**
+   * Maximum time allowed to cross from trigger to tooltip without pointer movement.
+   */
+  private static readonly HOVER_BRIDGE_TIMEOUT_MS = 150;
+
   /**
    * Access the trigger element
    */
@@ -74,6 +84,11 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
    * Access the global tooltip configuration.
    */
   private readonly config = injectTooltipConfig();
+
+  /**
+   * Disposables for managing event listeners and timers with automatic teardown.
+   */
+  private readonly disposables = injectDisposables();
 
   /**
    * Access the tooltip template ref.
@@ -221,6 +236,15 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
   });
 
   /**
+   * Whether hovering tooltip content keeps the tooltip open.
+   * @default false
+   */
+  readonly hoverableContent = input<boolean, BooleanInput>(this.config.hoverableContent, {
+    alias: 'ngpTooltipTriggerHoverableContent',
+    transform: booleanAttribute,
+  });
+
+  /**
    * The overlay that manages the tooltip
    * @internal
    */
@@ -243,6 +267,31 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
   private readonly hasOverflow: Signal<boolean>;
 
   /**
+   * Tracks whether pointer is currently over trigger.
+   */
+  private triggerHovered = false;
+
+  /**
+   * Tracks whether pointer is currently over tooltip content.
+   */
+  private contentHovered = false;
+
+  /**
+   * Current pointer grace polygon used while crossing trigger -> tooltip.
+   */
+  private hoverBridgePolygon: TooltipHoverBridgePoint[] | null = null;
+
+  /**
+   * Cleanup callback for the document pointermove listener.
+   */
+  private removePointerMoveListener?: () => void;
+
+  /**
+   * Cleanup callback for the hover bridge timeout.
+   */
+  private clearHoverBridgeTimeout?: () => void;
+
+  /**
    * Store the state of the tooltip.
    * @internal
    */
@@ -255,6 +304,7 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.clearHoverBridge();
     this.overlay()?.destroy();
   }
 
@@ -269,6 +319,7 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
    * Hide the tooltip.
    */
   hide(): void {
+    this.clearHoverBridge();
     this.overlay()?.hide();
   }
 
@@ -280,6 +331,8 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
     if (this.state.disabled()) {
       return;
     }
+    this.triggerHovered = true;
+    this.clearHoverBridge();
     this.performShow(false);
   }
 
@@ -311,11 +364,77 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
    * Hide the tooltip from an interaction (respects disabled state).
    * @internal
    */
-  protected hideFromInteraction(): void {
+  protected hideFromInteraction(event?: MouseEvent): void {
     if (this.state.disabled()) {
       return;
     }
-    this.hide();
+
+    this.triggerHovered = false;
+
+    // Blur should close regardless of hover bridge or tooltip hover state.
+    if (!event) {
+      this.contentHovered = false;
+      this.clearHoverBridge();
+      this.hide();
+      return;
+    }
+
+    if (!this.state.hoverableContent()) {
+      this.hide();
+      return;
+    }
+
+    const tooltipElement = this.overlay()?.getElements()[0];
+    if (!tooltipElement) {
+      this.hide();
+      return;
+    }
+
+    const polygon = createTooltipHoverBridgePolygon({
+      triggerRect: this.trigger.nativeElement.getBoundingClientRect(),
+      tooltipRect: tooltipElement.getBoundingClientRect(),
+      exitPoint: { x: event.clientX, y: event.clientY },
+    });
+
+    if (!polygon) {
+      this.hide();
+      return;
+    }
+
+    this.hoverBridgePolygon = polygon;
+    this.overlay()?.cancelPendingClose();
+    this.registerPointerMoveListener();
+    this.scheduleHoverBridgeCloseFallback();
+  }
+
+  /**
+   * Called by tooltip content when pointer enters the tooltip.
+   * @internal
+   */
+  onTooltipHoverStart(): void {
+    if (this.state.disabled() || !this.state.hoverableContent()) {
+      return;
+    }
+
+    this.contentHovered = true;
+    this.clearHoverBridge();
+    this.overlay()?.cancelPendingClose();
+  }
+
+  /**
+   * Called by tooltip content when pointer leaves the tooltip.
+   * @internal
+   */
+  onTooltipHoverEnd(): void {
+    if (this.state.disabled() || !this.state.hoverableContent()) {
+      return;
+    }
+
+    this.contentHovered = false;
+
+    if (!this.triggerHovered) {
+      this.hide();
+    }
   }
 
   /**
@@ -384,6 +503,68 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
    */
   setTooltipId(id: string): void {
     this.tooltipId.set(id);
+  }
+
+  /**
+   * Register document-level pointer tracking while crossing trigger -> tooltip.
+   */
+  private registerPointerMoveListener(): void {
+    if (this.removePointerMoveListener) {
+      return;
+    }
+
+    const cleanup = this.disposables.addEventListener(
+      document,
+      'pointermove' as keyof HTMLElementEventMap,
+      ((event: PointerEvent): void => {
+        if (this.triggerHovered || this.contentHovered || !this.hoverBridgePolygon) {
+          this.clearHoverBridge();
+          return;
+        }
+
+        const inBridge = isPointInHoverBridgePolygon(
+          { x: event.clientX, y: event.clientY },
+          this.hoverBridgePolygon,
+        );
+
+        if (!inBridge) {
+          this.clearHoverBridge();
+          this.hide();
+        }
+      }) as EventListener,
+      true,
+    );
+
+    this.removePointerMoveListener = () => {
+      cleanup();
+      this.removePointerMoveListener = undefined;
+    };
+  }
+
+  /**
+   * Clear hover bridge state and global listeners.
+   */
+  private clearHoverBridge(): void {
+    this.hoverBridgePolygon = null;
+    this.clearHoverBridgeTimeout?.();
+    this.clearHoverBridgeTimeout = undefined;
+    this.removePointerMoveListener?.();
+  }
+
+  /**
+   * Close if pointer leaves trigger and does not move into tooltip soon enough.
+   */
+  private scheduleHoverBridgeCloseFallback(): void {
+    this.clearHoverBridgeTimeout?.();
+
+    this.clearHoverBridgeTimeout = this.disposables.setTimeout(() => {
+      this.clearHoverBridgeTimeout = undefined;
+
+      if (!this.triggerHovered && !this.contentHovered && this.hoverBridgePolygon) {
+        this.clearHoverBridge();
+        this.hide();
+      }
+    }, NgpTooltipTrigger.HOVER_BRIDGE_TIMEOUT_MS);
   }
 }
 

--- a/packages/ng-primitives/tooltip/src/tooltip/tooltip.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip/tooltip.ts
@@ -44,14 +44,8 @@ export class NgpTooltip {
 
     // if the mouse moves over the tooltip, we want to keep it open
     ngpHover({
-      onHoverStart: () => this.overlay.cancelPendingClose(),
-      onHoverEnd: () => {
-        if (this.tooltipTrigger().disabled()) {
-          return;
-        }
-
-        this.tooltipTrigger().hide();
-      },
+      onHoverStart: () => this.tooltipTrigger().onTooltipHoverStart(),
+      onHoverEnd: () => this.tooltipTrigger().onTooltipHoverEnd(),
     });
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hoverable tooltip content so users can move the pointer from the trigger into the tooltip without closing it. Also fixes outside-click dismissal so popovers close even if a tooltip is topmost.

- **New Features**
  - `ngpTooltipTriggerHoverableContent` input to keep tooltips open while hovering content.
  - Config support via `provideTooltipConfig({ hoverableContent })` (default `false`).
  - Pointer grace “hover bridge” polygon with document `pointermove` tracking.
  - New docs and example for hoverable content in `@ng-primitives/tooltip`.

- **Bug Fixes**
  - Improved outside-click handling in `@ng-primitives/portal` overlay registry to dismiss all applicable overlay trees, not blocked by non-dismissable tooltips.
  - Ensures clicking another popover trigger closes the previous popover even when a tooltip is open.

<sup>Written for commit 6467d0cf25ae12c44b6668449211dcefd4c0c0bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

