### PR TITLE
feat(toasts): persistent toasts

### DIFF
--- a/apps/documentation/src/app/examples/toast/toast-persistent.example.ts
+++ b/apps/documentation/src/app/examples/toast/toast-persistent.example.ts
@@ -28,8 +28,8 @@ import { NgpToast, NgpToastManager } from 'ng-primitives/toast';
       </button>
       <button
         class="toast-trigger"
-        (click)="dismissLatest()"
         [disabled]="!hasOpenToasts()"
+        (click)="dismissLatest()"
         ngpButton
       >
         Dismiss latest

--- a/apps/documentation/src/app/examples/toast/toast-persistent.example.ts
+++ b/apps/documentation/src/app/examples/toast/toast-persistent.example.ts
@@ -1,39 +1,55 @@
-import { Component, inject, TemplateRef } from '@angular/core';
+import { Component, computed, inject, TemplateRef } from '@angular/core';
 import { NgpButton } from 'ng-primitives/button';
-import { NgpToastManager, NgpToast } from 'ng-primitives/toast';
+import { NgpToast, NgpToastManager } from 'ng-primitives/toast';
 
 /**
- * This example demonstrates the sequential toast feature.
- * When sequential mode is enabled, only the front-most toast's timer runs.
- * When that toast is dismissed, the timer starts on the next toast.
+ * This example demonstrates a persistent toast.
+ * When `persistent` is true, the toast does not auto-dismiss and must be
+ * dismissed explicitly — either by the user (swipe / dismiss button) or
+ * programmatically via the returned `NgpToastRef`.
  *
- * To enable sequential mode globally:
+ * To make all toasts persistent globally:
  *
  * bootstrapApplication(AppComponent, {
  *   providers: [
  *     provideToastConfig({
- *       sequential: true,
+ *       persistent: true,
  *     }),
  *   ],
  * });
  */
 @Component({
-  selector: 'app-toast-sequential',
+  selector: 'app-toast-persistent',
   imports: [NgpToast, NgpButton],
   template: `
-    <button class="toast-trigger" (click)="showMultipleToasts(toast)" ngpButton>
-      Show 3 Toasts
-    </button>
+    <div class="buttons">
+      <button class="toast-trigger" (click)="showPersistentToast(toast)" ngpButton>
+        Show toast
+      </button>
+      <button
+        class="toast-trigger"
+        (click)="dismissLatest()"
+        [disabled]="!hasOpenToasts()"
+        ngpButton
+      >
+        Dismiss latest
+      </button>
+    </div>
 
     <ng-template #toast let-dismiss="dismiss">
       <div ngpToast animate.enter="toast-enter" animate.leave="toast-leave">
-        <p class="toast-title">Sequential Toast</p>
-        <p class="toast-description">Only front toast timer runs in sequential mode.</p>
+        <p class="toast-title">Persistent Toast</p>
+        <p class="toast-description">This toast will not auto-dismiss.</p>
         <button class="toast-dismiss" (click)="dismiss()" ngpButton>Dismiss</button>
       </div>
     </ng-template>
   `,
   styles: `
+    .buttons {
+      display: flex;
+      gap: 0.5rem;
+    }
+
     .toast-trigger {
       padding-left: 1rem;
       padding-right: 1rem;
@@ -59,6 +75,11 @@ import { NgpToastManager, NgpToast } from 'ng-primitives/toast';
 
     .toast-trigger[data-press] {
       background-color: var(--ngp-background-active);
+    }
+
+    .toast-trigger[disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
     }
 
     [ngpToast] {
@@ -185,26 +206,21 @@ import { NgpToastManager, NgpToast } from 'ng-primitives/toast';
     }
 
     [ngpToast][data-swiping='true'][data-swipe-direction='left'] {
-      /* Fade out from -45px to -100px swipe */
       opacity: calc(1 - clamp(0, ((-1 * var(--ngp-toast-swipe-x, 0px)) - 45) / 55, 1));
     }
 
     [ngpToast][data-swiping='true'][data-swipe-direction='right'] {
-      /* Fade out from 45px to 100px swipe */
       opacity: calc(1 - clamp(0, (var(--ngp-toast-swipe-x, 0px) - 45) / 55, 1));
     }
 
     [ngpToast][data-swiping='true'][data-swipe-direction='top'] {
-      /* Fade out from -45px to -100px swipe */
       opacity: calc(1 - clamp(0, ((-1 * var(--ngp-toast-swipe-y, 0px)) - 45) / 55, 1));
     }
 
     [ngpToast][data-swiping='true'][data-swipe-direction='bottom'] {
-      /* Fade out from 45px to 100px swipe */
       opacity: calc(1 - clamp(0, (var(--ngp-toast-swipe-y, 0px) - 45) / 55, 1));
     }
 
-    /* Truncate text only when toast is not front AND not expanded */
     [ngpToast][data-front='false'][data-expanded='false'] .toast-title {
       overflow: hidden;
       text-overflow: ellipsis;
@@ -217,7 +233,6 @@ import { NgpToastManager, NgpToast } from 'ng-primitives/toast';
       white-space: nowrap;
     }
 
-    /* Angular animations using animate.enter and animate.leave */
     .toast-enter {
       animation: toast-slide-in 400ms cubic-bezier(0.215, 0.61, 0.355, 1);
     }
@@ -242,19 +257,21 @@ import { NgpToastManager, NgpToast } from 'ng-primitives/toast';
     }
   `,
 })
-export default class ToastSequentialExample {
+export default class ToastPersistentExample {
   private readonly toastManager = inject(NgpToastManager);
+  protected readonly hasOpenToasts = computed(() => this.toastManager.toasts().length > 0);
 
-  showMultipleToasts(toast: TemplateRef<void>): void {
-    // Show 3 toasts with a small delay between each
-    // Each toast has sequential mode enabled
-    for (let i = 0; i < 3; i++) {
-      setTimeout(() => {
-        this.toastManager.show(toast, {
-          placement: 'bottom-end',
-          sequential: true,
-        });
-      }, i * 300);
+  showPersistentToast(toast: TemplateRef<void>): void {
+    this.toastManager.show(toast, {
+      placement: 'bottom-end',
+      persistent: true,
+    });
+  }
+
+  async dismissLatest(): Promise<void> {
+    const [latest] = this.toastManager.toasts();
+    if (latest) {
+      await this.toastManager.dismiss(latest.instance);
     }
   }
 }

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
@@ -76,40 +76,17 @@ The sequential mode prevents background toasts from auto-closing. Only the front
 
 This is useful when you have multiple notifications in quick succession (e.g., health monitoring of external services) where you want to ensure users can see all notifications before they auto-close.
 
+Pass `sequential: true` when calling `show`, or set it globally via `provideToastConfig` to make it the default for every toast.
+
 <docs-example name="toast-sequential"></docs-example>
 
-You can enable sequential mode in two ways:
+### Persistent Toasts
 
-**1. Globally via configuration:**
+Persistent toasts do not auto-dismiss. They remain visible until the user dismisses them (by swiping when `dismissible` is enabled) or until they are dismissed programmatically — either via the returned `NgpToastRef` or via the manager (`toastManager.toasts()` + `toastManager.dismiss()`). This is useful for notification centers and other surfaces where messages must stay until acknowledged.
 
-```ts
-import { provideToastConfig } from 'ng-primitives/toast';
+Pass `persistent: true` when calling `show`, or set it globally via `provideToastConfig` to make it the default for every toast.
 
-bootstrapApplication(AppComponent, {
-  providers: [
-    provideToastConfig({
-      sequential: true,
-      // ... other config options
-    }),
-  ],
-});
-```
-
-**2. Per-toast via the show method:**
-
-```ts
-import { NgpToastManager } from 'ng-primitives/toast';
-
-export class MyComponent {
-  private readonly toastManager = inject(NgpToastManager);
-
-  showToast(): void {
-    this.toastManager.show(ToastComponent, {
-      sequential: true,
-    });
-  }
-}
-```
+<docs-example name="toast-persistent"></docs-example>
 
 ## API Reference
 
@@ -167,6 +144,7 @@ bootstrapApplication(AppComponent, {
       swipeDirections: ['left', 'right'],
       ariaLive: 'assertive',
       gap: 16,
+      persistent: false,
     }),
   ],
 });

--- a/packages/ng-primitives/project.json
+++ b/packages/ng-primitives/project.json
@@ -68,7 +68,7 @@
       "outputs": ["{options.outputPath}"],
       "options": {
         "clean": true,
-        "outputPath": "dist/packages/ng-primitives-schematics-test",
+        "outputPath": "dist/ng-primitives-schematics-test",
         "main": "packages/ng-primitives/src/index.ts",
         "tsConfig": "packages/ng-primitives/tsconfig.schematics.json",
         "generateExportsField": false,

--- a/packages/ng-primitives/project.json
+++ b/packages/ng-primitives/project.json
@@ -67,8 +67,8 @@
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
-        "clean": false,
-        "outputPath": "dist/packages/ng-primitives",
+        "clean": true,
+        "outputPath": "dist/packages/ng-primitives-schematics-test",
         "main": "packages/ng-primitives/src/index.ts",
         "tsConfig": "packages/ng-primitives/tsconfig.schematics.json",
         "generateExportsField": false,

--- a/packages/ng-primitives/schematics/mcp-setup/index.node.test.ts
+++ b/packages/ng-primitives/schematics/mcp-setup/index.node.test.ts
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 const workspaceRoot = resolve(fileURLToPath(new URL('../../../../', import.meta.url)));
 const collectionPath = resolve(
   workspaceRoot,
-  'dist/packages/ng-primitives-schematics-test/collection.json',
+  'dist/ng-primitives-schematics-test/collection.json',
 );
 const packageJsonPath = fileURLToPath(new URL('../../package.json', import.meta.url));
 const { version: packageVersion } = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {

--- a/packages/ng-primitives/schematics/mcp-setup/index.node.test.ts
+++ b/packages/ng-primitives/schematics/mcp-setup/index.node.test.ts
@@ -5,10 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 const workspaceRoot = resolve(fileURLToPath(new URL('../../../../', import.meta.url)));
-const collectionPath = resolve(
-  workspaceRoot,
-  'dist/ng-primitives-schematics-test/collection.json',
-);
+const collectionPath = resolve(workspaceRoot, 'dist/ng-primitives-schematics-test/collection.json');
 const packageJsonPath = fileURLToPath(new URL('../../package.json', import.meta.url));
 const { version: packageVersion } = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
   version: string;

--- a/packages/ng-primitives/schematics/mcp-setup/index.node.test.ts
+++ b/packages/ng-primitives/schematics/mcp-setup/index.node.test.ts
@@ -5,7 +5,10 @@ import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 const workspaceRoot = resolve(fileURLToPath(new URL('../../../../', import.meta.url)));
-const collectionPath = resolve(workspaceRoot, 'dist/packages/ng-primitives/collection.json');
+const collectionPath = resolve(
+  workspaceRoot,
+  'dist/packages/ng-primitives-schematics-test/collection.json',
+);
 const packageJsonPath = fileURLToPath(new URL('../../package.json', import.meta.url));
 const { version: packageVersion } = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
   version: string;

--- a/packages/ng-primitives/schematics/ng-add/index.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-add/index.node.test.ts
@@ -9,7 +9,7 @@ describe('Ng Add Schematic', () => {
   const workspaceRoot = resolve(fileURLToPath(new URL('../../../../', import.meta.url)));
   const schematicRunner = new SchematicTestRunner(
     'ng-primitives',
-    resolve(workspaceRoot, 'dist/packages/ng-primitives/collection.json'),
+    resolve(workspaceRoot, 'dist/packages/ng-primitives-schematics-test/collection.json'),
   );
 
   const workspaceOptions: WorkspaceOptions = {

--- a/packages/ng-primitives/schematics/ng-add/index.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-add/index.node.test.ts
@@ -9,7 +9,7 @@ describe('Ng Add Schematic', () => {
   const workspaceRoot = resolve(fileURLToPath(new URL('../../../../', import.meta.url)));
   const schematicRunner = new SchematicTestRunner(
     'ng-primitives',
-    resolve(workspaceRoot, 'dist/packages/ng-primitives-schematics-test/collection.json'),
+    resolve(workspaceRoot, 'dist/ng-primitives-schematics-test/collection.json'),
   );
 
   const workspaceOptions: WorkspaceOptions = {

--- a/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
@@ -10,7 +10,7 @@ describe('Component Schematic', () => {
   const workspaceRoot = resolve(fileURLToPath(new URL('../../../../', import.meta.url)));
   const schematicRunner = new SchematicTestRunner(
     'ng-primitives',
-    resolve(workspaceRoot, 'dist/packages/ng-primitives-schematics-test/collection.json'),
+    resolve(workspaceRoot, 'dist/ng-primitives-schematics-test/collection.json'),
   );
 
   const workspaceOptions: WorkspaceOptions = {

--- a/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
@@ -10,7 +10,7 @@ describe('Component Schematic', () => {
   const workspaceRoot = resolve(fileURLToPath(new URL('../../../../', import.meta.url)));
   const schematicRunner = new SchematicTestRunner(
     'ng-primitives',
-    resolve(workspaceRoot, 'dist/packages/ng-primitives/collection.json'),
+    resolve(workspaceRoot, 'dist/packages/ng-primitives-schematics-test/collection.json'),
   );
 
   const workspaceOptions: WorkspaceOptions = {

--- a/packages/ng-primitives/toast/src/config/toast-config.ts
+++ b/packages/ng-primitives/toast/src/config/toast-config.ts
@@ -73,6 +73,11 @@ export interface NgpToastConfig {
    * When a toast is dismissed, the timer will start on the next toast.
    */
   sequential: boolean;
+
+  /**
+   * When true, toasts will not auto-dismiss and must be dismissed explicitly.
+   */
+  persistent: boolean;
 }
 
 export const defaultToastConfig: NgpToastConfig = {
@@ -90,6 +95,7 @@ export const defaultToastConfig: NgpToastConfig = {
   zIndex: 9999999,
   ariaLive: 'polite',
   sequential: false,
+  persistent: false,
 };
 
 export const NgpToastConfigToken = new InjectionToken<NgpToastConfig>('NgpToastConfigToken');

--- a/packages/ng-primitives/toast/src/toast/toast-manager.ts
+++ b/packages/ng-primitives/toast/src/toast/toast-manager.ts
@@ -59,6 +59,7 @@ export class NgpToastManager {
             dismissible: options.dismissible ?? this.config.dismissible,
             swipeDirections: options.swipeDirections ?? this.config.swipeDirections,
             sequential: options.sequential ?? this.config.sequential,
+            persistent: options.persistent ?? this.config.persistent,
           }),
         ],
       }),
@@ -196,6 +197,9 @@ export interface NgpToastOptions<T = unknown> {
 
   /** When enabled, only the front toast's timer will run */
   sequential?: boolean;
+
+  /** When true, the toast will not auto-dismiss and must be dismissed explicitly */
+  persistent?: boolean;
 }
 
 interface NgpToastRecord {

--- a/packages/ng-primitives/toast/src/toast/toast-options.ts
+++ b/packages/ng-primitives/toast/src/toast/toast-options.ts
@@ -51,4 +51,10 @@ export interface NgpToastOptions {
    * @internal
    */
   sequential: boolean;
+
+  /**
+   * When true, the toast will not auto-dismiss and must be dismissed explicitly.
+   * @internal
+   */
+  persistent: boolean;
 }

--- a/packages/ng-primitives/toast/src/toast/toast-timer.test.ts
+++ b/packages/ng-primitives/toast/src/toast/toast-timer.test.ts
@@ -113,4 +113,39 @@ describe('toastTimer', () => {
     vi.advanceTimersByTime(1);
     expect(callback).toHaveBeenCalledTimes(1);
   });
+
+  it('should not call callback when persistent', () => {
+    const callback = vi.fn();
+    const timer = toastTimer(3000, callback, { persistent: true });
+
+    timer.start();
+    vi.advanceTimersByTime(10_000);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should remain inert across pause/start cycles when persistent', () => {
+    const callback = vi.fn();
+    const timer = toastTimer(3000, callback, { persistent: true });
+
+    timer.start();
+    vi.advanceTimersByTime(1000);
+    timer.pause();
+    vi.advanceTimersByTime(1000);
+    timer.start();
+    vi.advanceTimersByTime(10_000);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should not call callback after stop when persistent', () => {
+    const callback = vi.fn();
+    const timer = toastTimer(3000, callback, { persistent: true });
+
+    timer.start();
+    timer.stop();
+    vi.advanceTimersByTime(10_000);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ng-primitives/toast/src/toast/toast-timer.ts
+++ b/packages/ng-primitives/toast/src/toast/toast-timer.ts
@@ -7,11 +7,13 @@ class NgpToastTimer {
   constructor(
     private duration: number,
     private callback: () => void,
+    private readonly persistent = false,
   ) {
     this.remaining = duration;
   }
 
   start(): void {
+    if (this.persistent) return;
     if (this.isRunning) return;
 
     this.isRunning = true;
@@ -44,6 +46,18 @@ class NgpToastTimer {
   }
 }
 
-export function toastTimer(duration: number, callback: () => void): NgpToastTimer {
-  return new NgpToastTimer(duration, callback);
+export interface NgpToastTimerOptions {
+  /**
+   * When true, the timer never fires. `start()`, `pause()`, and `stop()` are safe
+   * to call but have no effect on the callback.
+   */
+  persistent?: boolean;
+}
+
+export function toastTimer(
+  duration: number,
+  callback: () => void,
+  options: NgpToastTimerOptions = {},
+): NgpToastTimer {
+  return new NgpToastTimer(duration, callback, options.persistent);
 }

--- a/packages/ng-primitives/toast/src/toast/toast.ts
+++ b/packages/ng-primitives/toast/src/toast/toast.ts
@@ -139,7 +139,11 @@ export class NgpToast {
   /**
    * The toast timer instance.
    */
-  private readonly timer = toastTimer(this.options.duration, () => this.manager.dismiss(this));
+  private readonly timer = toastTimer(
+    this.options.duration,
+    () => this.manager.dismiss(this),
+    { persistent: this.options.persistent },
+  );
 
   constructor() {
     this.options.register(this);

--- a/packages/ng-primitives/toast/src/toast/toast.ts
+++ b/packages/ng-primitives/toast/src/toast/toast.ts
@@ -139,11 +139,9 @@ export class NgpToast {
   /**
    * The toast timer instance.
    */
-  private readonly timer = toastTimer(
-    this.options.duration,
-    () => this.manager.dismiss(this),
-    { persistent: this.options.persistent },
-  );
+  private readonly timer = toastTimer(this.options.duration, () => this.manager.dismiss(this), {
+    persistent: this.options.persistent,
+  });
 
   constructor() {
     this.options.register(this);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #760 

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persistent toasts to `ng-primitives/toast`. Toasts with `persistent: true` never auto-dismiss; they must be dismissed by the user or programmatically.

- **New Features**
  - Added `persistent` to `NgpToastConfig` (default `false`) and `NgpToastManager.show()` options.
  - Updated `toastTimer` to accept `{ persistent }`; when true, `start()` is a no-op and the callback never fires.
  - `NgpToast` forwards `persistent` to the timer; works with sequential mode.
  - Docs updated with a new persistent toast example.

- **Bug Fixes**
  - Moved schematics test build output to `dist/ng-primitives-schematics-test` to prevent `collection.json` race conditions and avoid CI publish conflicts; updated schematics node tests to use the new path.

<sup>Written for commit 05c6ca81c015c8165c9c465401f925359971c618. Summary will update on new commits. <a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/764?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

