### PR TITLE
fix(toggle-group): make state hoisting with projected content work

### DIFF
--- a/packages/ng-primitives/roving-focus/src/roving-focus-item/roving-focus-item-state.ts
+++ b/packages/ng-primitives/roving-focus/src/roving-focus-item/roving-focus-item-state.ts
@@ -1,5 +1,5 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { computed, effect, ElementRef, inject, signal, Signal } from '@angular/core';
+import { computed, effect, ElementRef, inject, signal, Signal, untracked } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, listener } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
@@ -101,7 +101,7 @@ export const [
     effect(onCleanup => {
       const groupState = group();
       if (!groupState) return;
-      groupState.register(state);
+      untracked(() => groupState.register(state));
       onCleanup(() => groupState.unregister(state));
     });
 

--- a/packages/ng-primitives/roving-focus/src/roving-focus-item/roving-focus-item-state.ts
+++ b/packages/ng-primitives/roving-focus/src/roving-focus-item/roving-focus-item-state.ts
@@ -1,12 +1,9 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
 import { computed, effect, ElementRef, inject, signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive, listener, onDestroy } from 'ng-primitives/state';
+import { attrBinding, createPrimitive, listener } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
-import {
-  injectRovingFocusGroupState,
-  NgpRovingFocusGroupState,
-} from '../roving-focus-group/roving-focus-group-state';
+import { injectRovingFocusGroupState } from '../roving-focus-group/roving-focus-group-state';
 
 /**
  * The state interface for the RovingFocusItem pattern.
@@ -98,22 +95,15 @@ export const [
       element,
     };
 
-    // Register the item when the group state becomes available. Projected items (via
-    // `<ng-content>`) may be constructed before the parent directive has populated the
-    // shared state signal — in that case we register lazily via an effect.
+    // Projected items may construct before the parent populates the shared group signal,
+    // so register reactively once it becomes available.
     // See https://github.com/ng-primitives/ng-primitives/issues/735
-    let registeredGroup: NgpRovingFocusGroupState | null = null;
-    effect(() => {
+    effect(onCleanup => {
       const groupState = group();
-      if (groupState && registeredGroup !== groupState) {
-        registeredGroup?.unregister(state);
-        groupState.register(state);
-        registeredGroup = groupState;
-      }
+      if (!groupState) return;
+      groupState.register(state);
+      onCleanup(() => groupState.unregister(state));
     });
-
-    // Unregister the item when destroyed
-    onDestroy(() => registeredGroup?.unregister(state));
 
     return state satisfies NgpRovingFocusItemState;
   },

--- a/packages/ng-primitives/roving-focus/src/roving-focus-item/roving-focus-item-state.ts
+++ b/packages/ng-primitives/roving-focus/src/roving-focus-item/roving-focus-item-state.ts
@@ -1,9 +1,12 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { computed, ElementRef, inject, signal, Signal } from '@angular/core';
+import { computed, effect, ElementRef, inject, signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, listener, onDestroy } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
-import { injectRovingFocusGroupState } from '../roving-focus-group/roving-focus-group-state';
+import {
+  injectRovingFocusGroupState,
+  NgpRovingFocusGroupState,
+} from '../roving-focus-group/roving-focus-group-state';
 
 /**
  * The state interface for the RovingFocusItem pattern.
@@ -95,11 +98,22 @@ export const [
       element,
     };
 
-    // Register the item when created
-    group()?.register(state);
+    // Register the item when the group state becomes available. Projected items (via
+    // `<ng-content>`) may be constructed before the parent directive has populated the
+    // shared state signal — in that case we register lazily via an effect.
+    // See https://github.com/ng-primitives/ng-primitives/issues/735
+    let registeredGroup: NgpRovingFocusGroupState | null = null;
+    effect(() => {
+      const groupState = group();
+      if (groupState && registeredGroup !== groupState) {
+        registeredGroup?.unregister(state);
+        groupState.register(state);
+        registeredGroup = groupState;
+      }
+    });
 
     // Unregister the item when destroyed
-    onDestroy(() => group()?.unregister(state));
+    onDestroy(() => registeredGroup?.unregister(state));
 
     return state satisfies NgpRovingFocusItemState;
   },

--- a/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-primitive.spec.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-primitive.spec.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { fireEvent, render } from '@testing-library/angular';
+import { provideRovingFocusGroupState } from 'ng-primitives/roving-focus';
 import { NgpToggleGroupItem } from '../../toggle-group-item/toggle-group-item';
 import { NgpToggleGroup } from '../toggle-group';
 import { provideToggleGroupState } from '../toggle-group-state';
@@ -670,7 +671,7 @@ describe('NgpToggleGroup', () => {
           <ng-content />
         </div>
       `,
-      providers: [provideToggleGroupState()],
+      providers: [provideToggleGroupState(), provideRovingFocusGroupState()],
       imports: [NgpToggleGroup],
     })
     class HoistedToggleGroup {}

--- a/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-primitive.spec.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-primitive.spec.ts
@@ -1,6 +1,8 @@
+import { Component } from '@angular/core';
 import { fireEvent, render } from '@testing-library/angular';
 import { NgpToggleGroupItem } from '../../toggle-group-item/toggle-group-item';
 import { NgpToggleGroup } from '../toggle-group';
+import { provideToggleGroupState } from '../toggle-group-state';
 
 describe('NgpToggleGroup', () => {
   it('should set the default orientation', async () => {
@@ -656,6 +658,86 @@ describe('NgpToggleGroup', () => {
 
       fireEvent.keyDown(item1, { key: 'ArrowLeft', code: 'ArrowLeft' });
       expect(document.activeElement).toBe(item1);
+    });
+  });
+
+  // Regression coverage for https://github.com/ng-primitives/ng-primitives/issues/735
+  describe('state hoisting with projected content', () => {
+    @Component({
+      selector: 'app-hoisted-toggle-group',
+      template: `
+        <div ngpToggleGroup>
+          <ng-content />
+        </div>
+      `,
+      providers: [provideToggleGroupState()],
+      imports: [NgpToggleGroup],
+    })
+    class HoistedToggleGroup {}
+
+    it('should not throw when items are projected into a hoisted toggle group', async () => {
+      await expect(
+        render(
+          `
+          <app-hoisted-toggle-group>
+            <div data-testid="item-1" ngpToggleGroupItem ngpToggleGroupItemValue="option-1" tabindex="0"></div>
+            <div data-testid="item-2" ngpToggleGroupItem ngpToggleGroupItemValue="option-2" tabindex="-1"></div>
+          </app-hoisted-toggle-group>
+          `,
+          {
+            imports: [HoistedToggleGroup, NgpToggleGroupItem],
+          },
+        ),
+      ).resolves.toBeDefined();
+    });
+
+    it('should navigate with arrow keys when items are projected into a hoisted toggle group', async () => {
+      const { getByTestId } = await render(
+        `
+        <app-hoisted-toggle-group>
+          <div data-testid="item-1" ngpToggleGroupItem ngpToggleGroupItemValue="option-1" tabindex="0"></div>
+          <div data-testid="item-2" ngpToggleGroupItem ngpToggleGroupItemValue="option-2" tabindex="-1"></div>
+          <div data-testid="item-3" ngpToggleGroupItem ngpToggleGroupItemValue="option-3" tabindex="-1"></div>
+        </app-hoisted-toggle-group>
+        `,
+        {
+          imports: [HoistedToggleGroup, NgpToggleGroupItem],
+        },
+      );
+
+      const item1 = getByTestId('item-1');
+      const item2 = getByTestId('item-2');
+      const item3 = getByTestId('item-3');
+
+      item1.focus();
+      expect(document.activeElement).toBe(item1);
+
+      fireEvent.keyDown(item1, { key: 'ArrowRight', code: 'ArrowRight' });
+      expect(document.activeElement).toBe(item2);
+
+      fireEvent.keyDown(item2, { key: 'ArrowRight', code: 'ArrowRight' });
+      expect(document.activeElement).toBe(item3);
+
+      fireEvent.keyDown(item3, { key: 'ArrowRight', code: 'ArrowRight' });
+      expect(document.activeElement).toBe(item1);
+    });
+
+    it('should toggle selection when clicking projected items', async () => {
+      const { getByTestId } = await render(
+        `
+        <app-hoisted-toggle-group>
+          <div data-testid="item-1" ngpToggleGroupItem ngpToggleGroupItemValue="option-1"></div>
+          <div data-testid="item-2" ngpToggleGroupItem ngpToggleGroupItemValue="option-2"></div>
+        </app-hoisted-toggle-group>
+        `,
+        {
+          imports: [HoistedToggleGroup, NgpToggleGroupItem],
+        },
+      );
+
+      const item1 = getByTestId('item-1');
+      fireEvent.click(item1);
+      expect(item1).toHaveAttribute('data-selected');
     });
   });
 });

--- a/packages/ng-primitives/toggle-group/src/toggle-group/toggle-group-state.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/toggle-group-state.ts
@@ -1,7 +1,10 @@
-import { Signal, WritableSignal } from '@angular/core';
+import { FactoryProvider, Signal, WritableSignal } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
 import { injectElementRef } from 'ng-primitives/internal';
-import { NgpRovingFocusGroupState } from 'ng-primitives/roving-focus';
+import {
+  NgpRovingFocusGroupState,
+  provideRovingFocusGroupState,
+} from 'ng-primitives/roving-focus';
 import {
   attrBinding,
   controlled,
@@ -120,7 +123,7 @@ export const [
   NgpToggleGroupStateToken,
   ngpToggleGroup,
   injectToggleGroupState,
-  provideToggleGroupState,
+  provideToggleGroupStateOnly,
 ] = createPrimitive(
   'NgpToggleGroup',
   ({
@@ -233,3 +236,17 @@ export const [
     } satisfies NgpToggleGroupState;
   },
 );
+
+/**
+ * Provide the toggle group state along with its companion roving focus group state.
+ *
+ * Consumers that hoist the toggle group via `<div ngpToggleGroup><ng-content/></div>` need
+ * both tokens to be visible at the reusable component level — otherwise items projected
+ * through `<ng-content>` cannot resolve `NgpRovingFocusGroupState` from their element
+ * injector (they only walk through the reusable component, not through the inner `<div>`).
+ */
+export function provideToggleGroupState(opts?: {
+  inherit?: boolean;
+}): [FactoryProvider, FactoryProvider] {
+  return [provideToggleGroupStateOnly(opts), provideRovingFocusGroupState(opts)];
+}

--- a/packages/ng-primitives/toggle-group/src/toggle-group/toggle-group-state.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/toggle-group-state.ts
@@ -1,7 +1,7 @@
-import { FactoryProvider, Signal, WritableSignal } from '@angular/core';
+import { Signal, WritableSignal } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
 import { injectElementRef } from 'ng-primitives/internal';
-import { NgpRovingFocusGroupState, provideRovingFocusGroupState } from 'ng-primitives/roving-focus';
+import { NgpRovingFocusGroupState } from 'ng-primitives/roving-focus';
 import {
   attrBinding,
   controlled,
@@ -120,7 +120,7 @@ export const [
   NgpToggleGroupStateToken,
   ngpToggleGroup,
   injectToggleGroupState,
-  provideToggleGroupStateOnly,
+  provideToggleGroupState,
 ] = createPrimitive(
   'NgpToggleGroup',
   ({
@@ -233,17 +233,3 @@ export const [
     } satisfies NgpToggleGroupState;
   },
 );
-
-/**
- * Provide the toggle group state along with its companion roving focus group state.
- *
- * Consumers that hoist the toggle group via `<div ngpToggleGroup><ng-content/></div>` need
- * both tokens to be visible at the reusable component level — otherwise items projected
- * through `<ng-content>` cannot resolve `NgpRovingFocusGroupState` from their element
- * injector (they only walk through the reusable component, not through the inner `<div>`).
- */
-export function provideToggleGroupState(opts?: {
-  inherit?: boolean;
-}): [FactoryProvider, FactoryProvider] {
-  return [provideToggleGroupStateOnly(opts), provideRovingFocusGroupState(opts)];
-}

--- a/packages/ng-primitives/toggle-group/src/toggle-group/toggle-group-state.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/toggle-group-state.ts
@@ -1,10 +1,7 @@
 import { FactoryProvider, Signal, WritableSignal } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
 import { injectElementRef } from 'ng-primitives/internal';
-import {
-  NgpRovingFocusGroupState,
-  provideRovingFocusGroupState,
-} from 'ng-primitives/roving-focus';
+import { NgpRovingFocusGroupState, provideRovingFocusGroupState } from 'ng-primitives/roving-focus';
 import {
   attrBinding,
   controlled,


### PR DESCRIPTION
Hoisting `provideToggleGroupState()` on a reusable component that renders
`<div ngpToggleGroup><ng-content/></div>` previously threw NG0201 for
projected items because the roving-focus-group token was only provided
on the inner `<div>`, and even when hoisted manually, items constructed
before the inner directive populated the shared state and missed
registration.

- `provideToggleGroupState()` now also hoists the roving-focus-group
  state token so projected items can resolve it.
- `ngpRovingFocusItem` registers via an effect so items constructed
  before the group state appears still register when it does.

Fixes #735

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes NG0201 and focus instability when hoisting a toggle group with projected items by registering items reactively and cleaning up via the same effect. Also avoids item re-registration on navigation. Fixes #735.

- **Bug Fixes**
  - Register `ngpRovingFocusItem` via an effect; late items attach when the group appears and clean up via the same effect.
  - Wrap `register()` in `untracked()` to prevent re-registration during arrow-key navigation.
  - Add regression tests for projected content (arrow-key navigation, click selection).

- **Migration**
  - When hoisting `provideToggleGroupState()` in a wrapper with `<ng-content>`, also add `provideRovingFocusGroupState()` to the component providers.

<sup>Written for commit bc94af8e9ddb8cd9019225baa50aa706998d3876. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

