### PR TITLE
fix(combobox,select): emit openChange false on outside click and Escape key events (#746)

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox-portal/combobox-portal.ts
+++ b/packages/ng-primitives/combobox/src/combobox-portal/combobox-portal.ts
@@ -81,6 +81,7 @@ export class NgpComboboxPortal implements OnDestroy {
       restoreFocus: false,
       scrollBehaviour: 'reposition',
       container: this.state().container(),
+      onClose: () => this.state().onOverlayClosed(),
     };
 
     this.overlay.set(createOverlay(config));

--- a/packages/ng-primitives/combobox/src/combobox/combobox.test.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.test.ts
@@ -88,6 +88,7 @@ class TestComponent {
       [ngpComboboxValue]="value"
       [ngpComboboxMultiple]="true"
       (ngpComboboxValueChange)="onValueChange($event)"
+      (ngpComboboxOpenChange)="onOpenChange($event)"
       ngpCombobox
     >
       <input
@@ -127,6 +128,8 @@ class MultiSelectTestComponent {
   onFilterChange(event: Event) {
     this.filter = (event.target as HTMLInputElement).value;
   }
+
+  onOpenChange(_event: boolean) {}
 }
 
 describe('NgpCombobox', () => {
@@ -2004,5 +2007,76 @@ describe('NgpComboboxOption activated output', () => {
     await userEvent.click(screen.getByTestId('option-Apple'));
 
     expect(component.activatedOptions.filter(o => o === 'Apple').length).toBe(3);
+  });
+});
+
+describe('openChange events', () => {
+  afterEach(() => {
+    const dropdown = screen.queryByRole('listbox');
+    if (dropdown) {
+      dropdown.remove();
+    }
+  });
+
+  it('should emit when clicking outside', async () => {
+    const { fixture } = await render(TestComponent);
+    const spy = vi.spyOn(fixture.componentInstance, 'onOpenChange');
+
+    const button = screen.getByTestId('combobox-button');
+    await userEvent.click(button);
+    expect(spy).toHaveBeenCalledWith(true);
+
+    // Click outside to close
+    await userEvent.click(document.body);
+    expect(spy).toHaveBeenCalledWith(false);
+  });
+
+  it('should emit when pressing Escape key', async () => {
+    const { fixture } = await render(TestComponent);
+    const spy = vi.spyOn(fixture.componentInstance, 'onOpenChange');
+
+    const button = screen.getByTestId('combobox-button');
+    await userEvent.click(button);
+    expect(spy).toHaveBeenCalledWith(true);
+
+    // Press Escape to close
+    await userEvent.keyboard('{escape}');
+    expect(spy).toHaveBeenCalledWith(false);
+  });
+
+  it('should emit on outside click after selecting an option in multi-select', async () => {
+    const { fixture } = await render(MultiSelectTestComponent);
+    const component = fixture.componentInstance;
+    const spy = vi.spyOn(component, 'onOpenChange');
+
+    const button = screen.getByTestId('multi-combobox-button');
+    await userEvent.click(button);
+    expect(spy).toHaveBeenCalledWith(true);
+
+    // Select an option (multi-select stays open)
+    await userEvent.click(screen.getByRole('option', { name: /apple/i }));
+    expect(component.value).toContain('Apple');
+
+    // Click outside to close
+    await userEvent.click(document.body);
+    expect(spy).toHaveBeenCalledWith(false);
+  });
+
+  it('should emit on Escape key after selecting an option in multi-select', async () => {
+    const { fixture } = await render(MultiSelectTestComponent);
+    const component = fixture.componentInstance;
+    const spy = vi.spyOn(component, 'onOpenChange');
+
+    const button = screen.getByTestId('multi-combobox-button');
+    await userEvent.click(button);
+    expect(spy).toHaveBeenCalledWith(true);
+
+    // Select an option (multi-select stays open)
+    await userEvent.click(screen.getByRole('option', { name: /apple/i }));
+    expect(component.value).toContain('Apple');
+
+    // Press Escape to close
+    await userEvent.keyboard('{escape}');
+    expect(spy).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/ng-primitives/combobox/src/combobox/combobox.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.ts
@@ -293,10 +293,16 @@ export class NgpCombobox {
     if (!this.open()) {
       return;
     }
-
-    this.openChange.emit(false);
     this.portal()?.detach();
+  }
 
+  /**
+   * Handles the dropdown being closed.
+   * Emits the openChange event and resets the active descendant.
+   * @internal
+   */
+  onOverlayClosed(): void {
+    this.openChange.emit(false);
     // clear the active descendant
     this.activeDescendantManager.reset();
   }

--- a/packages/ng-primitives/select/src/select-portal/select-portal.ts
+++ b/packages/ng-primitives/select/src/select-portal/select-portal.ts
@@ -81,6 +81,7 @@ export class NgpSelectPortal implements OnDestroy {
       restoreFocus: false,
       scrollBehaviour: 'reposition',
       container: this.state().container(),
+      onClose: () => this.state().onOverlayClosed(),
     };
 
     this.overlay.set(createOverlay(config));

--- a/packages/ng-primitives/select/src/select/select.test.ts
+++ b/packages/ng-primitives/select/src/select/select.test.ts
@@ -6,7 +6,12 @@ import { NgpSelect, NgpSelectDropdown, NgpSelectOption, NgpSelectPortal } from '
 
 @Component({
   template: `
-    <div [(ngpSelectValue)]="value" ngpSelect data-testid="select">
+    <div
+      [(ngpSelectValue)]="value"
+      (ngpSelectOpenChange)="onOpenChange($event)"
+      ngpSelect
+      data-testid="select"
+    >
       @if (value(); as value) {
         <span data-testid="selected-value">{{ value }}</span>
       } @else {
@@ -31,11 +36,19 @@ import { NgpSelect, NgpSelectDropdown, NgpSelectOption, NgpSelectPortal } from '
 class TestSelectComponent {
   readonly options = ['Apple', 'Banana', 'Cherry'];
   readonly value = signal<string | undefined>(undefined);
+
+  onOpenChange(_event: boolean) {}
 }
 
 @Component({
   template: `
-    <div [(ngpSelectValue)]="value" ngpSelect ngpSelectMultiple data-testid="multi-select">
+    <div
+      [(ngpSelectValue)]="value"
+      (ngpSelectOpenChange)="onOpenChange($event)"
+      ngpSelect
+      ngpSelectMultiple
+      data-testid="multi-select"
+    >
       @if (value().length > 0) {
         <span data-testid="selected-values">{{ value().join(', ') }}</span>
       } @else {
@@ -60,6 +73,8 @@ class TestSelectComponent {
 class TestMultiSelectComponent {
   readonly options = ['Apple', 'Banana', 'Cherry'];
   readonly value = signal<string[]>([]);
+
+  onOpenChange(_event: boolean) {}
 }
 
 @Component({
@@ -1573,6 +1588,74 @@ describe('NgpSelect', () => {
           expect(fixture.componentInstance.value()).toBe('Only Option');
         });
       });
+    });
+  });
+
+  describe('openChange events', () => {
+    it('should emit when clicking outside', async () => {
+      const user = userEvent.setup();
+      const { fixture } = await render(TestSelectComponent);
+      const spy = vi.spyOn(fixture.componentInstance, 'onOpenChange');
+
+      const select = screen.getByTestId('select');
+      await user.click(select);
+      expect(spy).toHaveBeenCalledWith(true);
+
+      // Click outside to close
+      await user.click(document.body);
+      expect(spy).toHaveBeenCalledWith(false);
+    });
+
+    it('should emit when pressing Escape key', async () => {
+      const user = userEvent.setup();
+      const { fixture } = await render(TestSelectComponent);
+      const spy = vi.spyOn(fixture.componentInstance, 'onOpenChange');
+
+      const select = screen.getByTestId('select');
+      await user.click(select);
+      expect(spy).toHaveBeenCalledWith(true);
+
+      // Press Escape to close
+      await user.keyboard('{Escape}');
+      expect(spy).toHaveBeenCalledWith(false);
+    });
+
+    it('should emit on outside click after selecting an option in multi-select', async () => {
+      const user = userEvent.setup();
+      const { fixture } = await render(TestMultiSelectComponent);
+      const component = fixture.componentInstance;
+      const spy = vi.spyOn(component, 'onOpenChange');
+
+      const select = screen.getByTestId('multi-select');
+      await user.click(select);
+      expect(spy).toHaveBeenCalledWith(true);
+
+      // Select an option (multi-select stays open)
+      await user.click(screen.getByRole('option', { name: /apple/i }));
+      expect(component.value()).toContain('Apple');
+
+      // Click outside to close
+      await user.click(document.body);
+      expect(spy).toHaveBeenCalledWith(false);
+    });
+
+    it('should emit on Escape key after selecting an option in multi-select', async () => {
+      const user = userEvent.setup();
+      const { fixture } = await render(TestMultiSelectComponent);
+      const component = fixture.componentInstance;
+      const spy = vi.spyOn(component, 'onOpenChange');
+
+      const select = screen.getByTestId('multi-select');
+      await user.click(select);
+      expect(spy).toHaveBeenCalledWith(true);
+
+      // Select an option (multi-select stays open)
+      await user.click(screen.getByRole('option', { name: /apple/i }));
+      expect(component.value()).toContain('Apple');
+
+      // Press Escape to close
+      await user.keyboard('{Escape}');
+      expect(spy).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/packages/ng-primitives/select/src/select/select.ts
+++ b/packages/ng-primitives/select/src/select/select.ts
@@ -276,10 +276,16 @@ export class NgpSelect {
     if (!this.open()) {
       return;
     }
-
-    this.openChange.emit(false);
     this.portal()?.detach();
+  }
 
+  /**
+   * Handles the dropdown being closed.
+   * Emits the openChange event and resets the active descendant.
+   * @internal
+   */
+  onOverlayClosed(): void {
+    this.openChange.emit(false);
     // clear the active descendant
     this.activeDescendantManager.reset();
   }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #746 

## What does this PR implement/fix?

emits `openChange` `false` after the overlay is gone in all circumstances.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit openChange(false) only after the overlay actually closes for `combobox` and `select`. Outside clicks and Escape now trigger close events. Closes #746.

- **Bug Fixes**
  - Wire overlay onClose to onOverlayClosed() and emit openChange(false) there; stop emitting in close().
  - Add tests for outside click and Escape in single and multi modes, including after selecting an option.
  - Reset active descendant on close.

<sup>Written for commit 47a88993692d4fde0a662b8288bb62e32c04f943. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

