### PR TITLE
fix(slider): focus thumb on track click

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: tree:0
 
       # Connect your workspace on nx.app and uncomment this to enable task distribution.
       # The "--stop-agents-after" is optional, but allows idle agents to shut down once the "build" targets have been requested
@@ -26,7 +27,7 @@ jobs:
         with:
           version: 10
       # Cache node_modules
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: 'pnpm'
@@ -34,7 +35,7 @@ jobs:
       - uses: nrwl/nx-set-shas@v4
 
       - run: pnpm exec nx format:check
-      - run: pnpm exec nx run-many -t lint,build,test,e2e --all --parallel
+      - run: pnpm exec nx affected -t lint,build,test,e2e
         env:
           NODE_OPTIONS: '--max-old-space-size=8192' # Increase memory to 8GB
       - run: pnpx pkg-pr-new publish ./dist/packages/*

--- a/nx.json
+++ b/nx.json
@@ -70,13 +70,6 @@
       "unitTestRunner": "none"
     }
   },
-  "tasksRunnerOptions": {
-    "default": {
-      "options": {
-        "cacheableOperations": []
-      }
-    }
-  },
   "release": {
     "projects": ["ng-primitives", "state", "mcp"],
     "changelog": {

--- a/packages/ng-primitives/menu/src/submenu-trigger/submenu-trigger.spec.ts
+++ b/packages/ng-primitives/menu/src/submenu-trigger/submenu-trigger.spec.ts
@@ -416,7 +416,7 @@ describe('NgpSubmenuTrigger viewport awareness', () => {
         });
 
         expect(submenuCall).toBeDefined();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         const middleware = (submenuCall as any[])[2].middleware as any[];
         const hasFlip = middleware.some(m => m?.name === 'flip');
         expect(hasFlip).toBe(false);

--- a/packages/ng-primitives/slider/src/range-slider/range-slider-track/range-slider-track-state.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider-track/range-slider-track-state.ts
@@ -62,11 +62,19 @@ export const [
       rangeSlider().setHighValue(value);
     }
 
-    rangeSlider().focusThumb(closestThumb, 'mouse');
+    rangeSlider().focusThumb(closestThumb, event.pointerType === 'touch' ? 'touch' : 'mouse');
   }
 
   // Event listener
   listener(element, 'pointerdown', handlePointerDown);
+
+  // Prevent mousedown default to stop the browser from stealing focus
+  // from the thumb after a pointerdown-initiated focusVia call.
+  listener(element, 'mousedown', (event: MouseEvent) => {
+    if (!rangeSlider().disabled()) {
+      event.preventDefault();
+    }
+  });
 
   // Register track with parent
   rangeSlider().setTrack(element);

--- a/packages/ng-primitives/slider/src/range-slider/range-slider-track/range-slider-track-state.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider-track/range-slider-track-state.ts
@@ -61,6 +61,8 @@ export const [
     } else {
       rangeSlider().setHighValue(value);
     }
+
+    rangeSlider().focusThumb(closestThumb, 'mouse');
   }
 
   // Event listener

--- a/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider-state.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider-state.ts
@@ -1,4 +1,5 @@
-import { computed, ElementRef, Signal, signal, WritableSignal } from '@angular/core';
+import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
+import { computed, ElementRef, inject, Signal, signal, WritableSignal } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
 import { ngpFormControl } from 'ng-primitives/form-field';
 import { injectElementRef } from 'ng-primitives/internal';
@@ -147,6 +148,10 @@ export interface NgpRangeSliderState {
    */
   removeThumb(thumb: ElementRef<HTMLElement>): void;
   /**
+   * Focus the specified thumb element.
+   */
+  focusThumb(thumb: 'low' | 'high', origin: FocusOrigin): void;
+  /**
    * Set the track element reference.
    */
   setTrack(track: ElementRef<HTMLElement>): void;
@@ -180,6 +185,7 @@ export const [
     onHighChange,
   }: NgpRangeSliderProps): NgpRangeSliderState => {
     const element = injectElementRef();
+    const focusMonitor = inject(FocusMonitor);
     const low = controlled(_low);
     const high = controlled(_high);
     const disabled = controlled(_disabled);
@@ -243,6 +249,14 @@ export const [
       thumbs.update(t => t.filter(existing => existing !== thumb));
     }
 
+    function focusThumb(thumb: 'low' | 'high', origin: FocusOrigin): void {
+      const index = thumb === 'low' ? 0 : 1;
+      const el = thumbs()[index];
+      if (el) {
+        focusMonitor.focusVia(el, origin, { preventScroll: true });
+      }
+    }
+
     function setDisabled(isDisabled: boolean): void {
       disabled.set(isDisabled);
     }
@@ -276,6 +290,7 @@ export const [
       getClosestThumb,
       addThumb,
       removeThumb,
+      focusThumb,
       setDisabled,
       setOrientation,
       setTrack,

--- a/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider.spec.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider.spec.ts
@@ -11,10 +11,12 @@ import { NgpRangeSlider } from './range-slider';
 // Polyfill PointerEvent for jsdom
 class MockPointerEvent extends MouseEvent {
   readonly pointerId: number;
+  readonly pointerType: string;
 
   constructor(type: string, params: PointerEventInit = {}) {
     super(type, params);
     this.pointerId = params.pointerId ?? 0;
+    this.pointerType = params.pointerType ?? '';
   }
 }
 
@@ -337,6 +339,9 @@ describe('NgpRangeSlider', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
+    const lowThumbEl = screen.getByTestId('low-thumb');
+    const highThumbEl = screen.getByTestId('high-thumb');
+
     // Click near 10% (closer to low thumb at 20%)
     track.dispatchEvent(
       new MouseEvent('pointerdown', {
@@ -347,9 +352,11 @@ describe('NgpRangeSlider', () => {
       }),
     );
 
-    expect(focusViaSpy).toHaveBeenCalledWith(expect.anything(), 'mouse', {
-      preventScroll: true,
-    });
+    expect(focusViaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ nativeElement: lowThumbEl }),
+      'mouse',
+      { preventScroll: true },
+    );
 
     focusViaSpy.mockClear();
 
@@ -363,9 +370,72 @@ describe('NgpRangeSlider', () => {
       }),
     );
 
-    expect(focusViaSpy).toHaveBeenCalledWith(expect.anything(), 'mouse', {
-      preventScroll: true,
+    expect(focusViaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ nativeElement: highThumbEl }),
+      'mouse',
+      { preventScroll: true },
+    );
+  });
+
+  it('should use touch focus origin when track is tapped', async () => {
+    const { fixture } = await render(TestComponent);
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    const track = screen.getByTestId('slider-track');
+    const lowThumbEl = screen.getByTestId('low-thumb');
+
+    jest.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 20,
+      width: 100,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
     });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Tap near 10% (closer to low thumb at 20%)
+    track.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 10,
+        pointerType: 'touch',
+      }),
+    );
+
+    expect(focusViaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ nativeElement: lowThumbEl }),
+      'touch',
+      { preventScroll: true },
+    );
+  });
+
+  it('should prevent mousedown default to preserve thumb focus after track click', async () => {
+    const { fixture } = await render(TestComponent);
+
+    const track = screen.getByTestId('slider-track');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // In real browsers, mousedown fires after pointerdown and its default
+    // action steals focus from the thumb. The track must prevent it.
+    const mousedownEvent = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    });
+    track.dispatchEvent(mousedownEvent);
+
+    expect(mousedownEvent.defaultPrevented).toBe(true);
   });
 
   it('should not focus thumb when clicking the track while disabled', async () => {

--- a/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider.spec.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider.spec.ts
@@ -1,4 +1,6 @@
+import { FocusMonitor } from '@angular/cdk/a11y';
 import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { fireEvent, render, screen } from '@testing-library/angular';
 import { userEvent } from '@testing-library/user-event';
 import { NgpRangeSliderRange } from '../range-slider-range/range-slider-range';
@@ -309,6 +311,97 @@ describe('NgpRangeSlider', () => {
     await userEvent.pointer({ keys: '[MouseLeft>]', target: track, coords: { x: 10, y: 10 } });
 
     expect(component.low).toBeLessThan(20);
+  });
+
+  it('should focus the closest thumb with mouse origin when clicking the track', async () => {
+    const { fixture } = await render(TestComponent);
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    const track = screen.getByTestId('slider-track');
+
+    // Mock getBoundingClientRect for track
+    jest.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 20,
+      width: 100,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Click near 10% (closer to low thumb at 20%)
+    track.dispatchEvent(
+      new MouseEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 10,
+      }),
+    );
+
+    expect(focusViaSpy).toHaveBeenCalledWith(expect.anything(), 'mouse', {
+      preventScroll: true,
+    });
+
+    focusViaSpy.mockClear();
+
+    // Click near 90% (closer to high thumb at 80%)
+    track.dispatchEvent(
+      new MouseEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 90,
+        clientY: 10,
+      }),
+    );
+
+    expect(focusViaSpy).toHaveBeenCalledWith(expect.anything(), 'mouse', {
+      preventScroll: true,
+    });
+  });
+
+  it('should not focus thumb when clicking the track while disabled', async () => {
+    const { fixture } = await render(TestComponent);
+    const component = fixture.componentInstance;
+
+    component.disabled = true;
+    fixture.detectChanges();
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    const track = screen.getByTestId('slider-track');
+
+    jest.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 20,
+      width: 100,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    track.dispatchEvent(
+      new MouseEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 10,
+      }),
+    );
+
+    expect(focusViaSpy).not.toHaveBeenCalled();
   });
 
   it('should not respond to interactions when disabled', async () => {

--- a/packages/ng-primitives/slider/src/slider-thumb/slider-thumb-state.ts
+++ b/packages/ng-primitives/slider/src/slider-thumb/slider-thumb-state.ts
@@ -1,3 +1,4 @@
+import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
 import { DOCUMENT } from '@angular/common';
 import { computed, inject, Injector, Signal } from '@angular/core';
 import { ngpInteractions } from 'ng-primitives/interactions';
@@ -7,6 +8,7 @@ import {
   createPrimitive,
   dataBinding,
   listener,
+  onDestroy,
   styleBinding,
 } from 'ng-primitives/state';
 import { injectSliderState } from '../slider/slider-state';
@@ -24,7 +26,7 @@ export interface NgpSliderThumbState {
   /**
    * Focus the thumb element.
    */
-  focus(): void;
+  focus(origin?: FocusOrigin): void;
 }
 
 /**
@@ -51,6 +53,7 @@ export const [
   ({ onDragStart, onDragEnd }: NgpSliderThumbProps): NgpSliderThumbState => {
     const elementRef = injectElementRef<HTMLElement>();
     const slider = injectSliderState();
+    const focusMonitor = inject(FocusMonitor);
     const injector = inject(Injector);
     const document = inject(DOCUMENT);
 
@@ -83,6 +86,10 @@ export const [
       press: true,
       disabled: slider().disabled,
     });
+
+    // Register thumb with parent slider
+    slider().setThumb(elementRef);
+    onDestroy(() => slider().setThumb(undefined));
 
     // Pointer interactions
     listener(elementRef, 'pointerdown', (event: PointerEvent) => {
@@ -203,8 +210,8 @@ export const [
     /**
      * Moves keyboard focus to the host element without scrolling the page.
      */
-    function focus(): void {
-      elementRef.nativeElement.focus({ preventScroll: true });
+    function focus(origin: FocusOrigin = 'program'): void {
+      focusMonitor.focusVia(elementRef, origin, { preventScroll: true });
     }
 
     return {

--- a/packages/ng-primitives/slider/src/slider-track/slider-track-state.ts
+++ b/packages/ng-primitives/slider/src/slider-track/slider-track-state.ts
@@ -48,6 +48,7 @@ export const [
       slider().min() + (slider().max() - slider().min()) * Math.max(0, Math.min(1, percentage));
 
     slider().setValue(value);
+    slider().focusThumb('mouse');
   });
 
   return {} satisfies NgpSliderTrackState;

--- a/packages/ng-primitives/slider/src/slider-track/slider-track-state.ts
+++ b/packages/ng-primitives/slider/src/slider-track/slider-track-state.ts
@@ -48,7 +48,15 @@ export const [
       slider().min() + (slider().max() - slider().min()) * Math.max(0, Math.min(1, percentage));
 
     slider().setValue(value);
-    slider().focusThumb('mouse');
+    slider().focusThumb(event.pointerType === 'touch' ? 'touch' : 'mouse');
+  });
+
+  // Prevent mousedown default to stop the browser from stealing focus
+  // from the thumb after a pointerdown-initiated focusVia call.
+  listener(element, 'mousedown', (event: MouseEvent) => {
+    if (!slider().disabled()) {
+      event.preventDefault();
+    }
   });
 
   return {} satisfies NgpSliderTrackState;

--- a/packages/ng-primitives/slider/src/slider/slider-state.ts
+++ b/packages/ng-primitives/slider/src/slider/slider-state.ts
@@ -1,4 +1,5 @@
-import { computed, ElementRef, Signal, signal, WritableSignal } from '@angular/core';
+import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
+import { computed, ElementRef, inject, Signal, signal, WritableSignal } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
 import { ngpFormControl } from 'ng-primitives/form-field';
 import { injectElementRef } from 'ng-primitives/internal';
@@ -54,6 +55,10 @@ export interface NgpSliderState {
    */
   readonly track: Signal<ElementRef<HTMLElement> | undefined>;
   /**
+   * @internal The thumb element reference.
+   */
+  readonly thumb: Signal<ElementRef<HTMLElement> | undefined>;
+  /**
    * Emit when the value changes.
    */
   readonly valueChange: Observable<number>;
@@ -65,6 +70,14 @@ export interface NgpSliderState {
    * Register the track element.
    */
   setTrack(track: ElementRef<HTMLElement> | undefined): void;
+  /**
+   * Register the thumb element.
+   */
+  setThumb(thumb: ElementRef<HTMLElement> | undefined): void;
+  /**
+   * Focus the thumb element.
+   */
+  focusThumb(origin: FocusOrigin): void;
   /**
    * Set the disabled state.
    */
@@ -127,12 +140,14 @@ export const [NgpSliderStateToken, ngpSlider, injectSliderState, provideSliderSt
       onValueChange,
     }: NgpSliderProps): NgpSliderState => {
       const element = injectElementRef();
+      const focusMonitor = inject(FocusMonitor);
       const value = controlled(_value);
       const disabled = controlled(_disabled);
       const orientation = controlled(_orientation);
 
       const valueChange = emitter<number>();
       const track = signal<ElementRef<HTMLElement> | undefined>(undefined);
+      const thumb = signal<ElementRef<HTMLElement> | undefined>(undefined);
 
       // Form control integration
       const status = ngpFormControl({ id, disabled });
@@ -153,6 +168,17 @@ export const [NgpSliderStateToken, ngpSlider, injectSliderState, provideSliderSt
 
       function setTrack(newTrack: ElementRef<HTMLElement> | undefined): void {
         track.set(newTrack);
+      }
+
+      function setThumb(newThumb: ElementRef<HTMLElement> | undefined): void {
+        thumb.set(newThumb);
+      }
+
+      function focusThumb(origin: FocusOrigin): void {
+        const el = thumb();
+        if (el) {
+          focusMonitor.focusVia(el, origin, { preventScroll: true });
+        }
       }
 
       function setValue(newValue: number): void {
@@ -183,8 +209,11 @@ export const [NgpSliderStateToken, ngpSlider, injectSliderState, provideSliderSt
         valueChange: valueChange.asObservable(),
         percentage,
         track,
+        thumb,
         setValue,
         setTrack,
+        setThumb,
+        focusThumb,
         setDisabled,
         setOrientation,
       } satisfies NgpSliderState;

--- a/packages/ng-primitives/slider/src/slider/slider.spec.ts
+++ b/packages/ng-primitives/slider/src/slider/slider.spec.ts
@@ -6,6 +6,23 @@ import { NgpSliderThumb } from '../slider-thumb/slider-thumb';
 import { NgpSliderTrack } from '../slider-track/slider-track';
 import { NgpSlider } from './slider';
 
+// Polyfill PointerEvent for jsdom
+class MockPointerEvent extends MouseEvent {
+  readonly pointerId: number;
+  readonly pointerType: string;
+
+  constructor(type: string, params: PointerEventInit = {}) {
+    super(type, params);
+    this.pointerId = params.pointerId ?? 0;
+    this.pointerType = params.pointerType ?? '';
+  }
+}
+
+if (typeof globalThis.PointerEvent === 'undefined') {
+  (globalThis as unknown as { PointerEvent: typeof MockPointerEvent }).PointerEvent =
+    MockPointerEvent;
+}
+
 describe('NgpSlider', () => {
   function createTemplate(extraProps = ''): string {
     return `
@@ -282,6 +299,7 @@ describe('NgpSlider', () => {
     const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
 
     const track = getByTestId('track');
+    const thumbEl = getByTestId('thumb');
 
     jest.spyOn(track, 'getBoundingClientRect').mockReturnValue({
       left: 0,
@@ -307,7 +325,140 @@ describe('NgpSlider', () => {
     });
     track.dispatchEvent(pointerEvent);
 
-    expect(focusViaSpy).toHaveBeenCalledWith(expect.anything(), 'mouse', { preventScroll: true });
+    expect(focusViaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ nativeElement: thumbEl }),
+      'mouse',
+      { preventScroll: true },
+    );
+  });
+
+  it('should use touch focus origin when track is tapped', async () => {
+    const valueChange = jest.fn();
+    const { getByTestId, fixture } = await render(
+      createTemplate(`[ngpSliderValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="100"`),
+      {
+        imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+        componentProperties: { value: 50, valueChange },
+      },
+    );
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    const track = getByTestId('track');
+    const thumbEl = getByTestId('thumb');
+
+    jest.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 20,
+      width: 100,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    track.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 30,
+        clientY: 10,
+        pointerType: 'touch',
+      }),
+    );
+
+    expect(focusViaSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ nativeElement: thumbEl }),
+      'touch',
+      { preventScroll: true },
+    );
+  });
+
+  it('should allow arrow key interaction after clicking the track', async () => {
+    const valueChange = jest.fn();
+    const { getByTestId, fixture } = await render(
+      createTemplate(
+        `[ngpSliderValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="100" [ngpSliderStep]="1"`,
+      ),
+      {
+        imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+        componentProperties: { value: 50, valueChange },
+      },
+    );
+
+    const track = getByTestId('track');
+    const thumbEl = getByTestId('thumb');
+
+    jest.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 20,
+      width: 100,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Click the track at 30%
+    track.dispatchEvent(
+      new MouseEvent('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 30,
+        clientY: 10,
+      }),
+    );
+
+    fixture.detectChanges();
+
+    // Verify focus landed on the thumb
+    expect(document.activeElement).toBe(thumbEl);
+
+    // Press ArrowRight — should increase value by 1
+    thumbEl.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    );
+
+    fixture.detectChanges();
+
+    expect(thumbEl).toHaveAttribute('aria-valuenow', '31');
+  });
+
+  it('should prevent mousedown default to preserve thumb focus after track click', async () => {
+    const valueChange = jest.fn();
+    const { getByTestId, fixture } = await render(
+      createTemplate(`[ngpSliderValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="100"`),
+      {
+        imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+        componentProperties: { value: 50, valueChange },
+      },
+    );
+
+    const track = getByTestId('track');
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // In real browsers, mousedown fires after pointerdown and its default
+    // action steals focus from the thumb. The track must prevent it.
+    const mousedownEvent = new MouseEvent('mousedown', {
+      bubbles: true,
+      cancelable: true,
+    });
+    track.dispatchEvent(mousedownEvent);
+
+    expect(mousedownEvent.defaultPrevented).toBe(true);
   });
 
   it('should not focus the thumb when clicking the track while disabled', async () => {

--- a/packages/ng-primitives/slider/src/slider/slider.spec.ts
+++ b/packages/ng-primitives/slider/src/slider/slider.spec.ts
@@ -1,3 +1,5 @@
+import { FocusMonitor } from '@angular/cdk/a11y';
+import { TestBed } from '@angular/core/testing';
 import { fireEvent, render } from '@testing-library/angular';
 import { NgpSliderRange } from '../slider-range/slider-range';
 import { NgpSliderThumb } from '../slider-thumb/slider-thumb';
@@ -264,6 +266,91 @@ describe('NgpSlider', () => {
     fireEvent.keyDown(thumb, { key: 'ArrowLeft' });
     expect(valueChange).toHaveBeenCalledWith(4);
     expect(thumb).toHaveAttribute('aria-valuenow', '4');
+  });
+
+  it('should focus the thumb with mouse origin when clicking the track', async () => {
+    const valueChange = jest.fn();
+    const { getByTestId, fixture } = await render(
+      createTemplate(`[ngpSliderValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="100"`),
+      {
+        imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+        componentProperties: { value: 50, valueChange },
+      },
+    );
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    const track = getByTestId('track');
+
+    jest.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 20,
+      width: 100,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Click the track
+    const pointerEvent = new MouseEvent('pointerdown', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 30,
+      clientY: 10,
+    });
+    track.dispatchEvent(pointerEvent);
+
+    expect(focusViaSpy).toHaveBeenCalledWith(expect.anything(), 'mouse', { preventScroll: true });
+  });
+
+  it('should not focus the thumb when clicking the track while disabled', async () => {
+    const valueChange = jest.fn();
+    const { getByTestId, fixture } = await render(
+      createTemplate(
+        `[ngpSliderValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="100" [ngpSliderDisabled]="true"`,
+      ),
+      {
+        imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+        componentProperties: { value: 50, valueChange },
+      },
+    );
+
+    const focusMonitor = TestBed.inject(FocusMonitor);
+    const focusViaSpy = jest.spyOn(focusMonitor, 'focusVia');
+
+    const track = getByTestId('track');
+
+    jest.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 20,
+      width: 100,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const pointerEvent = new MouseEvent('pointerdown', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 30,
+      clientY: 10,
+    });
+    track.dispatchEvent(pointerEvent);
+
+    expect(focusViaSpy).not.toHaveBeenCalled();
   });
 
   it('should respect step value when setting value via pointer', async () => {

--- a/packages/ng-primitives/slider/src/slider/slider.spec.ts
+++ b/packages/ng-primitives/slider/src/slider/slider.spec.ts
@@ -426,9 +426,7 @@ describe('NgpSlider', () => {
     expect(document.activeElement).toBe(thumbEl);
 
     // Press ArrowRight — should increase value by 1
-    thumbEl.dispatchEvent(
-      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
-    );
+    thumbEl.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
 
     fixture.detectChanges();
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking a slider track now focuses the correct thumb (range: closest; single: its thumb). Uses `@angular/cdk/a11y` FocusMonitor with the right origin (`mouse`/`touch`) and respects disabled.

- **Bug Fixes**
  - Prevent mousedown on tracks from stealing thumb focus; derive focus origin from pointer type.
  - Focus is applied without scrolling, arrow keys work immediately after a track click, and range sliders focus the closest thumb; thumbs register for programmatic focus with tests for mouse/touch and disabled.

- **Refactors**
  - CI uses `pnpm exec nx affected`, upgrades to `actions/setup-node@v4`, enables `filter: tree:0` for faster clones, and removes deprecated Nx cache config.

<sup>Written for commit 5ea34db643e1194eb4cd497c1e6cef400c753589. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

