### PR TITLE
fix(accordion): use dataBinding for data attributes

### DIFF
--- a/packages/ng-primitives/accordion/src/accordion/accordion-state.ts
+++ b/packages/ng-primitives/accordion/src/accordion/accordion-state.ts
@@ -1,7 +1,7 @@
 import { signal, Signal, WritableSignal } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, controlled, createPrimitive, deprecatedSetter } from 'ng-primitives/state';
+import { controlled, createPrimitive, dataBinding, deprecatedSetter } from 'ng-primitives/state';
 
 /**
  * The state interface for the Accordion pattern.
@@ -95,8 +95,8 @@ export const [NgpAccordionStateToken, ngpAccordion, _injectAccordionState, provi
       const orientation = controlled(_orientation);
 
       // Host bindings extracted from directive
-      attrBinding(element, 'data-orientation', orientation);
-      attrBinding(element, 'data-disabled', disabled);
+      dataBinding(element, 'data-orientation', orientation);
+      dataBinding(element, 'data-disabled', disabled);
 
       // Setter methods
       function setDisabled(value: boolean): void {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

None

## What does this PR implement/fix?

`accordion-state` was using `attrBinding` for `data-disabled` and `data-orientation`, which rendered boolean values as string literals (`data-disabled="false"` / `data-disabled="true"`).

Replaced with `dataBinding`, which follows the rest of the library's convention: boolean attributes render as bare attribute presence (`data-disabled` when `true`, absent when `false`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No