### PR TITLE
Forward shift configuration into menu overlay config

### DIFF
--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -159,10 +159,8 @@ export interface NgpMenuTriggerProps<T = unknown> {
 
   /**
    * Configure shift behavior to keep the menu in view.
-   * Can be a boolean to enable/disable, or an object with padding and limiter options.
-   * @default undefined (enabled by default in overlay)
    */
-  shift: NgpShift;
+  readonly shift?: Signal<NgpShift>;
 
   /**
    * How the menu behaves when the window is scrolled.
@@ -206,6 +204,7 @@ export const [
     placement: _placement = signal('bottom-start' as NgpMenuPlacement),
     offset: _offset = signal(4),
     flip: _flip = signal(true),
+    shift: _shift = signal(undefined),
     context: _context = signal<T>(undefined as T),
     container,
     scrollBehavior,
@@ -224,6 +223,7 @@ export const [
     const disabled = controlled(_disabled);
     const placement = controlled(_placement);
     const flip = controlled(_flip);
+    const shift = controlled(_shift);
     const offset = controlled(_offset);
     const context = controlled(_context);
 
@@ -474,6 +474,7 @@ export const [
         placement: placement,
         offset: offset(),
         flip: flip(),
+        shift: shift(),
         closeOnOutsideClick: true,
         closeOnEscape: true,
         restoreFocus: shouldRestoreFocus,

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
@@ -153,7 +153,7 @@ export class NgpMenuTrigger<T = unknown> {
     placement: this.placement,
     offset: this.offset,
     flip: this.flip,
-    shift: this.shift(),
+    shift: this.shift,
     container: this.container,
     scrollBehavior: this.scrollBehavior,
     cooldown: this.cooldown,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## What does this PR implement/fix?

In `menu-trigger-state.ts` shift was not destructured from the props and not forwarded in `createOverlayInstance` into the config variable. Fixing this allows the shift configuration to work again.

Also converted the shift prop into a signal alike every other prop in `NgpMenuTriggerProps`

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `shift` option not being forwarded to the menu overlay, so menus now stay in view as expected. Also converts `shift` to a `Signal<NgpShift>` to match other `NgpMenuTrigger` props and wires it through `menu-trigger` and `menu-trigger-state`.

<sup>Written for commit 79c8a87eae93f7c4a35e7734e548a0228318f124. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

