### PR TITLE
Export NgpDatePickerConfig type from index.ts

### DIFF
--- a/packages/ng-primitives/date-picker/src/index.ts
+++ b/packages/ng-primitives/date-picker/src/index.ts
@@ -1,7 +1,7 @@
-export {  
-  injectDatePickerConfig,  
-  provideDatePickerConfig,  
-  type NgpDatePickerConfig,  
+export {
+  injectDatePickerConfig,
+  provideDatePickerConfig,
+  type NgpDatePickerConfig,
 } from './config/date-picker-config';
 export { NgpDatePickerCellRender } from './date-picker-cell-render/date-picker-cell-render';
 export {

--- a/packages/ng-primitives/date-picker/src/index.ts
+++ b/packages/ng-primitives/date-picker/src/index.ts
@@ -1,4 +1,8 @@
-export { injectDatePickerConfig, provideDatePickerConfig } from './config/date-picker-config';
+export {  
+  injectDatePickerConfig,  
+  provideDatePickerConfig,  
+  type NgpDatePickerConfig,  
+} from './config/date-picker-config';
 export { NgpDatePickerCellRender } from './date-picker-cell-render/date-picker-cell-render';
 export {
   injectDatePickerCellDate,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

`NgpDatePickerConfig` type wasn't exported in public entrypoint

## What does this PR implement/fix?

Added `NgpDatePickerConfig` to the re-exports in `packages/ng-primitives/date-picker/src/index.ts`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exported `NgpDatePickerConfig` as a type from the date-picker public entrypoint so consumers can import it directly without deep imports. This fixes the missing public API export.

<sup>Written for commit 031fa4cf32f25909cd01bc11fefb7066203f4de1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

