### PR TITLE
refactor: add injection option type

### DIFF
--- a/STATE_PATTERN_MIGRATION.md
+++ b/STATE_PATTERN_MIGRATION.md
@@ -390,8 +390,8 @@ export const [
   }
 );
 
-export function injectSelectState<T>(): NgpSelectState<T> {
-  return _injectSelectState<T>();
+export function injectSelectState<T>(options?: PrimitiveInjectionOptions): NgpSelectState<T> {
+  return _injectSelectState<T>(options);
 }
 ```
 

--- a/STATE_PATTERN_MIGRATION.md
+++ b/STATE_PATTERN_MIGRATION.md
@@ -390,7 +390,7 @@ export const [
   }
 );
 
-export function injectSelectState<T>(options?: PrimitiveStateInjectionOptions): NgpSelectState<T> {
+export function injectSelectState<T>(options?: StateInjectionOptions): NgpSelectState<T> {
   return _injectSelectState<T>(options);
 }
 ```

--- a/STATE_PATTERN_MIGRATION.md
+++ b/STATE_PATTERN_MIGRATION.md
@@ -390,7 +390,7 @@ export const [
   }
 );
 
-export function injectSelectState<T>(options?: PrimitiveInjectionOptions): NgpSelectState<T> {
+export function injectSelectState<T>(options?: PrimitiveStateInjectionOptions): NgpSelectState<T> {
   return _injectSelectState<T>(options);
 }
 ```

--- a/packages/ng-primitives/accordion/src/accordion-item/accordion-item-state.ts
+++ b/packages/ng-primitives/accordion/src/accordion-item/accordion-item-state.ts
@@ -5,7 +5,7 @@ import {
   createPrimitive,
   dataBinding,
   deprecatedSetter,
-  PrimitiveStateInjectionOptions,
+  StateInjectionOptions,
 } from 'ng-primitives/state';
 import { injectAccordionState } from '../accordion/accordion-state';
 
@@ -106,7 +106,7 @@ export const [
 );
 
 export function injectAccordionItemState<T>(
-  options?: PrimitiveStateInjectionOptions,
+  options?: StateInjectionOptions,
 ): Signal<NgpAccordionItemState<T>> {
   return _injectAccordionItemState(options) as Signal<NgpAccordionItemState<T>>;
 }

--- a/packages/ng-primitives/accordion/src/accordion-item/accordion-item-state.ts
+++ b/packages/ng-primitives/accordion/src/accordion-item/accordion-item-state.ts
@@ -1,6 +1,12 @@
 import { computed, Signal, signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { controlled, createPrimitive, dataBinding, deprecatedSetter } from 'ng-primitives/state';
+import {
+  controlled,
+  createPrimitive,
+  dataBinding,
+  deprecatedSetter,
+  PrimitiveInjectionOptions,
+} from 'ng-primitives/state';
 import { injectAccordionState } from '../accordion/accordion-state';
 
 export interface NgpAccordionItemState<T> {
@@ -99,6 +105,8 @@ export const [
   },
 );
 
-export function injectAccordionItemState<T>(): Signal<NgpAccordionItemState<T>> {
-  return _injectAccordionItemState() as Signal<NgpAccordionItemState<T>>;
+export function injectAccordionItemState<T>(
+  options?: PrimitiveInjectionOptions,
+): Signal<NgpAccordionItemState<T>> {
+  return _injectAccordionItemState(options) as Signal<NgpAccordionItemState<T>>;
 }

--- a/packages/ng-primitives/accordion/src/accordion-item/accordion-item-state.ts
+++ b/packages/ng-primitives/accordion/src/accordion-item/accordion-item-state.ts
@@ -5,7 +5,7 @@ import {
   createPrimitive,
   dataBinding,
   deprecatedSetter,
-  PrimitiveInjectionOptions,
+  PrimitiveStateInjectionOptions,
 } from 'ng-primitives/state';
 import { injectAccordionState } from '../accordion/accordion-state';
 
@@ -106,7 +106,7 @@ export const [
 );
 
 export function injectAccordionItemState<T>(
-  options?: PrimitiveInjectionOptions,
+  options?: PrimitiveStateInjectionOptions,
 ): Signal<NgpAccordionItemState<T>> {
   return _injectAccordionItemState(options) as Signal<NgpAccordionItemState<T>>;
 }

--- a/packages/ng-primitives/accordion/src/accordion/accordion-state.ts
+++ b/packages/ng-primitives/accordion/src/accordion/accordion-state.ts
@@ -1,7 +1,13 @@
 import { signal, Signal, WritableSignal } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
 import { injectElementRef } from 'ng-primitives/internal';
-import { controlled, createPrimitive, dataBinding, deprecatedSetter } from 'ng-primitives/state';
+import {
+  controlled,
+  createPrimitive,
+  dataBinding,
+  deprecatedSetter,
+  PrimitiveInjectionOptions,
+} from 'ng-primitives/state';
 
 /**
  * The state interface for the Accordion pattern.
@@ -166,6 +172,8 @@ export const [NgpAccordionStateToken, ngpAccordion, _injectAccordionState, provi
 
 export type NgpAccordionType = 'single' | 'multiple';
 
-export function injectAccordionState<T>(): Signal<NgpAccordionState<T>> {
-  return _injectAccordionState() as Signal<NgpAccordionState<T>>;
+export function injectAccordionState<T>(
+  options?: PrimitiveInjectionOptions,
+): Signal<NgpAccordionState<T>> {
+  return _injectAccordionState(options) as Signal<NgpAccordionState<T>>;
 }

--- a/packages/ng-primitives/accordion/src/accordion/accordion-state.ts
+++ b/packages/ng-primitives/accordion/src/accordion/accordion-state.ts
@@ -6,7 +6,7 @@ import {
   createPrimitive,
   dataBinding,
   deprecatedSetter,
-  PrimitiveInjectionOptions,
+  PrimitiveStateInjectionOptions,
 } from 'ng-primitives/state';
 
 /**
@@ -173,7 +173,7 @@ export const [NgpAccordionStateToken, ngpAccordion, _injectAccordionState, provi
 export type NgpAccordionType = 'single' | 'multiple';
 
 export function injectAccordionState<T>(
-  options?: PrimitiveInjectionOptions,
+  options?: PrimitiveStateInjectionOptions,
 ): Signal<NgpAccordionState<T>> {
   return _injectAccordionState(options) as Signal<NgpAccordionState<T>>;
 }

--- a/packages/ng-primitives/accordion/src/accordion/accordion-state.ts
+++ b/packages/ng-primitives/accordion/src/accordion/accordion-state.ts
@@ -6,7 +6,7 @@ import {
   createPrimitive,
   dataBinding,
   deprecatedSetter,
-  PrimitiveStateInjectionOptions,
+  StateInjectionOptions,
 } from 'ng-primitives/state';
 
 /**
@@ -173,7 +173,7 @@ export const [NgpAccordionStateToken, ngpAccordion, _injectAccordionState, provi
 export type NgpAccordionType = 'single' | 'multiple';
 
 export function injectAccordionState<T>(
-  options?: PrimitiveStateInjectionOptions,
+  options?: StateInjectionOptions,
 ): Signal<NgpAccordionState<T>> {
   return _injectAccordionState(options) as Signal<NgpAccordionState<T>>;
 }

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
@@ -19,6 +19,7 @@ import {
   dataBinding,
   listener,
   onDestroy,
+  PrimitiveInjectionOptions,
   styleBinding,
 } from 'ng-primitives/state';
 
@@ -324,6 +325,8 @@ export const [
   },
 );
 
-export function injectContextMenuTriggerState(): Signal<NgpContextMenuTriggerState> {
-  return _injectContextMenuTriggerState() as Signal<NgpContextMenuTriggerState>;
+export function injectContextMenuTriggerState(
+  options?: PrimitiveInjectionOptions,
+): Signal<NgpContextMenuTriggerState> {
+  return _injectContextMenuTriggerState(options) as Signal<NgpContextMenuTriggerState>;
 }

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
@@ -19,7 +19,7 @@ import {
   dataBinding,
   listener,
   onDestroy,
-  PrimitiveStateInjectionOptions,
+  StateInjectionOptions,
   styleBinding,
 } from 'ng-primitives/state';
 
@@ -326,7 +326,7 @@ export const [
 );
 
 export function injectContextMenuTriggerState(
-  options?: PrimitiveStateInjectionOptions,
+  options?: StateInjectionOptions,
 ): Signal<NgpContextMenuTriggerState> {
   return _injectContextMenuTriggerState(options) as Signal<NgpContextMenuTriggerState>;
 }

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
@@ -19,7 +19,7 @@ import {
   dataBinding,
   listener,
   onDestroy,
-  PrimitiveInjectionOptions,
+  PrimitiveStateInjectionOptions,
   styleBinding,
 } from 'ng-primitives/state';
 
@@ -326,7 +326,7 @@ export const [
 );
 
 export function injectContextMenuTriggerState(
-  options?: PrimitiveInjectionOptions,
+  options?: PrimitiveStateInjectionOptions,
 ): Signal<NgpContextMenuTriggerState> {
   return _injectContextMenuTriggerState(options) as Signal<NgpContextMenuTriggerState>;
 }

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -27,6 +27,7 @@ import {
   dataBinding,
   deprecatedSetter,
   listener,
+  PrimitiveInjectionOptions,
 } from 'ng-primitives/state';
 import { NgpMenuTriggerType } from '../config/menu-config';
 import { NgpMenuPlacement } from './menu-trigger';
@@ -558,6 +559,6 @@ export const [
   },
 );
 
-export function injectMenuTriggerState<T>(): Signal<NgpMenuTriggerState<T>> {
-  return _injectMenuTriggerState() as Signal<NgpMenuTriggerState<T>>;
+export function injectMenuTriggerState<T>(options?: PrimitiveInjectionOptions): Signal<NgpMenuTriggerState<T>> {
+  return _injectMenuTriggerState(options) as Signal<NgpMenuTriggerState<T>>;
 }

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -27,7 +27,7 @@ import {
   dataBinding,
   deprecatedSetter,
   listener,
-  PrimitiveStateInjectionOptions,
+  StateInjectionOptions,
 } from 'ng-primitives/state';
 import { NgpMenuTriggerType } from '../config/menu-config';
 import { NgpMenuPlacement } from './menu-trigger';
@@ -560,7 +560,7 @@ export const [
 );
 
 export function injectMenuTriggerState<T>(
-  options?: PrimitiveStateInjectionOptions,
+  options?: StateInjectionOptions,
 ): Signal<NgpMenuTriggerState<T>> {
   return _injectMenuTriggerState(options) as Signal<NgpMenuTriggerState<T>>;
 }

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -559,6 +559,8 @@ export const [
   },
 );
 
-export function injectMenuTriggerState<T>(options?: PrimitiveStateInjectionOptions): Signal<NgpMenuTriggerState<T>> {
+export function injectMenuTriggerState<T>(
+  options?: PrimitiveStateInjectionOptions,
+): Signal<NgpMenuTriggerState<T>> {
   return _injectMenuTriggerState(options) as Signal<NgpMenuTriggerState<T>>;
 }

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -27,7 +27,7 @@ import {
   dataBinding,
   deprecatedSetter,
   listener,
-  PrimitiveInjectionOptions,
+  PrimitiveStateInjectionOptions,
 } from 'ng-primitives/state';
 import { NgpMenuTriggerType } from '../config/menu-config';
 import { NgpMenuPlacement } from './menu-trigger';
@@ -559,6 +559,6 @@ export const [
   },
 );
 
-export function injectMenuTriggerState<T>(options?: PrimitiveInjectionOptions): Signal<NgpMenuTriggerState<T>> {
+export function injectMenuTriggerState<T>(options?: PrimitiveStateInjectionOptions): Signal<NgpMenuTriggerState<T>> {
   return _injectMenuTriggerState(options) as Signal<NgpMenuTriggerState<T>>;
 }

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -26,7 +26,7 @@ import {
   createPrimitive,
   dataBinding,
   listener,
-  PrimitiveInjectionOptions,
+  PrimitiveStateInjectionOptions,
 } from 'ng-primitives/state';
 
 export interface NgpPopoverTriggerState<T> {
@@ -384,7 +384,7 @@ export const [
 );
 
 export function injectPopoverTriggerState<T>(
-  options?: PrimitiveInjectionOptions,
+  options?: PrimitiveStateInjectionOptions,
 ): Signal<NgpPopoverTriggerState<T>> {
   return _injectPopoverTriggerState(options) as Signal<NgpPopoverTriggerState<T>>;
 }

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -26,7 +26,7 @@ import {
   createPrimitive,
   dataBinding,
   listener,
-  PrimitiveStateInjectionOptions,
+  StateInjectionOptions,
 } from 'ng-primitives/state';
 
 export interface NgpPopoverTriggerState<T> {
@@ -384,7 +384,7 @@ export const [
 );
 
 export function injectPopoverTriggerState<T>(
-  options?: PrimitiveStateInjectionOptions,
+  options?: StateInjectionOptions,
 ): Signal<NgpPopoverTriggerState<T>> {
   return _injectPopoverTriggerState(options) as Signal<NgpPopoverTriggerState<T>>;
 }

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -26,6 +26,7 @@ import {
   createPrimitive,
   dataBinding,
   listener,
+  PrimitiveInjectionOptions,
 } from 'ng-primitives/state';
 
 export interface NgpPopoverTriggerState<T> {
@@ -382,20 +383,8 @@ export const [
   },
 );
 
-export function injectPopoverTriggerState<T>(): Signal<NgpPopoverTriggerState<T>>;
-export function injectPopoverTriggerState<T>(options?: {
-  hoisted?: boolean;
-  optional?: boolean;
-  skipSelf?: boolean;
-}): Signal<NgpPopoverTriggerState<T>>;
 export function injectPopoverTriggerState<T>(
-  options?:
-    | {
-        hoisted?: boolean;
-        optional?: boolean;
-        skipSelf?: boolean;
-      }
-    | undefined,
+  options?: PrimitiveInjectionOptions,
 ): Signal<NgpPopoverTriggerState<T>> {
   return _injectPopoverTriggerState(options) as Signal<NgpPopoverTriggerState<T>>;
 }

--- a/packages/ng-primitives/select/src/select-dropdown/select-dropdown-state.ts
+++ b/packages/ng-primitives/select/src/select-dropdown/select-dropdown-state.ts
@@ -1,6 +1,11 @@
 import { ElementRef, Signal, signal } from '@angular/core';
 import { injectElementRef, observeResize } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive, styleBinding } from 'ng-primitives/state';
+import {
+  attrBinding,
+  createPrimitive,
+  PrimitiveInjectionOptions,
+  styleBinding,
+} from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectSelectState } from '../select/select-state';
 
@@ -64,6 +69,8 @@ export const [
   },
 );
 
-export function injectSelectDropdownState(): Signal<NgpSelectDropdownState> {
-  return _injectSelectDropdownState() as Signal<NgpSelectDropdownState>;
+export function injectSelectDropdownState(
+  options?: PrimitiveInjectionOptions,
+): Signal<NgpSelectDropdownState> {
+  return _injectSelectDropdownState(options) as Signal<NgpSelectDropdownState>;
 }

--- a/packages/ng-primitives/select/src/select-dropdown/select-dropdown-state.ts
+++ b/packages/ng-primitives/select/src/select-dropdown/select-dropdown-state.ts
@@ -3,7 +3,7 @@ import { injectElementRef, observeResize } from 'ng-primitives/internal';
 import {
   attrBinding,
   createPrimitive,
-  PrimitiveInjectionOptions,
+  PrimitiveStateInjectionOptions,
   styleBinding,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
@@ -70,7 +70,7 @@ export const [
 );
 
 export function injectSelectDropdownState(
-  options?: PrimitiveInjectionOptions,
+  options?: PrimitiveStateInjectionOptions,
 ): Signal<NgpSelectDropdownState> {
   return _injectSelectDropdownState(options) as Signal<NgpSelectDropdownState>;
 }

--- a/packages/ng-primitives/select/src/select-dropdown/select-dropdown-state.ts
+++ b/packages/ng-primitives/select/src/select-dropdown/select-dropdown-state.ts
@@ -3,7 +3,7 @@ import { injectElementRef, observeResize } from 'ng-primitives/internal';
 import {
   attrBinding,
   createPrimitive,
-  PrimitiveStateInjectionOptions,
+  StateInjectionOptions,
   styleBinding,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
@@ -70,7 +70,7 @@ export const [
 );
 
 export function injectSelectDropdownState(
-  options?: PrimitiveStateInjectionOptions,
+  options?: StateInjectionOptions,
 ): Signal<NgpSelectDropdownState> {
   return _injectSelectDropdownState(options) as Signal<NgpSelectDropdownState>;
 }

--- a/packages/ng-primitives/select/src/select-option/select-option-state.ts
+++ b/packages/ng-primitives/select/src/select-option/select-option-state.ts
@@ -7,7 +7,7 @@ import {
   dataBinding,
   listener,
   onDestroy,
-  PrimitiveStateInjectionOptions,
+  StateInjectionOptions,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectSelectState } from '../select/select-state';
@@ -221,7 +221,7 @@ export const [
 );
 
 export function injectSelectOptionState(
-  options?: PrimitiveStateInjectionOptions,
+  options?: StateInjectionOptions,
 ): Signal<NgpSelectOptionState> {
   return _injectSelectOptionState(options) as Signal<NgpSelectOptionState>;
 }

--- a/packages/ng-primitives/select/src/select-option/select-option-state.ts
+++ b/packages/ng-primitives/select/src/select-option/select-option-state.ts
@@ -7,7 +7,7 @@ import {
   dataBinding,
   listener,
   onDestroy,
-  PrimitiveInjectionOptions,
+  PrimitiveStateInjectionOptions,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectSelectState } from '../select/select-state';
@@ -221,7 +221,7 @@ export const [
 );
 
 export function injectSelectOptionState(
-  options?: PrimitiveInjectionOptions,
+  options?: PrimitiveStateInjectionOptions,
 ): Signal<NgpSelectOptionState> {
   return _injectSelectOptionState(options) as Signal<NgpSelectOptionState>;
 }

--- a/packages/ng-primitives/select/src/select-option/select-option-state.ts
+++ b/packages/ng-primitives/select/src/select-option/select-option-state.ts
@@ -7,6 +7,7 @@ import {
   dataBinding,
   listener,
   onDestroy,
+  PrimitiveInjectionOptions,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectSelectState } from '../select/select-state';
@@ -219,6 +220,8 @@ export const [
   },
 );
 
-export function injectSelectOptionState(): Signal<NgpSelectOptionState> {
-  return _injectSelectOptionState() as Signal<NgpSelectOptionState>;
+export function injectSelectOptionState(
+  options?: PrimitiveInjectionOptions,
+): Signal<NgpSelectOptionState> {
+  return _injectSelectOptionState(options) as Signal<NgpSelectOptionState>;
 }

--- a/packages/ng-primitives/select/src/select-portal/select-portal-state.ts
+++ b/packages/ng-primitives/select/src/select-portal/select-portal-state.ts
@@ -1,6 +1,6 @@
 import { inject, Injector, Signal, signal, TemplateRef, ViewContainerRef } from '@angular/core';
 import { createOverlay, NgpOverlay, NgpOverlayConfig } from 'ng-primitives/portal';
-import { createPrimitive, PrimitiveStateInjectionOptions } from 'ng-primitives/state';
+import { createPrimitive, StateInjectionOptions } from 'ng-primitives/state';
 import { injectSelectState } from '../select/select-state';
 
 export interface NgpSelectPortalState {
@@ -99,7 +99,7 @@ export const [
 });
 
 export function injectSelectPortalState(
-  options?: PrimitiveStateInjectionOptions,
+  options?: StateInjectionOptions,
 ): Signal<NgpSelectPortalState> {
   return _injectSelectPortalState(options) as Signal<NgpSelectPortalState>;
 }

--- a/packages/ng-primitives/select/src/select-portal/select-portal-state.ts
+++ b/packages/ng-primitives/select/src/select-portal/select-portal-state.ts
@@ -1,6 +1,6 @@
 import { inject, Injector, Signal, signal, TemplateRef, ViewContainerRef } from '@angular/core';
 import { createOverlay, NgpOverlay, NgpOverlayConfig } from 'ng-primitives/portal';
-import { createPrimitive, PrimitiveInjectionOptions } from 'ng-primitives/state';
+import { createPrimitive, PrimitiveStateInjectionOptions } from 'ng-primitives/state';
 import { injectSelectState } from '../select/select-state';
 
 export interface NgpSelectPortalState {
@@ -99,7 +99,7 @@ export const [
 });
 
 export function injectSelectPortalState(
-  options?: PrimitiveInjectionOptions,
+  options?: PrimitiveStateInjectionOptions,
 ): Signal<NgpSelectPortalState> {
   return _injectSelectPortalState(options) as Signal<NgpSelectPortalState>;
 }

--- a/packages/ng-primitives/select/src/select-portal/select-portal-state.ts
+++ b/packages/ng-primitives/select/src/select-portal/select-portal-state.ts
@@ -1,6 +1,6 @@
 import { inject, Injector, Signal, signal, TemplateRef, ViewContainerRef } from '@angular/core';
 import { createOverlay, NgpOverlay, NgpOverlayConfig } from 'ng-primitives/portal';
-import { createPrimitive } from 'ng-primitives/state';
+import { createPrimitive, PrimitiveInjectionOptions } from 'ng-primitives/state';
 import { injectSelectState } from '../select/select-state';
 
 export interface NgpSelectPortalState {
@@ -98,6 +98,8 @@ export const [
   return state;
 });
 
-export function injectSelectPortalState(): Signal<NgpSelectPortalState> {
-  return _injectSelectPortalState() as Signal<NgpSelectPortalState>;
+export function injectSelectPortalState(
+  options?: PrimitiveInjectionOptions,
+): Signal<NgpSelectPortalState> {
+  return _injectSelectPortalState(options) as Signal<NgpSelectPortalState>;
 }

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -13,6 +13,7 @@ import {
   deprecatedSetter,
   emitter,
   listener,
+  PrimitiveInjectionOptions,
   SetterOptions,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
@@ -823,6 +824,8 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
     },
   );
 
-export function injectSelectState<T>(): Signal<NgpSelectState<T>> {
-  return _injectSelectState() as Signal<NgpSelectState<T>>;
+export function injectSelectState<T>(
+  options?: PrimitiveInjectionOptions,
+): Signal<NgpSelectState<T>> {
+  return _injectSelectState(options) as Signal<NgpSelectState<T>>;
 }

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -13,7 +13,7 @@ import {
   deprecatedSetter,
   emitter,
   listener,
-  PrimitiveInjectionOptions,
+  PrimitiveStateInjectionOptions,
   SetterOptions,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
@@ -825,7 +825,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
   );
 
 export function injectSelectState<T>(
-  options?: PrimitiveInjectionOptions,
+  options?: PrimitiveStateInjectionOptions,
 ): Signal<NgpSelectState<T>> {
   return _injectSelectState(options) as Signal<NgpSelectState<T>>;
 }

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -13,8 +13,8 @@ import {
   deprecatedSetter,
   emitter,
   listener,
-  PrimitiveStateInjectionOptions,
   SetterOptions,
+  StateInjectionOptions,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { Observable } from 'rxjs';
@@ -824,8 +824,6 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
     },
   );
 
-export function injectSelectState<T>(
-  options?: PrimitiveStateInjectionOptions,
-): Signal<NgpSelectState<T>> {
+export function injectSelectState<T>(options?: StateInjectionOptions): Signal<NgpSelectState<T>> {
   return _injectSelectState(options) as Signal<NgpSelectState<T>>;
 }

--- a/packages/ng-primitives/state/src/index.ts
+++ b/packages/ng-primitives/state/src/index.ts
@@ -71,6 +71,14 @@ export interface CreateStateProviderOptions {
   inherit?: boolean;
 }
 
+export type PrimitiveInjectionOptions =
+  | {
+      hoisted?: boolean;
+      optional?: boolean;
+      skipSelf?: boolean;
+    }
+  | undefined;
+
 /**
  * Create a new provider for the state. It first tries to inject the state from the parent injector,
  * as this allows for the state to be hoisted to a higher level in the component tree. This can
@@ -262,12 +270,8 @@ type PrimitiveState<TFactory extends (...args: any[]) => unknown> = TFactory ext
 
 type BasePrimitiveInjectionFn<TState> = {
   (): Signal<TState>;
-  (options: { hoisted: true; optional?: boolean; skipSelf?: boolean }): Signal<TState | null>;
-  (options?: {
-    hoisted?: boolean;
-    optional?: boolean;
-    skipSelf?: boolean;
-  }): Signal<TState | null> | Signal<TState>;
+  (options: PrimitiveInjectionOptions): Signal<TState | null>;
+  (options?: PrimitiveInjectionOptions): Signal<TState | null> | Signal<TState>;
 };
 
 type PrimitiveInjectionFn<TFactory extends (...args: any[]) => unknown> = TFactory extends (
@@ -275,12 +279,8 @@ type PrimitiveInjectionFn<TFactory extends (...args: any[]) => unknown> = TFacto
 ) => infer R
   ? {
       (): Signal<R>;
-      (options: { hoisted: true; optional?: boolean; skipSelf?: boolean }): Signal<R | null>;
-      (options?: {
-        hoisted?: boolean;
-        optional?: boolean;
-        skipSelf?: boolean;
-      }): Signal<R | null> | Signal<R>;
+      (options: PrimitiveInjectionOptions): Signal<R | null>;
+      (options?: PrimitiveInjectionOptions): Signal<R | null> | Signal<R>;
     }
   : BasePrimitiveInjectionFn<PrimitiveState<TFactory>>;
 
@@ -333,11 +333,9 @@ export function createPrimitive<TFactory extends (...args: any[]) => unknown>(
   function injectFn<T = PrimitiveState<TFactory>>(
     options: { hoisted: true } & InjectOptions,
   ): Signal<T | null>;
-  function injectFn<T = PrimitiveState<TFactory>>(options?: {
-    hoisted?: boolean;
-    optional?: boolean;
-    skipSelf?: boolean;
-  }): Signal<T | null> | Signal<T> {
+  function injectFn<T = PrimitiveState<TFactory>>(
+    options?: PrimitiveInjectionOptions,
+  ): Signal<T | null> | Signal<T> {
     const hoisted = options?.hoisted ?? false;
     const optional = options?.optional ?? false;
     const skipSelf = options?.skipSelf ?? false;

--- a/packages/ng-primitives/state/src/index.ts
+++ b/packages/ng-primitives/state/src/index.ts
@@ -71,7 +71,7 @@ export interface CreateStateProviderOptions {
   inherit?: boolean;
 }
 
-export type PrimitiveInjectionOptions =
+export type PrimitiveStateInjectionOptions =
   | {
       hoisted?: boolean;
       optional?: boolean;
@@ -270,8 +270,8 @@ type PrimitiveState<TFactory extends (...args: any[]) => unknown> = TFactory ext
 
 type BasePrimitiveInjectionFn<TState> = {
   (): Signal<TState>;
-  (options: PrimitiveInjectionOptions): Signal<TState | null>;
-  (options?: PrimitiveInjectionOptions): Signal<TState | null> | Signal<TState>;
+  (options: PrimitiveStateInjectionOptions): Signal<TState | null>;
+  (options?: PrimitiveStateInjectionOptions): Signal<TState | null> | Signal<TState>;
 };
 
 type PrimitiveInjectionFn<TFactory extends (...args: any[]) => unknown> = TFactory extends (
@@ -279,8 +279,8 @@ type PrimitiveInjectionFn<TFactory extends (...args: any[]) => unknown> = TFacto
 ) => infer R
   ? {
       (): Signal<R>;
-      (options: PrimitiveInjectionOptions): Signal<R | null>;
-      (options?: PrimitiveInjectionOptions): Signal<R | null> | Signal<R>;
+      (options: PrimitiveStateInjectionOptions): Signal<R | null>;
+      (options?: PrimitiveStateInjectionOptions): Signal<R | null> | Signal<R>;
     }
   : BasePrimitiveInjectionFn<PrimitiveState<TFactory>>;
 
@@ -334,7 +334,7 @@ export function createPrimitive<TFactory extends (...args: any[]) => unknown>(
     options: { hoisted: true } & InjectOptions,
   ): Signal<T | null>;
   function injectFn<T = PrimitiveState<TFactory>>(
-    options?: PrimitiveInjectionOptions,
+    options?: PrimitiveStateInjectionOptions,
   ): Signal<T | null> | Signal<T> {
     const hoisted = options?.hoisted ?? false;
     const optional = options?.optional ?? false;

--- a/packages/ng-primitives/state/src/index.ts
+++ b/packages/ng-primitives/state/src/index.ts
@@ -71,7 +71,7 @@ export interface CreateStateProviderOptions {
   inherit?: boolean;
 }
 
-export type PrimitiveStateInjectionOptions =
+export type StateInjectionOptions =
   | {
       hoisted?: boolean;
       optional?: boolean;
@@ -270,8 +270,8 @@ type PrimitiveState<TFactory extends (...args: any[]) => unknown> = TFactory ext
 
 type BasePrimitiveInjectionFn<TState> = {
   (): Signal<TState>;
-  (options: PrimitiveStateInjectionOptions): Signal<TState | null>;
-  (options?: PrimitiveStateInjectionOptions): Signal<TState | null> | Signal<TState>;
+  (options: StateInjectionOptions): Signal<TState | null>;
+  (options?: StateInjectionOptions): Signal<TState | null> | Signal<TState>;
 };
 
 type PrimitiveInjectionFn<TFactory extends (...args: any[]) => unknown> = TFactory extends (
@@ -279,8 +279,8 @@ type PrimitiveInjectionFn<TFactory extends (...args: any[]) => unknown> = TFacto
 ) => infer R
   ? {
       (): Signal<R>;
-      (options: PrimitiveStateInjectionOptions): Signal<R | null>;
-      (options?: PrimitiveStateInjectionOptions): Signal<R | null> | Signal<R>;
+      (options: StateInjectionOptions): Signal<R | null>;
+      (options?: StateInjectionOptions): Signal<R | null> | Signal<R>;
     }
   : BasePrimitiveInjectionFn<PrimitiveState<TFactory>>;
 
@@ -334,7 +334,7 @@ export function createPrimitive<TFactory extends (...args: any[]) => unknown>(
     options: { hoisted: true } & InjectOptions,
   ): Signal<T | null>;
   function injectFn<T = PrimitiveState<TFactory>>(
-    options?: PrimitiveStateInjectionOptions,
+    options?: StateInjectionOptions,
   ): Signal<T | null> | Signal<T> {
     const hoisted = options?.hoisted ?? false;
     const optional = options?.optional ?? false;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

With the new state pattern, we can export a "custom" `inject<Primitive>State<T>()` function. I noticed that there is no explicit type for the option parameter, and it makes it more verbose than it should be. I created a little type `PrimitiveStateInjectionOptions` with this signature :

```typescript
export type PrimitiveStateInjectionOptions =
  | {
      hoisted?: boolean;
      optional?: boolean;
      skipSelf?: boolean;
    }
  | undefined;
```

it makes it easier to create the custom `inject<Primitive>State<T>()` function with correct parameters

I also updated `STATE_PATTERN_MIGRATION.md` file to reflect the changes.

All tests are OK with no changes.

> If this PR is merged, #759 will have to be updated.

## Issue

Closes #

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduced a shared `StateInjectionOptions` type and updated primitive state injectors to use it, replacing ad‑hoc option shapes and overloads. No functional changes.

- **Refactors**
  - Added `StateInjectionOptions` in `ng-primitives/state` and updated `createPrimitive` injection typings to use it.
  - Switched injectors in `accordion`, `context-menu`, `menu`, `popover`, and `select` to accept `StateInjectionOptions`.
  - Updated `STATE_PATTERN_MIGRATION.md` with the new injector signature.

<sup>Written for commit f54150e4491926e0f91706968ef1358822525256. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

