### PR TITLE
test: update playwright version to 1.60.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@typescript-eslint/rule-tester": "8.45.0",
     "@typescript-eslint/utils": "8.45.0",
     "@vitest/browser-playwright": "^4.1.0",
-    "playwright": "^1.53.0",
+    "playwright": "^1.60.0",
     "@vitest/ui": "4.1.0",
     "all-contributors-cli": "^6.26.1",
     "angular-eslint": "^20.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,7 +275,7 @@ importers:
         version: 8.45.0(eslint@9.30.1(jiti@2.4.2))(typescript@5.8.3)
       '@vitest/browser-playwright':
         specifier: ^4.1.0
-        version: 4.1.0(playwright@1.53.2)(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.4)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.0))(vitest@4.1.0)
+        version: 4.1.0(playwright@1.60.0)(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.4)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.0))(vitest@4.1.0)
       '@vitest/ui':
         specifier: 4.1.0
         version: 4.1.0(vitest@4.1.0)
@@ -325,8 +325,8 @@ importers:
         specifier: ^0.0.39
         version: 0.0.39
       playwright:
-        specifier: ^1.53.0
-        version: 1.53.2
+        specifier: ^1.60.0
+        version: 1.60.0
       postcss:
         specifier: ^8.4.38
         version: 8.5.8
@@ -9772,8 +9772,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.53.2:
     resolution: {integrity: sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -18076,11 +18086,11 @@ snapshots:
       vite: 7.3.0(@types/node@22.19.1)(jiti@2.4.2)(less@4.4.0)(lightningcss@1.32.0)(sass-embedded@1.89.2)(sass@1.97.1)(terser@5.43.1)(yaml@2.8.0)
     optional: true
 
-  '@vitest/browser-playwright@4.1.0(playwright@1.53.2)(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.4)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.0))(vitest@4.1.0)':
+  '@vitest/browser-playwright@4.1.0(playwright@1.60.0)(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.4)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.0))(vitest@4.1.0)':
     dependencies:
       '@vitest/browser': 4.1.0(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.4)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.0))(vitest@4.1.0)
       '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.4)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.0))
-      playwright: 1.53.2
+      playwright: 1.60.0
       tinyrainbow: 3.1.0
       vitest: 4.1.0(@types/node@22.19.1)(@vitest/browser-playwright@4.1.0)(@vitest/ui@4.1.0)(jsdom@27.2.0)(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.4)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.0))
     transitivePeerDependencies:
@@ -23454,11 +23464,21 @@ snapshots:
       exsolve: 1.0.7
       pathe: 2.0.3
 
-  playwright-core@1.53.2: {}
+  playwright-core@1.53.2:
+    optional: true
+
+  playwright-core@1.60.0: {}
 
   playwright@1.53.2:
     dependencies:
       playwright-core: 1.53.2
+    optionalDependencies:
+      fsevents: 2.3.2
+    optional: true
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -25709,7 +25729,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.1
-      '@vitest/browser-playwright': 4.1.0(playwright@1.53.2)(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.4)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.0))(vitest@4.1.0)
+      '@vitest/browser-playwright': 4.1.0(playwright@1.60.0)(vite@8.0.0(@types/node@22.19.1)(esbuild@0.27.4)(jiti@2.4.2)(less@4.4.0)(sass-embedded@1.89.2)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.0))(vitest@4.1.0)
       '@vitest/ui': 4.1.0(vitest@4.1.0)
       jsdom: 27.2.0
     transitivePeerDependencies:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [x] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current version of Playwright only support Debian 12, and support for Debian 13 (latest version for now) was added on 1.55.0 : [Release note](https://playwright.dev/docs/release-notes#version-155). This issue happen for anyone using Debian 13 while contributing to the repository and make impossible for us to start any tests.

All tests are OK without any changes.

## Issue

Closes #

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `playwright` to 1.60.0 to support Debian 13 and keep e2e tests running for contributors. No code changes; existing tests pass.

<sup>Written for commit 637f5c2b0a124fcf50d691acbc0e80df5a98f974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

