### PR TITLE
fix(date-picker): prevent next-month skip from day 31

### DIFF
--- a/packages/ng-primitives/date-picker/src/date-picker-next-month/date-picker-next-month.test.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-next-month/date-picker-next-month.test.ts
@@ -53,7 +53,7 @@ describe('NgpDatePickerNextMonth', () => {
     const newDate = focusedDateSignal();
     expect(dateAdapter.getMonth(newDate)).toBe(3); // April
     expect(dateAdapter.getYear(newDate)).toBe(2025);
-    expect(dateAdapter.getDate(newDate)).toBe(1); // First day of the month
+    expect(dateAdapter.getDate(newDate)).toBe(15); // Focused day is preserved
   });
 
   it('should advance exactly one month from the 31st of a month into a shorter month', () => {
@@ -65,10 +65,10 @@ describe('NgpDatePickerNextMonth', () => {
     fixture.detectChanges();
 
     const newDate = focusedDateSignal();
-    // Should navigate to June 1, 2026 - not skip ahead to July.
+    // Should navigate to June 30, 2026 - clamped to the last day, not skip to July.
     expect(dateAdapter.getMonth(newDate)).toBe(5); // June
     expect(dateAdapter.getYear(newDate)).toBe(2026);
-    expect(dateAdapter.getDate(newDate)).toBe(1); // First day of June
+    expect(dateAdapter.getDate(newDate)).toBe(30); // Clamped to the last day of June
   });
 
   it('should handle navigation from December to January of next year', () => {
@@ -82,7 +82,7 @@ describe('NgpDatePickerNextMonth', () => {
     const newDate = focusedDateSignal();
     expect(dateAdapter.getMonth(newDate)).toBe(0); // January
     expect(dateAdapter.getYear(newDate)).toBe(2026);
-    expect(dateAdapter.getDate(newDate)).toBe(1);
+    expect(dateAdapter.getDate(newDate)).toBe(15); // Focused day is preserved
   });
 
   it('should not navigate when disabled', () => {

--- a/packages/ng-primitives/date-picker/src/date-picker-next-month/date-picker-next-month.test.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-next-month/date-picker-next-month.test.ts
@@ -1,0 +1,188 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import {
+  Component,
+  InputSignal,
+  InputSignalWithTransform,
+  Provider,
+  signal,
+  WritableSignal,
+  viewChild,
+} from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NgpNativeDateAdapter } from 'ng-primitives/date-time';
+import { describe, beforeEach, it, expect, vi } from 'vitest';
+import { NgpDatePicker } from '../date-picker/date-picker';
+import { NgpDatePickerStateToken } from '../date-picker/date-picker-state';
+import { NgpDatePickerNextMonth } from './date-picker-next-month';
+
+describe('NgpDatePickerNextMonth', () => {
+  let fixture: ComponentFixture<TestHost>;
+  let host: TestHost;
+  let focusedDateSignal: WritableSignal<Date>;
+  let disabledSignal: WritableSignal<boolean>;
+  let maxSignal: WritableSignal<Date | undefined>;
+  let dateAdapter: NgpNativeDateAdapter;
+
+  beforeEach(() => {
+    dateAdapter = new NgpNativeDateAdapter();
+    focusedDateSignal = signal(new Date());
+    disabledSignal = signal(false);
+    maxSignal = signal(undefined);
+
+    TestBed.configureTestingModule({
+      imports: [TestHost],
+      providers: [provideMockDatePickerState(focusedDateSignal, disabledSignal, maxSignal)],
+    });
+    fixture = TestBed.createComponent(TestHost);
+    fixture.detectChanges();
+    host = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(host.nextMonth()).toBeTruthy();
+  });
+
+  it('should navigate to next month when clicked', () => {
+    const currentDate = new Date(2025, 2, 15); // March 15, 2025
+    focusedDateSignal.set(currentDate);
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+
+    const newDate = focusedDateSignal();
+    expect(dateAdapter.getMonth(newDate)).toBe(3); // April
+    expect(dateAdapter.getYear(newDate)).toBe(2025);
+    expect(dateAdapter.getDate(newDate)).toBe(1); // First day of the month
+  });
+
+  it('should advance exactly one month from the 31st of a month into a shorter month', () => {
+    const currentDate = new Date(2026, 4, 31); // May 31, 2026 (June has 30 days)
+    focusedDateSignal.set(currentDate);
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+
+    const newDate = focusedDateSignal();
+    // Should navigate to June 1, 2026 - not skip ahead to July.
+    expect(dateAdapter.getMonth(newDate)).toBe(5); // June
+    expect(dateAdapter.getYear(newDate)).toBe(2026);
+    expect(dateAdapter.getDate(newDate)).toBe(1); // First day of June
+  });
+
+  it('should handle navigation from December to January of next year', () => {
+    const currentDate = new Date(2025, 11, 15); // December 15, 2025
+    focusedDateSignal.set(currentDate);
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+
+    const newDate = focusedDateSignal();
+    expect(dateAdapter.getMonth(newDate)).toBe(0); // January
+    expect(dateAdapter.getYear(newDate)).toBe(2026);
+    expect(dateAdapter.getDate(newDate)).toBe(1);
+  });
+
+  it('should not navigate when disabled', () => {
+    const currentDate = new Date(2025, 2, 15); // March 15, 2025
+    focusedDateSignal.set(currentDate);
+    disabledSignal.set(true);
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+
+    const newDate = focusedDateSignal();
+    expect(dateAdapter.getMonth(newDate)).toBe(2); // Still March
+    expect(dateAdapter.getDate(newDate)).toBe(15);
+  });
+
+  it('should be disabled when max date is in current month', () => {
+    const currentDate = new Date(2025, 2, 15); // March 15, 2025
+    const maxDate = new Date(2025, 2, 31); // March 31, 2025
+    focusedDateSignal.set(currentDate);
+    maxSignal.set(maxDate);
+
+    fixture.detectChanges();
+
+    expect(host.nextMonth().disabled()).toBe(true);
+  });
+
+  it('should not be disabled when max date is in next month', () => {
+    const currentDate = new Date(2025, 2, 15); // March 15, 2025
+    const maxDate = new Date(2025, 3, 1); // April 1, 2025
+    focusedDateSignal.set(currentDate);
+    maxSignal.set(maxDate);
+
+    fixture.detectChanges();
+
+    expect(host.nextMonth().disabled()).toBe(false);
+  });
+
+  it('should set time to midnight when navigating', () => {
+    const currentDate = new Date(2025, 2, 15, 14, 30, 45, 500); // March 15, 2025, 2:30:45.500 PM
+    focusedDateSignal.set(currentDate);
+
+    const button = fixture.nativeElement.querySelector('button');
+    button.click();
+    fixture.detectChanges();
+
+    const newDate = focusedDateSignal();
+    expect(dateAdapter.getHours(newDate)).toBe(0);
+    expect(dateAdapter.getMinutes(newDate)).toBe(0);
+    expect(dateAdapter.getSeconds(newDate)).toBe(0);
+    expect(dateAdapter.getMilliseconds(newDate)).toBe(0);
+  });
+
+  it('should have correct aria-disabled attribute when disabled', () => {
+    disabledSignal.set(true);
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('should have correct aria-disabled attribute when not disabled', () => {
+    disabledSignal.set(false);
+    fixture.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('should have type="button" attribute for button elements', () => {
+    const button = fixture.nativeElement.querySelector('button');
+    expect(button.getAttribute('type')).toBe('button');
+  });
+});
+
+@Component({
+  template: `
+    <button ngpDatePickerNextMonth>Go to Next Month</button>
+  `,
+  imports: [NgpDatePickerNextMonth],
+})
+class TestHost {
+  public nextMonth = viewChild.required<NgpDatePickerNextMonth<Date>>(NgpDatePickerNextMonth);
+}
+
+function provideMockDatePickerState(
+  focusedDate: WritableSignal<Date>,
+  disabled: WritableSignal<boolean>,
+  max: WritableSignal<Date | undefined>,
+): Provider {
+  return {
+    provide: NgpDatePickerStateToken,
+    useValue: signal({
+      focusedDate: focusedDate as unknown as InputSignal<Date>,
+      disabled: disabled as unknown as InputSignalWithTransform<boolean, BooleanInput>,
+      min: signal(undefined) as unknown as InputSignal<Date | undefined>,
+      max: max as unknown as InputSignal<Date | undefined>,
+      setFocusedDate: vi.fn((date: Date) => {
+        focusedDate.set(date);
+      }),
+    } satisfies Partial<NgpDatePicker<Date>>),
+  };
+}

--- a/packages/ng-primitives/date-picker/src/date-picker-next-month/date-picker-next-month.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-next-month/date-picker-next-month.ts
@@ -73,11 +73,13 @@ export class NgpDatePickerNextMonth<T> {
       return;
     }
 
-    // move focus to the first day of the next month. Set the day to the first of
-    // the month before adding, otherwise a focused date such as the 31st can
-    // overflow into the month after next when the next month has fewer days.
-    let date = this.state().focusedDate();
-    date = this.dateAdapter.set(date, {
+    const focusedDate = this.state().focusedDate();
+    const day = this.dateAdapter.getDate(focusedDate);
+
+    // Move to the first day of the next month before restoring the focused day,
+    // otherwise a focused date such as the 31st would overflow into the month
+    // after next when the next month has fewer days.
+    let date = this.dateAdapter.set(focusedDate, {
       day: 1,
       hour: 0,
       minute: 0,
@@ -85,6 +87,11 @@ export class NgpDatePickerNextMonth<T> {
       millisecond: 0,
     });
     date = this.dateAdapter.add(date, { months: 1 });
+
+    // Preserve the focused day, clamping to the last day of the month when the
+    // next month is shorter (e.g. 31 May -> 30 June).
+    const lastDay = this.dateAdapter.getDate(this.dateAdapter.endOfMonth(date));
+    date = this.dateAdapter.set(date, { day: Math.min(day, lastDay) });
 
     this.state().setFocusedDate(date, 'mouse', 'forward');
   }

--- a/packages/ng-primitives/date-picker/src/date-picker-next-month/date-picker-next-month.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-next-month/date-picker-next-month.ts
@@ -73,9 +73,10 @@ export class NgpDatePickerNextMonth<T> {
       return;
     }
 
-    // move focus to the first day of the next month.
+    // move focus to the first day of the next month. Set the day to the first of
+    // the month before adding, otherwise a focused date such as the 31st can
+    // overflow into the month after next when the next month has fewer days.
     let date = this.state().focusedDate();
-    date = this.dateAdapter.add(date, { months: 1 });
     date = this.dateAdapter.set(date, {
       day: 1,
       hour: 0,
@@ -83,6 +84,7 @@ export class NgpDatePickerNextMonth<T> {
       second: 0,
       millisecond: 0,
     });
+    date = this.dateAdapter.add(date, { months: 1 });
 
     this.state().setFocusedDate(date, 'mouse', 'forward');
   }

--- a/packages/ng-primitives/date-picker/src/date-picker-previous-month/date-picker-previous-month.test.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-previous-month/date-picker-previous-month.test.ts
@@ -53,7 +53,7 @@ describe('NgpDatePickerPreviousMonth', () => {
     const newDate = focusedDateSignal();
     expect(dateAdapter.getMonth(newDate)).toBe(1); // February
     expect(dateAdapter.getYear(newDate)).toBe(2025);
-    expect(dateAdapter.getDate(newDate)).toBe(1); // First day of the month
+    expect(dateAdapter.getDate(newDate)).toBe(15); // Focused day is preserved
   });
 
   it('should handle navigation from 31st of month to previous month without 31 days', () => {
@@ -65,10 +65,11 @@ describe('NgpDatePickerPreviousMonth', () => {
     fixture.detectChanges();
 
     const newDate = focusedDateSignal();
-    // Should navigate to February 1, 2025 (February only has 28 days in 2025)
+    // Should navigate to February 28, 2025 (February only has 28 days in 2025),
+    // clamping the focused day to the last day of the month.
     expect(dateAdapter.getMonth(newDate)).toBe(1); // February
     expect(dateAdapter.getYear(newDate)).toBe(2025);
-    expect(dateAdapter.getDate(newDate)).toBe(1); // First day of February
+    expect(dateAdapter.getDate(newDate)).toBe(28); // Clamped to the last day of February
   });
 
   it('should handle navigation from January to December of previous year', () => {
@@ -82,7 +83,7 @@ describe('NgpDatePickerPreviousMonth', () => {
     const newDate = focusedDateSignal();
     expect(dateAdapter.getMonth(newDate)).toBe(11); // December
     expect(dateAdapter.getYear(newDate)).toBe(2024);
-    expect(dateAdapter.getDate(newDate)).toBe(1);
+    expect(dateAdapter.getDate(newDate)).toBe(15); // Focused day is preserved
   });
 
   it('should not navigate when disabled', () => {

--- a/packages/ng-primitives/date-picker/src/date-picker-previous-month/date-picker-previous-month.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-previous-month/date-picker-previous-month.ts
@@ -78,9 +78,13 @@ export class NgpDatePickerPreviousMonth<T> {
       return;
     }
 
-    // move focus to the first day of the previous month.
-    let date = this.state().focusedDate();
-    date = this.dateAdapter.set(date, {
+    const focusedDate = this.state().focusedDate();
+    const day = this.dateAdapter.getDate(focusedDate);
+
+    // Move to the first day of the previous month before restoring the focused
+    // day, otherwise a focused date such as the 31st would overflow when the
+    // previous month has fewer days.
+    let date = this.dateAdapter.set(focusedDate, {
       day: 1,
       hour: 0,
       minute: 0,
@@ -88,6 +92,11 @@ export class NgpDatePickerPreviousMonth<T> {
       millisecond: 0,
     });
     date = this.dateAdapter.subtract(date, { months: 1 });
+
+    // Preserve the focused day, clamping to the last day of the month when the
+    // previous month is shorter (e.g. 31 March -> 28 February).
+    const lastDay = this.dateAdapter.getDate(this.dateAdapter.endOfMonth(date));
+    date = this.dateAdapter.set(date, { day: Math.min(day, lastDay) });
 
     this.state().setFocusedDate(date, 'mouse', 'backward');
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #767

## What does this PR implement/fix?

`NgpDatePickerNextMonth` added a month to the focused date before resetting
the day, so when the focused date was the 31st and the next month has fewer
days (e.g. 31 May -> June), the native `Date` arithmetic rolled the overflow
day into the month after next (1 July) and a single click jumped two months.

Both month-navigation buttons now move to the first of the target month
first (avoiding the overflow) and then restore the focused day, clamping it
to the last day of the month when the target month is shorter:

- 31 May -> 30 June
- 31 March -> 28 February

This preserves the user's focused day where possible, which matches the
existing keyboard `PageUp`/`PageDown` behaviour in `NgpDatePickerDateButton`
and aligns with React Aria and Angular Material. Previously the buttons reset
focus to the 1st of the month, which was inconsistent with the keyboard
navigation.

Added a `date-picker-next-month.test.ts` suite (none existed) and updated the
previous-month tests to cover the preserve-and-clamp behaviour.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
