### PR TITLE
fix(overlay): only call `onClose` when previously open  #754

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox/combobox.test.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.test.ts
@@ -2079,4 +2079,45 @@ describe('openChange events', () => {
     await userEvent.keyboard('{escape}');
     expect(spy).toHaveBeenCalledWith(false);
   });
+
+  it('should emit openChange false when destroyed while open', async () => {
+    const { fixture } = await render(TestComponent);
+    const component = fixture.componentInstance;
+    const spy = vi.spyOn(component, 'onOpenChange');
+
+    // Open the combobox
+    const button = screen.getByTestId('combobox-button');
+    await userEvent.click(button);
+    expect(spy).toHaveBeenCalledWith(true);
+    spy.mockClear();
+
+    // Destroy while open — should emit false
+    fixture.destroy();
+    expect(spy).toHaveBeenCalledWith(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not emit when destroyed when already closed', async () => {
+    const { fixture } = await render(TestComponent);
+    const component = fixture.componentInstance;
+    const spy = vi.spyOn(component, 'onOpenChange');
+
+    // Open the combobox
+    const button = screen.getByTestId('combobox-button');
+    await userEvent.click(button);
+    expect(spy).toHaveBeenCalledWith(true);
+
+    // Close the combobox
+    await userEvent.click(document.body);
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith(false);
+    });
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    spy.mockClear();
+
+    // Destroy the component — should NOT emit openChange
+    fixture.destroy();
+    expect(spy).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.test.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.test.ts
@@ -5,22 +5,25 @@ import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
 import { NgpTooltip, NgpTooltipTrigger, provideTooltipConfig } from 'ng-primitives/tooltip';
 import { describe, expect, it, vi } from 'vitest';
 
+@Component({
+  template: `
+    <button [ngpPopoverTrigger]="content" (ngpPopoverTriggerOpenChange)="onOpenChange($event)">
+      Open Popover
+    </button>
+
+    <ng-template #content>
+      <div ngpPopover>Popover content</div>
+    </ng-template>
+  `,
+  imports: [NgpPopoverTrigger, NgpPopover],
+})
+class OpenChangeTestComponent {
+  onOpenChange = vi.fn();
+}
+
 describe('NgpPopoverTrigger', () => {
   it('should destroy the overlay when the trigger is destroyed', async () => {
-    const { fixture, getByRole } = await render(
-      `
-        <button [ngpPopoverTrigger]="content"></button>
-
-        <ng-template #content>
-          <div ngpPopover>
-            Popover content
-          </div>
-        </ng-template>
-      `,
-      {
-        imports: [NgpPopoverTrigger, NgpPopover],
-      },
-    );
+    const { fixture, getByRole } = await render(OpenChangeTestComponent);
 
     const trigger = getByRole('button');
     fireEvent.click(trigger);
@@ -37,23 +40,7 @@ describe('NgpPopoverTrigger', () => {
   });
 
   it('should emit openChange event with correct state', async () => {
-    @Component({
-      template: `
-        <button [ngpPopoverTrigger]="content" (ngpPopoverTriggerOpenChange)="onOpenChange($event)">
-          Open Popover
-        </button>
-
-        <ng-template #content>
-          <div ngpPopover>Popover content</div>
-        </ng-template>
-      `,
-      imports: [NgpPopoverTrigger, NgpPopover],
-    })
-    class EventTestComponent {
-      onOpenChange = vi.fn();
-    }
-
-    const { fixture, getByRole } = await render(EventTestComponent);
+    const { fixture, getByRole } = await render(OpenChangeTestComponent);
     const component = fixture.componentInstance;
     const trigger = getByRole('button');
 
@@ -77,23 +64,7 @@ describe('NgpPopoverTrigger', () => {
   });
 
   it('should emit openChange false when closing on outside click', async () => {
-    @Component({
-      template: `
-        <button [ngpPopoverTrigger]="content" (ngpPopoverTriggerOpenChange)="onOpenChange($event)">
-          Open Popover
-        </button>
-
-        <ng-template #content>
-          <div ngpPopover>Popover content</div>
-        </ng-template>
-      `,
-      imports: [NgpPopoverTrigger, NgpPopover],
-    })
-    class OutsideClickEventTestComponent {
-      onOpenChange = vi.fn();
-    }
-
-    const { fixture, getByRole } = await render(OutsideClickEventTestComponent);
+    const { fixture, getByRole } = await render(OpenChangeTestComponent);
     const component = fixture.componentInstance;
     const trigger = getByRole('button');
 
@@ -115,23 +86,7 @@ describe('NgpPopoverTrigger', () => {
   });
 
   it('should emit openChange false when closing on Escape', async () => {
-    @Component({
-      template: `
-        <button [ngpPopoverTrigger]="content" (ngpPopoverTriggerOpenChange)="onOpenChange($event)">
-          Open Popover
-        </button>
-
-        <ng-template #content>
-          <div ngpPopover>Popover content</div>
-        </ng-template>
-      `,
-      imports: [NgpPopoverTrigger, NgpPopover],
-    })
-    class EscapeEventTestComponent {
-      onOpenChange = vi.fn();
-    }
-
-    const { fixture, getByRole } = await render(EscapeEventTestComponent);
+    const { fixture, getByRole } = await render(OpenChangeTestComponent);
     const component = fixture.componentInstance;
     const trigger = getByRole('button');
 
@@ -150,6 +105,53 @@ describe('NgpPopoverTrigger', () => {
       expect(component.onOpenChange).toHaveBeenCalledTimes(2);
       expect(component.onOpenChange).toHaveBeenLastCalledWith(false);
     });
+  });
+
+  it('should emit openChange false when destroyed while open', async () => {
+    const { fixture, getByRole } = await render(OpenChangeTestComponent);
+    const component = fixture.componentInstance;
+    const trigger = getByRole('button');
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      expect(component.onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    component.onOpenChange.mockClear();
+
+    // Destroy while open — should emit false
+    fixture.destroy();
+    expect(component.onOpenChange).toHaveBeenCalledWith(false);
+    expect(component.onOpenChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not emit openChange on destroy when already closed', async () => {
+    const { fixture, getByRole } = await render(OpenChangeTestComponent);
+    const component = fixture.componentInstance;
+    const trigger = getByRole('button');
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      expect(component.onOpenChange).toHaveBeenCalledWith(true);
+    });
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      expect(component.onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    expect(component.onOpenChange).toHaveBeenCalledTimes(2);
+    component.onOpenChange.mockClear();
+
+    // Destroy the component — should NOT emit openChange
+    fixture.destroy();
+    expect(component.onOpenChange).not.toHaveBeenCalled();
   });
 
   it('should position popover relative to anchor element when provided', async () => {

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -591,13 +591,14 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       this.closeTimeout = undefined;
     }
 
-    // Emit closing event
-    this.closing.next();
+    if (this.isOpen()) {
+      // Emit closing event
+      this.closing.next();
 
-    // Update close origin and call callback (default to 'program' for immediate closes)
-    this.closeOrigin.set('program');
-    this.config.onClose?.('program');
-
+      // Update close origin and call callback (default to 'program' for immediate closes)
+      this.closeOrigin.set('program');
+      this.config.onClose?.('program');
+    }
     // Destroy immediately without animations
     this.destroyOverlay(true);
   }

--- a/packages/ng-primitives/select/src/select/select.test.ts
+++ b/packages/ng-primitives/select/src/select/select.test.ts
@@ -1657,5 +1657,42 @@ describe('NgpSelect', () => {
       await user.keyboard('{Escape}');
       expect(spy).toHaveBeenCalledWith(false);
     });
+
+    it('should emit openChange false when destroyed while open', async () => {
+      const user = userEvent.setup();
+      const { fixture } = await render(TestSelectComponent);
+      const spy = vi.spyOn(fixture.componentInstance, 'onOpenChange');
+
+      const select = screen.getByTestId('select');
+      await user.click(select);
+      expect(spy).toHaveBeenCalledWith(true);
+      spy.mockClear();
+
+      // Destroy while open — should emit false
+      fixture.destroy();
+      expect(spy).toHaveBeenCalledWith(false);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not emit openChange on destroy when already closed', async () => {
+      const user = userEvent.setup();
+      const { fixture } = await render(TestSelectComponent);
+      const spy = vi.spyOn(fixture.componentInstance, 'onOpenChange');
+
+      const select = screen.getByTestId('select');
+      await user.click(select);
+      expect(spy).toHaveBeenCalledWith(true);
+
+      // Close the select
+      await user.click(document.body);
+      expect(spy).toHaveBeenCalledWith(false);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      spy.mockClear();
+
+      // Destroy the component — should NOT emit openChange
+      fixture.destroy();
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- guards the `onClose` callback in the overlay's `hideImmediate()` to only fire when the overlay was actually open.
- adds regression tests for the openChange emit-on-destroy bug across combobox, select, and popover components.

## Issue

Closes #754 

## What does this PR implement/fix?
<!-- Please describe the changes in this PR. -->

This fix prevents wrong `openChange` emissions during component destruction.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlay close behavior to only fire when the overlay was open, preventing false `openChange(false)` emissions during component destroy. Adds regression tests for combobox, select, and popover to lock this in.

- **Bug Fixes**
  - Guard `NgpOverlay.hideImmediate()` to emit closing and call `onClose('program')` only when `isOpen()`.
  - Add tests ensuring `openChange(false)` emits on destroy only if open, and no emission when already closed (combobox, select, popover).

<sup>Written for commit 182971aaa34704542f31106be0faccbee67693d8. Summary will update on new commits. <a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/755?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

