### PR TITLE
feat(tooltip): allow to provide anchor element

### DIFF
--- a/apps/documentation/src/app/examples/tooltip/tooltip-custom-anchor.example.ts
+++ b/apps/documentation/src/app/examples/tooltip/tooltip-custom-anchor.example.ts
@@ -1,0 +1,113 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroInformationCircle } from '@ng-icons/heroicons/outline';
+import { NgpTooltip, NgpTooltipArrow, NgpTooltipTrigger } from 'ng-primitives/tooltip';
+
+@Component({
+  selector: 'app-tooltip-custom-anchor',
+  imports: [NgpTooltipTrigger, NgpTooltip, NgpTooltipArrow, NgIcon],
+  viewProviders: [provideIcons({ heroInformationCircle })],
+  template: `
+    <span
+      class="pill"
+      [ngpTooltipTrigger]="tooltip"
+      [ngpTooltipTriggerAnchor]="infoIcon"
+      ngpTooltipTriggerPlacement="bottom-end"
+      ngpTooltipTriggerOffset="12"
+    >
+      Custom Anchor
+      <span class="info-icon" #infoIcon>
+        <ng-icon #icon name="heroInformationCircle" size="20" />
+      </span>
+    </span>
+
+    <ng-template #tooltip>
+      <div ngpTooltip>
+        The tooltip is anchored to the info icon, but the entire pill acts as the trigger.
+        <div ngpTooltipArrow ngpTooltipArrowPadding="12"></div>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      color: var(--ngp-text-primary);
+      background-color: var(--ngp-background);
+      box-shadow: var(--ngp-button-shadow);
+    }
+
+    .pill[data-open] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    .info-icon {
+      height: 20px;
+      width: 20px;
+      display: grid;
+      place-items: center;
+    }
+
+    [ngpTooltip] {
+      position: absolute;
+      max-width: 16rem;
+      border-radius: 0.5rem;
+      background-color: var(--ngp-background-inverse);
+      padding: 0.5rem 0.75rem;
+      border: none;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--ngp-text-inverse);
+      animation: tooltip-show 200ms ease-in-out;
+      transform-origin: var(--ngp-tooltip-transform-origin);
+    }
+
+    [ngpTooltip][data-exit] {
+      animation: tooltip-hide 200ms ease-in-out;
+    }
+
+    [ngpTooltipArrow] {
+      position: absolute;
+      pointer-events: none;
+      background-color: var(--ngp-background-inverse);
+      width: 8px;
+      height: 8px;
+      border-radius: 2px;
+      transform: rotate(45deg);
+    }
+
+    [ngpTooltipArrow][data-placement^='top'] {
+      top: calc(100% - 5px);
+    }
+
+    [ngpTooltipArrow][data-placement^='bottom'] {
+      bottom: calc(100% - 5px);
+    }
+
+    @keyframes tooltip-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes tooltip-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+  `,
+})
+export default class TooltipCustomAnchorExample {}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -82,6 +82,12 @@ You can customize the offset using either a simple number or an object for more 
 </button>
 ```
 
+### Custom Anchor
+
+You can provide a separate anchor element using `ngpTooltipTriggerAnchor` to control where the tooltip appears while keeping the full trigger area interactive.
+
+<docs-example name="tooltip-custom-anchor"></docs-example>
+
 ### Custom Shift
 
 You can customize the shift behavior to control how the tooltip stays within the viewport:

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.test.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.test.ts
@@ -1043,6 +1043,108 @@ describe('NgpTooltipTrigger', () => {
     });
   });
 
+  describe('anchor', () => {
+    it('should position tooltip relative to anchor element when provided', async () => {
+      const { getByRole } = await render(
+        `
+          <div
+            #anchor
+            style="position: absolute; top: 100px; left: 200px; width: 50px; height: 30px;"
+          >
+            Anchor Element
+          </div>
+          <button
+            [ngpTooltipTrigger]="content"
+            [ngpTooltipTriggerAnchor]="anchor"
+            style="position: absolute; top: 300px; left: 400px;"
+          >
+            Trigger
+          </button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+
+      // The tooltip should be positioned relative to the anchor element (top: 100px, left: 200px)
+      // rather than the trigger element (top: 300px, left: 400px)
+      const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement;
+      const tooltipRect = tooltip.getBoundingClientRect();
+
+      // The tooltip should be positioned close to the anchor's position (200px left)
+      // rather than near the trigger's position (400px left)
+      expect(tooltipRect.left).toBeLessThan(300);
+    });
+
+    it('should fall back to trigger element when anchor is null', async () => {
+      const { getByRole } = await render(
+        `
+          <button
+            [ngpTooltipTrigger]="content"
+            [ngpTooltipTriggerAnchor]="null"
+            style="position: absolute; top: 100px; left: 200px;"
+          >
+            Trigger
+          </button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+
+      // Should position relative to trigger when anchor is null
+      const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement;
+      expect(tooltip).toBeInTheDocument();
+    });
+
+    it('should accept anchor element input', async () => {
+      const { getByRole } = await render(
+        `
+          <div #anchor>Anchor Element</div>
+          <button [ngpTooltipTrigger]="content" [ngpTooltipTriggerAnchor]="anchor">Trigger</button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      const trigger = getByRole('button');
+
+      // Should be able to open tooltip with anchor element configured
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+    });
+  });
+
   describe('position', () => {
     it('should accept position input for programmatic positioning', async () => {
       const { fixture } = await render(

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -181,6 +181,12 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
   });
 
   /**
+   * Define an anchor element for positioning the tooltip.
+   * If provided, the tooltip will be positioned relative to this element instead of the trigger.
+   */
+  readonly anchor = input<HTMLElement | null>(null, { alias: 'ngpTooltipTriggerAnchor' });
+
+  /**
    * Provide context to the tooltip. This can be used to pass data to the tooltip content.
    */
   readonly context = input<T>(undefined, {
@@ -475,6 +481,7 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
     const config: NgpOverlayConfig<T | string> = {
       content,
       triggerElement: this.trigger.nativeElement,
+      anchorElement: this.state.anchor(),
       injector: this.injector,
       context,
       container: this.state.container(),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

no issue exists for this matter

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->
Allows to provide (pass through) the anchor element for the the tooltip positioning.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for a custom tooltip anchor in `ng-primitives/tooltip` so you can position a tooltip relative to a different element while keeping the original trigger interactive. Adds anchor behavior tests and a “Custom Anchor” docs example.

- **New Features**
  - `NgpTooltipTrigger` now accepts `ngpTooltipTriggerAnchor` to set an anchor `HTMLElement` for positioning.
  - Falls back to the trigger when not provided; no breaking change.

<sup>Written for commit 147e26e551a19912c38fd49fb36c6a94ff58a359. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

