### PR TITLE
feat(popover): migrate popover state

### DIFF
--- a/packages/ng-primitives/popover/src/index.ts
+++ b/packages/ng-primitives/popover/src/index.ts
@@ -9,17 +9,22 @@ export {
   ngpPopoverArrow,
   providePopoverArrowState,
 } from './popover-arrow/popover-arrow-state';
-export { NgpPopoverTrigger, type NgpPopoverPlacement } from './popover-trigger/popover-trigger';
-export {
-  injectPopoverTriggerState,
-  providePopoverTriggerState,
-} from './popover-trigger/popover-trigger-state';
+export { NgpPopoverTrigger } from './popover-trigger/popover-trigger';
 export { NgpPopover } from './popover/popover';
 export {
-  NgpPopoverProps,
-  NgpPopoverState,
+  type NgpPopoverProps,
+  type NgpPopoverState,
   NgpPopoverStateToken,
   ngpPopover,
   injectPopoverState,
   providePopoverState,
 } from './popover/popover-state';
+export {
+  NgpPopoverTriggerStateToken,
+  ngpPopoverTrigger,
+  injectPopoverTriggerState,
+  providePopoverTriggerState,
+  type NgpPopoverTriggerState,
+  type NgpPopoverTriggerProps,
+  type NgpPopoverPlacement,
+} from './popover-trigger/popover-trigger-state';

--- a/packages/ng-primitives/popover/src/index.ts
+++ b/packages/ng-primitives/popover/src/index.ts
@@ -15,3 +15,11 @@ export {
   providePopoverTriggerState,
 } from './popover-trigger/popover-trigger-state';
 export { NgpPopover } from './popover/popover';
+export {
+  NgpPopoverProps,
+  NgpPopoverState,
+  NgpPopoverStateToken,
+  ngpPopover,
+  injectPopoverState,
+  providePopoverState,
+} from './popover/popover-state';

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -352,7 +352,7 @@ export const [
       }
 
       // Hide the overlay
-      overlay()?.hide({ origin });
+      await overlay()?.hide({ origin });
     }
 
     return {

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -1,31 +1,415 @@
-import { InjectOptions, Signal } from '@angular/core';
+import { FocusOrigin } from '@angular/cdk/a11y';
 import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-  State,
+  computed,
+  ElementRef,
+  inject,
+  Injector,
+  signal,
+  Signal,
+  ViewContainerRef,
+  WritableSignal,
+} from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  createOverlay,
+  NgpDismissGuard,
+  NgpFlip,
+  NgpOffset,
+  NgpOverlay,
+  NgpOverlayConfig,
+  NgpOverlayContent,
+  NgpShift,
+} from 'ng-primitives/portal';
+import {
+  attrBinding,
+  controlled,
+  createPrimitive,
+  dataBinding,
+  listener,
 } from 'ng-primitives/state';
-import type { NgpPopoverTrigger } from './popover-trigger';
 
-/**
- * The state token  for the PopoverTrigger primitive.
- */
-export const NgpPopoverTriggerStateToken = createStateToken<NgpPopoverTrigger>('PopoverTrigger');
+export interface NgpPopoverTriggerState<T> {
+  /** Access the trigger element. */
+  readonly elementRef: ElementRef;
+  /** Access the popover template ref. */
+  readonly popover: WritableSignal<NgpOverlayContent<T> | undefined>;
+  /**
+   * Define if the trigger should be disabled.
+   * @default false
+   */
+  readonly disabled: Signal<boolean>;
+  /**
+   * Define the placement of the popover relative to the trigger.
+   * @default 'top'
+   */
+  readonly placement: Signal<NgpPopoverPlacement>;
+  /**
+   * Define the offset of the popover relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
+   * @default 0
+   */
+  readonly offset: Signal<NgpOffset>;
+  /**
+   * Define the delay before the popover is displayed.
+   * @default 0
+   */
+  readonly showDelay: Signal<number>;
+  /**
+   * Define the delay before the popover is hidden.
+   * @default 0
+   */
+  readonly hideDelay: Signal<number>;
+  /**
+   * Define whether the popover should flip when there is not enough space for the popover.
+   * Can be a boolean to enable/disable, or an object with padding and fallbackPlacements options.
+   * @default true
+   */
+  readonly flip: Signal<NgpFlip>;
+  /**
+   * Configure shift behavior to keep the popover in view.
+   * Can be a boolean to enable/disable, or an object with padding and limiter options.
+   * @default undefined (enabled by default in overlay)
+   */
+  readonly shift: Signal<NgpShift>;
+  /**
+   * Define the container in which the popover should be attached.
+   * @default document.body
+   */
+  readonly container: Signal<HTMLElement | string | null>;
+  /**
+   * Define whether the popover should close when clicking outside of it, or a guard function.
+   * @default true
+   */
+  readonly closeOnOutsideClick: Signal<NgpDismissGuard<Element>>;
+  /**
+   * Define whether the popover should close when the escape key is pressed, or a guard function.
+   * @default true
+   */
+  readonly closeOnEscape: Signal<NgpDismissGuard<KeyboardEvent>>;
+  /**
+   * Defines how the popover behaves when the window is scrolled.
+   * @default 'reposition'
+   */
+  readonly scrollBehavior: Signal<'reposition' | 'block' | 'close'>;
+  /**
+   * Provide context to the popover. This can be used to pass data to the popover content.
+   */
+  readonly context: Signal<T | undefined>;
+  /**
+   * Define an anchor element for positioning the popover.
+   * If provided, the popover will be positioned relative to this element instead of the trigger.
+   */
+  readonly anchor: Signal<HTMLElement | null>;
+  /**
+   * Define whether to track the trigger element position on every animation frame.
+   * Useful for moving elements like slider thumbs.
+   * @default false
+   */
+  readonly trackPosition: Signal<boolean>;
+  /**
+   * Define the cooldown duration in milliseconds.
+   * When moving from one popover to another within this duration,
+   * the showDelay is skipped for the new popover.
+   * @default 0
+   */
+  readonly cooldown: Signal<number>;
+  /**
+   * The overlay that manages the popover
+   * @internal
+   */
+  readonly overlay: Signal<NgpOverlay<T> | null>;
+  /**
+   * The open state of the popover.
+   * @internal
+   */
+  readonly open: Signal<boolean>;
+  /** @internal onDestroy callback */
+  destroy: () => void;
+  /**
+   * Show the popover.
+   * @returns A promise that resolves when the popover has been shown
+   */
+  show: () => Promise<void>;
+  /**
+   * @internal
+   * Hide the popover.
+   * @returns A promise that resolves when the popover has been hidden
+   */
+  hide: (origin: FocusOrigin) => Promise<void>;
+}
 
-/**
- * Provides the PopoverTrigger state.
- */
-export const providePopoverTriggerState = createStateProvider(NgpPopoverTriggerStateToken);
+export interface NgpPopoverTriggerProps<T> {
+  /** Access the popover template ref. */
+  readonly popover?: Signal<NgpOverlayContent<T> | undefined>;
+  /**
+   * Define if the trigger should be disabled.
+   * @default false
+   */
+  readonly disabled?: Signal<boolean>;
+  /**
+   * Define the placement of the popover relative to the trigger.
+   * @default 'top'
+   */
+  readonly placement?: Signal<NgpPopoverPlacement>;
+  /**
+   * Define the offset of the popover relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
+   * @default 0
+   */
+  readonly offset?: Signal<NgpOffset>;
+  /**
+   * Define the delay before the popover is displayed.
+   * @default 0
+   */
+  readonly showDelay?: Signal<number>;
+  /**
+   * Define the delay before the popover is hidden.
+   * @default 0
+   */
+  readonly hideDelay?: Signal<number>;
+  /**
+   * Define whether the popover should flip when there is not enough space for the popover.
+   * Can be a boolean to enable/disable, or an object with padding and fallbackPlacements options.
+   * @default true
+   */
+  readonly flip?: Signal<NgpFlip>;
+  /**
+   * Configure shift behavior to keep the popover in view.
+   * Can be a boolean to enable/disable, or an object with padding and limiter options.
+   * @default undefined (enabled by default in overlay)
+   */
+  readonly shift?: Signal<NgpShift>;
+  /**
+   * Define the container in which the popover should be attached.
+   * @default document.body
+   */
+  readonly container?: Signal<HTMLElement | string | null>;
+  /**
+   * Define whether the popover should close when clicking outside of it, or a guard function.
+   * @default true
+   */
+  readonly closeOnOutsideClick?: Signal<NgpDismissGuard<Element>>;
+  /**
+   * Define whether the popover should close when the escape key is pressed, or a guard function.
+   * @default true
+   */
+  readonly closeOnEscape?: Signal<NgpDismissGuard<KeyboardEvent>>;
+  /**
+   * Defines how the popover behaves when the window is scrolled.
+   * @default 'reposition'
+   */
+  readonly scrollBehavior?: Signal<'reposition' | 'block' | 'close'>;
+  /**
+   * Provide context to the popover. This can be used to pass data to the popover content.
+   */
+  readonly context?: Signal<T | undefined>;
+  /**
+   * Define an anchor element for positioning the popover.
+   * If provided, the popover will be positioned relative to this element instead of the trigger.
+   */
+  readonly anchor?: Signal<HTMLElement | null>;
+  /**
+   * Define whether to track the trigger element position on every animation frame.
+   * Useful for moving elements like slider thumbs.
+   * @default false
+   */
+  readonly trackPosition?: Signal<boolean>;
+  /**
+   * Define the cooldown duration in milliseconds.
+   * When moving from one popover to another within this duration,
+   * the showDelay is skipped for the new popover.
+   * @default 0
+   */
+  readonly cooldown?: Signal<number>;
+  /** Callback fired when the open state changes.  */
+  readonly onOpenChange?: (value: boolean) => void;
+}
 
-/**
- * Injects the PopoverTrigger state.
- */
-export const injectPopoverTriggerState = createStateInjector<NgpPopoverTrigger>(
+export const [
   NgpPopoverTriggerStateToken,
-) as <T>(options?: InjectOptions) => Signal<State<NgpPopoverTrigger<T>>>;
+  ngpPopoverTrigger,
+  _injectPopoverTriggerState,
+  providePopoverTriggerState,
+] = createPrimitive(
+  'NgpPopoverTrigger',
+  <T>({
+    popover: _popover = signal<NgpOverlayContent<T> | undefined>(undefined),
+    disabled = signal<boolean>(false),
+    placement = signal<NgpPopoverPlacement>('bottom'),
+    offset = signal<NgpOffset>(4),
+    showDelay = signal<number>(0),
+    hideDelay = signal<number>(0),
+    flip = signal<NgpFlip>(true),
+    shift = signal<NgpShift>(undefined),
+    container = signal<HTMLElement | string | null>('body'),
+    closeOnOutsideClick = signal<NgpDismissGuard<Element>>(true),
+    closeOnEscape = signal<NgpDismissGuard<KeyboardEvent>>(true),
+    scrollBehavior = signal<'reposition' | 'block' | 'close'>('reposition'),
+    context = signal<T | undefined>(undefined),
+    anchor = signal<HTMLElement | null>(null),
+    trackPosition = signal<boolean>(false),
+    cooldown = signal<number>(0),
+    onOpenChange,
+  }: NgpPopoverTriggerProps<T>): NgpPopoverTriggerState<T> => {
+    const elementRef = injectElementRef<HTMLElement>();
+    const viewContainerRef = inject(ViewContainerRef);
+    const injector = inject(Injector);
 
-/**
- * The PopoverTrigger state registration function.
- */
-export const popoverTriggerState = createState(NgpPopoverTriggerStateToken);
+    const popover = controlled(_popover);
+
+    const overlay = signal<NgpOverlay<T> | null>(null);
+    const open = computed(() => overlay()?.isOpen() ?? false);
+
+    // Host binding
+    attrBinding(elementRef, 'aria-expanded', () => (open() ? 'true' : 'false'));
+    attrBinding(elementRef, 'aria-describedby', () => overlay()?.ariaDescribedBy());
+    dataBinding(elementRef, 'data-open', open);
+    dataBinding(elementRef, 'data-placement', placement);
+    dataBinding(elementRef, 'data-disabled', disabled);
+
+    // Event listener
+    listener(elementRef, 'click', toggle);
+
+    function destroy(): void {
+      overlay()?.destroy();
+    }
+
+    function createOverlayInstance(): void {
+      const popoverInstance = popover();
+
+      if (!popoverInstance) {
+        throw new Error('Popover must be either a TemplateRef or a ComponentType');
+      }
+
+      // Create config for the overlay
+      const config: NgpOverlayConfig<T> = {
+        content: popoverInstance,
+        triggerElement: elementRef.nativeElement,
+        anchorElement: anchor(),
+        injector: injector,
+        context: context,
+        container: container(),
+        placement: placement,
+        offset: offset(),
+        flip: flip(),
+        shift: shift(),
+        showDelay: showDelay(),
+        hideDelay: hideDelay(),
+        closeOnOutsideClick: closeOnOutsideClick(),
+        closeOnEscape: closeOnEscape(),
+        restoreFocus: true,
+        scrollBehaviour: scrollBehavior(),
+        viewContainerRef: viewContainerRef,
+        trackPosition: trackPosition(),
+        overlayType: 'popover',
+        cooldown: cooldown(),
+        onClose: () => onOpenChange?.(false),
+      };
+
+      overlay.set(createOverlay(config));
+    }
+
+    function toggle(event: MouseEvent): void {
+      // if the trigger is disabled then do not toggle the popover
+      if (disabled()) {
+        return;
+      }
+
+      // determine the origin of the event, 0 is keyboard, 1 is mouse
+      const origin: FocusOrigin = event.detail === 0 ? 'keyboard' : 'mouse';
+
+      // if the popover is open then hide it
+      if (open()) {
+        hide(origin);
+      } else {
+        show();
+      }
+    }
+
+    async function show(): Promise<void> {
+      // If the trigger is disabled, don't show the popover
+      if (disabled()) {
+        return;
+      }
+
+      // Create the overlay if it doesn't exist yet
+      if (!overlay()) {
+        createOverlayInstance();
+      }
+
+      // Show the overlay
+      await overlay()?.show();
+
+      if (open()) {
+        onOpenChange?.(true);
+      }
+    }
+
+    async function hide(origin: FocusOrigin): Promise<void> {
+      // If the trigger is disabled or the popover is not open, do nothing
+      if (disabled() || !open()) {
+        return;
+      }
+
+      // Hide the overlay
+      overlay()?.hide({ origin });
+    }
+
+    return {
+      elementRef,
+      popover,
+      disabled,
+      placement,
+      offset,
+      showDelay,
+      hideDelay,
+      flip,
+      shift,
+      container,
+      closeOnOutsideClick,
+      closeOnEscape,
+      scrollBehavior,
+      context,
+      anchor,
+      trackPosition,
+      cooldown,
+      overlay,
+      open,
+      destroy,
+      show,
+      hide,
+    } satisfies NgpPopoverTriggerState<T>;
+  },
+);
+
+export function injectPopoverTriggerState<T>(): Signal<NgpPopoverTriggerState<T>>;
+export function injectPopoverTriggerState<T>(options?: {
+  hoisted?: boolean;
+  optional?: boolean;
+  skipSelf?: boolean;
+}): Signal<NgpPopoverTriggerState<T>>;
+export function injectPopoverTriggerState<T>(
+  options?:
+    | {
+        hoisted?: boolean;
+        optional?: boolean;
+        skipSelf?: boolean;
+      }
+    | undefined,
+): Signal<NgpPopoverTriggerState<T>> {
+  return _injectPopoverTriggerState(options) as Signal<NgpPopoverTriggerState<T>>;
+}
+
+export type NgpPopoverPlacement =
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left'
+  | 'top-start'
+  | 'top-end'
+  | 'right-start'
+  | 'right-end'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left-start'
+  | 'left-end';

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
@@ -2,28 +2,19 @@ import { FocusOrigin } from '@angular/cdk/a11y';
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
 import {
   booleanAttribute,
-  computed,
   Directive,
-  inject,
-  Injector,
   input,
   numberAttribute,
   OnDestroy,
   output,
-  signal,
-  ViewContainerRef,
 } from '@angular/core';
-import { injectElementRef } from 'ng-primitives/internal';
 import {
-  createOverlay,
   coerceFlip,
   dismissGuardAttribute,
   NgpDismissGuard,
   NgpDismissGuardInput,
   NgpFlip,
   NgpFlipInput,
-  NgpOverlay,
-  NgpOverlayConfig,
   NgpOverlayContent,
   coerceOffset,
   NgpOffset,
@@ -33,7 +24,11 @@ import {
   NgpShiftInput,
 } from 'ng-primitives/portal';
 import { injectPopoverConfig } from '../config/popover-config';
-import { popoverTriggerState, providePopoverTriggerState } from './popover-trigger-state';
+import {
+  NgpPopoverPlacement,
+  ngpPopoverTrigger,
+  providePopoverTriggerState,
+} from './popover-trigger-state';
 
 /**
  * Apply the `ngpPopoverTrigger` directive to an element that triggers the popover to show.
@@ -42,31 +37,8 @@ import { popoverTriggerState, providePopoverTriggerState } from './popover-trigg
   selector: '[ngpPopoverTrigger]',
   exportAs: 'ngpPopoverTrigger',
   providers: [providePopoverTriggerState({ inherit: false })],
-  host: {
-    '[attr.aria-expanded]': 'open() ? "true" : "false"',
-    '[attr.data-open]': 'open() ? "" : null',
-    '[attr.data-placement]': 'state.placement()',
-    '[attr.data-disabled]': 'state.disabled() ? "" : null',
-    '[attr.aria-describedby]': 'overlay()?.ariaDescribedBy()',
-    '(click)': 'toggle($event)',
-  },
 })
 export class NgpPopoverTrigger<T = null> implements OnDestroy {
-  /**
-   * Access the trigger element
-   */
-  private readonly trigger = injectElementRef();
-
-  /**
-   * Access the injector.
-   */
-  private readonly injector = inject(Injector);
-
-  /**
-   * Access the view container reference.
-   */
-  private readonly viewContainerRef = inject(ViewContainerRef);
-
   /**
    * Access the global popover configuration.
    */
@@ -221,18 +193,6 @@ export class NgpPopoverTrigger<T = null> implements OnDestroy {
   });
 
   /**
-   * The overlay that manages the popover
-   * @internal
-   */
-  readonly overlay = signal<NgpOverlay<T> | null>(null);
-
-  /**
-   * The open state of the popover.
-   * @internal
-   */
-  readonly open = computed(() => this.overlay()?.isOpen() ?? false);
-
-  /**
    * Event emitted when the popover open state changes.
    */
   readonly openChange = output<boolean>({
@@ -242,50 +202,36 @@ export class NgpPopoverTrigger<T = null> implements OnDestroy {
   /**
    * The popover trigger state.
    */
-  readonly state = popoverTriggerState<NgpPopoverTrigger<T>>(this);
+  protected readonly state = ngpPopoverTrigger({
+    popover: this.popover,
+    disabled: this.disabled,
+    placement: this.placement,
+    offset: this.offset,
+    showDelay: this.showDelay,
+    hideDelay: this.hideDelay,
+    flip: this.flip,
+    shift: this.shift,
+    container: this.container,
+    closeOnOutsideClick: this.closeOnOutsideClick,
+    closeOnEscape: this.closeOnEscape,
+    scrollBehavior: this.scrollBehavior,
+    context: this.context,
+    anchor: this.anchor,
+    trackPosition: this.trackPosition,
+    cooldown: this.cooldown,
+    onOpenChange: (value: boolean) => this.openChange.emit(value),
+  });
 
   ngOnDestroy(): void {
-    this.overlay()?.destroy();
-  }
-
-  protected toggle(event: MouseEvent): void {
-    // if the trigger is disabled then do not toggle the popover
-    if (this.state.disabled()) {
-      return;
-    }
-
-    // determine the origin of the event, 0 is keyboard, 1 is mouse
-    const origin: FocusOrigin = event.detail === 0 ? 'keyboard' : 'mouse';
-
-    // if the popover is open then hide it
-    if (this.open()) {
-      this.hide(origin);
-    } else {
-      this.show();
-    }
+    this.state.destroy();
   }
 
   /**
    * Show the popover.
    * @returns A promise that resolves when the popover has been shown
    */
-  async show(): Promise<void> {
-    // If the trigger is disabled, don't show the popover
-    if (this.state.disabled()) {
-      return;
-    }
-
-    // Create the overlay if it doesn't exist yet
-    if (!this.overlay()) {
-      this.createOverlay();
-    }
-
-    // Show the overlay
-    await this.overlay()?.show();
-
-    if (this.open()) {
-      this.openChange.emit(true);
-    }
+  show(): Promise<void> {
+    return this.state.show();
   }
 
   /**
@@ -293,65 +239,7 @@ export class NgpPopoverTrigger<T = null> implements OnDestroy {
    * Hide the popover.
    * @returns A promise that resolves when the popover has been hidden
    */
-  async hide(origin: FocusOrigin = 'program'): Promise<void> {
-    // If the trigger is disabled or the popover is not open, do nothing
-    if (this.state.disabled() || !this.open()) {
-      return;
-    }
-
-    // Hide the overlay
-    await this.overlay()?.hide({ origin });
-  }
-
-  /**
-   * Create the overlay that will contain the popover
-   */
-  private createOverlay(): void {
-    const popover = this.state.popover();
-
-    if (!popover) {
-      throw new Error('Popover must be either a TemplateRef or a ComponentType');
-    }
-
-    // Create config for the overlay
-    const config: NgpOverlayConfig<T> = {
-      content: popover,
-      triggerElement: this.trigger.nativeElement,
-      anchorElement: this.state.anchor(),
-      injector: this.injector,
-      context: this.state.context,
-      container: this.state.container(),
-      placement: this.state.placement,
-      offset: this.state.offset(),
-      flip: this.state.flip(),
-      shift: this.state.shift(),
-      showDelay: this.state.showDelay(),
-      hideDelay: this.state.hideDelay(),
-      closeOnOutsideClick: this.state.closeOnOutsideClick(),
-      closeOnEscape: this.state.closeOnEscape(),
-      restoreFocus: true,
-      scrollBehaviour: this.state.scrollBehavior(),
-      viewContainerRef: this.viewContainerRef,
-      trackPosition: this.state.trackPosition(),
-      overlayType: 'popover',
-      cooldown: this.state.cooldown(),
-      onClose: () => this.openChange.emit(false),
-    };
-
-    this.overlay.set(createOverlay(config));
+  hide(origin: FocusOrigin = 'program'): Promise<void> {
+    return this.state.hide(origin);
   }
 }
-
-export type NgpPopoverPlacement =
-  | 'top'
-  | 'right'
-  | 'bottom'
-  | 'left'
-  | 'top-start'
-  | 'top-end'
-  | 'right-start'
-  | 'right-end'
-  | 'bottom-start'
-  | 'bottom-end'
-  | 'left-start'
-  | 'left-end';

--- a/packages/ng-primitives/popover/src/popover/popover-state.ts
+++ b/packages/ng-primitives/popover/src/popover/popover-state.ts
@@ -29,20 +29,21 @@ export const [NgpPopoverStateToken, ngpPopover, injectPopoverState, providePopov
     id.set(overlay.id());
 
     // Host binding
-    attrBinding(elementRef, 'id', _id);
+    attrBinding(elementRef, 'role', 'dialog');
+    attrBinding(elementRef, 'id', id);
     styleBinding(elementRef, 'left.px', () => overlay.position().x ?? null);
     styleBinding(elementRef, 'top.px', () => overlay.position().y ?? null);
-    styleBinding(elementRef, '--ngp-popover-trigger-width.px', overlay.triggerWidth());
-    styleBinding(elementRef, '--ngp-popover-transform-origin', overlay.transformOrigin());
-    styleBinding(elementRef, '--ngp-popover-available-width.px', overlay.availableWidth());
-    styleBinding(elementRef, '--ngp-popover-available-height.px', overlay.availableHeight());
-    dataBinding(elementRef, 'data-placement', () => (overlay.finalPlacement() ? '' : null));
+    styleBinding(elementRef, '--ngp-popover-trigger-width.px', () => overlay.triggerWidth());
+    styleBinding(elementRef, '--ngp-popover-transform-origin', () => overlay.transformOrigin());
+    styleBinding(elementRef, '--ngp-popover-available-width.px', () => overlay.availableWidth());
+    styleBinding(elementRef, '--ngp-popover-available-height.px', () => overlay.availableHeight());
+    dataBinding(elementRef, 'data-placement', () => overlay.finalPlacement() ?? null);
     dataBinding(elementRef, 'data-overlay', '');
 
     // Effect handle
-    explicitEffect([_id], ([id]) => overlay.id.set(id));
+    explicitEffect([id], ([id]) => overlay.id.set(id));
 
     return {
-      id: _id,
+      id,
     } satisfies NgpPopoverState;
   });

--- a/packages/ng-primitives/popover/src/popover/popover-state.ts
+++ b/packages/ng-primitives/popover/src/popover/popover-state.ts
@@ -1,0 +1,48 @@
+import { signal, Signal } from '@angular/core';
+import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
+import { injectOverlay } from 'ng-primitives/portal';
+import {
+  attrBinding,
+  controlled,
+  createPrimitive,
+  dataBinding,
+  styleBinding,
+} from 'ng-primitives/state';
+
+export interface NgpPopoverState {
+  /** The unique id of the tooltip. */
+  readonly id: Signal<string>;
+}
+
+export interface NgpPopoverProps {
+  /** The unique id of the tooltip. */
+  readonly id?: Signal<string>;
+}
+
+export const [NgpPopoverStateToken, ngpPopover, injectPopoverState, providePopoverState] =
+  createPrimitive('NgpPopover', ({ id: _id = signal<string>('') }: NgpPopoverProps) => {
+    const elementRef = injectElementRef<HTMLElement>();
+
+    const overlay = injectOverlay();
+    const id = controlled(_id);
+
+    id.set(overlay.id());
+
+    // Host binding
+    attrBinding(elementRef, 'id', _id);
+    styleBinding(elementRef, 'left.px', () => overlay.position().x ?? null);
+    styleBinding(elementRef, 'top.px', () => overlay.position().y ?? null);
+    styleBinding(elementRef, '--ngp-popover-trigger-width.px', overlay.triggerWidth());
+    styleBinding(elementRef, '--ngp-popover-transform-origin', overlay.transformOrigin());
+    styleBinding(elementRef, '--ngp-popover-available-width.px', overlay.availableWidth());
+    styleBinding(elementRef, '--ngp-popover-available-height.px', overlay.availableHeight());
+    dataBinding(elementRef, 'data-placement', () => (overlay.finalPlacement() ? '' : null));
+    dataBinding(elementRef, 'data-overlay', '');
+
+    // Effect handle
+    explicitEffect([_id], ([id]) => overlay.id.set(id));
+
+    return {
+      id: _id,
+    } satisfies NgpPopoverState;
+  });

--- a/packages/ng-primitives/popover/src/popover/popover.test.ts
+++ b/packages/ng-primitives/popover/src/popover/popover.test.ts
@@ -1,0 +1,108 @@
+import { Component } from '@angular/core';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpPopover, type NgpPopoverPlacement, NgpPopoverTrigger } from 'ng-primitives/popover';
+import { afterEach, describe, expect, it } from 'vitest';
+
+@Component({
+  template: `
+    <button [ngpPopoverTrigger]="content">Open Popover</button>
+
+    <ng-template #content>
+      <div ngpPopover>Popover content</div>
+    </ng-template>
+  `,
+  imports: [NgpPopoverTrigger, NgpPopover],
+})
+class PopoverTestComponent {}
+
+describe('NgpPopover', () => {
+  afterEach(() => {
+    // Overlay content is attached to the document body, not the fixture, so remove
+    // any leftover popovers in case a test ends with one still open.
+    document.querySelectorAll('[ngpPopover]').forEach(el => el.remove());
+  });
+
+  it('should expose role="dialog" on the popover element', async () => {
+    const { getByRole } = await render(PopoverTestComponent);
+    fireEvent.click(getByRole('button'));
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+    });
+
+    const popover = document.querySelector('[ngpPopover]') as HTMLElement;
+    expect(popover.getAttribute('role')).toBe('dialog');
+  });
+
+  it('should link the trigger to the popover via aria-describedby and a matching id', async () => {
+    const { getByRole } = await render(PopoverTestComponent);
+    const trigger = getByRole('button');
+    fireEvent.click(trigger);
+
+    // The popover must have a real, generated id (not empty) and the trigger must
+    // describe it for assistive technology. Both bindings settle after render.
+    await waitFor(() => {
+      const popover = document.querySelector('[ngpPopover]') as HTMLElement | null;
+      const id = popover?.getAttribute('id');
+      expect(id).toBeTruthy();
+      expect(trigger.getAttribute('aria-describedby')).toBe(id);
+    });
+  });
+
+  it('should reflect the resolved placement value on data-placement', async () => {
+    const { getByRole } = await render(PopoverTestComponent);
+    fireEvent.click(getByRole('button'));
+
+    // data-placement should carry the actual placement (e.g. "bottom"), not an empty string.
+    await waitFor(() => {
+      const popover = document.querySelector('[ngpPopover]') as HTMLElement | null;
+      expect(popover?.getAttribute('data-placement')).toBeTruthy();
+    });
+  });
+
+  it('should keep positioning CSS variables reactive when the popover repositions', async () => {
+    @Component({
+      template: `
+        <button
+          [ngpPopoverTrigger]="content"
+          [ngpPopoverTriggerPlacement]="placement"
+          [ngpPopoverTriggerFlip]="false"
+        >
+          Open
+        </button>
+
+        <ng-template #content>
+          <div ngpPopover>Popover content</div>
+        </ng-template>
+      `,
+      imports: [NgpPopoverTrigger, NgpPopover],
+    })
+    class PlacementTestComponent {
+      placement: NgpPopoverPlacement = 'bottom';
+    }
+
+    const { fixture, getByRole } = await render(PlacementTestComponent);
+    fireEvent.click(getByRole('button'));
+
+    // The size middleware sets --ngp-popover-available-height once the popover positions.
+    let initialHeight = '';
+    await waitFor(() => {
+      const popover = document.querySelector('[ngpPopover]') as HTMLElement;
+      initialHeight = popover.style.getPropertyValue('--ngp-popover-available-height');
+      expect(initialHeight).not.toBe('');
+    });
+
+    // Changing the placement repositions the popover, which recomputes the available
+    // space. A frozen (non-reactive) binding captures the value once and would keep the
+    // original height here. With flip disabled, top vs bottom yields different space.
+    fixture.componentInstance.placement = 'top';
+    fixture.detectChanges();
+
+    await waitFor(() => {
+      const popover = document.querySelector('[ngpPopover]') as HTMLElement;
+      expect(popover.style.getPropertyValue('--ngp-popover-available-height')).not.toBe(
+        initialHeight,
+      );
+    });
+  });
+});

--- a/packages/ng-primitives/popover/src/popover/popover.ts
+++ b/packages/ng-primitives/popover/src/popover/popover.ts
@@ -1,7 +1,6 @@
 import { Directive, input } from '@angular/core';
 import { NgpFocusTrap } from 'ng-primitives/focus-trap';
-import { explicitEffect } from 'ng-primitives/internal';
-import { injectOverlay } from 'ng-primitives/portal';
+import { ngpPopover, providePopoverState } from './popover-state';
 
 /**
  * Apply the `ngpPopover` directive to an element that represents the popover. This typically would be a `div` inside an `ng-template`.
@@ -10,31 +9,15 @@ import { injectOverlay } from 'ng-primitives/portal';
   selector: '[ngpPopover]',
   exportAs: 'ngpPopover',
   hostDirectives: [NgpFocusTrap],
-  host: {
-    role: 'dialog',
-    '[id]': 'id()',
-    '[style.left.px]': 'overlay.position().x',
-    '[style.top.px]': 'overlay.position().y',
-    '[style.--ngp-popover-trigger-width.px]': 'overlay.triggerWidth()',
-    '[style.--ngp-popover-transform-origin]': 'overlay.transformOrigin()',
-    '[style.--ngp-popover-available-width.px]': 'overlay.availableWidth()',
-    '[style.--ngp-popover-available-height.px]': 'overlay.availableHeight()',
-    '[attr.data-placement]': 'overlay.finalPlacement()',
-    'data-overlay': '',
-  },
+  providers: [providePopoverState()],
 })
 export class NgpPopover {
   /**
-   * Access the overlay.
-   */
-  protected readonly overlay = injectOverlay();
-
-  /**
    * The unique id of the tooltip.
    */
-  readonly id = input(this.overlay.id());
+  readonly id = input('');
 
-  constructor() {
-    explicitEffect([this.id], ([id]) => this.overlay.id.set(id));
-  }
+  protected readonly state = ngpPopover({
+    id: this.id,
+  });
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #565 

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates popover trigger and content to the new state primitive API, moving overlay control, events, and host bindings into dedicated state. Restores reactive bindings and awaited hide(), and adds tests; closes #565.

- **New Features**
  - Exported: `NgpPopoverStateToken`, `ngpPopover`, `injectPopoverState`, `providePopoverState`, `NgpPopoverTriggerStateToken`, `ngpPopoverTrigger`, `injectPopoverTriggerState`, `providePopoverTriggerState`, plus types `NgpPopoverState`, `NgpPopoverProps`, `NgpPopoverTriggerState`, `NgpPopoverTriggerProps`, and `NgpPopoverPlacement`.
  - Consumers can inject trigger state to read `open`, call `show()`/`hide()`, and configure placement, offset, flip/shift, scroll behavior, tracking, and cooldown via signals.

- **Bug Fixes**
  - Restored reactive style bindings and `data-placement` so positioning vars update and placement reflects the resolved value.
  - `hide()` now awaits the overlay hide, matching the “resolves when hidden” contract.
  - Added tests covering role, id/aria-describedby linkage, placement, and reactive positioning variables.

<sup>Written for commit c324192b4bc6298123d228823c16e483eab1c567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/761?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

