### PR TITLE
feat(checkbox): support defaultChecked for uncontrolled usage

### DIFF
--- a/apps/documentation/src/app/examples/checkbox/checkbox-default-checked.example.ts
+++ b/apps/documentation/src/app/examples/checkbox/checkbox-default-checked.example.ts
@@ -1,0 +1,57 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheckMini } from '@ng-icons/heroicons/mini';
+import { NgpCheckbox } from 'ng-primitives/checkbox';
+
+@Component({
+  selector: 'app-checkbox-default-checked',
+  imports: [NgIcon, NgpCheckbox],
+  providers: [provideIcons({ heroCheckMini })],
+  styles: `
+    [ngpCheckbox] {
+      display: flex;
+      width: 1.25rem;
+      height: 1.25rem;
+      cursor: pointer;
+      align-items: center;
+      justify-content: center;
+      border-radius: 0.25rem;
+      border: 1px solid var(--ngp-border);
+      background-color: transparent;
+      padding: 0;
+      outline: none;
+      flex: none;
+      color: var(--ngp-text-inverse);
+      font-size: 0.75rem;
+    }
+
+    [ngpCheckbox][data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpCheckbox][data-checked],
+    [ngpCheckbox][data-indeterminate] {
+      border-color: var(--ngp-background-inverse);
+      background-color: var(--ngp-background-inverse);
+    }
+
+    [ngpCheckbox][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    ng-icon {
+      display: none;
+    }
+
+    [ngpCheckbox][data-checked] ng-icon {
+      display: block;
+    }
+  `,
+  template: `
+    <span ngpCheckbox ngpCheckboxDefaultChecked>
+      <ng-icon name="heroCheckMini" aria-hidden="true" />
+    </span>
+  `,
+})
+export default class CheckboxDefaultCheckedExample {}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
@@ -53,6 +53,12 @@ ng g ng-primitives:primitive checkbox
 
 Here are some additional examples of how to use the Checkbox primitives.
 
+### Default Checked
+
+Use `ngpCheckboxDefaultChecked` to set the initial checked state in uncontrolled mode.
+
+<docs-example name="checkbox-default-checked"></docs-example>
+
 ### Checkbox Form Field
 
 The checkbox automatically integrates with the form field primitives.

--- a/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
@@ -57,6 +57,8 @@ Here are some additional examples of how to use the Checkbox primitives.
 
 Use `ngpCheckboxDefaultChecked` to set the initial checked state in uncontrolled mode.
 
+Binding `[ngpCheckboxChecked]` makes it controlled; if omitted (`undefined`), it stays uncontrolled.
+
 <docs-example name="checkbox-default-checked"></docs-example>
 
 ### Checkbox Form Field

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
@@ -5,11 +5,13 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   dataBinding,
   deprecatedSetter,
   emitter,
   listener,
+  SetterOptions,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { Observable } from 'rxjs';
@@ -49,7 +51,11 @@ export interface NgpCheckboxState {
   /**
    * Update the checked value.
    */
-  setChecked(value: boolean): void;
+  setChecked(value: boolean, options?: SetterOptions): void;
+  /**
+   * Set the default checked state.
+   */
+  setDefaultChecked(value: boolean): void;
   /**
    * Update the indeterminate value.
    */
@@ -71,7 +77,11 @@ export interface NgpCheckboxProps {
   /**
    * Whether the checkbox is checked.
    */
-  readonly checked?: Signal<boolean>;
+  readonly checked?: Signal<boolean | undefined>;
+  /**
+   * The default checked state for uncontrolled usage.
+   */
+  readonly defaultChecked?: Signal<boolean>;
   /**
    * Whether the checkbox is indeterminate.
    */
@@ -95,17 +105,22 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
     'NgpCheckbox',
     ({
       id = signal(uniqueId('ngp-checkbox')),
-      checked: _checked = signal(false),
+      checked: _checked = signal<boolean | undefined>(undefined),
+      defaultChecked: _defaultChecked,
       indeterminate: _indeterminate = signal(false),
       disabled: _disabled = signal(false),
       onCheckedChange,
       onIndeterminateChange,
     }: NgpCheckboxProps): NgpCheckboxState => {
       const element = injectElementRef();
-      const checked = controlled(_checked);
+      const defaultChecked = controlled(_defaultChecked, false);
+      const [checked, setChecked, checkedChange] = controlledState({
+        value: _checked,
+        defaultValue: defaultChecked,
+        onChange: onCheckedChange,
+      });
       const indeterminate = controlled(_indeterminate);
       const disabled = controlled(_disabled);
-      const checkedChange = emitter<boolean>();
       const indeterminateChange = emitter<boolean>();
       const tabindex = computed(() => (disabled() ? -1 : 0));
 
@@ -152,12 +167,6 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
         }
       }
 
-      function setChecked(value: boolean): void {
-        checked.set(value);
-        onCheckedChange?.(value);
-        checkedChange.emit(value);
-      }
-
       function setIndeterminate(value: boolean): void {
         indeterminate.set(value);
         onIndeterminateChange?.(value);
@@ -170,13 +179,14 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
 
       return {
         id,
-        checked: deprecatedSetter(checked, 'setChecked'),
+        checked: deprecatedSetter(checked, 'setChecked', setChecked),
         indeterminate: deprecatedSetter(indeterminate, 'setIndeterminate'),
         disabled: deprecatedSetter(disabled, 'setDisabled'),
-        checkedChange: checkedChange.asObservable(),
+        checkedChange,
         indeterminateChange: indeterminateChange.asObservable(),
         toggle,
         setChecked,
+        setDefaultChecked: defaultChecked.set,
         setIndeterminate,
         setDisabled,
       } satisfies NgpCheckboxState;

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox.spec.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox.spec.ts
@@ -1,3 +1,4 @@
+import { By } from '@angular/platform-browser';
 import { RenderResult, fireEvent, render, screen } from '@testing-library/angular';
 import { NgpCheckbox } from './checkbox';
 
@@ -121,6 +122,62 @@ describe('NgpCheckbox', () => {
       fireEvent.click(container.getByRole('checkbox'));
       expect(checkedChange).toHaveBeenCalledWith(true);
       expect(indeterminateChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('controlled mode', () => {
+    it('should update the DOM when controlled value changes via two-way binding on click', async () => {
+      await render(`<div ngpCheckbox [(ngpCheckboxChecked)]="checked"></div>`, {
+        imports: [NgpCheckbox],
+        componentProperties: { checked: false },
+      });
+
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.click(checkbox);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+      expect(checkbox).toHaveAttribute('data-checked', '');
+
+      fireEvent.click(checkbox);
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+      expect(checkbox).not.toHaveAttribute('data-checked');
+    });
+
+    it('should emit checkedChange on click but not update DOM without parent updating binding', async () => {
+      const spy = jest.fn();
+
+      await render(
+        `<div ngpCheckbox [ngpCheckboxChecked]="false" (ngpCheckboxCheckedChange)="onChange($event)"></div>`,
+        { imports: [NgpCheckbox], componentProperties: { onChange: spy } },
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      fireEvent.click(checkbox);
+
+      expect(spy).toHaveBeenCalledWith(true);
+      // DOM must stay at the controlled value — no internal divergence
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('should update state silently without emitting checkedChange when emit: false', async () => {
+      const spy = jest.fn();
+      const { fixture } = await render(
+        `<div ngpCheckbox (ngpCheckboxCheckedChange)="onChange($event)"></div>`,
+        { imports: [NgpCheckbox], componentProperties: { onChange: spy } },
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      const directive = fixture.debugElement
+        .query(By.directive(NgpCheckbox))
+        .injector.get(NgpCheckbox);
+      directive.setChecked(true, { emit: false });
+      fixture.detectChanges();
+
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox.spec.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox.spec.ts
@@ -1,41 +1,41 @@
-import { RenderResult, fireEvent, render } from '@testing-library/angular';
+import { RenderResult, fireEvent, render, screen } from '@testing-library/angular';
 import { NgpCheckbox } from './checkbox';
 
 describe('NgpCheckbox', () => {
-  let container: RenderResult<unknown, unknown>;
-  let checkbox: HTMLElement;
-  let checkedChange: jest.Mock;
-  let indeterminateChange: jest.Mock;
-
-  beforeEach(async () => {
-    checkedChange = jest.fn();
-    indeterminateChange = jest.fn();
-
-    container = await render(
-      `<div
-        ngpCheckbox
-        [(ngpCheckboxChecked)]="checked"
-        [ngpCheckboxIndeterminate]="indeterminate"
-        (ngpCheckboxCheckedChange)="checkedChange($event)"
-        (ngpCheckboxIndeterminateChange)="indeterminateChange($event)"
-        [ngpCheckboxDisabled]="disabled">
-      </div>`,
-      {
-        imports: [NgpCheckbox],
-        componentProperties: {
-          checked: false,
-          indeterminate: false,
-          disabled: false,
-          checkedChange,
-          indeterminateChange,
-        },
-      },
-    );
-
-    checkbox = container.getByRole('checkbox');
-  });
-
   describe('checkbox', () => {
+    let container: RenderResult<unknown, unknown>;
+    let checkbox: HTMLElement;
+    let checkedChange: jest.Mock;
+    let indeterminateChange: jest.Mock;
+
+    beforeEach(async () => {
+      checkedChange = jest.fn();
+      indeterminateChange = jest.fn();
+
+      container = await render(
+        `<div
+          ngpCheckbox
+          [(ngpCheckboxChecked)]="checked"
+          [ngpCheckboxIndeterminate]="indeterminate"
+          (ngpCheckboxCheckedChange)="checkedChange($event)"
+          (ngpCheckboxIndeterminateChange)="indeterminateChange($event)"
+          [ngpCheckboxDisabled]="disabled">
+        </div>`,
+        {
+          imports: [NgpCheckbox],
+          componentProperties: {
+            checked: false,
+            indeterminate: false,
+            disabled: false,
+            checkedChange,
+            indeterminateChange,
+          },
+        },
+      );
+
+      checkbox = container.getByRole('checkbox');
+    });
+
     it('should have a role of checkbox', () => {
       expect(checkbox).toHaveAttribute('role', 'checkbox');
     });
@@ -121,6 +121,79 @@ describe('NgpCheckbox', () => {
       fireEvent.click(container.getByRole('checkbox'));
       expect(checkedChange).toHaveBeenCalledWith(true);
       expect(indeterminateChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('defaultChecked (uncontrolled)', () => {
+    it('should initialize as unchecked when no defaultChecked is provided', async () => {
+      await render(`<div ngpCheckbox></div>`, { imports: [NgpCheckbox] });
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+      expect(checkbox).not.toHaveAttribute('data-checked');
+    });
+
+    it('should initialize as checked when defaultChecked is true', async () => {
+      await render(`<div ngpCheckbox ngpCheckboxDefaultChecked></div>`, { imports: [NgpCheckbox] });
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+      expect(checkbox).toHaveAttribute('data-checked', '');
+    });
+
+    it('should toggle from defaultChecked state on click', async () => {
+      const spy = jest.fn();
+      await render(
+        `<div ngpCheckbox ngpCheckboxDefaultChecked (ngpCheckboxCheckedChange)="onChange($event)"></div>`,
+        { imports: [NgpCheckbox], componentProperties: { onChange: spy } },
+      );
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(checkbox);
+      expect(spy).toHaveBeenCalledWith(false);
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.click(checkbox);
+      expect(spy).toHaveBeenCalledWith(true);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('should not reset internal state when parent re-renders with same defaultChecked', async () => {
+      const spy = jest.fn();
+      const { rerender } = await render(
+        `<div ngpCheckbox [ngpCheckboxDefaultChecked]="defaultChecked" (ngpCheckboxCheckedChange)="onChange($event)"></div>`,
+        { imports: [NgpCheckbox], componentProperties: { defaultChecked: true, onChange: spy } },
+      );
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(checkbox);
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      await rerender({ componentProperties: { defaultChecked: true, onChange: spy } });
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('should resolve indeterminate to checked then unchecked uncontrolled', async () => {
+      const checkedSpy = jest.fn();
+      const indeterminateSpy = jest.fn();
+      await render(
+        `<div ngpCheckbox [ngpCheckboxIndeterminate]="indeterminate" (ngpCheckboxCheckedChange)="onChecked($event)" (ngpCheckboxIndeterminateChange)="onIndeterminate($event)"></div>`,
+        {
+          imports: [NgpCheckbox],
+          componentProperties: {
+            indeterminate: true,
+            onChecked: checkedSpy,
+            onIndeterminate: indeterminateSpy,
+          },
+        },
+      );
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'mixed');
+
+      fireEvent.click(checkbox);
+      expect(checkedSpy).toHaveBeenCalledWith(true);
+      expect(indeterminateSpy).toHaveBeenCalledWith(false);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
     });
   });
 });

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox.spec.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox.spec.ts
@@ -173,6 +173,71 @@ describe('NgpCheckbox', () => {
       expect(checkbox).toHaveAttribute('aria-checked', 'false');
     });
 
+    it('should not reset internal state when defaultChecked changes after user interaction', async () => {
+      const spy = jest.fn();
+      const { rerender } = await render(
+        `<div ngpCheckbox [ngpCheckboxDefaultChecked]="defaultChecked" (ngpCheckboxCheckedChange)="onChange($event)"></div>`,
+        { imports: [NgpCheckbox], componentProperties: { defaultChecked: true, onChange: spy } },
+      );
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(checkbox);
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      // Parent changes defaultChecked to false — should NOT reset user's state
+      await rerender({ componentProperties: { defaultChecked: false, onChange: spy } });
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.click(checkbox);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      // Parent changes defaultChecked back to true — should NOT reset
+      await rerender({ componentProperties: { defaultChecked: true, onChange: spy } });
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('should not toggle when disabled in uncontrolled mode', async () => {
+      const spy = jest.fn();
+      await render(
+        `<div ngpCheckbox ngpCheckboxDefaultChecked [ngpCheckboxDisabled]="true" (ngpCheckboxCheckedChange)="onChange($event)"></div>`,
+        { imports: [NgpCheckbox], componentProperties: { onChange: spy } },
+      );
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(checkbox);
+      expect(spy).not.toHaveBeenCalled();
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('should use controlled checked over defaultChecked when both provided', async () => {
+      await render(
+        `<div ngpCheckbox [ngpCheckboxChecked]="false" ngpCheckboxDefaultChecked></div>`,
+        { imports: [NgpCheckbox] },
+      );
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('should toggle on click with no defaultChecked and no checked binding', async () => {
+      const spy = jest.fn();
+      await render(`<div ngpCheckbox (ngpCheckboxCheckedChange)="onChange($event)"></div>`, {
+        imports: [NgpCheckbox],
+        componentProperties: { onChange: spy },
+      });
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      fireEvent.click(checkbox);
+      expect(spy).toHaveBeenCalledWith(true);
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(checkbox);
+      expect(spy).toHaveBeenCalledWith(false);
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    });
+
     it('should resolve indeterminate to checked then unchecked uncontrolled', async () => {
       const checkedSpy = jest.fn();
       const indeterminateSpy = jest.fn();

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox.spec.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox.spec.ts
@@ -158,6 +158,7 @@ describe('NgpCheckbox', () => {
       expect(spy).toHaveBeenCalledWith(true);
       // DOM must stay at the controlled value — no internal divergence
       expect(checkbox).toHaveAttribute('aria-checked', 'false');
+      expect(checkbox).not.toHaveAttribute('data-checked');
     });
   });
 

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox.spec.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox.spec.ts
@@ -159,26 +159,6 @@ describe('NgpCheckbox', () => {
       // DOM must stay at the controlled value — no internal divergence
       expect(checkbox).toHaveAttribute('aria-checked', 'false');
     });
-
-    it('should update state silently without emitting checkedChange when emit: false', async () => {
-      const spy = jest.fn();
-      const { fixture } = await render(
-        `<div ngpCheckbox (ngpCheckboxCheckedChange)="onChange($event)"></div>`,
-        { imports: [NgpCheckbox], componentProperties: { onChange: spy } },
-      );
-
-      const checkbox = screen.getByRole('checkbox');
-      expect(checkbox).toHaveAttribute('aria-checked', 'false');
-
-      const directive = fixture.debugElement
-        .query(By.directive(NgpCheckbox))
-        .injector.get(NgpCheckbox);
-      directive.setChecked(true, { emit: false });
-      fixture.detectChanges();
-
-      expect(checkbox).toHaveAttribute('aria-checked', 'true');
-      expect(spy).not.toHaveBeenCalled();
-    });
   });
 
   describe('defaultChecked (uncontrolled)', () => {
@@ -295,6 +275,26 @@ describe('NgpCheckbox', () => {
       expect(checkbox).toHaveAttribute('aria-checked', 'false');
     });
 
+    it('should update state silently without emitting checkedChange when emit: false', async () => {
+      const spy = jest.fn();
+      const { fixture } = await render(
+        `<div ngpCheckbox (ngpCheckboxCheckedChange)="onChange($event)"></div>`,
+        { imports: [NgpCheckbox], componentProperties: { onChange: spy } },
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+      const directive = fixture.debugElement
+        .query(By.directive(NgpCheckbox))
+        .injector.get(NgpCheckbox);
+      directive.setChecked(true, { emit: false });
+      fixture.detectChanges();
+
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+      expect(spy).not.toHaveBeenCalled();
+    });
+
     it('should resolve indeterminate to checked then unchecked uncontrolled', async () => {
       const checkedSpy = jest.fn();
       const indeterminateSpy = jest.fn();
@@ -316,6 +316,10 @@ describe('NgpCheckbox', () => {
       expect(checkedSpy).toHaveBeenCalledWith(true);
       expect(indeterminateSpy).toHaveBeenCalledWith(false);
       expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(checkbox);
+      expect(checkedSpy).toHaveBeenCalledWith(false);
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
     });
   });
 });

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox.ts
@@ -1,5 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import { Directive, booleanAttribute, input, output } from '@angular/core';
+import { SetterOptions } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { ngpCheckbox, provideCheckboxState } from './checkbox-state';
 
@@ -20,8 +21,17 @@ export class NgpCheckbox {
   /**
    * Defines whether the checkbox is checked.
    */
-  readonly checked = input<boolean, BooleanInput>(false, {
+  readonly checked = input<boolean | undefined, BooleanInput>(undefined, {
     alias: 'ngpCheckboxChecked',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * The default checked state for uncontrolled usage.
+   * @default false
+   */
+  readonly defaultChecked = input<boolean, BooleanInput>(false, {
+    alias: 'ngpCheckboxDefaultChecked',
     transform: booleanAttribute,
   });
 
@@ -69,6 +79,7 @@ export class NgpCheckbox {
   protected readonly state = ngpCheckbox({
     id: this.id,
     checked: this.checked,
+    defaultChecked: this.defaultChecked,
     indeterminate: this.indeterminate,
     disabled: this.disabled,
     onCheckedChange: value => this.checkedChange.emit(value),
@@ -82,8 +93,15 @@ export class NgpCheckbox {
   /**
    * Update the checked value.
    */
-  setChecked(value: boolean): void {
-    this.state.setChecked(value);
+  setChecked(value: boolean, options?: SetterOptions): void {
+    this.state.setChecked(value, options);
+  }
+
+  /**
+   * Set the default checked state.
+   */
+  setDefaultChecked(value: boolean): void {
+    this.state.setDefaultChecked(value);
   }
 
   /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

## What does this PR implement/fix?

Applies the controlled/uncontrolled pattern introduced for `NgpToggle` in #723 to `NgpCheckbox`. (original issue: #722)

- Adds `ngpCheckboxDefaultChecked` input to set the initial checked state in uncontrolled mode
- Migrates the `checked` state from `controlled()` + manual `emitter()` to `controlledState()`, matching the toggle implementation
- Adds `SetterOptions` to `setChecked()` to support silent CVA writes (`emit: false`)
- Exposes `setDefaultChecked()` method on both the directive and the state interface
- Scopes the existing `beforeEach` inside a nested `describe` to allow uncontrolled tests to call `render()` independently

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

`ngpCheckboxChecked` now defaults to `undefined` instead of `false`. This allows distinguishing "not bound" (uncontrolled) from "bound to false" (controlled). The resolved state always returns a boolean, so consumers reading the checkbox state are unaffected.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds uncontrolled usage to `NgpCheckbox` via `ngpCheckboxDefaultChecked`, aligned with `NgpToggle`. Migrates internals to `controlledState`, updates docs, and expands tests (including asserting no `data-checked` when controlled value is `false`).

- **New Features**
  - New input `ngpCheckboxDefaultChecked` to set initial state in uncontrolled mode.
  - Controlled `checked` takes precedence over `defaultChecked` when both are set.
  - Internals migrated to `controlledState`; `setChecked(value, options?: SetterOptions)` supports silent CVA writes (`emit: false`).
  - New `setDefaultChecked(value)` method on the directive and state.
  - Docs: added default-checked example; tests cover controlled/uncontrolled flows and ensure no `data-checked` when controlled `false`.

- **Migration**
  - `ngpCheckboxChecked` now defaults to `undefined` (uncontrolled). To keep controlled `false`, set `[ngpCheckboxChecked]="false"` explicitly.
  - For uncontrolled default-on behavior, use `ngpCheckboxDefaultChecked`.

<sup>Written for commit 583ac0717c12dc58fbc04260b266b3578b07e73b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



