### PR TITLE
Expose `offset` configuration in NgpCombobox and NgpSelect

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -65,6 +65,20 @@ Create a reusable component that uses the `NgpCombobox` directive.
 
 ## Examples
 
+### Custom Offset
+
+You can customize the offset using either a simple number or an object for more precise control:
+
+```html
+<!-- Simple number offset -->
+<div ngpCombobox [ngpComboboxDropdownOffset]="12">Dropdown with 12px offset</div>
+
+<!-- Object offset for precise control -->
+<div ngpCombobox [ngpComboboxDropdownOffset]="{mainAxis: 8, crossAxis: 4, alignmentAxis: 2}">
+  Dropdown with custom offset
+</div>
+```
+
 ### Button-only Combobox
 
 This example demonstrates a combobox without an input field. The combobox element itself becomes focusable.
@@ -255,7 +269,14 @@ You can configure the default options for all comboboxes in your application by 
 import { provideComboboxConfig } from 'ng-primitives/combobox';
 
 bootstrapApplication(AppComponent, {
-  providers: [provideComboboxConfig({ placement: 'bottom', container: document.body, flip: true })],
+  providers: [
+    provideComboboxConfig({
+      placement: 'bottom',
+      container: document.body,
+      flip: true,
+      offset: 4,
+    }),
+  ],
 });
 ```
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -60,7 +60,19 @@ ng g ng-primitives:primitive select
 
 ## Examples
 
-Here are some additional examples of how to use the Select primitives.
+### Custom Offset
+
+You can customize the offset using either a simple number or an object for more precise control:
+
+```html
+<!-- Simple number offset -->
+<div ngpSelect [ngpSelectDropdownOffset]="12">Dropdown with 12px offset</div>
+
+<!-- Object offset for precise control -->
+<div ngpSelect [ngpSelectDropdownOffset]="{mainAxis: 8, crossAxis: 4, alignmentAxis: 2}">
+  Dropdown with custom offset
+</div>
+```
 
 ### Select Form Field
 
@@ -152,7 +164,14 @@ You can configure the default options for all selects in your application by usi
 import { provideSelectConfig } from 'ng-primitives/select';
 
 bootstrapApplication(AppComponent, {
-  providers: [provideSelectConfig({ placement: 'bottom', container: document.body, flip: true })],
+  providers: [
+    provideSelectConfig({
+      placement: 'bottom',
+      container: document.body,
+      flip: true,
+      offset: 4,
+    }),
+  ],
 });
 ```
 

--- a/packages/ng-primitives/combobox/src/combobox-portal/combobox-portal.ts
+++ b/packages/ng-primitives/combobox/src/combobox-portal/combobox-portal.ts
@@ -74,6 +74,7 @@ export class NgpComboboxPortal implements OnDestroy {
       triggerElement: this.state().elementRef.nativeElement,
       injector: this.injector,
       placement: this.state().placement,
+      offset: this.state().offset(),
       flip: this.state().flip(),
       closeOnOutsideClick: true,
       closeOnEscape: true,

--- a/packages/ng-primitives/combobox/src/combobox/combobox.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.ts
@@ -13,7 +13,14 @@ import {
 import { activeDescendantManager } from 'ng-primitives/a11y';
 import { ngpInteractions } from 'ng-primitives/interactions';
 import { domSort, injectElementRef } from 'ng-primitives/internal';
-import { coerceFlip, NgpFlip, NgpFlipInput } from 'ng-primitives/portal';
+import {
+  coerceFlip,
+  coerceOffset,
+  NgpFlip,
+  NgpFlipInput,
+  NgpOffset,
+  NgpOffsetInput,
+} from 'ng-primitives/portal';
 import type { NgpComboboxButton } from '../combobox-button/combobox-button';
 import type { NgpComboboxDropdown } from '../combobox-dropdown/combobox-dropdown';
 import type { NgpComboboxInput } from '../combobox-input/combobox-input';
@@ -116,6 +123,16 @@ export class NgpCombobox {
   readonly flip = input<NgpFlip, NgpFlipInput>(this.config.flip, {
     alias: 'ngpComboboxDropdownFlip',
     transform: coerceFlip,
+  });
+
+  /**
+   * Define the offset of the combobox dropdown relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
+   * @default 0
+   */
+  readonly offset = input<NgpOffset, NgpOffsetInput>(this.config.offset, {
+    alias: 'ngpComboboxDropdownOffset',
+    transform: coerceOffset,
   });
 
   /**

--- a/packages/ng-primitives/combobox/src/config/combobox-config.ts
+++ b/packages/ng-primitives/combobox/src/config/combobox-config.ts
@@ -1,5 +1,5 @@
 import { InjectionToken, Provider, inject } from '@angular/core';
-import { NgpFlip } from 'ng-primitives/portal';
+import { NgpFlip, NgpOffset } from 'ng-primitives/portal';
 import { type NgpComboboxPlacement } from '../combobox/combobox';
 
 export interface NgpComboboxConfig {
@@ -22,12 +22,20 @@ export interface NgpComboboxConfig {
    * @default true
    */
   flip: NgpFlip;
+
+  /**
+   * Define the offset of the combobox dropdown relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
+   * @default 0
+   */
+  offset: NgpOffset;
 }
 
 export const defaultComboboxConfig: NgpComboboxConfig = {
   placement: 'bottom',
   container: 'body',
   flip: true,
+  offset: 0,
 };
 
 export const NgpComboboxConfigToken = new InjectionToken<NgpComboboxConfig>(

--- a/packages/ng-primitives/select/src/config/select-config.ts
+++ b/packages/ng-primitives/select/src/config/select-config.ts
@@ -1,6 +1,6 @@
 import { InjectionToken, Provider, inject } from '@angular/core';
 import type { Placement } from '@floating-ui/dom';
-import { NgpFlip } from 'ng-primitives/portal';
+import { NgpFlip, NgpOffset } from 'ng-primitives/portal';
 
 export interface NgpSelectConfig {
   /**
@@ -22,12 +22,20 @@ export interface NgpSelectConfig {
    * @default true
    */
   flip: NgpFlip;
+
+  /**
+   * Define the offset of the select dropdown relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
+   * @default 0
+   */
+  offset: NgpOffset;
 }
 
 export const defaultSelectConfig: NgpSelectConfig = {
   placement: 'bottom',
   container: 'body',
   flip: true,
+  offset: 0,
 };
 
 export const NgpSelectConfigToken = new InjectionToken<NgpSelectConfig>('NgpSelectConfigToken');

--- a/packages/ng-primitives/select/src/select-portal/select-portal.ts
+++ b/packages/ng-primitives/select/src/select-portal/select-portal.ts
@@ -74,6 +74,7 @@ export class NgpSelectPortal implements OnDestroy {
       triggerElement: this.state().elementRef.nativeElement,
       injector: this.injector,
       placement: this.state().placement,
+      offset: this.state().offset(),
       flip: this.state().flip(),
       closeOnOutsideClick: true,
       closeOnEscape: true,

--- a/packages/ng-primitives/select/src/select/select.ts
+++ b/packages/ng-primitives/select/src/select/select.ts
@@ -15,7 +15,14 @@ import { activeDescendantManager } from 'ng-primitives/a11y';
 import { ngpFormControl } from 'ng-primitives/form-field';
 import { ngpInteractions } from 'ng-primitives/interactions';
 import { domSort, injectElementRef } from 'ng-primitives/internal';
-import { coerceFlip, NgpFlip, NgpFlipInput } from 'ng-primitives/portal';
+import {
+  coerceFlip,
+  coerceOffset,
+  NgpFlip,
+  NgpFlipInput,
+  NgpOffset,
+  NgpOffsetInput,
+} from 'ng-primitives/portal';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectSelectConfig } from '../config/select-config';
 import type { NgpSelectDropdown } from '../select-dropdown/select-dropdown';
@@ -112,6 +119,16 @@ export class NgpSelect {
   readonly flip = input<NgpFlip, NgpFlipInput>(this.config.flip, {
     alias: 'ngpSelectDropdownFlip',
     transform: coerceFlip,
+  });
+
+  /**
+   * Define the offset of the select dropdown relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
+   * @default 0
+   */
+  readonly offset = input<NgpOffset, NgpOffsetInput>(this.config.offset, {
+    alias: 'ngpSelectDropdownOffset',
+    transform: coerceOffset,
   });
 
   /**


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:



## Issue
Without the possibilite for Select/Combobox to pass an offset configuration through to NgpOverlay, CSS margins must be used instead. This causes issues with fallback positions. For example, margin-top may be set assuming the dropdown appears below. If there isn’t enough space and it is placed above, the margin becomes incorrect and the dropdown overlaps the trigger.

See example in the docs itself:
<img width="808" height="399" alt="image" src="https://github.com/user-attachments/assets/a9c4e3f9-4b24-4d70-a418-c74921fee7fe" />
<img width="808" height="361" alt="image" src="https://github.com/user-attachments/assets/b44aabe3-f027-4c79-adc7-36545c0d3fbb" />



## What does this PR implement/fix?

This PR extends `NgpCombobox` and `NgpSelect` to expose the `offset` configuration for the `createOverlay` as config and input in the same way as `NgpPopoverTrigger`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose dropdown offset controls in `NgpCombobox` and `NgpSelect` so dropdowns keep consistent spacing across fallback placements without CSS margin hacks. Adds new inputs and config options that forward `offset` to the overlay.

- **New Features**
  - New inputs: `[ngpComboboxDropdownOffset]` and `[ngpSelectDropdownOffset]` accept a number or `{ mainAxis, crossAxis, alignmentAxis }`.
  - New config: `provideComboboxConfig` and `provideSelectConfig` support `offset` (default `0`).
  - Portals pass `offset` to the overlay; docs updated with examples.

<sup>Written for commit eb91f6f5bf4ce582a8b53be42b9da40bdd4aac86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

