### PR TITLE
feat(dialog): support InjectOptions in injectDialogRef

### DIFF
--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -1,5 +1,5 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { inject, Injector } from '@angular/core';
+import { inject, InjectOptions, Injector } from '@angular/core';
 import { NgpExitAnimationManager } from 'ng-primitives/internal';
 import { NgpDismissGuard, NgpOverlayRef } from 'ng-primitives/portal';
 import { defer, EMPTY, fromEvent, Observable, Subject } from 'rxjs';
@@ -192,6 +192,14 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
   }
 }
 
-export function injectDialogRef<T = unknown, R = unknown>(): NgpDialogRef<T, R> {
-  return inject<NgpDialogRef<T, R>>(NgpDialogRef);
+export function injectDialogRef<T = unknown, R = unknown>(
+  options?: InjectOptions & { optional?: false },
+): NgpDialogRef<T, R>;
+export function injectDialogRef<T = unknown, R = unknown>(
+  options: InjectOptions & { optional: true },
+): NgpDialogRef<T, R> | null;
+export function injectDialogRef<T = unknown, R = unknown>(
+  options?: InjectOptions,
+): NgpDialogRef<T, R> | null {
+  return inject<NgpDialogRef<T, R>>(NgpDialogRef, options ?? {});
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## Issue

No issue linked to this PR

## What does this PR implement/fix?


`injectDialogRef` now accepts Angular's `InjectOptions` as an optional parameter,
enabling optional injection via `injectDialogRef({ optional: true })`.


Useful for components that may render inside or outside a dialog context.

Note that a current workaround is to not use `injectDialogRef` and directly use `inject` function with `NgpDialogRef`

Something like
```ts
private readonly modalRef = inject<NgpDialogRef<IData, ICloseData>(NgpDialogRef, { 
 optional: true
})
```

@ashley-hunter If you'd rather keep `injectDialogRef` simple and avoid the extra overload complexity, feel free to close this PR, the workaround is sufficient.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for Angular’s `InjectOptions` in `injectDialogRef`, including `optional`. You can now call `injectDialogRef({ optional: true })` to get `null` when no dialog is present, so components work both inside and outside a dialog.

<sup>Written for commit 00750bd8dc6ad217b1150578a0fa681cba4cd697. Summary will update on new commits. <a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/763?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

