### PR TITLE
feat: context menu

### DIFF
--- a/apps/components/src/app/app.ts
+++ b/apps/components/src/app/app.ts
@@ -11,6 +11,7 @@ import { RouterLink, RouterOutlet } from '@angular/router';
       <a routerLink="/reusable-components/button">Button</a>
       <a routerLink="/reusable-components/checkbox">Checkbox</a>
       <a routerLink="/reusable-components/combobox">Combobox</a>
+      <a routerLink="/reusable-components/context-menu">Context Menu</a>
       <a routerLink="/reusable-components/date-picker">Date Picker</a>
       <a routerLink="/reusable-components/dialog">Dialog</a>
       <a routerLink="/reusable-components/file-upload">File Upload</a>

--- a/apps/components/src/app/pages/reusable-components/context-menu/context-menu-item.ts
+++ b/apps/components/src/app/pages/reusable-components/context-menu/context-menu-item.ts
@@ -4,6 +4,7 @@ import { NgpContextMenuItem } from 'ng-primitives/context-menu';
 @Component({
   selector: 'button[app-context-menu-item]',
   hostDirectives: [NgpContextMenuItem],
+  host: { type: 'button' },
   template: `
     <ng-content />
   `,

--- a/apps/components/src/app/pages/reusable-components/context-menu/context-menu-item.ts
+++ b/apps/components/src/app/pages/reusable-components/context-menu/context-menu-item.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+import { NgpContextMenuItem } from 'ng-primitives/context-menu';
+
+@Component({
+  selector: 'button[app-context-menu-item]',
+  hostDirectives: [NgpContextMenuItem],
+  template: `
+    <ng-content />
+  `,
+  styles: `
+    :host {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 8px 6px 14px;
+      border: none;
+      background: none;
+      cursor: pointer;
+      transition: background-color 0.2s;
+      border-radius: 4px;
+      min-width: 120px;
+      text-align: start;
+      outline: none;
+      font-size: 14px;
+      font-weight: 400;
+    }
+
+    :host[data-hover] {
+      background-color: var(--ngp-background-active);
+    }
+
+    :host[data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      z-index: 1;
+    }
+  `,
+})
+export class ContextMenuItem {}

--- a/apps/components/src/app/pages/reusable-components/context-menu/context-menu.ts
+++ b/apps/components/src/app/pages/reusable-components/context-menu/context-menu.ts
@@ -18,6 +18,7 @@ import { NgpContextMenu } from 'ng-primitives/context-menu';
       box-shadow: var(--ngp-shadow);
       border-radius: 8px;
       padding: 4px;
+      transform-origin: var(--ngp-menu-transform-origin);
       animation: menu-show 300ms ease-out;
     }
 

--- a/apps/components/src/app/pages/reusable-components/context-menu/context-menu.ts
+++ b/apps/components/src/app/pages/reusable-components/context-menu/context-menu.ts
@@ -1,0 +1,51 @@
+import { Component } from '@angular/core';
+import { NgpContextMenu } from 'ng-primitives/context-menu';
+
+@Component({
+  selector: 'app-context-menu',
+  hostDirectives: [NgpContextMenu],
+  template: `
+    <ng-content />
+  `,
+  styles: `
+    :host {
+      position: fixed;
+      display: flex;
+      flex-direction: column;
+      width: max-content;
+      background: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      box-shadow: var(--ngp-shadow);
+      border-radius: 8px;
+      padding: 4px;
+      animation: menu-show 300ms ease-out;
+    }
+
+    :host[data-exit] {
+      animation: menu-hide 300ms ease-out;
+    }
+
+    @keyframes menu-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes menu-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+  `,
+})
+export class ContextMenu {}

--- a/apps/components/src/app/pages/reusable-components/context-menu/index.page.ts
+++ b/apps/components/src/app/pages/reusable-components/context-menu/index.page.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { NgpContextMenuTrigger } from 'ng-primitives/context-menu';
+import { ContextMenu } from './context-menu';
+import { ContextMenuItem } from './context-menu-item';
+
+@Component({
+  selector: 'app-context-menu-example',
+  imports: [ContextMenu, NgpContextMenuTrigger, ContextMenuItem],
+  template: `
+    <div [ngpContextMenuTrigger]="menu">Right-click me</div>
+
+    <ng-template #menu>
+      <app-context-menu>
+        <button app-context-menu-item>Cut</button>
+        <button app-context-menu-item>Copy</button>
+        <button app-context-menu-item>Paste</button>
+      </app-context-menu>
+    </ng-template>
+  `,
+  styles: `
+    [ngpContextMenuTrigger] {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 300px;
+      height: 150px;
+      border: 2px dashed var(--ngp-border);
+      border-radius: 8px;
+      color: var(--ngp-text-secondary);
+      font-size: 14px;
+      user-select: none;
+    }
+  `,
+})
+export default class App {}

--- a/apps/documentation/src/app/examples/context-menu/context-menu-submenu.example.ts
+++ b/apps/documentation/src/app/examples/context-menu/context-menu-submenu.example.ts
@@ -1,0 +1,131 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronRightMini } from '@ng-icons/heroicons/mini';
+import {
+  NgpContextMenu,
+  NgpContextMenuItem,
+  NgpContextMenuSubmenuTrigger,
+  NgpContextMenuTrigger,
+} from 'ng-primitives/context-menu';
+
+@Component({
+  selector: 'app-context-menu-submenu',
+  imports: [
+    NgpContextMenu,
+    NgpContextMenuTrigger,
+    NgpContextMenuItem,
+    NgpContextMenuSubmenuTrigger,
+    NgIcon,
+  ],
+  providers: [provideIcons({ heroChevronRightMini })],
+  template: `
+    <div class="trigger" [ngpContextMenuTrigger]="menu">Right-click me</div>
+
+    <ng-template #menu>
+      <div ngpContextMenu>
+        <button ngpContextMenuItem>Cut</button>
+        <button ngpContextMenuItem>Copy</button>
+        <button [ngpContextMenuSubmenuTrigger]="submenu" ngpContextMenuItem>
+          More
+          <ng-icon name="heroChevronRightMini" />
+        </button>
+      </div>
+    </ng-template>
+
+    <ng-template #submenu>
+      <div ngpContextMenu>
+        <button ngpContextMenuItem>Paste</button>
+        <button ngpContextMenuItem>Paste Special</button>
+        <button ngpContextMenuItem>Delete</button>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    .trigger {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 300px;
+      height: 150px;
+      border: 2px dashed var(--ngp-border);
+      border-radius: 8px;
+      color: var(--ngp-text-secondary);
+      font-size: 14px;
+      user-select: none;
+    }
+
+    [ngpContextMenu] {
+      position: fixed;
+      display: flex;
+      flex-direction: column;
+      width: max-content;
+      background: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      box-shadow: var(--ngp-shadow-lg);
+      border-radius: 8px;
+      padding: 4px;
+      transform-origin: var(--ngp-menu-transform-origin);
+    }
+
+    [ngpContextMenu][data-enter] {
+      animation: menu-show 0.1s ease-out;
+    }
+
+    [ngpContextMenu][data-exit] {
+      animation: menu-hide 0.1s ease-out;
+    }
+
+    [ngpContextMenuItem] {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 8px 6px 14px;
+      border: none;
+      background: none;
+      cursor: pointer;
+      transition: background-color 0.2s;
+      border-radius: 4px;
+      min-width: 120px;
+      text-align: start;
+      outline: none;
+      font-size: 14px;
+      font-weight: 400;
+    }
+
+    [ngpContextMenuItem][data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpContextMenuItem][data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpContextMenuItem][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      z-index: 1;
+    }
+
+    @keyframes menu-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes menu-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+  `,
+})
+export default class ContextMenuSubmenuExample {}

--- a/apps/documentation/src/app/examples/context-menu/context-menu-submenu.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/context-menu/context-menu-submenu.tailwind.example.ts
@@ -1,0 +1,84 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronRightMini } from '@ng-icons/heroicons/mini';
+import {
+  NgpContextMenu,
+  NgpContextMenuItem,
+  NgpContextMenuSubmenuTrigger,
+  NgpContextMenuTrigger,
+} from 'ng-primitives/context-menu';
+
+@Component({
+  selector: 'app-context-menu-submenu-tailwind',
+  imports: [
+    NgpContextMenu,
+    NgpContextMenuTrigger,
+    NgpContextMenuItem,
+    NgpContextMenuSubmenuTrigger,
+    NgIcon,
+  ],
+  providers: [provideIcons({ heroChevronRightMini })],
+  template: `
+    <div
+      class="flex h-[150px] w-[300px] items-center justify-center rounded-lg border-2 border-dashed border-gray-300 text-sm text-gray-500 select-none dark:border-gray-600 dark:text-gray-400"
+      [ngpContextMenuTrigger]="menu"
+    >
+      Right-click me
+    </div>
+
+    <ng-template #menu>
+      <div
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-lg border border-gray-200 bg-white p-1 shadow-lg dark:border-gray-700 dark:bg-black"
+        ngpContextMenu
+      >
+        <button
+          class="flex min-w-[120px] cursor-pointer items-center justify-between rounded-sm border-none bg-transparent px-[14px] py-[6px] text-left text-[14px] font-normal outline-hidden transition-colors hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-blue-500 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20"
+          ngpContextMenuItem
+        >
+          Cut
+        </button>
+        <button
+          class="flex min-w-[120px] cursor-pointer items-center justify-between rounded-sm border-none bg-transparent px-[14px] py-[6px] text-left text-[14px] font-normal outline-hidden transition-colors hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-blue-500 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20"
+          ngpContextMenuItem
+        >
+          Copy
+        </button>
+        <button
+          class="flex min-w-[120px] cursor-pointer items-center justify-between rounded-sm border-none bg-transparent px-[14px] py-[6px] text-left text-[14px] font-normal outline-hidden transition-colors hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-blue-500 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20"
+          [ngpContextMenuSubmenuTrigger]="submenu"
+          ngpContextMenuItem
+        >
+          More
+          <ng-icon name="heroChevronRightMini" />
+        </button>
+      </div>
+    </ng-template>
+
+    <ng-template #submenu>
+      <div
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-lg border border-gray-200 bg-white p-1 shadow-lg dark:border-gray-700 dark:bg-black"
+        ngpContextMenu
+      >
+        <button
+          class="flex min-w-[120px] cursor-pointer items-center justify-between rounded-sm border-none bg-transparent px-[14px] py-[6px] text-left text-[14px] font-normal outline-hidden transition-colors hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-blue-500 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20"
+          ngpContextMenuItem
+        >
+          Paste
+        </button>
+        <button
+          class="flex min-w-[120px] cursor-pointer items-center justify-between rounded-sm border-none bg-transparent px-[14px] py-[6px] text-left text-[14px] font-normal outline-hidden transition-colors hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-blue-500 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20"
+          ngpContextMenuItem
+        >
+          Paste Special
+        </button>
+        <button
+          class="flex min-w-[120px] cursor-pointer items-center justify-between rounded-sm border-none bg-transparent px-[14px] py-[6px] text-left text-[14px] font-normal outline-hidden transition-colors hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-blue-500 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20"
+          ngpContextMenuItem
+        >
+          Delete
+        </button>
+      </div>
+    </ng-template>
+  `,
+})
+export default class ContextMenuSubmenuTailwindExample {}

--- a/apps/documentation/src/app/examples/context-menu/context-menu.example.ts
+++ b/apps/documentation/src/app/examples/context-menu/context-menu.example.ts
@@ -1,0 +1,107 @@
+import { Component } from '@angular/core';
+import {
+  NgpContextMenu,
+  NgpContextMenuItem,
+  NgpContextMenuTrigger,
+} from 'ng-primitives/context-menu';
+
+@Component({
+  selector: 'app-context-menu',
+  imports: [NgpContextMenu, NgpContextMenuTrigger, NgpContextMenuItem],
+  template: `
+    <div class="trigger" [ngpContextMenuTrigger]="menu">Right-click me</div>
+
+    <ng-template #menu>
+      <div ngpContextMenu>
+        <button ngpContextMenuItem>Cut</button>
+        <button ngpContextMenuItem>Copy</button>
+        <button ngpContextMenuItem>Paste</button>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    .trigger {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 300px;
+      height: 150px;
+      border: 2px dashed var(--ngp-border);
+      border-radius: 8px;
+      color: var(--ngp-text-secondary);
+      font-size: 14px;
+      user-select: none;
+    }
+
+    [ngpContextMenu] {
+      position: fixed;
+      display: flex;
+      flex-direction: column;
+      width: max-content;
+      background: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      box-shadow: var(--ngp-shadow-lg);
+      border-radius: 8px;
+      padding: 4px;
+      transform-origin: var(--ngp-menu-transform-origin);
+    }
+
+    [ngpContextMenu][data-enter] {
+      animation: menu-show 0.1s ease-out;
+    }
+
+    [ngpContextMenu][data-exit] {
+      animation: menu-hide 0.1s ease-out;
+    }
+
+    [ngpContextMenuItem] {
+      padding: 6px 14px;
+      border: none;
+      background: none;
+      cursor: pointer;
+      transition: background-color 0.2s;
+      border-radius: 4px;
+      min-width: 120px;
+      text-align: start;
+      outline: none;
+      font-size: 14px;
+      font-weight: 400;
+    }
+
+    [ngpContextMenuItem][data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpContextMenuItem][data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpContextMenuItem][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      z-index: 1;
+    }
+
+    @keyframes menu-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes menu-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+  `,
+})
+export default class ContextMenuExample {}

--- a/apps/documentation/src/app/examples/context-menu/context-menu.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/context-menu/context-menu.tailwind.example.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import {
+  NgpContextMenu,
+  NgpContextMenuItem,
+  NgpContextMenuTrigger,
+} from 'ng-primitives/context-menu';
+
+@Component({
+  selector: 'app-context-menu-tailwind',
+  imports: [NgpContextMenu, NgpContextMenuTrigger, NgpContextMenuItem],
+  template: `
+    <div
+      class="flex h-[150px] w-[300px] items-center justify-center rounded-lg border-2 border-dashed border-gray-300 text-sm text-gray-500 select-none dark:border-gray-600 dark:text-gray-400"
+      [ngpContextMenuTrigger]="menu"
+    >
+      Right-click me
+    </div>
+
+    <ng-template #menu>
+      <div
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-lg border border-gray-200 bg-white p-1 shadow-lg dark:border-gray-700 dark:bg-black"
+        ngpContextMenu
+      >
+        <button
+          class="min-w-[120px] cursor-pointer rounded-sm border-none bg-transparent px-3 py-1.5 text-left text-[14px] font-normal outline-hidden transition-colors hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-blue-500 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20"
+          ngpContextMenuItem
+        >
+          Cut
+        </button>
+        <button
+          class="min-w-[120px] cursor-pointer rounded-sm border-none bg-transparent px-3 py-1.5 text-left text-[14px] font-normal outline-hidden transition-colors hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-blue-500 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20"
+          ngpContextMenuItem
+        >
+          Copy
+        </button>
+        <button
+          class="min-w-[120px] cursor-pointer rounded-sm border-none bg-transparent px-3 py-1.5 text-left text-[14px] font-normal outline-hidden transition-colors hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-blue-500 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20"
+          ngpContextMenuItem
+        >
+          Paste
+        </button>
+      </div>
+    </ng-template>
+  `,
+})
+export default class ContextMenuTailwindExample {}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/context-menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/context-menu.md
@@ -66,102 +66,88 @@ The following directives are available to import from the `ng-primitives/context
 
 <api-docs name="NgpContextMenuTrigger"></api-docs>
 
-#### Data Attributes
+<api-reference-props name="NgpContextMenuTrigger"></api-reference-props>
 
-The following data attributes are available on the `NgpContextMenuTrigger` directive:
-
-| Attribute   | Description                            |
-| ----------- | -------------------------------------- |
-| `data-open` | Applied when the context menu is open. |
+<api-reference-attributes>
+  <api-attribute name="data-open" description="Applied when the context menu is open." />
+</api-reference-attributes>
 
 ### NgpContextMenu
 
 <api-docs name="NgpContextMenu"></api-docs>
 
-#### Data Attributes
+<api-reference-props name="NgpContextMenu"></api-reference-props>
 
-The following data attributes are available on the `NgpContextMenu` directive:
+<api-reference-attributes>
+  <api-attribute name="data-enter" description="Applied when the menu is being added to the DOM. This can be used to trigger animations." />
+  <api-attribute name="data-exit" description="Applied when the menu is being removed from the DOM. This can be used to trigger animations." />
+  <api-attribute name="data-placement" description="The final rendered placement of the menu." />
+</api-reference-attributes>
 
-| Attribute        | Description                                                                                  |
-| ---------------- | -------------------------------------------------------------------------------------------- |
-| `data-enter`     | Applied when the menu is being added to the DOM. This can be used to trigger animations.     |
-| `data-exit`      | Applied when the menu is being removed from the DOM. This can be used to trigger animations. |
-| `data-placement` | The final rendered placement of the menu.                                                    |
-
-The following CSS custom properties are applied to the `ngpContextMenu` directive:
-
-| Property                      | Description                                                        |
-| ----------------------------- | ------------------------------------------------------------------ |
-| `--ngp-menu-transform-origin` | The transform origin of the menu for animations.                   |
-| `--ngp-menu-trigger-width`    | The width of the trigger element.                                  |
-| `--ngp-menu-available-width`  | The available width of the menu before it overflows the viewport.  |
-| `--ngp-menu-available-height` | The available height of the menu before it overflows the viewport. |
+<api-reference-css-vars>
+  <api-css-var name="--ngp-menu-transform-origin" description="The transform origin of the menu for animations." />
+  <api-css-var name="--ngp-menu-trigger-width" description="The width of the trigger element." />
+  <api-css-var name="--ngp-menu-available-width" description="The available width of the menu before it overflows the viewport." />
+  <api-css-var name="--ngp-menu-available-height" description="The available height of the menu before it overflows the viewport." />
+</api-reference-css-vars>
 
 ### NgpContextMenuItem
 
 <api-docs name="NgpContextMenuItem"></api-docs>
 
-#### Data Attributes
+<api-reference-props name="NgpContextMenuItem"></api-reference-props>
 
-The following data attributes are available on the `NgpContextMenuItem` directive:
-
-| Attribute       | Description                        |
-| --------------- | ---------------------------------- |
-| `data-disabled` | Applied when the item is disabled. |
+<api-reference-attributes>
+  <api-attribute name="data-disabled" description="Applied when the item is disabled." />
+</api-reference-attributes>
 
 ### NgpContextMenuSubmenuTrigger
 
 <api-docs name="NgpContextMenuSubmenuTrigger"></api-docs>
 
-#### Data Attributes
+<api-reference-props name="NgpContextMenuSubmenuTrigger"></api-reference-props>
 
-The following data attributes are available on the `NgpContextMenuSubmenuTrigger` directive:
-
-| Attribute   | Description                       |
-| ----------- | --------------------------------- |
-| `data-open` | Applied when the submenu is open. |
+<api-reference-attributes>
+  <api-attribute name="data-open" description="Applied when the submenu is open." />
+</api-reference-attributes>
 
 ### NgpContextMenuItemCheckbox
 
 <api-docs name="NgpContextMenuItemCheckbox"></api-docs>
 
-#### Data Attributes
+<api-reference-props name="NgpContextMenuItemCheckbox"></api-reference-props>
 
-The following data attributes are available on the `NgpContextMenuItemCheckbox` directive:
-
-| Attribute       | Description                                 |
-| --------------- | ------------------------------------------- |
-| `data-checked`  | Applied when the checkbox item is checked.  |
-| `data-disabled` | Applied when the checkbox item is disabled. |
+<api-reference-attributes>
+  <api-attribute name="data-checked" description="Applied when the checkbox item is checked." />
+  <api-attribute name="data-disabled" description="Applied when the checkbox item is disabled." />
+</api-reference-attributes>
 
 ### NgpContextMenuItemRadioGroup
 
 <api-docs name="NgpContextMenuItemRadioGroup"></api-docs>
 
+<api-reference-props name="NgpContextMenuItemRadioGroup"></api-reference-props>
+
 ### NgpContextMenuItemRadio
 
 <api-docs name="NgpContextMenuItemRadio"></api-docs>
 
-#### Data Attributes
+<api-reference-props name="NgpContextMenuItemRadio"></api-reference-props>
 
-The following data attributes are available on the `NgpContextMenuItemRadio` directive:
-
-| Attribute       | Description                              |
-| --------------- | ---------------------------------------- |
-| `data-checked`  | Applied when the radio item is checked.  |
-| `data-disabled` | Applied when the radio item is disabled. |
+<api-reference-attributes>
+  <api-attribute name="data-checked" description="Applied when the radio item is checked." />
+  <api-attribute name="data-disabled" description="Applied when the radio item is disabled." />
+</api-reference-attributes>
 
 ### NgpContextMenuItemIndicator
 
 <api-docs name="NgpContextMenuItemIndicator"></api-docs>
 
-#### Data Attributes
+<api-reference-props name="NgpContextMenuItemIndicator"></api-reference-props>
 
-The following data attributes are available on the `NgpContextMenuItemIndicator` directive:
-
-| Attribute      | Description                                           |
-| -------------- | ----------------------------------------------------- |
-| `data-checked` | Applied when the parent checkbox or radio is checked. |
+<api-reference-attributes>
+  <api-attribute name="data-checked" description="Applied when the parent checkbox or radio is checked." />
+</api-reference-attributes>
 
 ## Styling
 
@@ -210,25 +196,7 @@ bootstrapApplication(AppComponent, {
 
 ### NgpContextMenuConfig
 
-<prop-details name="offset" type="number | NgpOffsetOptions">
-  Define the offset from the cursor position. Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis properties.
-</prop-details>
-
-<prop-details name="flip" type="boolean">
-  Define if the context menu should flip when it reaches the edge of the viewport.
-</prop-details>
-
-<prop-details name="container" type="HTMLElement | string | null" default="'body'">
-  Define the container element for the context menu. This is the document body by default.
-</prop-details>
-
-<prop-details name="scrollBehavior" type="'reposition' | 'block' | 'close'" default="'close'">
-  Defines how the context menu behaves when the window is scrolled. If set to `close`, the context menu will close when the window is scrolled. If set to `reposition`, the menu will adjust its position. If set to `block`, scrolling will be disabled.
-</prop-details>
-
-<prop-details name="shift" type="boolean | NgpShiftOptions">
-  Configure shift behavior to keep the context menu in view.
-</prop-details>
+<api-reference-config name="NgpContextMenuConfig"></api-reference-config>
 
 ## Accessibility
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/context-menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/context-menu.md
@@ -166,11 +166,11 @@ The `ngpContextMenu` primitive adds a CSS custom property `--ngp-menu-transform-
 The `ngpContextMenu` will also add the `data-enter` and `data-exit` attributes to the element when it is being added or removed from the DOM. This can be used to trigger animations.
 
 ```css
-:host[data-enter] {
+[ngpContextMenu][data-enter] {
   animation: fade-in 0.2s ease-in-out;
 }
 
-:host[data-exit] {
+[ngpContextMenu][data-exit] {
   animation: fade-out 0.2s ease-in-out;
 }
 ```

--- a/apps/documentation/src/app/pages/(documentation)/primitives/context-menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/context-menu.md
@@ -1,0 +1,248 @@
+---
+name: 'Context Menu'
+sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/context-menu'
+---
+
+# Context Menu
+
+A context menu displays a list of actions or options triggered by a right-click or long-press on an element.
+
+<docs-example name="context-menu"></docs-example>
+
+## Import
+
+Import the Context Menu primitives from `ng-primitives/context-menu`.
+
+```ts
+import {
+  NgpContextMenu,
+  NgpContextMenuItem,
+  NgpContextMenuTrigger,
+  NgpContextMenuSubmenuTrigger,
+  NgpContextMenuItemCheckbox,
+  NgpContextMenuItemRadioGroup,
+  NgpContextMenuItemRadio,
+  NgpContextMenuItemIndicator,
+} from 'ng-primitives/context-menu';
+```
+
+## Usage
+
+Assemble the context menu directives in your template.
+
+```html
+<div [ngpContextMenuTrigger]="menu">Right-click me</div>
+
+<ng-template #menu>
+  <div ngpContextMenu>
+    <button ngpContextMenuItem>Cut</button>
+    <button ngpContextMenuItem>Copy</button>
+    <button ngpContextMenuItem>Paste</button>
+  </div>
+</ng-template>
+```
+
+## Reusable Component
+
+Create reusable components that use the `NgpContextMenu` directive.
+
+<docs-snippet name="context-menu"></docs-snippet>
+
+## Examples
+
+Here are some additional examples of how to use the Context Menu primitives.
+
+### Submenu
+
+The context menu can contain submenus, which are nested menus that can be opened by hovering on a menu item.
+
+<docs-example name="context-menu-submenu"></docs-example>
+
+## API Reference
+
+The following directives are available to import from the `ng-primitives/context-menu` package:
+
+### NgpContextMenuTrigger
+
+<api-docs name="NgpContextMenuTrigger"></api-docs>
+
+#### Data Attributes
+
+The following data attributes are available on the `NgpContextMenuTrigger` directive:
+
+| Attribute   | Description                            |
+| ----------- | -------------------------------------- |
+| `data-open` | Applied when the context menu is open. |
+
+### NgpContextMenu
+
+<api-docs name="NgpContextMenu"></api-docs>
+
+#### Data Attributes
+
+The following data attributes are available on the `NgpContextMenu` directive:
+
+| Attribute        | Description                                                                                  |
+| ---------------- | -------------------------------------------------------------------------------------------- |
+| `data-enter`     | Applied when the menu is being added to the DOM. This can be used to trigger animations.     |
+| `data-exit`      | Applied when the menu is being removed from the DOM. This can be used to trigger animations. |
+| `data-placement` | The final rendered placement of the menu.                                                    |
+
+The following CSS custom properties are applied to the `ngpContextMenu` directive:
+
+| Property                      | Description                                                        |
+| ----------------------------- | ------------------------------------------------------------------ |
+| `--ngp-menu-transform-origin` | The transform origin of the menu for animations.                   |
+| `--ngp-menu-trigger-width`    | The width of the trigger element.                                  |
+| `--ngp-menu-available-width`  | The available width of the menu before it overflows the viewport.  |
+| `--ngp-menu-available-height` | The available height of the menu before it overflows the viewport. |
+
+### NgpContextMenuItem
+
+<api-docs name="NgpContextMenuItem"></api-docs>
+
+#### Data Attributes
+
+The following data attributes are available on the `NgpContextMenuItem` directive:
+
+| Attribute       | Description                        |
+| --------------- | ---------------------------------- |
+| `data-disabled` | Applied when the item is disabled. |
+
+### NgpContextMenuSubmenuTrigger
+
+<api-docs name="NgpContextMenuSubmenuTrigger"></api-docs>
+
+#### Data Attributes
+
+The following data attributes are available on the `NgpContextMenuSubmenuTrigger` directive:
+
+| Attribute   | Description                       |
+| ----------- | --------------------------------- |
+| `data-open` | Applied when the submenu is open. |
+
+### NgpContextMenuItemCheckbox
+
+<api-docs name="NgpContextMenuItemCheckbox"></api-docs>
+
+#### Data Attributes
+
+The following data attributes are available on the `NgpContextMenuItemCheckbox` directive:
+
+| Attribute       | Description                                 |
+| --------------- | ------------------------------------------- |
+| `data-checked`  | Applied when the checkbox item is checked.  |
+| `data-disabled` | Applied when the checkbox item is disabled. |
+
+### NgpContextMenuItemRadioGroup
+
+<api-docs name="NgpContextMenuItemRadioGroup"></api-docs>
+
+### NgpContextMenuItemRadio
+
+<api-docs name="NgpContextMenuItemRadio"></api-docs>
+
+#### Data Attributes
+
+The following data attributes are available on the `NgpContextMenuItemRadio` directive:
+
+| Attribute       | Description                              |
+| --------------- | ---------------------------------------- |
+| `data-checked`  | Applied when the radio item is checked.  |
+| `data-disabled` | Applied when the radio item is disabled. |
+
+### NgpContextMenuItemIndicator
+
+<api-docs name="NgpContextMenuItemIndicator"></api-docs>
+
+#### Data Attributes
+
+The following data attributes are available on the `NgpContextMenuItemIndicator` directive:
+
+| Attribute      | Description                                           |
+| -------------- | ----------------------------------------------------- |
+| `data-checked` | Applied when the parent checkbox or radio is checked. |
+
+## Styling
+
+For the context menu to be positioned correctly relative to the cursor, it should use fixed positioning. For example, you can use the following CSS:
+
+```css
+[ngpContextMenu] {
+  position: fixed;
+}
+```
+
+## Animations
+
+The `ngpContextMenu` primitive adds a CSS custom property `--ngp-menu-transform-origin` to the element that can be used to animate the menu from the cursor position.
+
+The `ngpContextMenu` will also add the `data-enter` and `data-exit` attributes to the element when it is being added or removed from the DOM. This can be used to trigger animations.
+
+```css
+:host[data-enter] {
+  animation: fade-in 0.2s ease-in-out;
+}
+
+:host[data-exit] {
+  animation: fade-out 0.2s ease-in-out;
+}
+```
+
+## Global Configuration
+
+You can configure the default options for all context menus in your application by using the `provideContextMenuConfig` function in a providers array.
+
+```ts
+import { provideContextMenuConfig } from 'ng-primitives/context-menu';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideContextMenuConfig({
+      offset: 2,
+      flip: true,
+      container: document.body,
+      scrollBehavior: 'close',
+    }),
+  ],
+});
+```
+
+### NgpContextMenuConfig
+
+<prop-details name="offset" type="number | NgpOffsetOptions">
+  Define the offset from the cursor position. Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis properties.
+</prop-details>
+
+<prop-details name="flip" type="boolean">
+  Define if the context menu should flip when it reaches the edge of the viewport.
+</prop-details>
+
+<prop-details name="container" type="HTMLElement | string | null" default="'body'">
+  Define the container element for the context menu. This is the document body by default.
+</prop-details>
+
+<prop-details name="scrollBehavior" type="'reposition' | 'block' | 'close'" default="'close'">
+  Defines how the context menu behaves when the window is scrolled. If set to `close`, the context menu will close when the window is scrolled. If set to `reposition`, the menu will adjust its position. If set to `block`, scrolling will be disabled.
+</prop-details>
+
+<prop-details name="shift" type="boolean | NgpShiftOptions">
+  Configure shift behavior to keep the context menu in view.
+</prop-details>
+
+## Accessibility
+
+Adheres to the [WAI-ARIA Menu Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menu/).
+
+### Keyboard Interactions
+
+| Key                   | Description                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------- |
+| <kbd>Enter</kbd>      | Activates the focused menu item. Closes all menus unless the item is a checkbox or radio item. |
+| <kbd>Escape</kbd>     | Closes all open menus.                                                                         |
+| <kbd>ArrowDown</kbd>  | Moves focus to the next menu item.                                                             |
+| <kbd>ArrowUp</kbd>    | Moves focus to the previous menu item.                                                         |
+| <kbd>ArrowRight</kbd> | Opens a submenu when focused on a submenu trigger.                                             |
+| <kbd>ArrowLeft</kbd>  | Closes the current submenu and moves focus to the parent submenu trigger.                      |
+| <kbd>Home</kbd>       | Moves focus to the first menu item.                                                            |
+| <kbd>End</kbd>        | Moves focus to the last menu item.                                                             |

--- a/packages/ng-primitives/context-menu/README.md
+++ b/packages/ng-primitives/context-menu/README.md
@@ -1,0 +1,3 @@
+# ng-primitives/context-menu
+
+Secondary entry point of `ng-primitives`. It can be used by importing from `ng-primitives/context-menu`.

--- a/packages/ng-primitives/context-menu/ng-package.json
+++ b/packages/ng-primitives/context-menu/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/ng-primitives/context-menu/src/config/context-menu-config.ts
+++ b/packages/ng-primitives/context-menu/src/config/context-menu-config.ts
@@ -1,0 +1,68 @@
+import { InjectionToken, Provider, inject } from '@angular/core';
+import { NgpFlip, NgpOffset, NgpShift } from 'ng-primitives/portal';
+
+export interface NgpContextMenuConfig {
+  /**
+   * Define the offset of the context menu relative to the cursor position.
+   * @default 2
+   */
+  offset: NgpOffset;
+
+  /**
+   * Define whether the context menu should flip when there is not enough space.
+   * @default true
+   */
+  flip: NgpFlip;
+
+  /**
+   * Define the container element or selector in which the context menu should be attached.
+   * @default 'body'
+   */
+  container: HTMLElement | string | null;
+
+  /**
+   * Defines how the context menu behaves when the window is scrolled.
+   * @default 'close'
+   */
+  scrollBehavior: 'reposition' | 'block' | 'close';
+
+  /**
+   * Configure shift behavior to keep the context menu in view.
+   * @default undefined
+   */
+  shift: NgpShift;
+}
+
+export const defaultContextMenuConfig: NgpContextMenuConfig = {
+  offset: 2,
+  flip: true,
+  container: 'body',
+  scrollBehavior: 'close',
+  shift: undefined,
+};
+
+export const NgpContextMenuConfigToken = new InjectionToken<NgpContextMenuConfig>(
+  'NgpContextMenuConfigToken',
+);
+
+/**
+ * Provide the default Context Menu configuration
+ * @param config The Context Menu configuration
+ * @returns The provider
+ */
+export function provideContextMenuConfig(config: Partial<NgpContextMenuConfig>): Provider[] {
+  return [
+    {
+      provide: NgpContextMenuConfigToken,
+      useValue: { ...defaultContextMenuConfig, ...config },
+    },
+  ];
+}
+
+/**
+ * Inject the Context Menu configuration
+ * @returns The global Context Menu configuration
+ */
+export function injectContextMenuConfig(): NgpContextMenuConfig {
+  return inject(NgpContextMenuConfigToken, { optional: true }) ?? defaultContextMenuConfig;
+}

--- a/packages/ng-primitives/context-menu/src/context-menu-item-checkbox/context-menu-item-checkbox.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-item-checkbox/context-menu-item-checkbox.ts
@@ -1,0 +1,40 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input, output } from '@angular/core';
+import { ngpMenuItemCheckbox, provideMenuItemCheckboxState } from 'ng-primitives/menu';
+import { ngpRovingFocusItem, provideRovingFocusItemState } from 'ng-primitives/roving-focus';
+
+/**
+ * The `NgpContextMenuItemCheckbox` directive represents a context menu item that can be toggled on and off.
+ */
+@Directive({
+  selector: '[ngpContextMenuItemCheckbox]',
+  exportAs: 'ngpContextMenuItemCheckbox',
+  providers: [provideMenuItemCheckboxState(), provideRovingFocusItemState()],
+})
+export class NgpContextMenuItemCheckbox {
+  /** Whether the checkbox is checked */
+  readonly checked = input<boolean, BooleanInput>(false, {
+    alias: 'ngpContextMenuItemCheckboxChecked',
+    transform: booleanAttribute,
+  });
+
+  /** Event emitted when the checked state changes */
+  readonly checkedChange = output<boolean>({
+    alias: 'ngpContextMenuItemCheckboxCheckedChange',
+  });
+
+  /** Whether the menu item checkbox is disabled */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpContextMenuItemCheckboxDisabled',
+    transform: booleanAttribute,
+  });
+
+  constructor() {
+    ngpMenuItemCheckbox({
+      checked: this.checked,
+      disabled: this.disabled,
+      onCheckedChange: value => this.checkedChange.emit(value),
+    });
+    ngpRovingFocusItem({ disabled: this.disabled });
+  }
+}

--- a/packages/ng-primitives/context-menu/src/context-menu-item-indicator/context-menu-item-indicator.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-item-indicator/context-menu-item-indicator.ts
@@ -1,0 +1,24 @@
+import { computed, Directive } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { injectMenuItemCheckboxState, injectMenuItemRadioState } from 'ng-primitives/menu';
+import { dataBinding } from 'ng-primitives/state';
+
+/**
+ * The `NgpContextMenuItemIndicator` directive renders inside a checkbox or radio context menu item
+ * and exposes `data-checked` based on the parent item's checked state.
+ */
+@Directive({
+  selector: '[ngpContextMenuItemIndicator]',
+  exportAs: 'ngpContextMenuItemIndicator',
+})
+export class NgpContextMenuItemIndicator {
+  constructor() {
+    const element = injectElementRef();
+    const checkboxState = injectMenuItemCheckboxState({ optional: true });
+    const radioState = injectMenuItemRadioState({ optional: true });
+
+    const checked = computed(() => checkboxState()?.checked() ?? radioState()?.checked() ?? false);
+
+    dataBinding(element, 'data-checked', checked);
+  }
+}

--- a/packages/ng-primitives/context-menu/src/context-menu-item-radio-group/context-menu-item-radio-group.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-item-radio-group/context-menu-item-radio-group.ts
@@ -1,0 +1,29 @@
+import { Directive, input, output } from '@angular/core';
+import { ngpMenuItemRadioGroup, provideMenuItemRadioGroupState } from 'ng-primitives/menu';
+
+/**
+ * The `NgpContextMenuItemRadioGroup` directive represents a group of radio context menu items.
+ */
+@Directive({
+  selector: '[ngpContextMenuItemRadioGroup]',
+  exportAs: 'ngpContextMenuItemRadioGroup',
+  providers: [provideMenuItemRadioGroupState()],
+})
+export class NgpContextMenuItemRadioGroup {
+  /** The current value of the radio group */
+  readonly value = input<string | null>(null, {
+    alias: 'ngpContextMenuItemRadioGroupValue',
+  });
+
+  /** Event emitted when the value changes */
+  readonly valueChange = output<string>({
+    alias: 'ngpContextMenuItemRadioGroupValueChange',
+  });
+
+  constructor() {
+    ngpMenuItemRadioGroup({
+      value: this.value,
+      onValueChange: value => this.valueChange.emit(value),
+    });
+  }
+}

--- a/packages/ng-primitives/context-menu/src/context-menu-item-radio/context-menu-item-radio.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-item-radio/context-menu-item-radio.ts
@@ -1,0 +1,30 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import { ngpMenuItemRadio, provideMenuItemRadioState } from 'ng-primitives/menu';
+import { ngpRovingFocusItem, provideRovingFocusItemState } from 'ng-primitives/roving-focus';
+
+/**
+ * The `NgpContextMenuItemRadio` directive represents a radio context menu item within a radio group.
+ */
+@Directive({
+  selector: '[ngpContextMenuItemRadio]',
+  exportAs: 'ngpContextMenuItemRadio',
+  providers: [provideMenuItemRadioState(), provideRovingFocusItemState()],
+})
+export class NgpContextMenuItemRadio {
+  /** The value this radio item represents */
+  readonly value = input.required<string>({
+    alias: 'ngpContextMenuItemRadioValue',
+  });
+
+  /** Whether the radio item is disabled */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpContextMenuItemRadioDisabled',
+    transform: booleanAttribute,
+  });
+
+  constructor() {
+    ngpMenuItemRadio({ value: this.value, disabled: this.disabled });
+    ngpRovingFocusItem({ disabled: this.disabled });
+  }
+}

--- a/packages/ng-primitives/context-menu/src/context-menu-item/context-menu-item.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-item/context-menu-item.ts
@@ -1,0 +1,31 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import { ngpMenuItem, provideMenuItemState } from 'ng-primitives/menu';
+import { ngpRovingFocusItem, provideRovingFocusItemState } from 'ng-primitives/roving-focus';
+
+/**
+ * The `NgpContextMenuItem` directive represents a context menu item.
+ */
+@Directive({
+  selector: '[ngpContextMenuItem]',
+  exportAs: 'ngpContextMenuItem',
+  providers: [provideMenuItemState(), provideRovingFocusItemState()],
+})
+export class NgpContextMenuItem {
+  /** Whether the menu item is disabled */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpContextMenuItemDisabled',
+    transform: booleanAttribute,
+  });
+
+  /** Whether the menu should close when this item is selected */
+  readonly closeOnSelect = input<boolean, BooleanInput>(true, {
+    alias: 'ngpContextMenuItemCloseOnSelect',
+    transform: booleanAttribute,
+  });
+
+  constructor() {
+    ngpMenuItem({ disabled: this.disabled, closeOnSelect: this.closeOnSelect });
+    ngpRovingFocusItem({ disabled: this.disabled });
+  }
+}

--- a/packages/ng-primitives/context-menu/src/context-menu-submenu-trigger/context-menu-submenu-trigger.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-submenu-trigger/context-menu-submenu-trigger.ts
@@ -1,0 +1,101 @@
+import { FocusOrigin } from '@angular/cdk/a11y';
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import {
+  NgpMenuTriggerStateToken,
+  NgpSubmenuTrigger,
+  NgpSubmenuTriggerStateToken,
+  ngpSubmenuTrigger,
+  provideSubmenuTriggerState,
+  type NgpMenuPlacement,
+} from 'ng-primitives/menu';
+import {
+  coerceFlip,
+  coerceOffset,
+  NgpFlip,
+  NgpFlipInput,
+  NgpOffset,
+  NgpOffsetInput,
+  NgpOverlayContent,
+} from 'ng-primitives/portal';
+
+/**
+ * The `NgpContextMenuSubmenuTrigger` directive turns a context menu item into a submenu trigger.
+ */
+@Directive({
+  selector: '[ngpContextMenuSubmenuTrigger]',
+  exportAs: 'ngpContextMenuSubmenuTrigger',
+  providers: [
+    provideSubmenuTriggerState(),
+    { provide: NgpMenuTriggerStateToken, useExisting: NgpSubmenuTriggerStateToken },
+    // Provide as NgpSubmenuTrigger so ngpMenuItem can detect this is a submenu trigger
+    { provide: NgpSubmenuTrigger, useExisting: NgpContextMenuSubmenuTrigger },
+  ],
+})
+export class NgpContextMenuSubmenuTrigger<T = unknown> {
+  /**
+   * Access the submenu template ref.
+   */
+  readonly menu = input<NgpOverlayContent<T>>(undefined, {
+    alias: 'ngpContextMenuSubmenuTrigger',
+  });
+
+  /**
+   * Define if the trigger should be disabled.
+   * @default false
+   */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpContextMenuSubmenuTriggerDisabled',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * Define the placement of the submenu relative to the trigger.
+   * @default 'right-start'
+   */
+  readonly placement = input<NgpMenuPlacement>('right-start', {
+    alias: 'ngpContextMenuSubmenuTriggerPlacement',
+  });
+
+  /**
+   * Define the offset of the submenu relative to the trigger.
+   * @default 0
+   */
+  readonly offset = input<NgpOffset, NgpOffsetInput>(0, {
+    alias: 'ngpContextMenuSubmenuTriggerOffset',
+    transform: coerceOffset,
+  });
+
+  /**
+   * Define whether the submenu should flip when there is not enough space.
+   * @default true
+   */
+  readonly flip = input<NgpFlip, NgpFlipInput>(true, {
+    alias: 'ngpContextMenuSubmenuTriggerFlip',
+    transform: coerceFlip,
+  });
+
+  private readonly state = ngpSubmenuTrigger<T>({
+    disabled: this.disabled,
+    menu: this.menu,
+    placement: this.placement,
+    offset: this.offset,
+    flip: this.flip,
+  });
+
+  show(): void {
+    this.state.show();
+  }
+
+  hide(origin: FocusOrigin = 'program'): void {
+    this.state.hide(origin);
+  }
+
+  toggle(event: MouseEvent): void {
+    this.state.toggle(event);
+  }
+
+  focus(origin: FocusOrigin = 'program'): void {
+    this.state.focus(origin);
+  }
+}

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
@@ -148,11 +148,11 @@ export const [
     listener(element, 'pointercancel', onPointerCancel);
 
     function onContextMenu(event: MouseEvent): void {
-      event.preventDefault();
-
       if (disabled?.()) {
         return;
       }
+
+      event.preventDefault();
 
       // If long-press already triggered, don't re-open
       if (longPressTriggered) {

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
@@ -1,0 +1,317 @@
+import { FocusOrigin } from '@angular/cdk/a11y';
+import { computed, inject, Injector, signal, Signal, ViewContainerRef } from '@angular/core';
+import { Placement } from '@floating-ui/dom';
+import { injectElementRef } from 'ng-primitives/internal';
+import { NgpMenuTriggerStateToken } from 'ng-primitives/menu';
+import {
+  createOverlay,
+  NgpFlip,
+  NgpOffset,
+  NgpOverlay,
+  NgpOverlayConfig,
+  NgpOverlayContent,
+  NgpPosition,
+  NgpShift,
+} from 'ng-primitives/portal';
+import { controlled, createPrimitive, dataBinding, listener, onDestroy } from 'ng-primitives/state';
+
+export interface NgpContextMenuTriggerState {
+  /**
+   * Whether the context menu is open.
+   */
+  readonly open: Signal<boolean>;
+
+  /**
+   * The focus origin that was used to open the menu.
+   */
+  readonly openOrigin: Signal<FocusOrigin>;
+
+  /**
+   * Show the context menu.
+   */
+  show(origin?: FocusOrigin): void;
+
+  /**
+   * Hide the context menu.
+   */
+  hide(origin?: FocusOrigin): void;
+
+  /**
+   * Set whether the pointer is over the menu content.
+   */
+  setPointerOverContent(isOver: boolean): void;
+}
+
+export interface NgpContextMenuTriggerProps<T = unknown> {
+  /**
+   * The menu template or component.
+   */
+  readonly menu?: Signal<NgpOverlayContent<T> | undefined>;
+
+  /**
+   * Whether the trigger is disabled.
+   */
+  readonly disabled?: Signal<boolean>;
+
+  /**
+   * The offset of the menu.
+   */
+  readonly offset?: Signal<NgpOffset>;
+
+  /**
+   * Whether the menu should flip when there is not enough space.
+   */
+  readonly flip?: Signal<NgpFlip>;
+
+  /**
+   * The container in which the menu should be attached.
+   */
+  readonly container?: Signal<HTMLElement | string | null>;
+
+  /**
+   * Configure shift behavior.
+   */
+  shift: NgpShift;
+
+  /**
+   * How the menu behaves when the window is scrolled.
+   */
+  readonly scrollBehavior?: Signal<'reposition' | 'block' | 'close'>;
+
+  /**
+   * Context to provide to the menu.
+   */
+  readonly context?: Signal<T>;
+}
+
+/** Duration in ms before a long-press fires. */
+const LONG_PRESS_DURATION = 700;
+
+/** Movement threshold in px to cancel a long-press. */
+const LONG_PRESS_MOVE_THRESHOLD = 10;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-function
+const noop = (): any => {};
+
+export const [
+  NgpContextMenuTriggerStateToken,
+  ngpContextMenuTrigger,
+  _injectContextMenuTriggerState,
+  provideContextMenuTriggerState,
+] = createPrimitive(
+  'NgpContextMenuTrigger',
+  <T>({
+    disabled: _disabled = signal(false),
+    menu: _menu = signal<NgpOverlayContent<T> | undefined>(undefined),
+    offset: _offset = signal(2),
+    flip: _flip = signal(true),
+    context: _context = signal<T>(undefined as T),
+    container,
+    scrollBehavior,
+    shift,
+  }: NgpContextMenuTriggerProps<T>) => {
+    const element = injectElementRef();
+    const injector = inject(Injector);
+    const viewContainerRef = inject(ViewContainerRef);
+
+    // Controlled properties
+    const menu = controlled(_menu);
+    const disabled = controlled(_disabled);
+    const flip = controlled(_flip);
+    const offset = controlled(_offset);
+    const context = controlled(_context);
+
+    // Internal state
+    const overlay = signal<NgpOverlay<T> | null>(null);
+    const open = computed(() => overlay()?.isOpen() ?? false);
+    const openOrigin = signal<FocusOrigin>('program');
+    const cursorPosition = signal<NgpPosition | null>(null);
+
+    // Host bindings
+    dataBinding(element, 'data-open', open);
+
+    // Long-press state
+    let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+    let longPressStartX = 0;
+    let longPressStartY = 0;
+    let longPressTriggered = false;
+
+    // Event listeners
+    listener(element, 'contextmenu', onContextMenu);
+    listener(element, 'pointerdown', onPointerDown);
+    listener(element, 'pointermove', onPointerMove);
+    listener(element, 'pointerup', onPointerUp);
+    listener(element, 'pointercancel', onPointerCancel);
+
+    function onContextMenu(event: MouseEvent): void {
+      event.preventDefault();
+
+      if (disabled?.()) {
+        return;
+      }
+
+      // If long-press already triggered, don't re-open
+      if (longPressTriggered) {
+        longPressTriggered = false;
+        return;
+      }
+
+      cursorPosition.set({ x: event.clientX, y: event.clientY });
+      openOrigin.set('mouse');
+
+      if (open()) {
+        // Already open - reposition by updating cursor position and triggering reposition
+        overlay()?.updatePosition();
+      } else {
+        showMenu();
+      }
+    }
+
+    function onPointerDown(event: PointerEvent): void {
+      if (event.pointerType !== 'touch' || disabled?.()) {
+        return;
+      }
+
+      longPressTriggered = false;
+      longPressStartX = event.clientX;
+      longPressStartY = event.clientY;
+
+      longPressTimer = setTimeout(() => {
+        longPressTriggered = true;
+        cursorPosition.set({ x: longPressStartX, y: longPressStartY });
+        openOrigin.set('touch');
+        showMenu();
+      }, LONG_PRESS_DURATION);
+    }
+
+    function onPointerMove(event: PointerEvent): void {
+      if (event.pointerType !== 'touch' || !longPressTimer) {
+        return;
+      }
+
+      const dx = event.clientX - longPressStartX;
+      const dy = event.clientY - longPressStartY;
+      if (Math.sqrt(dx * dx + dy * dy) > LONG_PRESS_MOVE_THRESHOLD) {
+        cancelLongPress();
+      }
+    }
+
+    function onPointerUp(event: PointerEvent): void {
+      if (event.pointerType !== 'touch') {
+        return;
+      }
+      cancelLongPress();
+    }
+
+    function onPointerCancel(event: PointerEvent): void {
+      if (event.pointerType !== 'touch') {
+        return;
+      }
+      cancelLongPress();
+    }
+
+    function cancelLongPress(): void {
+      if (longPressTimer) {
+        clearTimeout(longPressTimer);
+        longPressTimer = null;
+      }
+    }
+
+    onDestroy(() => cancelLongPress());
+
+    function showMenu(): void {
+      if (!overlay()) {
+        createOverlayInstance();
+      }
+      overlay()?.show();
+    }
+
+    function show(origin: FocusOrigin = 'program'): void {
+      openOrigin.set(origin);
+      showMenu();
+    }
+
+    function hide(origin: FocusOrigin = 'program'): void {
+      const currentOverlay = overlay();
+      if (!currentOverlay) {
+        return;
+      }
+      currentOverlay.hide({ origin });
+    }
+
+    function createOverlayInstance(): void {
+      const menuContent = menu?.();
+
+      if (!menuContent) {
+        throw new Error('Context menu must be either a TemplateRef or a ComponentType');
+      }
+
+      const config: NgpOverlayConfig<T> = {
+        content: menuContent,
+        triggerElement: element.nativeElement,
+        viewContainerRef,
+        injector,
+        context,
+        container: container?.(),
+        offset: offset(),
+        flip: flip(),
+        shift,
+        placement: signal<Placement>('right-start'),
+        closeOnOutsideClick: true,
+        closeOnEscape: true,
+        treatTriggerClickAsOutside: true,
+        restoreFocus: false,
+        scrollBehaviour: scrollBehavior?.() ?? 'close',
+        overlayType: 'menu',
+        position: cursorPosition,
+        trackPosition: true,
+      };
+
+      overlay.set(createOverlay(config));
+    }
+
+    function setPointerOverContent(_isOver: boolean): void {
+      // No-op for context menu
+    }
+
+    // Set the compat state on NgpMenuTriggerStateToken so NgpMenu can find it.
+    // NgpMenu injects this token and calls hide(), openOrigin(), setPointerOverContent() on it.
+    const menuTriggerToken = inject(NgpMenuTriggerStateToken, { optional: true });
+    // eslint-disable-next-line @angular-eslint/no-uncalled-signals -- checking inject() nullability, not signal value
+    if (menuTriggerToken) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (menuTriggerToken as any).set({
+        menu,
+        placement: signal('bottom-start'),
+        open,
+        offset,
+        disabled,
+        flip,
+        context,
+        openOrigin,
+        setDisabled: noop,
+        setFlip: noop,
+        setPlacement: noop,
+        setOffset: noop,
+        setContext: noop,
+        show,
+        hide,
+        toggle: noop,
+        setMenu: noop,
+        setPointerOverContent,
+      });
+    }
+
+    return {
+      open,
+      openOrigin,
+      show,
+      hide,
+      setPointerOverContent,
+    } satisfies NgpContextMenuTriggerState;
+  },
+);
+
+export function injectContextMenuTriggerState(): Signal<NgpContextMenuTriggerState> {
+  return _injectContextMenuTriggerState() as Signal<NgpContextMenuTriggerState>;
+}

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
@@ -130,6 +130,10 @@ export const [
     // Host bindings
     dataBinding(element, 'data-open', open);
 
+    // Prevent iOS text selection and callout on long-press
+    const el = element.nativeElement as HTMLElement;
+    el.style.setProperty('-webkit-touch-callout', 'none');
+
     // Long-press state
     let longPressTimer: ReturnType<typeof setTimeout> | null = null;
     let longPressStartX = 0;
@@ -215,6 +219,7 @@ export const [
         clearTimeout(longPressTimer);
         longPressTimer = null;
       }
+      longPressTriggered = false;
     }
 
     onDestroy(() => cancelLongPress());

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
@@ -13,7 +13,14 @@ import {
   NgpPosition,
   NgpShift,
 } from 'ng-primitives/portal';
-import { controlled, createPrimitive, dataBinding, listener, onDestroy } from 'ng-primitives/state';
+import {
+  controlled,
+  createPrimitive,
+  dataBinding,
+  listener,
+  onDestroy,
+  styleBinding,
+} from 'ng-primitives/state';
 
 export interface NgpContextMenuTriggerState {
   /**
@@ -130,9 +137,9 @@ export const [
     // Host bindings
     dataBinding(element, 'data-open', open);
 
-    // Prevent iOS text selection and callout on long-press
-    const el = element.nativeElement as HTMLElement;
-    el.style.setProperty('-webkit-touch-callout', 'none');
+    // Prevent iOS text selection and callout on long-press.
+    // Only apply when the trigger is enabled so disabled triggers retain native behavior.
+    styleBinding(element, '-webkit-touch-callout', () => (disabled?.() ? null : 'none'));
 
     // Long-press state
     let longPressTimer: ReturnType<typeof setTimeout> | null = null;

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger.spec.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger.spec.ts
@@ -1,0 +1,868 @@
+import { Component } from '@angular/core';
+import { fakeAsync, flush } from '@angular/core/testing';
+import { fireEvent, render, screen } from '@testing-library/angular';
+import {
+  NgpContextMenu,
+  NgpContextMenuItem,
+  NgpContextMenuItemCheckbox,
+  NgpContextMenuItemIndicator,
+  NgpContextMenuItemRadio,
+  NgpContextMenuItemRadioGroup,
+  NgpContextMenuSubmenuTrigger,
+  NgpContextMenuTrigger,
+} from '../index';
+
+@Component({
+  template: `
+    <div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">Right-click me</div>
+    <ng-template #menu>
+      <div ngpContextMenu data-testid="context-menu">
+        <button
+          [ngpContextMenuItemCheckboxChecked]="checked"
+          (ngpContextMenuItemCheckboxCheckedChange)="checked = $event"
+          ngpContextMenuItemCheckbox
+          data-testid="checkbox-item"
+        >
+          <span ngpContextMenuItemIndicator data-testid="checkbox-indicator"></span>
+          Bold
+        </button>
+        <button ngpContextMenuItem data-testid="regular-item">Regular</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [
+    NgpContextMenuTrigger,
+    NgpContextMenu,
+    NgpContextMenuItem,
+    NgpContextMenuItemCheckbox,
+    NgpContextMenuItemIndicator,
+  ],
+})
+class ContextMenuCheckboxComponent {
+  checked = false;
+}
+
+@Component({
+  template: `
+    <div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">Right-click me</div>
+    <ng-template #menu>
+      <div ngpContextMenu data-testid="context-menu">
+        <div
+          [ngpContextMenuItemRadioGroup]
+          [ngpContextMenuItemRadioGroupValue]="theme"
+          (ngpContextMenuItemRadioGroupValueChange)="theme = $event"
+          data-testid="radio-group"
+        >
+          <button
+            ngpContextMenuItemRadio
+            ngpContextMenuItemRadioValue="light"
+            data-testid="radio-light"
+          >
+            <span ngpContextMenuItemIndicator data-testid="indicator-light"></span>
+            Light
+          </button>
+          <button
+            ngpContextMenuItemRadio
+            ngpContextMenuItemRadioValue="dark"
+            data-testid="radio-dark"
+          >
+            <span ngpContextMenuItemIndicator data-testid="indicator-dark"></span>
+            Dark
+          </button>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  imports: [
+    NgpContextMenuTrigger,
+    NgpContextMenu,
+    NgpContextMenuItemRadio,
+    NgpContextMenuItemRadioGroup,
+    NgpContextMenuItemIndicator,
+  ],
+})
+class ContextMenuRadioComponent {
+  theme = 'light';
+}
+
+@Component({
+  template: `
+    <div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">Right-click me</div>
+    <ng-template #menu>
+      <div ngpContextMenu data-testid="context-menu">
+        <button ngpContextMenuItem data-testid="item-1">Item 1</button>
+        <button ngpContextMenuItem ngpContextMenuItemDisabled data-testid="item-disabled">
+          Disabled
+        </button>
+        <button ngpContextMenuItem data-testid="item-3">Item 3</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpContextMenuTrigger, NgpContextMenu, NgpContextMenuItem],
+})
+class ContextMenuDisabledItemsComponent {}
+
+@Component({
+  template: `
+    <div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">Right-click me</div>
+    <ng-template #menu>
+      <div ngpContextMenu data-testid="context-menu">
+        <button ngpContextMenuItem data-testid="item-cut">Cut</button>
+        <button [ngpContextMenuSubmenuTrigger]="submenu" ngpContextMenuItem data-testid="more-item">
+          More
+        </button>
+      </div>
+    </ng-template>
+    <ng-template #submenu>
+      <div ngpContextMenu data-testid="submenu">
+        <button ngpContextMenuItem data-testid="submenu-item-a">Option A</button>
+        <button ngpContextMenuItem data-testid="submenu-item-b">Option B</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [
+    NgpContextMenuTrigger,
+    NgpContextMenu,
+    NgpContextMenuItem,
+    NgpContextMenuSubmenuTrigger,
+  ],
+})
+class ContextMenuWithSubmenuComponent {}
+
+@Component({
+  template: `
+    <div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">Right-click me</div>
+    <ng-template #menu>
+      <div ngpContextMenu data-testid="context-menu">
+        <button
+          [ngpContextMenuItemCheckboxChecked]="checked"
+          (ngpContextMenuItemCheckboxCheckedChange)="checked = $event"
+          ngpContextMenuItemCheckbox
+          ngpContextMenuItemCheckboxDisabled
+          data-testid="checkbox-disabled"
+        >
+          <span ngpContextMenuItemIndicator data-testid="checkbox-disabled-indicator"></span>
+          Disabled Checkbox
+        </button>
+      </div>
+    </ng-template>
+  `,
+  imports: [
+    NgpContextMenuTrigger,
+    NgpContextMenu,
+    NgpContextMenuItemCheckbox,
+    NgpContextMenuItemIndicator,
+  ],
+})
+class ContextMenuDisabledCheckboxComponent {
+  checked = false;
+}
+
+@Component({
+  template: `
+    <div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">Right-click me</div>
+    <ng-template #menu>
+      <div ngpContextMenu data-testid="context-menu">
+        <div
+          [ngpContextMenuItemRadioGroup]
+          [ngpContextMenuItemRadioGroupValue]="theme"
+          (ngpContextMenuItemRadioGroupValueChange)="theme = $event"
+          data-testid="radio-group"
+        >
+          <button
+            ngpContextMenuItemRadio
+            ngpContextMenuItemRadioValue="light"
+            data-testid="radio-light"
+          >
+            Light
+          </button>
+          <button
+            ngpContextMenuItemRadio
+            ngpContextMenuItemRadioValue="dark"
+            ngpContextMenuItemRadioDisabled
+            data-testid="radio-disabled"
+          >
+            Dark
+          </button>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  imports: [
+    NgpContextMenuTrigger,
+    NgpContextMenu,
+    NgpContextMenuItemRadio,
+    NgpContextMenuItemRadioGroup,
+  ],
+})
+class ContextMenuDisabledRadioComponent {
+  theme = 'light';
+}
+
+/** Helper: open context menu on the trigger area and flush */
+function openContextMenu() {
+  const triggerArea = screen.getByTestId('trigger-area');
+  fireEvent.contextMenu(triggerArea);
+  flush();
+}
+
+describe('NgpContextMenuTrigger', () => {
+  it('should open a menu on right-click', fakeAsync(async () => {
+    await render(
+      `<div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">
+        Right-click me
+      </div>
+      <ng-template #menu>
+        <div ngpContextMenu data-testid="context-menu">
+          <button ngpContextMenuItem>Cut</button>
+          <button ngpContextMenuItem>Copy</button>
+          <button ngpContextMenuItem>Paste</button>
+        </div>
+      </ng-template>`,
+      {
+        imports: [NgpContextMenuTrigger, NgpContextMenu, NgpContextMenuItem],
+      },
+    );
+
+    const triggerArea = screen.getByTestId('trigger-area');
+    fireEvent.contextMenu(triggerArea);
+    flush();
+
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+  }));
+
+  it('should prevent native context menu', fakeAsync(async () => {
+    await render(
+      `<div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">
+        Right-click me
+      </div>
+      <ng-template #menu>
+        <div ngpContextMenu data-testid="context-menu">
+          <button ngpContextMenuItem>Cut</button>
+        </div>
+      </ng-template>`,
+      {
+        imports: [NgpContextMenuTrigger, NgpContextMenu, NgpContextMenuItem],
+      },
+    );
+
+    const triggerArea = screen.getByTestId('trigger-area');
+    const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    triggerArea.dispatchEvent(event);
+    flush();
+
+    expect(event.defaultPrevented).toBe(true);
+  }));
+
+  it('should close menu on Escape', fakeAsync(async () => {
+    await render(
+      `<div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">
+        Right-click me
+      </div>
+      <ng-template #menu>
+        <div ngpContextMenu data-testid="context-menu">
+          <button ngpContextMenuItem>Cut</button>
+        </div>
+      </ng-template>`,
+      {
+        imports: [NgpContextMenuTrigger, NgpContextMenu, NgpContextMenuItem],
+      },
+    );
+
+    const triggerArea = screen.getByTestId('trigger-area');
+    fireEvent.contextMenu(triggerArea);
+    flush();
+
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+
+    const menuEl = screen.getByTestId('context-menu');
+    fireEvent.keyDown(menuEl, { key: 'Escape' });
+    flush();
+
+    expect(screen.queryByTestId('context-menu')).not.toBeInTheDocument();
+  }));
+
+  it('should close menu on click outside', fakeAsync(async () => {
+    await render(
+      `<div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">
+        Right-click me
+      </div>
+      <div data-testid="outside">Outside</div>
+      <ng-template #menu>
+        <div ngpContextMenu data-testid="context-menu">
+          <button ngpContextMenuItem>Cut</button>
+        </div>
+      </ng-template>`,
+      {
+        imports: [NgpContextMenuTrigger, NgpContextMenu, NgpContextMenuItem],
+      },
+    );
+
+    const triggerArea = screen.getByTestId('trigger-area');
+    fireEvent.contextMenu(triggerArea);
+    flush();
+
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+
+    // Overlay registry uses mouseup for outside click detection
+    fireEvent.mouseUp(document.body);
+    flush();
+
+    expect(screen.queryByTestId('context-menu')).not.toBeInTheDocument();
+  }));
+
+  it('should not close menu on right-click mouseup', fakeAsync(async () => {
+    await render(
+      `<div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">
+        Right-click me
+      </div>
+      <div data-testid="outside">Outside</div>
+      <ng-template #menu>
+        <div ngpContextMenu data-testid="context-menu">
+          <button ngpContextMenuItem>Cut</button>
+        </div>
+      </ng-template>`,
+      {
+        imports: [NgpContextMenuTrigger, NgpContextMenu, NgpContextMenuItem],
+      },
+    );
+
+    const triggerArea = screen.getByTestId('trigger-area');
+    fireEvent.contextMenu(triggerArea);
+    flush();
+
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+
+    // Right-click mouseup (button 2) should NOT close the menu
+    fireEvent.mouseUp(document.body, { button: 2 });
+    flush();
+
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+  }));
+
+  it('should not open when disabled', fakeAsync(async () => {
+    await render(
+      `<div [ngpContextMenuTrigger]="menu" ngpContextMenuTriggerDisabled data-testid="trigger-area">
+        Right-click me
+      </div>
+      <ng-template #menu>
+        <div ngpContextMenu data-testid="context-menu">
+          <button ngpContextMenuItem>Cut</button>
+        </div>
+      </ng-template>`,
+      {
+        imports: [NgpContextMenuTrigger, NgpContextMenu, NgpContextMenuItem],
+      },
+    );
+
+    const triggerArea = screen.getByTestId('trigger-area');
+    fireEvent.contextMenu(triggerArea);
+    flush();
+
+    expect(screen.queryByTestId('context-menu')).not.toBeInTheDocument();
+  }));
+
+  it('should close menu when a menu item is clicked', fakeAsync(async () => {
+    await render(
+      `<div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">
+        Right-click me
+      </div>
+      <ng-template #menu>
+        <div ngpContextMenu data-testid="context-menu">
+          <button ngpContextMenuItem data-testid="cut-item">Cut</button>
+          <button ngpContextMenuItem>Copy</button>
+        </div>
+      </ng-template>`,
+      {
+        imports: [NgpContextMenuTrigger, NgpContextMenu, NgpContextMenuItem],
+      },
+    );
+
+    const triggerArea = screen.getByTestId('trigger-area');
+    fireEvent.contextMenu(triggerArea);
+    flush();
+
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+
+    const cutItem = screen.getByTestId('cut-item');
+    fireEvent.click(cutItem);
+    flush();
+
+    expect(screen.queryByTestId('context-menu')).not.toBeInTheDocument();
+  }));
+
+  it('should close menu when left-clicking on trigger area', fakeAsync(async () => {
+    await render(
+      `<div [ngpContextMenuTrigger]="menu" data-testid="trigger-area">
+        Right-click me
+      </div>
+      <ng-template #menu>
+        <div ngpContextMenu data-testid="context-menu">
+          <button ngpContextMenuItem>Cut</button>
+        </div>
+      </ng-template>`,
+      {
+        imports: [NgpContextMenuTrigger, NgpContextMenu, NgpContextMenuItem],
+      },
+    );
+
+    const triggerArea = screen.getByTestId('trigger-area');
+    fireEvent.contextMenu(triggerArea);
+    flush();
+
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+
+    // Left-clicking on the trigger area should dismiss the context menu
+    fireEvent.mouseUp(triggerArea);
+    flush();
+
+    expect(screen.queryByTestId('context-menu')).not.toBeInTheDocument();
+  }));
+
+  it('should support submenu', fakeAsync(async () => {
+    await render(ContextMenuWithSubmenuComponent);
+
+    openContextMenu();
+
+    expect(screen.getByTestId('context-menu')).toBeInTheDocument();
+
+    // Click the submenu trigger to open submenu
+    const moreItem = screen.getByTestId('more-item');
+    fireEvent.click(moreItem);
+    flush();
+
+    expect(screen.getByTestId('submenu')).toBeInTheDocument();
+  }));
+
+  describe('ARIA attributes', () => {
+    it('should render context menu with role="menu"', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const menu = document.querySelector('[data-testid="context-menu"]');
+      expect(menu).toHaveAttribute('role', 'menu');
+    }));
+
+    it('should render menu items with role="menuitem"', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const item1 = document.querySelector('[data-testid="item-1"]');
+      expect(item1).toHaveAttribute('role', 'menuitem');
+    }));
+
+    it('should set role="menuitemcheckbox" and aria-checked on checkbox items', fakeAsync(async () => {
+      await render(ContextMenuCheckboxComponent);
+      openContextMenu();
+
+      const checkbox = document.querySelector('[data-testid="checkbox-item"]');
+      expect(checkbox).toHaveAttribute('role', 'menuitemcheckbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    }));
+
+    it('should set role="menuitemradio" and aria-checked on radio items', fakeAsync(async () => {
+      await render(ContextMenuRadioComponent);
+      openContextMenu();
+
+      const radioLight = document.querySelector('[data-testid="radio-light"]');
+      const radioDark = document.querySelector('[data-testid="radio-dark"]');
+      expect(radioLight).toHaveAttribute('role', 'menuitemradio');
+      expect(radioLight).toHaveAttribute('aria-checked', 'true');
+      expect(radioDark).toHaveAttribute('role', 'menuitemradio');
+      expect(radioDark).toHaveAttribute('aria-checked', 'false');
+    }));
+
+    it('should render radio group with role="group"', fakeAsync(async () => {
+      await render(ContextMenuRadioComponent);
+      openContextMenu();
+
+      const radioGroup = document.querySelector('[data-testid="radio-group"]');
+      expect(radioGroup).toHaveAttribute('role', 'group');
+    }));
+
+    it('should have data-focus-trap on context menu', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const menu = document.querySelector('[data-testid="context-menu"]');
+      expect(menu).toHaveAttribute('data-focus-trap');
+    }));
+
+    it('should set data-open on trigger when menu is open', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+
+      const triggerArea = screen.getByTestId('trigger-area');
+      expect(triggerArea).not.toHaveAttribute('data-open');
+
+      openContextMenu();
+      expect(triggerArea).toHaveAttribute('data-open');
+
+      const menuEl = document.querySelector('[data-testid="context-menu"]') as HTMLElement;
+      fireEvent.keyDown(menuEl, { key: 'Escape' });
+      flush();
+
+      expect(triggerArea).not.toHaveAttribute('data-open');
+    }));
+
+    it('should set aria-haspopup on submenu trigger', fakeAsync(async () => {
+      await render(ContextMenuWithSubmenuComponent);
+      openContextMenu();
+
+      const moreItem = document.querySelector('[data-testid="more-item"]');
+      expect(moreItem).toHaveAttribute('aria-haspopup', 'true');
+    }));
+
+    it('should set aria-expanded on submenu trigger', fakeAsync(async () => {
+      await render(ContextMenuWithSubmenuComponent);
+      openContextMenu();
+
+      const moreItem = document.querySelector('[data-testid="more-item"]') as HTMLElement;
+      expect(moreItem).toHaveAttribute('aria-expanded', 'false');
+
+      fireEvent.keyDown(moreItem, { key: 'ArrowDown' });
+      flush();
+      fireEvent.keyDown(moreItem, { key: 'ArrowRight' });
+      flush();
+
+      expect(moreItem).toHaveAttribute('aria-expanded', 'true');
+    }));
+  });
+
+  describe('Keyboard navigation', () => {
+    it('should focus first menu item when context menu opens', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const item1 = document.querySelector('[data-testid="item-1"]') as HTMLElement;
+      expect(document.activeElement).toBe(item1);
+    }));
+
+    it('should move focus down with ArrowDown', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      // Focus should already be on first item from focus trap
+      const item1 = document.querySelector('[data-testid="item-1"]') as HTMLElement;
+      expect(document.activeElement).toBe(item1);
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown' });
+      flush();
+
+      const item3 = document.querySelector('[data-testid="item-3"]') as HTMLElement;
+      expect(document.activeElement).toBe(item3);
+    }));
+
+    it('should move focus up with ArrowUp', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const item1 = document.querySelector('[data-testid="item-1"]') as HTMLElement;
+      expect(document.activeElement).toBe(item1);
+
+      // Navigate down first to reach item-3 (skipping disabled)
+      fireEvent.keyDown(item1, { key: 'ArrowDown' });
+      flush();
+
+      const item3 = document.querySelector('[data-testid="item-3"]') as HTMLElement;
+      expect(document.activeElement).toBe(item3);
+
+      // Now navigate up
+      fireEvent.keyDown(item3, { key: 'ArrowUp' });
+      flush();
+
+      expect(document.activeElement).toBe(item1);
+    }));
+
+    it('should wrap focus at the end', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const item1 = document.querySelector('[data-testid="item-1"]') as HTMLElement;
+      expect(document.activeElement).toBe(item1);
+
+      // Navigate down to item-3 (skipping disabled)
+      fireEvent.keyDown(item1, { key: 'ArrowDown' });
+      flush();
+
+      const item3 = document.querySelector('[data-testid="item-3"]') as HTMLElement;
+      expect(document.activeElement).toBe(item3);
+
+      // ArrowDown from last item should wrap to first
+      fireEvent.keyDown(item3, { key: 'ArrowDown' });
+      flush();
+
+      expect(document.activeElement).toBe(item1);
+    }));
+
+    it('should skip disabled items during keyboard navigation', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const item1 = document.querySelector('[data-testid="item-1"]') as HTMLElement;
+      expect(document.activeElement).toBe(item1);
+
+      fireEvent.keyDown(item1, { key: 'ArrowDown' });
+      flush();
+
+      const item3 = document.querySelector('[data-testid="item-3"]') as HTMLElement;
+      expect(document.activeElement).toBe(item3);
+    }));
+
+    it('should activate item and close menu on Enter key', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const item1 = document.querySelector('[data-testid="item-1"]') as HTMLElement;
+      expect(document.activeElement).toBe(item1);
+
+      // fireEvent.click with detail: 0 simulates keyboard activation (Enter)
+      fireEvent.click(item1, { detail: 0 });
+      flush();
+
+      expect(document.querySelector('[data-testid="context-menu"]')).not.toBeInTheDocument();
+    }));
+
+    it('should move focus to first item on Home key', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const item1 = document.querySelector('[data-testid="item-1"]') as HTMLElement;
+      // Navigate to last item
+      fireEvent.keyDown(item1, { key: 'ArrowDown' });
+      flush();
+
+      const item3 = document.querySelector('[data-testid="item-3"]') as HTMLElement;
+      expect(document.activeElement).toBe(item3);
+
+      fireEvent.keyDown(item3, { key: 'Home' });
+      flush();
+
+      expect(document.activeElement).toBe(item1);
+    }));
+
+    it('should move focus to last item on End key', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const item1 = document.querySelector('[data-testid="item-1"]') as HTMLElement;
+      expect(document.activeElement).toBe(item1);
+
+      fireEvent.keyDown(item1, { key: 'End' });
+      flush();
+
+      const item3 = document.querySelector('[data-testid="item-3"]') as HTMLElement;
+      expect(document.activeElement).toBe(item3);
+    }));
+
+    it('should open submenu with ArrowRight', fakeAsync(async () => {
+      await render(ContextMenuWithSubmenuComponent);
+      openContextMenu();
+
+      // Focus should be on first item (item-cut)
+      const cutItem = document.querySelector('[data-testid="item-cut"]') as HTMLElement;
+      expect(document.activeElement).toBe(cutItem);
+
+      // Navigate to submenu trigger
+      fireEvent.keyDown(cutItem, { key: 'ArrowDown' });
+      flush();
+
+      const moreItem = document.querySelector('[data-testid="more-item"]') as HTMLElement;
+      expect(document.activeElement).toBe(moreItem);
+
+      fireEvent.keyDown(moreItem, { key: 'ArrowRight' });
+      flush();
+
+      expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
+    }));
+
+    it('should close submenu with ArrowLeft', fakeAsync(async () => {
+      await render(ContextMenuWithSubmenuComponent);
+      openContextMenu();
+
+      // Navigate to submenu trigger and open it
+      const cutItem = document.querySelector('[data-testid="item-cut"]') as HTMLElement;
+      fireEvent.keyDown(cutItem, { key: 'ArrowDown' });
+      flush();
+
+      const moreItem = document.querySelector('[data-testid="more-item"]') as HTMLElement;
+      fireEvent.keyDown(moreItem, { key: 'ArrowRight' });
+      flush();
+
+      expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
+
+      const submenuItem = document.querySelector('[data-testid="submenu-item-a"]') as HTMLElement;
+      expect(document.activeElement).toBe(submenuItem);
+      fireEvent.keyDown(submenuItem, { key: 'ArrowLeft' });
+      flush();
+
+      expect(document.querySelector('[data-testid="submenu"]')).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(moreItem);
+    }));
+  });
+
+  describe('Checkbox items', () => {
+    it('should toggle checkbox item on click', fakeAsync(async () => {
+      const { fixture } = await render(ContextMenuCheckboxComponent);
+      openContextMenu();
+
+      const checkbox = document.querySelector('[data-testid="checkbox-item"]') as HTMLElement;
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.click(checkbox);
+      flush();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.checked).toBe(true);
+      // Menu may still be open — re-query after state change
+      const checkboxAfter = document.querySelector('[data-testid="checkbox-item"]');
+      expect(checkboxAfter).toHaveAttribute('aria-checked', 'true');
+      expect(checkboxAfter).toHaveAttribute('data-checked');
+    }));
+
+    it('should not close menu when checkbox item is clicked', fakeAsync(async () => {
+      await render(ContextMenuCheckboxComponent);
+      openContextMenu();
+
+      const checkbox = document.querySelector('[data-testid="checkbox-item"]') as HTMLElement;
+      fireEvent.click(checkbox);
+      flush();
+
+      expect(document.querySelector('[data-testid="context-menu"]')).toBeInTheDocument();
+    }));
+
+    it('should show indicator with data-checked when checkbox is checked', fakeAsync(async () => {
+      const { fixture } = await render(ContextMenuCheckboxComponent);
+      openContextMenu();
+
+      const indicator = document.querySelector('[data-testid="checkbox-indicator"]');
+      expect(indicator).not.toHaveAttribute('data-checked');
+
+      const checkbox = document.querySelector('[data-testid="checkbox-item"]') as HTMLElement;
+      fireEvent.click(checkbox);
+      flush();
+      fixture.detectChanges();
+
+      const indicatorAfter = document.querySelector('[data-testid="checkbox-indicator"]');
+      expect(indicatorAfter).toHaveAttribute('data-checked');
+    }));
+  });
+
+  describe('Radio items', () => {
+    it('should select radio item on click and update group value', fakeAsync(async () => {
+      const { fixture } = await render(ContextMenuRadioComponent);
+      openContextMenu();
+
+      const radioDark = document.querySelector('[data-testid="radio-dark"]') as HTMLElement;
+      fireEvent.click(radioDark);
+      flush();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.theme).toBe('dark');
+
+      const radioLight = document.querySelector('[data-testid="radio-light"]');
+      const radioDarkAfter = document.querySelector('[data-testid="radio-dark"]');
+      expect(radioDarkAfter).toHaveAttribute('aria-checked', 'true');
+      expect(radioDarkAfter).toHaveAttribute('data-checked');
+      expect(radioLight).toHaveAttribute('aria-checked', 'false');
+    }));
+
+    it('should not close menu when radio item is clicked', fakeAsync(async () => {
+      await render(ContextMenuRadioComponent);
+      openContextMenu();
+
+      const radioDark = document.querySelector('[data-testid="radio-dark"]') as HTMLElement;
+      fireEvent.click(radioDark);
+      flush();
+
+      expect(document.querySelector('[data-testid="context-menu"]')).toBeInTheDocument();
+    }));
+
+    it('should show indicator with data-checked for selected radio', fakeAsync(async () => {
+      const { fixture } = await render(ContextMenuRadioComponent);
+      openContextMenu();
+
+      const indicatorLight = document.querySelector('[data-testid="indicator-light"]');
+      const indicatorDark = document.querySelector('[data-testid="indicator-dark"]');
+      expect(indicatorLight).toHaveAttribute('data-checked');
+      expect(indicatorDark).not.toHaveAttribute('data-checked');
+
+      const radioDark = document.querySelector('[data-testid="radio-dark"]') as HTMLElement;
+      fireEvent.click(radioDark);
+      flush();
+      fixture.detectChanges();
+
+      const indicatorLightAfter = document.querySelector('[data-testid="indicator-light"]');
+      const indicatorDarkAfter = document.querySelector('[data-testid="indicator-dark"]');
+      expect(indicatorLightAfter).not.toHaveAttribute('data-checked');
+      expect(indicatorDarkAfter).toHaveAttribute('data-checked');
+    }));
+  });
+
+  describe('Disabled items', () => {
+    it('should have data-disabled on disabled menu item', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+      openContextMenu();
+
+      const disabledItem = document.querySelector('[data-testid="item-disabled"]');
+      expect(disabledItem).toHaveAttribute('data-disabled');
+    }));
+
+    it('should not toggle disabled checkbox item', fakeAsync(async () => {
+      const { fixture } = await render(ContextMenuDisabledCheckboxComponent);
+      openContextMenu();
+
+      const checkbox = document.querySelector('[data-testid="checkbox-disabled"]') as HTMLElement;
+      fireEvent.click(checkbox);
+      flush();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.checked).toBe(false);
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    }));
+
+    it('should not select disabled radio item', fakeAsync(async () => {
+      const { fixture } = await render(ContextMenuDisabledRadioComponent);
+      openContextMenu();
+
+      const radioDisabled = document.querySelector('[data-testid="radio-disabled"]') as HTMLElement;
+      fireEvent.click(radioDisabled);
+      flush();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.theme).toBe('light');
+      expect(radioDisabled).toHaveAttribute('aria-checked', 'false');
+    }));
+  });
+
+  describe('Context-menu-specific behavior', () => {
+    it('should reposition menu on second right-click while already open', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+
+      const triggerArea = screen.getByTestId('trigger-area');
+      fireEvent.contextMenu(triggerArea);
+      flush();
+
+      expect(document.querySelector('[data-testid="context-menu"]')).toBeInTheDocument();
+
+      // Right-click again while menu is open
+      fireEvent.contextMenu(triggerArea);
+      flush();
+
+      expect(document.querySelector('[data-testid="context-menu"]')).toBeInTheDocument();
+    }));
+
+    it('should not restore focus to trigger area on close', fakeAsync(async () => {
+      await render(ContextMenuDisabledItemsComponent);
+
+      const triggerArea = screen.getByTestId('trigger-area');
+      fireEvent.contextMenu(triggerArea);
+      flush();
+
+      const menuEl = document.querySelector('[data-testid="context-menu"]') as HTMLElement;
+      fireEvent.keyDown(menuEl, { key: 'Escape' });
+      flush();
+
+      expect(document.activeElement).not.toBe(triggerArea);
+    }));
+  });
+});

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger.ts
@@ -1,0 +1,116 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input, Signal } from '@angular/core';
+import { provideMenuTriggerState } from 'ng-primitives/menu';
+import {
+  coerceFlip,
+  coerceOffset,
+  coerceShift,
+  NgpFlip,
+  NgpFlipInput,
+  NgpOffset,
+  NgpOffsetInput,
+  NgpOverlayContent,
+  NgpShift,
+  NgpShiftInput,
+} from 'ng-primitives/portal';
+import { injectContextMenuConfig } from '../config/context-menu-config';
+import {
+  ngpContextMenuTrigger,
+  provideContextMenuTriggerState,
+} from './context-menu-trigger-state';
+
+/**
+ * The `NgpContextMenuTrigger` directive allows you to turn an element into a context menu trigger.
+ * Right-clicking or long-pressing the element will open the specified menu at the cursor position.
+ */
+@Directive({
+  selector: '[ngpContextMenuTrigger]',
+  exportAs: 'ngpContextMenuTrigger',
+  providers: [provideContextMenuTriggerState(), provideMenuTriggerState()],
+})
+export class NgpContextMenuTrigger<T = unknown> {
+  /**
+   * Access the global context menu configuration.
+   */
+  private readonly config = injectContextMenuConfig();
+
+  /**
+   * The menu template ref or ComponentType to display.
+   */
+  readonly menu = input<NgpOverlayContent<T>>(undefined, {
+    alias: 'ngpContextMenuTrigger',
+  });
+
+  /**
+   * Define if the trigger should be disabled.
+   * @default false
+   */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpContextMenuTriggerDisabled',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * Define the offset of the context menu relative to the cursor position.
+   * @default 2
+   */
+  readonly offset = input<NgpOffset, NgpOffsetInput>(this.config.offset, {
+    alias: 'ngpContextMenuTriggerOffset',
+    transform: coerceOffset,
+  });
+
+  /**
+   * Define whether the context menu should flip when there is not enough space.
+   * @default true
+   */
+  readonly flip = input<NgpFlip, NgpFlipInput>(this.config.flip, {
+    alias: 'ngpContextMenuTriggerFlip',
+    transform: coerceFlip,
+  });
+
+  /**
+   * Configure shift behavior to keep the context menu in view.
+   * @default undefined
+   */
+  readonly shift = input<NgpShift, NgpShiftInput>(this.config.shift, {
+    alias: 'ngpContextMenuTriggerShift',
+    transform: coerceShift,
+  });
+
+  /**
+   * Define the container in which the context menu should be attached.
+   * @default document.body
+   */
+  readonly container = input<HTMLElement | string | null>(this.config.container, {
+    alias: 'ngpContextMenuTriggerContainer',
+  });
+
+  /**
+   * Defines how the context menu behaves when the window is scrolled.
+   * @default 'close'
+   */
+  readonly scrollBehavior = input<'reposition' | 'block' | 'close'>(this.config.scrollBehavior, {
+    alias: 'ngpContextMenuTriggerScrollBehavior',
+  });
+
+  /**
+   * Provide context to the menu. This can be used to pass data to the menu content.
+   */
+  readonly context = input<T>(undefined, {
+    alias: 'ngpContextMenuTriggerContext',
+  });
+
+  /**
+   * The context menu trigger state.
+   */
+  private readonly state = ngpContextMenuTrigger<T>({
+    disabled: this.disabled,
+    menu: this.menu,
+    offset: this.offset,
+    flip: this.flip,
+    shift: this.shift(),
+    container: this.container,
+    scrollBehavior: this.scrollBehavior,
+    context: this.context as Signal<T>,
+  });
+}

--- a/packages/ng-primitives/context-menu/src/context-menu/context-menu.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu/context-menu.ts
@@ -1,0 +1,40 @@
+import { FocusOrigin } from '@angular/cdk/a11y';
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import { provideFocusTrapState } from 'ng-primitives/focus-trap';
+import { ngpMenu, provideMenuState } from 'ng-primitives/menu';
+import { ngpRovingFocusGroup, provideRovingFocusGroupState } from 'ng-primitives/roving-focus';
+
+/**
+ * The `NgpContextMenu` is a container for context menu items.
+ */
+@Directive({
+  selector: '[ngpContextMenu]',
+  exportAs: 'ngpContextMenu',
+  providers: [
+    provideRovingFocusGroupState({ inherit: false }),
+    provideMenuState({ inherit: false }),
+    provideFocusTrapState(),
+  ],
+})
+export class NgpContextMenu {
+  /**
+   * Whether focus should wrap around when reaching the end of the menu.
+   * @default true
+   */
+  readonly wrap = input<boolean, BooleanInput>(true, {
+    alias: 'ngpContextMenuWrap',
+    transform: booleanAttribute,
+  });
+
+  private readonly state = ngpMenu({ wrap: this.wrap });
+
+  constructor() {
+    ngpRovingFocusGroup({ inherit: false, wrap: this.wrap });
+  }
+
+  /** @internal Close the menu and any parent menus */
+  closeAllMenus(origin: FocusOrigin): void {
+    this.state.closeAllMenus(origin);
+  }
+}

--- a/packages/ng-primitives/context-menu/src/index.ts
+++ b/packages/ng-primitives/context-menu/src/index.ts
@@ -1,0 +1,16 @@
+export { NgpContextMenuConfig, provideContextMenuConfig } from './config/context-menu-config';
+export { NgpContextMenu } from './context-menu/context-menu';
+export { NgpContextMenuItem } from './context-menu-item/context-menu-item';
+export { NgpContextMenuItemCheckbox } from './context-menu-item-checkbox/context-menu-item-checkbox';
+export { NgpContextMenuItemIndicator } from './context-menu-item-indicator/context-menu-item-indicator';
+export { NgpContextMenuItemRadio } from './context-menu-item-radio/context-menu-item-radio';
+export { NgpContextMenuItemRadioGroup } from './context-menu-item-radio-group/context-menu-item-radio-group';
+export { NgpContextMenuSubmenuTrigger } from './context-menu-submenu-trigger/context-menu-submenu-trigger';
+export { NgpContextMenuTrigger } from './context-menu-trigger/context-menu-trigger';
+export {
+  ngpContextMenuTrigger,
+  injectContextMenuTriggerState,
+  NgpContextMenuTriggerProps,
+  NgpContextMenuTriggerState,
+  provideContextMenuTriggerState,
+} from './context-menu-trigger/context-menu-trigger-state';

--- a/packages/ng-primitives/menu/src/index.ts
+++ b/packages/ng-primitives/menu/src/index.ts
@@ -35,6 +35,7 @@ export {
 } from './menu-item-radio/menu-item-radio-state';
 export { NgpMenuTrigger, type NgpMenuPlacement } from './menu-trigger/menu-trigger';
 export {
+  NgpMenuTriggerStateToken,
   ngpMenuTrigger,
   injectMenuTriggerState,
   NgpMenuTriggerProps,
@@ -51,6 +52,7 @@ export {
 } from './menu/menu-state';
 export { NgpSubmenuTrigger } from './submenu-trigger/submenu-trigger';
 export {
+  NgpSubmenuTriggerStateToken,
   ngpSubmenuTrigger,
   injectSubmenuTriggerState,
   NgpSubmenuTriggerProps,

--- a/packages/ng-primitives/portal/src/overlay-registry.ts
+++ b/packages/ng-primitives/portal/src/overlay-registry.ts
@@ -42,6 +42,8 @@ export interface NgpOverlayEntry {
   anchorElement?: HTMLElement | null;
   /** Per-instance dismiss configuration */
   dismissPolicy: NgpDismissPolicy;
+  /** If true, clicks on the trigger element are treated as outside clicks */
+  treatTriggerClickAsOutside?: boolean;
   /** Optional subject that receives pointer events that occur outside the overlay */
   outsidePointerEvents$?: Subject<MouseEvent>;
 }
@@ -267,6 +269,14 @@ export class NgpOverlayRegistry {
       return;
     }
 
+    // Ignore right-click mouseup — right-clicks open context menus via the
+    // `contextmenu` event, and the corresponding mouseup should never dismiss
+    // an overlay. If the user right-clicks elsewhere, the new `contextmenu`
+    // event on that target will handle repositioning or reopening.
+    if (event.button === 2) {
+      return;
+    }
+
     // Ignore scrollbar clicks — the click lands outside the viewport's client area.
     const { clientWidth, clientHeight } = this.document.documentElement;
     if (
@@ -356,7 +366,8 @@ export class NgpOverlayRegistry {
    */
   private isClickOutsideEntry(entry: NgpOverlayEntry, path: EventTarget[]): boolean {
     const isInsideElements = entry.getElements().some(el => path.includes(el));
-    const isInsideTrigger = path.includes(entry.triggerElement);
+    const isInsideTrigger =
+      !entry.treatTriggerClickAsOutside && path.includes(entry.triggerElement);
     const isInsideAnchor = entry.anchorElement ? path.includes(entry.anchorElement) : false;
     return !(isInsideElements || isInsideTrigger || isInsideAnchor);
   }

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -194,6 +194,12 @@ export interface NgpOverlayConfig<T = unknown> {
   position?: Signal<NgpPosition | null>;
 
   /**
+   * If true, clicks on the trigger element count as outside clicks for dismiss purposes.
+   * Useful for context menus where the trigger area is large and clicks on it should dismiss the menu.
+   */
+  treatTriggerClickAsOutside?: boolean;
+
+  /**
    * Overlay type identifier for cooldown grouping.
    * When set, overlays of the same type share a cooldown period.
    * For example, 'tooltip' ensures quickly moving between tooltips shows
@@ -789,6 +795,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
         outsidePress: this.config.closeOnOutsideClick ?? false,
         escapeKey: this.config.closeOnEscape ?? false,
       },
+      treatTriggerClickAsOutside: this.config.treatTriggerClickAsOutside,
     });
 
     // Register as active overlay for this type (skip when cooldown is bypassed)

--- a/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu-item.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import { NgpContextMenuItem } from 'ng-primitives/context-menu';
+
+@Component({
+  selector: 'button[<%= prefix %>-context-menu-item]',
+  hostDirectives: [NgpContextMenuItem],
+  template: `
+    <ng-content />
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 8px 6px 14px;
+      border: none;
+      background: none;
+      cursor: pointer;
+      transition: background-color 0.2s;
+      border-radius: 4px;
+      min-width: 120px;
+      text-align: start;
+      outline: none;
+      font-size: 14px;
+      font-weight: 400;
+    }
+
+    :host[data-hover] {
+      background-color: var(--ngp-background-active);
+    }
+
+    :host[data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      z-index: 1;
+    }
+  `,
+})
+export class ContextMenuItem<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,53 @@
+import { Component } from '@angular/core';
+import { NgpContextMenu } from 'ng-primitives/context-menu';
+
+@Component({
+  selector: '<%= prefix %>-context-menu',
+  hostDirectives: [NgpContextMenu],
+  template: `
+    <ng-content />
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host {
+      position: fixed;
+      display: flex;
+      flex-direction: column;
+      width: max-content;
+      background: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      box-shadow: var(--ngp-shadow);
+      border-radius: 8px;
+      padding: 4px;
+      animation: menu-show 300ms ease-out;
+    }
+
+    :host[data-exit] {
+      animation: menu-hide 300ms ease-out;
+    }
+
+    @keyframes menu-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes menu-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+  `,
+})
+export class ContextMenu<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip-trigger.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip-trigger.__fileSuffix@dasherize__.ts.template
@@ -16,6 +16,7 @@ import { Tooltip } from './tooltip';
         'ngpTooltipTriggerFlip:appTooltipTriggerFlip',
         'ngpTooltipTriggerContainer:appTooltipTriggerContainer',
         'ngpTooltipTriggerShowOnOverflow:appTooltipTriggerShowOnOverflow',
+        'ngpTooltipTriggerHoverableContent:appTooltipTriggerHoverableContent',
         'ngpTooltipTriggerContext:appTooltipTrigger',
       ],
     },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -66,7 +66,8 @@
       "ng-primitives/utils": ["packages/ng-primitives/utils/src/index.ts"],
       "@ng-primitives/mcp": ["packages/mcp/src/index.ts"],
       "ng-primitives/navigation-menu": ["packages/ng-primitives/navigation-menu/src/index.ts"],
-      "ng-primitives/number-field": ["packages/ng-primitives/number-field/src/index.ts"]
+      "ng-primitives/number-field": ["packages/ng-primitives/number-field/src/index.ts"],
+      "ng-primitives/context-menu": ["packages/ng-primitives/context-menu/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `ng-primitives/context-menu` for right‑click and long‑press menus with submenus, checkbox/radio items, and full ARIA/keyboard support. Updates overlay behavior and animations, and restores native iOS callout on disabled triggers.

- **New Features**
  - Directives: `NgpContextMenuTrigger`, `NgpContextMenu`, item/checkbox/radio + indicator, and submenu trigger.
  - Cursor‑positioned overlay on right‑click/long‑press; repositions on repeat right‑click; ignores right‑click mouseup; can treat trigger clicks as outside to dismiss.
  - Keyboard navigation and focus management (Arrow/Home/End, focus trap, roving focus) with ARIA roles and `data-*` hooks; CSS var `--ngp-menu-transform-origin` with examples/reusable component using transform‑origin; global config via `provideContextMenuConfig` (`offset`, `flip`, `shift`, `container`, `scrollBehavior`); docs, examples (standard/Tailwind/submenu), and schematics.

- **Bug Fixes**
  - iOS long‑press: use only `-webkit-touch-callout: none` to suppress the native menu without breaking scroll or selection.
  - Disabled triggers: allow the native browser context menu and restore native iOS callout; update docs to use `[ngpContextMenu][data-enter/exit]` for animations.

<sup>Written for commit 46d783bbf9d260aa239414c93acc69d1a4ab485a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

