### PR TITLE
feat(pagination): migrate state pattern

### DIFF
--- a/packages/ng-primitives/pagination/src/index.ts
+++ b/packages/ng-primitives/pagination/src/index.ts
@@ -44,3 +44,11 @@ export {
   type NgpPaginationNextState,
   type NgpPaginationNextProps,
 } from './pagination-next/pagination-next-state';
+export {
+  NgpPaginationPreviousStateToken,
+  ngpPaginationPrevious,
+  injectPaginationPreviousState,
+  providePaginationPreviousState,
+  type NgpPaginationPreviousState,
+  type NgpPaginationPreviousProps,
+} from './pagination-previous/pagination-previous-state';

--- a/packages/ng-primitives/pagination/src/index.ts
+++ b/packages/ng-primitives/pagination/src/index.ts
@@ -4,4 +4,11 @@ export { NgpPaginationLast } from './pagination-last/pagination-last';
 export { NgpPaginationNext } from './pagination-next/pagination-next';
 export { NgpPaginationPrevious } from './pagination-previous/pagination-previous';
 export { NgpPagination } from './pagination/pagination';
-export { injectPaginationState, providePaginationState } from './pagination/pagination-state';
+export {
+  NgpPaginationStateToken,
+  ngpPagination,
+  injectPaginationState,
+  providePaginationState,
+  type NgpPaginationState,
+  type NgpPaginationProps,
+} from './pagination/pagination-state';

--- a/packages/ng-primitives/pagination/src/index.ts
+++ b/packages/ng-primitives/pagination/src/index.ts
@@ -28,3 +28,11 @@ export {
   type NgpPaginationFirstState,
   type NgpPaginationFirstProps,
 } from './pagination-first/pagination-first-state';
+export {
+  NgpPaginationLastStateToken,
+  ngpPaginationLast,
+  injectPaginationLastState,
+  providePaginationLastState,
+  type NgpPaginationLastState,
+  type NgpPaginationLastProps,
+} from './pagination-last/pagination-last-state';

--- a/packages/ng-primitives/pagination/src/index.ts
+++ b/packages/ng-primitives/pagination/src/index.ts
@@ -12,3 +12,11 @@ export {
   type NgpPaginationState,
   type NgpPaginationProps,
 } from './pagination/pagination-state';
+export {
+  NgpPaginationButtonStateToken,
+  ngpPaginationButton,
+  injectPaginationButtonState,
+  providePaginationButtonState,
+  type NgpPaginationButtonState,
+  type NgpPaginationButtonProps,
+} from './pagination-button/pagination-button-state';

--- a/packages/ng-primitives/pagination/src/index.ts
+++ b/packages/ng-primitives/pagination/src/index.ts
@@ -36,3 +36,11 @@ export {
   type NgpPaginationLastState,
   type NgpPaginationLastProps,
 } from './pagination-last/pagination-last-state';
+export {
+  NgpPaginationNextStateToken,
+  ngpPaginationNext,
+  injectPaginationNextState,
+  providePaginationNextState,
+  type NgpPaginationNextState,
+  type NgpPaginationNextProps,
+} from './pagination-next/pagination-next-state';

--- a/packages/ng-primitives/pagination/src/index.ts
+++ b/packages/ng-primitives/pagination/src/index.ts
@@ -20,3 +20,11 @@ export {
   type NgpPaginationButtonState,
   type NgpPaginationButtonProps,
 } from './pagination-button/pagination-button-state';
+export {
+  NgpPaginationFirstStateToken,
+  ngpPaginationFirst,
+  injectPaginationFirstState,
+  providePaginationFirstState,
+  type NgpPaginationFirstState,
+  type NgpPaginationFirstProps,
+} from './pagination-first/pagination-first-state';

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
@@ -1,12 +1,10 @@
-import { computed, ElementRef, signal, Signal } from '@angular/core';
+import { computed, signal, Signal } from '@angular/core';
 import { ngpButton } from 'ng-primitives/button';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
 import { injectPaginationState } from '../pagination/pagination-state';
 
 export interface NgpPaginationButtonState {
-  /** Access the element's reference. */
-  readonly elementRef: ElementRef;
   /**
    * Define the page this button represents.
    */
@@ -78,7 +76,6 @@ export const [
     }
 
     return {
-      elementRef,
       page,
       disabled,
       goToPage,

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
@@ -1,0 +1,99 @@
+import { computed, ElementRef, signal, Signal, WritableSignal } from '@angular/core';
+import { ngpButton } from 'ng-primitives/button';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  controlledState,
+  createPrimitive,
+  dataBinding,
+  listener,
+} from 'ng-primitives/state';
+import { Observable } from 'rxjs';
+import { injectPaginationState } from '../pagination/pagination-state';
+
+export interface NgpPaginationButtonState {
+  /** Access te element's reference. */
+  readonly elementRef: ElementRef;
+  /**
+   * Define the page this button represents.
+   */
+  readonly page: Signal<number>;
+  /**
+   * Whether the button is disabled.
+   */
+  readonly buttonDisabled: Signal<boolean>;
+  /**
+   * Whether the button is disabled.
+   */
+  readonly disabled: Signal<boolean>;
+  /**
+   * Go to the page this button represents.
+   */
+  goToPage(): void;
+}
+
+export interface NgpPaginationButtonProps {
+  /**
+   * Define the page this button represents.
+   */
+  readonly page?: Signal<number>;
+  /**
+   * Whether the button is disabled.
+   */
+  readonly buttonDisabled?: Signal<boolean>;
+}
+
+export const [
+  NgpPaginationButtonStateToken,
+  ngpPaginationButton,
+  injectPaginationButtonState,
+  providePaginationButtonState,
+] = createPrimitive(
+  'NgpPaginationButton',
+  ({
+    page = signal<number>(-1),
+    buttonDisabled = signal<boolean>(false),
+  }: NgpPaginationButtonProps) => {
+    const elementRef = injectElementRef();
+    const paginationState = injectPaginationState();
+
+    const selected = computed(() => page() == paginationState().page());
+    const disabled = computed(() => buttonDisabled() || paginationState().disabled());
+
+    // Setup interactions
+    ngpButton({ disabled: disabled });
+
+    // Host binding
+    attrBinding(elementRef, 'tabindex', () => (disabled() ? -1 : 0));
+    attrBinding(elementRef, 'aria-current', selected);
+    dataBinding(elementRef, 'data-page', () => page().toString());
+    dataBinding(elementRef, 'data-selected', () => (selected() ? '' : null));
+
+    // Listeners
+    listener(elementRef, 'click', goToPage);
+    listener(elementRef, 'keydown.space', handleKeydownEvent);
+    listener(elementRef, 'keydown.enter', handleKeydownEvent);
+
+    function goToPage(): void {
+      if (disabled()) {
+        return;
+      }
+
+      paginationState().goToPage(page());
+    }
+
+    function handleKeydownEvent(event: Event): void {
+      event.preventDefault();
+      event.stopPropagation();
+      goToPage();
+    }
+
+    return {
+      elementRef,
+      page,
+      buttonDisabled,
+      disabled,
+      goToPage,
+    } satisfies NgpPaginationButtonState;
+  },
+);

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
@@ -10,7 +10,7 @@ import {
 import { injectPaginationState } from '../pagination/pagination-state';
 
 export interface NgpPaginationButtonState {
-  /** Access te element's reference. */
+  /** Access the element's reference. */
   readonly elementRef: ElementRef;
   /**
    * Define the page this button represents.

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
@@ -1,12 +1,7 @@
 import { computed, ElementRef, signal, Signal } from '@angular/core';
 import { ngpButton } from 'ng-primitives/button';
 import { injectElementRef } from 'ng-primitives/internal';
-import {
-  attrBinding,
-  createPrimitive,
-  dataBinding,
-  listener,
-} from 'ng-primitives/state';
+import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
 import { injectPaginationState } from '../pagination/pagination-state';
 
 export interface NgpPaginationButtonState {

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
@@ -1,14 +1,12 @@
-import { computed, ElementRef, signal, Signal, WritableSignal } from '@angular/core';
+import { computed, ElementRef, signal, Signal } from '@angular/core';
 import { ngpButton } from 'ng-primitives/button';
 import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
-  controlledState,
   createPrimitive,
   dataBinding,
   listener,
 } from 'ng-primitives/state';
-import { Observable } from 'rxjs';
 import { injectPaginationState } from '../pagination/pagination-state';
 
 export interface NgpPaginationButtonState {
@@ -71,8 +69,8 @@ export const [
 
     // Listeners
     listener(elementRef, 'click', goToPage);
-    listener(elementRef, 'keydown.space', handleKeydownEvent);
-    listener(elementRef, 'keydown.enter', handleKeydownEvent);
+    listener(elementRef, 'keydown.space', handleOnEnter);
+    listener(elementRef, 'keydown.enter', handleOnEnter);
 
     function goToPage(): void {
       if (disabled()) {
@@ -82,7 +80,7 @@ export const [
       paginationState().goToPage(page());
     }
 
-    function handleKeydownEvent(event: Event): void {
+    function handleOnEnter(event: Event): void {
       event.preventDefault();
       event.stopPropagation();
       goToPage();

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
@@ -12,11 +12,7 @@ export interface NgpPaginationButtonState {
    */
   readonly page: Signal<number>;
   /**
-   * Whether the button is disabled.
-   */
-  readonly buttonDisabled: Signal<boolean>;
-  /**
-   * Whether the button is disabled.
+   * Whether the button is disabled, accounting for the parent pagination state.
    */
   readonly disabled: Signal<boolean>;
   /**
@@ -33,7 +29,7 @@ export interface NgpPaginationButtonProps {
   /**
    * Whether the button is disabled.
    */
-  readonly buttonDisabled?: Signal<boolean>;
+  readonly disabled?: Signal<boolean>;
 }
 
 export const [
@@ -45,13 +41,13 @@ export const [
   'NgpPaginationButton',
   ({
     page = signal<number>(-1),
-    buttonDisabled = signal<boolean>(false),
+    disabled: _disabled = signal<boolean>(false),
   }: NgpPaginationButtonProps) => {
     const elementRef = injectElementRef();
     const paginationState = injectPaginationState();
 
-    const selected = computed(() => page() == paginationState().page());
-    const disabled = computed(() => buttonDisabled() || paginationState().disabled());
+    const selected = computed(() => page() === paginationState().page());
+    const disabled = computed(() => _disabled() || paginationState().disabled());
 
     // Setup interactions
     ngpButton({ disabled: disabled });
@@ -84,7 +80,6 @@ export const [
     return {
       elementRef,
       page,
-      buttonDisabled,
       disabled,
       goToPage,
     } satisfies NgpPaginationButtonState;

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button.ts
@@ -1,14 +1,10 @@
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
 import {
   booleanAttribute,
-  computed,
   Directive,
-  HostListener,
   input,
   numberAttribute,
 } from '@angular/core';
-import { ngpButton } from 'ng-primitives/button';
-import { injectPaginationState } from '../pagination/pagination-state';
 import { ngpPaginationButton } from './pagination-button-state';
 
 /**

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button.ts
@@ -1,10 +1,5 @@
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
-import {
-  booleanAttribute,
-  Directive,
-  input,
-  numberAttribute,
-} from '@angular/core';
+import { booleanAttribute, Directive, input, numberAttribute } from '@angular/core';
 import { ngpPaginationButton } from './pagination-button-state';
 
 /**

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import { ngpButton } from 'ng-primitives/button';
 import { injectPaginationState } from '../pagination/pagination-state';
+import { ngpPaginationButton } from './pagination-button-state';
 
 /**
  * The `NgpPaginationButton` directive is used to create a pagination button.
@@ -16,19 +17,8 @@ import { injectPaginationState } from '../pagination/pagination-state';
 @Directive({
   selector: '[ngpPaginationButton]',
   exportAs: 'ngpPaginationButton',
-  host: {
-    '[tabindex]': 'disabled() ? -1 : 0',
-    '[attr.data-page]': 'page()',
-    '[attr.data-selected]': 'selected() ? "" : null',
-    '[attr.aria-current]': 'selected()',
-  },
 })
 export class NgpPaginationButton {
-  /**
-   * Access the pagination state.
-   */
-  protected readonly paginationState = injectPaginationState();
-
   /**
    * Define the page this button represents.
    */
@@ -45,41 +35,15 @@ export class NgpPaginationButton {
     transform: booleanAttribute,
   });
 
-  /**
-   * Whether the button is disabled.
-   */
-  readonly disabled = computed(() => this.buttonDisabled() || this.paginationState().disabled());
-
-  /**
-   * Whether this page is the currently selected page.
-   */
-  protected readonly selected = computed(() => this.page() === this.paginationState().page());
-
-  constructor() {
-    ngpButton({ disabled: this.disabled });
-  }
+  protected readonly state = ngpPaginationButton({
+    page: this.page,
+    buttonDisabled: this.buttonDisabled,
+  });
 
   /**
    * Go to the page this button represents.
    */
-  @HostListener('click')
   goToPage(): void {
-    if (this.disabled()) {
-      return;
-    }
-
-    this.paginationState().goToPage(this.page());
-  }
-
-  /**
-   * A click event may not be fired if this is on an anchor tag and the href is empty.
-   * This is a workaround to ensure the click event is fired.
-   */
-  @HostListener('keydown.enter', ['$event'])
-  @HostListener('keydown.space', ['$event'])
-  protected onEnter(event: Event): void {
-    event.preventDefault();
-    event.stopPropagation();
-    this.goToPage();
+    return this.state.goToPage();
   }
 }

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button.ts
@@ -21,14 +21,14 @@ export class NgpPaginationButton {
   /**
    * Whether the button is disabled.
    */
-  readonly buttonDisabled = input<boolean, BooleanInput>(false, {
+  readonly disabled = input<boolean, BooleanInput>(false, {
     alias: 'ngpPaginationButtonDisabled',
     transform: booleanAttribute,
   });
 
   protected readonly state = ngpPaginationButton({
     page: this.page,
-    buttonDisabled: this.buttonDisabled,
+    disabled: this.disabled,
   });
 
   /**

--- a/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
@@ -8,11 +8,7 @@ export interface NgpPaginationFirstState {
   /** Access the element's reference. */
   readonly elementRef: ElementRef;
   /**
-   * Whether the button is disabled.
-   */
-  readonly buttonDisabled: Signal<boolean>;
-  /**
-   * Whether the button is disabled.
+   * Whether the button is disabled, accounting for the parent pagination state.
    */
   readonly disabled: Signal<boolean>;
   /**
@@ -25,7 +21,7 @@ export interface NgpPaginationFirstProps {
   /**
    * Whether the button is disabled.
    */
-  readonly buttonDisabled: Signal<boolean>;
+  readonly disabled?: Signal<boolean>;
 }
 
 export const [
@@ -35,12 +31,12 @@ export const [
   providePaginationFirstState,
 ] = createPrimitive(
   'NgpPaginationFirst',
-  ({ buttonDisabled = signal<boolean>(false) }: NgpPaginationFirstProps) => {
+  ({ disabled: _disabled = signal<boolean>(false) }: NgpPaginationFirstProps) => {
     const elementRef = injectElementRef();
     const paginationState = injectPaginationState();
 
     const disabled = computed(
-      () => buttonDisabled() || paginationState().disabled() || paginationState().firstPage(),
+      () => _disabled() || paginationState().disabled() || paginationState().firstPage(),
     );
 
     // Setup interactions
@@ -71,7 +67,6 @@ export const [
 
     return {
       elementRef,
-      buttonDisabled,
       disabled,
       goToFirstPage,
     } satisfies NgpPaginationFirstState;

--- a/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
@@ -25,7 +25,7 @@ export interface NgpPaginationFirstProps {
   /**
    * Whether the button is disabled.
    */
-  buttonDisabled: Signal<boolean>;
+  readonly buttonDisabled: Signal<boolean>;
 }
 
 export const [

--- a/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
@@ -47,7 +47,7 @@ export const [
     ngpButton({ disabled: disabled });
 
     // Host binding
-    attrBinding(elementRef, 'tabindex', disabled() ? -1 : 0);
+    attrBinding(elementRef, 'tabindex', () => (disabled() ? -1 : 0));
     dataBinding(elementRef, 'data-first-page', () => (paginationState().firstPage() ? '' : null));
 
     // Listener

--- a/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
@@ -1,12 +1,10 @@
-import { computed, ElementRef, signal, Signal } from '@angular/core';
+import { computed, signal, Signal } from '@angular/core';
 import { ngpButton } from 'ng-primitives/button';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
 import { injectPaginationState } from '../pagination/pagination-state';
 
 export interface NgpPaginationFirstState {
-  /** Access the element's reference. */
-  readonly elementRef: ElementRef;
   /**
    * Whether the button is disabled, accounting for the parent pagination state.
    */
@@ -66,7 +64,6 @@ export const [
     }
 
     return {
-      elementRef,
       disabled,
       goToFirstPage,
     } satisfies NgpPaginationFirstState;

--- a/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
@@ -1,0 +1,79 @@
+import { computed, ElementRef, signal, Signal } from '@angular/core';
+import { ngpButton } from 'ng-primitives/button';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
+import { injectPaginationState } from '../pagination/pagination-state';
+
+export interface NgpPaginationFirstState {
+  /** Access te element's reference. */
+  readonly elementRef: ElementRef;
+  /**
+   * Whether the button is disabled.
+   */
+  readonly buttonDisabled: Signal<boolean>;
+  /**
+   * Whether the button is disabled.
+   */
+  readonly disabled: Signal<boolean>;
+  /**
+   * Go to the first page.
+   */
+  goToFirstPage(): void;
+}
+
+export interface NgpPaginationFirstProps {
+  /**
+   * Whether the button is disabled.
+   */
+  buttonDisabled: Signal<boolean>;
+}
+
+export const [
+  NgpPaginationFirstStateToken,
+  ngpPaginationFirst,
+  injectPaginationFirstState,
+  providePaginationFirstState,
+] = createPrimitive(
+  'NgpPaginationFirst',
+  ({ buttonDisabled = signal<boolean>(false) }: NgpPaginationFirstProps) => {
+    const elementRef = injectElementRef();
+    const paginationState = injectPaginationState();
+
+    const disabled = computed(
+      () => buttonDisabled() || paginationState().disabled() || paginationState().firstPage(),
+    );
+
+    // Setup interactions
+    ngpButton({ disabled: disabled });
+
+    // Host binding
+    attrBinding(elementRef, 'tabindex', disabled() ? -1 : 0);
+    dataBinding(elementRef, 'data-first-page', () => (paginationState().firstPage() ? '' : null));
+
+    // Listener
+    listener(elementRef, 'click', goToFirstPage);
+    listener(elementRef, 'keydown.enter', handleOnEnter);
+    listener(elementRef, 'keydown.space', handleOnEnter);
+
+    function goToFirstPage(): void {
+      if (disabled()) {
+        return;
+      }
+
+      paginationState().goToPage(1);
+    }
+
+    function handleOnEnter(event: Event): void {
+      event.preventDefault();
+      event.stopPropagation();
+      goToFirstPage();
+    }
+
+    return {
+      elementRef,
+      buttonDisabled,
+      disabled,
+      goToFirstPage,
+    } satisfies NgpPaginationFirstState;
+  },
+);

--- a/packages/ng-primitives/pagination/src/pagination-first/pagination-first.ts
+++ b/packages/ng-primitives/pagination/src/pagination-first/pagination-first.ts
@@ -1,7 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, computed, Directive, HostListener, input } from '@angular/core';
-import { ngpButton } from 'ng-primitives/button';
-import { injectPaginationState } from '../pagination/pagination-state';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import { ngpPaginationFirst } from './pagination-first-state';
 
 /**
  * The `NgpPaginationFirst` directive is used to create a pagination button that navigates to the first page.
@@ -9,17 +8,8 @@ import { injectPaginationState } from '../pagination/pagination-state';
 @Directive({
   selector: '[ngpPaginationFirst]',
   exportAs: 'ngpPaginationFirst',
-  host: {
-    '[tabindex]': 'disabled() ? -1 : 0',
-    '[attr.data-first-page]': 'paginationState().firstPage() ? "" : null',
-  },
 })
 export class NgpPaginationFirst {
-  /**
-   * Access the pagination state.
-   */
-  protected readonly paginationState = injectPaginationState();
-
   /**
    * Whether the button is disabled.
    */
@@ -28,37 +18,14 @@ export class NgpPaginationFirst {
     transform: booleanAttribute,
   });
 
-  readonly disabled = computed(
-    () =>
-      this.buttonDisabled() ||
-      this.paginationState().disabled() ||
-      this.paginationState().firstPage(),
-  );
+  protected readonly state = ngpPaginationFirst({
+    buttonDisabled: this.buttonDisabled,
+  });
 
-  constructor() {
-    ngpButton({ disabled: this.disabled });
-  }
   /**
    * Go to the first page.
    */
-  @HostListener('click')
   goToFirstPage() {
-    if (this.disabled()) {
-      return;
-    }
-
-    this.paginationState().goToPage(1);
-  }
-
-  /**
-   * A click event may not be fired if this is on an anchor tag and the href is empty.
-   * This is a workaround to ensure the click event is fired.
-   */
-  @HostListener('keydown.enter', ['$event'])
-  @HostListener('keydown.space', ['$event'])
-  protected onEnter(event: Event): void {
-    event.preventDefault();
-    event.stopPropagation();
-    this.goToFirstPage();
+    return this.state.goToFirstPage();
   }
 }

--- a/packages/ng-primitives/pagination/src/pagination-first/pagination-first.ts
+++ b/packages/ng-primitives/pagination/src/pagination-first/pagination-first.ts
@@ -13,13 +13,13 @@ export class NgpPaginationFirst {
   /**
    * Whether the button is disabled.
    */
-  readonly buttonDisabled = input<boolean, BooleanInput>(false, {
+  readonly disabled = input<boolean, BooleanInput>(false, {
     alias: 'ngpPaginationFirstDisabled',
     transform: booleanAttribute,
   });
 
   protected readonly state = ngpPaginationFirst({
-    buttonDisabled: this.buttonDisabled,
+    disabled: this.disabled,
   });
 
   /**

--- a/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
@@ -1,12 +1,10 @@
-import { computed, ElementRef, signal, Signal } from '@angular/core';
+import { computed, signal, Signal } from '@angular/core';
 import { ngpButton } from 'ng-primitives/button';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
 import { injectPaginationState } from '../pagination/pagination-state';
 
 export interface NgpPaginationLastState {
-  /** Access the element's reference. */
-  readonly elementRef: ElementRef;
   /** Whether the button is disabled, accounting for the parent pagination state. */
   readonly disabled: Signal<boolean>;
   /** Go to the last page. */
@@ -60,7 +58,6 @@ export const [
     }
 
     return {
-      elementRef,
       disabled,
       goToLastPage,
     } satisfies NgpPaginationLastState;

--- a/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
@@ -4,43 +4,35 @@ import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
 import { injectPaginationState } from '../pagination/pagination-state';
 
-export interface NgpPaginationFirstState {
+export interface NgpPaginationLastState {
   /** Access the element's reference. */
   readonly elementRef: ElementRef;
-  /**
-   * Whether the button is disabled.
-   */
+  /** Whether the button is disabled. */
   readonly buttonDisabled: Signal<boolean>;
-  /**
-   * Whether the button is disabled.
-   */
+  /** Whether the button is disabled. */
   readonly disabled: Signal<boolean>;
-  /**
-   * Go to the first page.
-   */
-  goToFirstPage(): void;
+  /** Go to the last page. */
+  goToLastPage(): void;
 }
 
-export interface NgpPaginationFirstProps {
-  /**
-   * Whether the button is disabled.
-   */
+export interface NgpPaginationLastProps {
+  /** Whether the button is disabled. */
   buttonDisabled: Signal<boolean>;
 }
 
 export const [
-  NgpPaginationFirstStateToken,
-  ngpPaginationFirst,
-  injectPaginationFirstState,
-  providePaginationFirstState,
+  NgpPaginationLastStateToken,
+  ngpPaginationLast,
+  injectPaginationLastState,
+  providePaginationLastState,
 ] = createPrimitive(
-  'NgpPaginationFirst',
-  ({ buttonDisabled = signal<boolean>(false) }: NgpPaginationFirstProps) => {
+  'NgpPaginationLast',
+  ({ buttonDisabled = signal<boolean>(false) }: NgpPaginationLastProps) => {
     const elementRef = injectElementRef();
     const paginationState = injectPaginationState();
 
     const disabled = computed(
-      () => buttonDisabled() || paginationState().disabled() || paginationState().firstPage(),
+      () => buttonDisabled() || paginationState().disabled() || paginationState().lastPage(),
     );
 
     // Setup interactions
@@ -48,32 +40,32 @@ export const [
 
     // Host binding
     attrBinding(elementRef, 'tabindex', disabled() ? -1 : 0);
-    dataBinding(elementRef, 'data-first-page', () => (paginationState().firstPage() ? '' : null));
+    dataBinding(elementRef, 'data-last-page', () => (paginationState().lastPage() ? '' : null));
 
     // Listener
-    listener(elementRef, 'click', goToFirstPage);
+    listener(elementRef, 'click', goToLastPage);
     listener(elementRef, 'keydown.enter', handleOnEnter);
     listener(elementRef, 'keydown.space', handleOnEnter);
 
-    function goToFirstPage(): void {
+    function goToLastPage(): void {
       if (disabled()) {
         return;
       }
 
-      paginationState().goToPage(1);
+      paginationState().goToPage(paginationState().pageCount());
     }
 
     function handleOnEnter(event: Event): void {
       event.preventDefault();
       event.stopPropagation();
-      goToFirstPage();
+      goToLastPage();
     }
 
     return {
       elementRef,
       buttonDisabled,
       disabled,
-      goToFirstPage,
-    } satisfies NgpPaginationFirstState;
+      goToLastPage,
+    } satisfies NgpPaginationLastState;
   },
 );

--- a/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
@@ -7,9 +7,7 @@ import { injectPaginationState } from '../pagination/pagination-state';
 export interface NgpPaginationLastState {
   /** Access the element's reference. */
   readonly elementRef: ElementRef;
-  /** Whether the button is disabled. */
-  readonly buttonDisabled: Signal<boolean>;
-  /** Whether the button is disabled. */
+  /** Whether the button is disabled, accounting for the parent pagination state. */
   readonly disabled: Signal<boolean>;
   /** Go to the last page. */
   goToLastPage(): void;
@@ -17,7 +15,7 @@ export interface NgpPaginationLastState {
 
 export interface NgpPaginationLastProps {
   /** Whether the button is disabled. */
-  readonly buttonDisabled: Signal<boolean>;
+  readonly disabled?: Signal<boolean>;
 }
 
 export const [
@@ -27,12 +25,12 @@ export const [
   providePaginationLastState,
 ] = createPrimitive(
   'NgpPaginationLast',
-  ({ buttonDisabled = signal<boolean>(false) }: NgpPaginationLastProps) => {
+  ({ disabled: _disabled = signal<boolean>(false) }: NgpPaginationLastProps) => {
     const elementRef = injectElementRef();
     const paginationState = injectPaginationState();
 
     const disabled = computed(
-      () => buttonDisabled() || paginationState().disabled() || paginationState().lastPage(),
+      () => _disabled() || paginationState().disabled() || paginationState().lastPage(),
     );
 
     // Setup interactions
@@ -63,7 +61,6 @@ export const [
 
     return {
       elementRef,
-      buttonDisabled,
       disabled,
       goToLastPage,
     } satisfies NgpPaginationLastState;

--- a/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
@@ -39,7 +39,7 @@ export const [
     ngpButton({ disabled: disabled });
 
     // Host binding
-    attrBinding(elementRef, 'tabindex', disabled() ? -1 : 0);
+    attrBinding(elementRef, 'tabindex', () => (disabled() ? -1 : 0));
     dataBinding(elementRef, 'data-last-page', () => (paginationState().lastPage() ? '' : null));
 
     // Listener

--- a/packages/ng-primitives/pagination/src/pagination-last/pagination-last.ts
+++ b/packages/ng-primitives/pagination/src/pagination-last/pagination-last.ts
@@ -13,13 +13,13 @@ export class NgpPaginationLast {
   /**
    * Whether the button is disabled.
    */
-  readonly buttonDisabled = input<boolean, BooleanInput>(false, {
+  readonly disabled = input<boolean, BooleanInput>(false, {
     alias: 'ngpPaginationLastDisabled',
     transform: booleanAttribute,
   });
 
   protected readonly state = ngpPaginationLast({
-    buttonDisabled: this.buttonDisabled,
+    disabled: this.disabled,
   });
 
   /**

--- a/packages/ng-primitives/pagination/src/pagination-last/pagination-last.ts
+++ b/packages/ng-primitives/pagination/src/pagination-last/pagination-last.ts
@@ -1,7 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, computed, Directive, HostListener, input } from '@angular/core';
-import { ngpButton } from 'ng-primitives/button';
-import { injectPaginationState } from '../pagination/pagination-state';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import { ngpPaginationLast } from './pagination-last-state';
 
 /**
  * The `NgpPaginationLast` directive is used to create a pagination button that navigates to the last page.
@@ -9,17 +8,8 @@ import { injectPaginationState } from '../pagination/pagination-state';
 @Directive({
   selector: '[ngpPaginationLast]',
   exportAs: 'ngpPaginationLast',
-  host: {
-    '[tabindex]': 'disabled() ? -1 : 0',
-    '[attr.data-last-page]': 'paginationState().lastPage() ? "" : null',
-  },
 })
 export class NgpPaginationLast {
-  /**
-   * Access the pagination state.
-   */
-  protected readonly paginationState = injectPaginationState();
-
   /**
    * Whether the button is disabled.
    */
@@ -28,38 +18,14 @@ export class NgpPaginationLast {
     transform: booleanAttribute,
   });
 
-  readonly disabled = computed(
-    () =>
-      this.buttonDisabled() ||
-      this.paginationState().disabled() ||
-      this.paginationState().lastPage(),
-  );
-
-  constructor() {
-    ngpButton({ disabled: this.disabled });
-  }
+  protected readonly state = ngpPaginationLast({
+    buttonDisabled: this.buttonDisabled,
+  });
 
   /**
    * Go to the last page.
    */
-  @HostListener('click')
   goToLastPage(): void {
-    if (this.disabled()) {
-      return;
-    }
-
-    this.paginationState().goToPage(this.paginationState().pageCount());
-  }
-
-  /**
-   * A click event may not be fired if this is on an anchor tag and the href is empty.
-   * This is a workaround to ensure the click event is fired.
-   */
-  @HostListener('keydown.enter', ['$event'])
-  @HostListener('keydown.space', ['$event'])
-  protected onEnter(event: Event): void {
-    event.preventDefault();
-    event.stopPropagation();
-    this.goToLastPage();
+    this.state.goToLastPage();
   }
 }

--- a/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
@@ -1,33 +1,33 @@
-import { computed, ElementRef, signal, Signal } from '@angular/core';
+import { computed, ElementRef, Signal, signal } from '@angular/core';
 import { ngpButton } from 'ng-primitives/button';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
 import { injectPaginationState } from '../pagination/pagination-state';
 
-export interface NgpPaginationLastState {
+export interface NgpPaginationNextState {
   /** Access the element's reference. */
   readonly elementRef: ElementRef;
   /** Whether the button is disabled. */
   readonly buttonDisabled: Signal<boolean>;
   /** Whether the button is disabled. */
   readonly disabled: Signal<boolean>;
-  /** Go to the last page. */
-  goToLastPage(): void;
+  /** Go to the next page. */
+  goToNextPage(): void;
 }
 
-export interface NgpPaginationLastProps {
-  /** Whether the button is disabled. */
+export interface NgpPaginationNextProps {
+  /** Whether the button is disabled */
   readonly buttonDisabled: Signal<boolean>;
 }
 
 export const [
-  NgpPaginationLastStateToken,
-  ngpPaginationLast,
-  injectPaginationLastState,
-  providePaginationLastState,
+  NgpPaginationNextStateToken,
+  ngpPaginationNext,
+  injectPaginationNextState,
+  providePaginationNextState,
 ] = createPrimitive(
-  'NgpPaginationLast',
-  ({ buttonDisabled = signal<boolean>(false) }: NgpPaginationLastProps) => {
+  'NgpPaginationNext',
+  ({ buttonDisabled = signal<boolean>(false) }: NgpPaginationNextProps) => {
     const elementRef = injectElementRef();
     const paginationState = injectPaginationState();
 
@@ -43,29 +43,29 @@ export const [
     dataBinding(elementRef, 'data-last-page', () => (paginationState().lastPage() ? '' : null));
 
     // Listener
-    listener(elementRef, 'click', goToLastPage);
+    listener(elementRef, 'click', goToNextPage);
     listener(elementRef, 'keydown.enter', handleOnEnter);
     listener(elementRef, 'keydown.space', handleOnEnter);
 
-    function goToLastPage(): void {
+    function goToNextPage(): void {
       if (disabled()) {
         return;
       }
 
-      paginationState().goToPage(paginationState().pageCount());
+      paginationState().goToPage(paginationState().page() + 1);
     }
 
     function handleOnEnter(event: Event): void {
       event.preventDefault();
       event.stopPropagation();
-      goToLastPage();
+      goToNextPage();
     }
 
     return {
       elementRef,
       buttonDisabled,
       disabled,
-      goToLastPage,
-    } satisfies NgpPaginationLastState;
+      goToNextPage,
+    } satisfies NgpPaginationNextState;
   },
 );

--- a/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
@@ -7,9 +7,7 @@ import { injectPaginationState } from '../pagination/pagination-state';
 export interface NgpPaginationNextState {
   /** Access the element's reference. */
   readonly elementRef: ElementRef;
-  /** Whether the button is disabled. */
-  readonly buttonDisabled: Signal<boolean>;
-  /** Whether the button is disabled. */
+  /** Whether the button is disabled, accounting for the parent pagination state. */
   readonly disabled: Signal<boolean>;
   /** Go to the next page. */
   goToNextPage(): void;
@@ -17,7 +15,7 @@ export interface NgpPaginationNextState {
 
 export interface NgpPaginationNextProps {
   /** Whether the button is disabled */
-  readonly buttonDisabled: Signal<boolean>;
+  readonly disabled?: Signal<boolean>;
 }
 
 export const [
@@ -27,12 +25,12 @@ export const [
   providePaginationNextState,
 ] = createPrimitive(
   'NgpPaginationNext',
-  ({ buttonDisabled = signal<boolean>(false) }: NgpPaginationNextProps) => {
+  ({ disabled: _disabled = signal<boolean>(false) }: NgpPaginationNextProps) => {
     const elementRef = injectElementRef();
     const paginationState = injectPaginationState();
 
     const disabled = computed(
-      () => buttonDisabled() || paginationState().disabled() || paginationState().lastPage(),
+      () => _disabled() || paginationState().disabled() || paginationState().lastPage(),
     );
 
     // Setup interactions
@@ -63,7 +61,6 @@ export const [
 
     return {
       elementRef,
-      buttonDisabled,
       disabled,
       goToNextPage,
     } satisfies NgpPaginationNextState;

--- a/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
@@ -39,7 +39,7 @@ export const [
     ngpButton({ disabled: disabled });
 
     // Host binding
-    attrBinding(elementRef, 'tabindex', disabled() ? -1 : 0);
+    attrBinding(elementRef, 'tabindex', () => (disabled() ? -1 : 0));
     dataBinding(elementRef, 'data-last-page', () => (paginationState().lastPage() ? '' : null));
 
     // Listener

--- a/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
@@ -1,12 +1,10 @@
-import { computed, ElementRef, Signal, signal } from '@angular/core';
+import { computed, Signal, signal } from '@angular/core';
 import { ngpButton } from 'ng-primitives/button';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
 import { injectPaginationState } from '../pagination/pagination-state';
 
 export interface NgpPaginationNextState {
-  /** Access the element's reference. */
-  readonly elementRef: ElementRef;
   /** Whether the button is disabled, accounting for the parent pagination state. */
   readonly disabled: Signal<boolean>;
   /** Go to the next page. */
@@ -60,7 +58,6 @@ export const [
     }
 
     return {
-      elementRef,
       disabled,
       goToNextPage,
     } satisfies NgpPaginationNextState;

--- a/packages/ng-primitives/pagination/src/pagination-next/pagination-next.ts
+++ b/packages/ng-primitives/pagination/src/pagination-next/pagination-next.ts
@@ -1,7 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, computed, Directive, HostListener, input } from '@angular/core';
-import { ngpButton } from 'ng-primitives/button';
-import { injectPaginationState } from '../pagination/pagination-state';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import { ngpPaginationNext } from './pagination-next-state';
 
 /**
  * The `NgpPaginationNext` directive is used to create a pagination button that navigates to the next page.
@@ -9,17 +8,8 @@ import { injectPaginationState } from '../pagination/pagination-state';
 @Directive({
   selector: '[ngpPaginationNext]',
   exportAs: 'ngpPaginationNext',
-  host: {
-    '[tabindex]': 'disabled() ? -1 : 0',
-    '[attr.data-last-page]': 'paginationState().lastPage() ? "" : null',
-  },
 })
 export class NgpPaginationNext {
-  /**
-   * Access the pagination state.
-   */
-  protected readonly paginationState = injectPaginationState();
-
   /**
    * Whether the button is disabled.
    */
@@ -28,41 +18,14 @@ export class NgpPaginationNext {
     transform: booleanAttribute,
   });
 
-  /**
-   * Whether the button is disabled.
-   */
-  readonly disabled = computed(
-    () =>
-      this.buttonDisabled() ||
-      this.paginationState().disabled() ||
-      this.paginationState().lastPage(),
-  );
-
-  constructor() {
-    ngpButton({ disabled: this.disabled });
-  }
+  protected readonly state = ngpPaginationNext({
+    buttonDisabled: this.buttonDisabled,
+  });
 
   /**
    * Go to the next page.
    */
-  @HostListener('click')
   goToNextPage(): void {
-    if (this.disabled()) {
-      return;
-    }
-
-    this.paginationState().goToPage(this.paginationState().page() + 1);
-  }
-
-  /**
-   * A click event may not be fired if this is on an anchor tag and the href is empty.
-   * This is a workaround to ensure the click event is fired.
-   */
-  @HostListener('keydown.enter', ['$event'])
-  @HostListener('keydown.space', ['$event'])
-  protected onEnter(event: Event): void {
-    event.preventDefault();
-    event.stopPropagation();
-    this.goToNextPage();
+    return this.state.goToNextPage();
   }
 }

--- a/packages/ng-primitives/pagination/src/pagination-next/pagination-next.ts
+++ b/packages/ng-primitives/pagination/src/pagination-next/pagination-next.ts
@@ -13,13 +13,13 @@ export class NgpPaginationNext {
   /**
    * Whether the button is disabled.
    */
-  readonly buttonDisabled = input<boolean, BooleanInput>(false, {
+  readonly disabled = input<boolean, BooleanInput>(false, {
     alias: 'ngpPaginationNextDisabled',
     transform: booleanAttribute,
   });
 
   protected readonly state = ngpPaginationNext({
-    buttonDisabled: this.buttonDisabled,
+    disabled: this.disabled,
   });
 
   /**

--- a/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
@@ -1,12 +1,10 @@
-import { computed, ElementRef, signal, Signal } from '@angular/core';
+import { computed, signal, Signal } from '@angular/core';
 import { ngpButton } from 'ng-primitives/button';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
 import { injectPaginationState } from '../pagination/pagination-state';
 
 export interface NgpPaginationPreviousState {
-  /** Access the element's reference. */
-  readonly elementRef: ElementRef;
   /**
    * Whether the button is disabled, accounting for the parent pagination state.
    */
@@ -66,7 +64,6 @@ export const [
     }
 
     return {
-      elementRef,
       disabled,
       goToPreviousPage,
     } satisfies NgpPaginationPreviousState;

--- a/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
@@ -8,15 +8,11 @@ export interface NgpPaginationPreviousState {
   /** Access the element's reference. */
   readonly elementRef: ElementRef;
   /**
-   * Whether the button is disabled.
-   */
-  readonly buttonDisabled: Signal<boolean>;
-  /**
-   * Whether the button is disabled.
+   * Whether the button is disabled, accounting for the parent pagination state.
    */
   readonly disabled: Signal<boolean>;
   /**
-   * Go to the first page.
+   * Go to the previous page.
    */
   goToPreviousPage(): void;
 }
@@ -25,7 +21,7 @@ export interface NgpPaginationPreviousProps {
   /**
    * Whether the button is disabled.
    */
-  readonly buttonDisabled: Signal<boolean>;
+  readonly disabled?: Signal<boolean>;
 }
 
 export const [
@@ -35,12 +31,12 @@ export const [
   providePaginationPreviousState,
 ] = createPrimitive(
   'NgpPaginationPrevious',
-  ({ buttonDisabled = signal<boolean>(false) }: NgpPaginationPreviousProps) => {
+  ({ disabled: _disabled = signal<boolean>(false) }: NgpPaginationPreviousProps) => {
     const elementRef = injectElementRef();
     const paginationState = injectPaginationState();
 
     const disabled = computed(
-      () => buttonDisabled() || paginationState().disabled() || paginationState().firstPage(),
+      () => _disabled() || paginationState().disabled() || paginationState().firstPage(),
     );
 
     // Setup interactions
@@ -71,7 +67,6 @@ export const [
 
     return {
       elementRef,
-      buttonDisabled,
       disabled,
       goToPreviousPage,
     } satisfies NgpPaginationPreviousState;

--- a/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
@@ -1,0 +1,79 @@
+import { computed, ElementRef, signal, Signal } from '@angular/core';
+import { ngpButton } from 'ng-primitives/button';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
+import { injectPaginationState } from '../pagination/pagination-state';
+
+export interface NgpPaginationPreviousState {
+  /** Access the element's reference. */
+  readonly elementRef: ElementRef;
+  /**
+   * Whether the button is disabled.
+   */
+  readonly buttonDisabled: Signal<boolean>;
+  /**
+   * Whether the button is disabled.
+   */
+  readonly disabled: Signal<boolean>;
+  /**
+   * Go to the first page.
+   */
+  goToPreviousPage(): void;
+}
+
+export interface NgpPaginationPreviousProps {
+  /**
+   * Whether the button is disabled.
+   */
+  readonly buttonDisabled: Signal<boolean>;
+}
+
+export const [
+  NgpPaginationPreviousStateToken,
+  ngpPaginationPrevious,
+  injectPaginationPreviousState,
+  providePaginationPreviousState,
+] = createPrimitive(
+  'NgpPaginationPrevious',
+  ({ buttonDisabled = signal<boolean>(false) }: NgpPaginationPreviousProps) => {
+    const elementRef = injectElementRef();
+    const paginationState = injectPaginationState();
+
+    const disabled = computed(
+      () => buttonDisabled() || paginationState().disabled() || paginationState().firstPage(),
+    );
+
+    // Setup interactions
+    ngpButton({ disabled: disabled });
+
+    // Host binding
+    attrBinding(elementRef, 'tabindex', disabled() ? -1 : 0);
+    dataBinding(elementRef, 'data-first-page', () => (paginationState().firstPage() ? '' : null));
+
+    // Listener
+    listener(elementRef, 'click', goToPreviousPage);
+    listener(elementRef, 'keydown.enter', handleOnEnter);
+    listener(elementRef, 'keydown.space', handleOnEnter);
+
+    function goToPreviousPage(): void {
+      if (disabled()) {
+        return;
+      }
+
+      paginationState().goToPage(paginationState().page() - 1);
+    }
+
+    function handleOnEnter(event: Event): void {
+      event.preventDefault();
+      event.stopPropagation();
+      goToPreviousPage();
+    }
+
+    return {
+      elementRef,
+      buttonDisabled,
+      disabled,
+      goToPreviousPage,
+    } satisfies NgpPaginationPreviousState;
+  },
+);

--- a/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
@@ -47,7 +47,7 @@ export const [
     ngpButton({ disabled: disabled });
 
     // Host binding
-    attrBinding(elementRef, 'tabindex', disabled() ? -1 : 0);
+    attrBinding(elementRef, 'tabindex', () => (disabled() ? -1 : 0));
     dataBinding(elementRef, 'data-first-page', () => (paginationState().firstPage() ? '' : null));
 
     // Listener

--- a/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous.ts
+++ b/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous.ts
@@ -1,7 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, computed, Directive, HostListener, input } from '@angular/core';
-import { ngpButton } from 'ng-primitives/button';
-import { injectPaginationState } from '../pagination/pagination-state';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import { ngpPaginationPrevious } from './pagination-previous-state';
 
 /**
  * The `NgpPaginationPrevious` directive is used to create a pagination button that navigates to the previous page.
@@ -9,17 +8,8 @@ import { injectPaginationState } from '../pagination/pagination-state';
 @Directive({
   selector: '[ngpPaginationPrevious]',
   exportAs: 'ngpPaginationPrevious',
-  host: {
-    '[tabindex]': 'disabled() ? -1 : 0',
-    '[attr.data-first-page]': 'paginationState().firstPage() ? "" : null',
-  },
 })
 export class NgpPaginationPrevious {
-  /**
-   * Access the pagination state.
-   */
-  protected readonly paginationState = injectPaginationState();
-
   /**
    * Whether the button is disabled.
    */
@@ -28,41 +18,14 @@ export class NgpPaginationPrevious {
     transform: booleanAttribute,
   });
 
-  /**
-   * Whether the button is disabled.
-   */
-  readonly disabled = computed(
-    () =>
-      this.buttonDisabled() ||
-      this.paginationState().disabled() ||
-      this.paginationState().firstPage(),
-  );
-
-  constructor() {
-    ngpButton({ disabled: this.disabled });
-  }
+  protected readonly state = ngpPaginationPrevious({
+    buttonDisabled: this.buttonDisabled,
+  });
 
   /**
    * Go to the previous page.
    */
-  @HostListener('click')
   goToPreviousPage() {
-    if (this.disabled()) {
-      return;
-    }
-
-    this.paginationState().goToPage(this.paginationState().page() - 1);
-  }
-
-  /**
-   * A click event may not be fired if this is on an anchor tag and the href is empty.
-   * This is a workaround to ensure the click event is fired.
-   */
-  @HostListener('keydown.enter', ['$event'])
-  @HostListener('keydown.space', ['$event'])
-  protected onEnter(event: Event): void {
-    event.preventDefault();
-    event.stopPropagation();
-    this.goToPreviousPage();
+    return this.state.goToPreviousPage();
   }
 }

--- a/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous.ts
+++ b/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous.ts
@@ -13,13 +13,13 @@ export class NgpPaginationPrevious {
   /**
    * Whether the button is disabled.
    */
-  readonly buttonDisabled = input<boolean, BooleanInput>(false, {
+  readonly disabled = input<boolean, BooleanInput>(false, {
     alias: 'ngpPaginationPreviousDisabled',
     transform: booleanAttribute,
   });
 
   protected readonly state = ngpPaginationPrevious({
-    buttonDisabled: this.buttonDisabled,
+    disabled: this.disabled,
   });
 
   /**

--- a/packages/ng-primitives/pagination/src/pagination/pagination-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination-state.ts
@@ -2,7 +2,6 @@ import { computed, signal, Signal, WritableSignal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
-  controlled,
   controlledState,
   createPrimitive,
   dataBinding,
@@ -82,10 +81,9 @@ export const [
   }: NgpPaginationProps) => {
     const elementRef = injectElementRef();
 
-    const defaultPage = controlled(_defaultPage, 1);
     const [page, setPage, pageChange] = controlledState({
       value: _page,
-      defaultValue: defaultPage,
+      defaultValue: _defaultPage,
       onChange: onPageChange,
     });
 
@@ -112,7 +110,7 @@ export const [
     return {
       page: deprecatedSetter(page, 'setPage', setPage),
       pageCount: _pageCount,
-      pageChange: pageChange,
+      pageChange,
       disabled: _disabled,
       firstPage,
       lastPage,

--- a/packages/ng-primitives/pagination/src/pagination/pagination-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination-state.ts
@@ -2,6 +2,7 @@ import { computed, ElementRef, signal, Signal, WritableSignal } from '@angular/c
 import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
+  controlled,
   controlledState,
   createPrimitive,
   dataBinding,
@@ -47,9 +48,14 @@ export interface NgpPaginationState {
 
 export interface NgpPaginationProps {
   /**
-   * The currently selected page.
+   * The currently selected page. When `undefined`, the pagination is uncontrolled
+   * and seeds from `defaultPage`.
    */
-  readonly page?: Signal<number>;
+  readonly page?: Signal<number | undefined>;
+  /**
+   * The default page for uncontrolled usage.
+   */
+  readonly defaultPage?: Signal<number>;
   /**
    * The total number of pages.
    */
@@ -70,20 +76,23 @@ export const [
 ] = createPrimitive(
   'NgpPagination',
   ({
-    page: _page = signal<number>(1),
+    page: _page = signal<number | undefined>(undefined),
+    defaultPage: _defaultPage = signal<number>(1),
     pageCount: _pageCount = signal<number>(0),
     disabled: _disabled = signal<boolean>(false),
     onPageChange,
   }: NgpPaginationProps) => {
     const elementRef = injectElementRef();
 
+    const defaultPage = controlled(_defaultPage, 1);
     const [page, setPage, pageChange] = controlledState({
       value: _page,
+      defaultValue: defaultPage,
       onChange: onPageChange,
     });
 
-    const firstPage = computed(() => page() == 1);
-    const lastPage = computed(() => page() == _pageCount());
+    const firstPage = computed(() => page() === 1);
+    const lastPage = computed(() => page() === _pageCount());
 
     // Host bindings
     attrBinding(elementRef, 'role', 'navigation');

--- a/packages/ng-primitives/pagination/src/pagination/pagination-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination-state.ts
@@ -1,4 +1,4 @@
-import { computed, ElementRef, signal, Signal, WritableSignal } from '@angular/core';
+import { computed, signal, Signal, WritableSignal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
@@ -11,8 +11,6 @@ import {
 import { Observable } from 'rxjs';
 
 export interface NgpPaginationState {
-  /** Access the element's reference. */
-  readonly elementRef: ElementRef;
   /**
    * The currently selected page.
    */
@@ -112,7 +110,6 @@ export const [
     }
 
     return {
-      elementRef,
       page: deprecatedSetter(page, 'setPage', setPage),
       pageCount: _pageCount,
       pageChange: pageChange,

--- a/packages/ng-primitives/pagination/src/pagination/pagination-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination-state.ts
@@ -1,27 +1,116 @@
+import { computed, ElementRef, signal, Signal, WritableSignal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
 import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
+  attrBinding,
+  controlledState,
+  createPrimitive,
+  dataBinding,
+  deprecatedSetter,
 } from 'ng-primitives/state';
-import type { NgpPagination } from './pagination';
+import { Observable } from 'rxjs';
 
-/**
- * The state token  for the Pagination primitive.
- */
-export const NgpPaginationStateToken = createStateToken<NgpPagination>('Pagination');
+export interface NgpPaginationState {
+  /** Access the element's reference. */
+  readonly elementRef: ElementRef;
+  /**
+   * The currently selected page.
+   */
+  readonly page: WritableSignal<number>;
+  /**
+   * The total number of pages.
+   */
+  readonly pageCount: Signal<number>;
+  /**
+   * Whether the pagination is disabled.
+   */
+  readonly disabled: Signal<boolean>;
+  /**
+   * Determine if we are on the first page.
+   * @internal
+   */
+  readonly firstPage: Signal<boolean>;
+  /**
+   * Determine if we are on the last page.
+   * @internal
+   */
+  readonly lastPage: Signal<boolean>;
+  /**
+   * The event that is fired when the page changes.
+   */
+  readonly pageChange: Observable<number>;
+  /**
+   * Go to the specified page.
+   * @param page The page to go to.
+   */
+  goToPage: (page: number) => void;
+}
 
-/**
- * Provides the Pagination state.
- */
-export const providePaginationState = createStateProvider(NgpPaginationStateToken);
+export interface NgpPaginationProps {
+  /**
+   * The currently selected page.
+   */
+  readonly page?: Signal<number>;
+  /**
+   * The total number of pages.
+   */
+  readonly pageCount?: Signal<number>;
+  /**
+   * Whether the pagination is disabled.
+   */
+  readonly disabled?: Signal<boolean>;
+  /** Callback fired when the page state changes. */
+  onPageChange: (page: number) => void;
+}
 
-/**
- * Injects the Pagination state.
- */
-export const injectPaginationState = createStateInjector<NgpPagination>(NgpPaginationStateToken);
+export const [
+  NgpPaginationStateToken,
+  ngpPagination,
+  injectPaginationState,
+  providePaginationState,
+] = createPrimitive(
+  'NgpPagination',
+  ({
+    page: _page = signal<number>(1),
+    pageCount: _pageCount = signal<number>(0),
+    disabled: _disabled = signal<boolean>(false),
+    onPageChange,
+  }: NgpPaginationProps) => {
+    const elementRef = injectElementRef();
 
-/**
- * The Pagination state registration function.
- */
-export const paginationState = createState(NgpPaginationStateToken);
+    const [page, setPage, pageChange] = controlledState({
+      value: _page,
+      onChange: onPageChange,
+    });
+
+    const firstPage = computed(() => page() == 1);
+    const lastPage = computed(() => page() == _pageCount());
+
+    // Host bindings
+    attrBinding(elementRef, 'role', 'navigation');
+    dataBinding(elementRef, 'data-page', () => page().toString());
+    dataBinding(elementRef, 'data-page-count', () => _pageCount().toString());
+    dataBinding(elementRef, 'data-first-page', () => (firstPage() ? '' : null));
+    dataBinding(elementRef, 'data-last-page', () => (lastPage() ? '' : null));
+    dataBinding(elementRef, 'data-disabled', () => (_disabled() ? '' : null));
+
+    function goToPage(page: number) {
+      // check if the page is within the bounds of the pagination
+      if (page < 1 || page > _pageCount()) {
+        return;
+      }
+
+      setPage(page);
+    }
+
+    return {
+      elementRef,
+      page: deprecatedSetter(page, 'setPage', setPage),
+      pageCount: _pageCount,
+      pageChange: pageChange,
+      disabled: _disabled,
+      firstPage,
+      lastPage,
+      goToPage,
+    } satisfies NgpPaginationState;
+  },
+);

--- a/packages/ng-primitives/pagination/src/pagination/pagination.test.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination.test.ts
@@ -251,4 +251,40 @@ describe('NgpPagination', () => {
     expect(getByTestId('last-page-button')).not.toHaveAttribute('data-disabled');
     expect(getByTestId('last-page-button')).not.toHaveAttribute('disabled');
   });
+
+  it('should navigate in uncontrolled mode seeded from defaultPage', async () => {
+    const { getByRole, getByTestId } = await render(
+      `<div ngpPagination ngpPaginationDefaultPage="1" ngpPaginationPageCount="5">
+        <button data-testid="next-page-button" ngpPaginationNext>Next</button>
+      </div>`,
+      { imports: [NgpPagination, NgpPaginationNext] },
+    );
+    const pagination = getByRole('navigation');
+    await waitFor(() => expect(pagination).toHaveAttribute('data-page', '1'));
+
+    fireEvent.click(getByTestId('next-page-button'));
+    await waitFor(() => expect(pagination).toHaveAttribute('data-page', '2'));
+  });
+
+  it('should re-evaluate button tabindex when pagination disabled changes', async () => {
+    const { getByTestId, rerender } = await render(
+      `<div
+        ngpPagination
+        [ngpPaginationPage]="page"
+        [ngpPaginationPageCount]="5"
+        [ngpPaginationDisabled]="disabled"
+      >
+        <button data-testid="next-page-button" ngpPaginationNext>Next</button>
+      </div>`,
+      {
+        imports: [NgpPagination, NgpPaginationNext],
+        componentProperties: { page: 2, disabled: false },
+      },
+    );
+    const next = getByTestId('next-page-button');
+    await waitFor(() => expect(next).toHaveAttribute('tabindex', '0'));
+
+    await rerender({ componentProperties: { page: 2, disabled: true } });
+    await waitFor(() => expect(next).toHaveAttribute('tabindex', '-1'));
+  });
 });

--- a/packages/ng-primitives/pagination/src/pagination/pagination.test.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/angular';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
 import {
   NgpPagination,
   NgpPaginationButton,
@@ -44,14 +44,18 @@ describe('NgpPagination', () => {
         componentProperties: { page: 1, pageCount: 2 },
       },
     );
-    let pagination = getByRole('navigation');
-    expect(pagination).toHaveAttribute('data-first-page');
-    expect(pagination).not.toHaveAttribute('data-last-page');
+    await waitFor(() => {
+      const pagination = getByRole('navigation');
+      expect(pagination).toHaveAttribute('data-first-page');
+      expect(pagination).not.toHaveAttribute('data-last-page');
+    });
 
     await rerender({ componentProperties: { page: 2, pageCount: 2 } });
-    pagination = getByRole('navigation');
-    expect(pagination).not.toHaveAttribute('data-first-page');
-    expect(pagination).toHaveAttribute('data-last-page');
+    await waitFor(() => {
+      const pagination = getByRole('navigation');
+      expect(pagination).not.toHaveAttribute('data-first-page');
+      expect(pagination).toHaveAttribute('data-last-page');
+    });
   });
 
   it('should emit pageChange when goToPage is called', async () => {
@@ -111,16 +115,21 @@ describe('NgpPagination', () => {
         componentProperties: { page: 1, pageCount: 2, disabled: false },
       },
     );
-    let pagination = getByRole('navigation');
-    expect(pagination).toHaveAttribute('data-page', '1');
-    expect(pagination).toHaveAttribute('data-page-count', '2');
-    expect(pagination).not.toHaveAttribute('data-disabled');
+    await waitFor(() => {
+      const pagination = getByRole('navigation');
+      expect(pagination).toHaveAttribute('data-page', '1');
+      expect(pagination).toHaveAttribute('data-page-count', '2');
+      expect(pagination).not.toHaveAttribute('data-disabled');
+    });
 
     await rerender({ componentProperties: { page: 2, pageCount: 2, disabled: true } });
-    pagination = getByRole('navigation');
-    expect(pagination).toHaveAttribute('data-page', '2');
-    expect(pagination).toHaveAttribute('data-page-count', '2');
-    expect(pagination).toHaveAttribute('data-disabled');
+
+    await waitFor(() => {
+      const pagination = getByRole('navigation');
+      expect(pagination).toHaveAttribute('data-page', '2');
+      expect(pagination).toHaveAttribute('data-page-count', '2');
+      expect(pagination).toHaveAttribute('data-disabled');
+    });
   });
 
   it('should navigate to the first page when first button is clicked', async () => {

--- a/packages/ng-primitives/pagination/src/pagination/pagination.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination.ts
@@ -1,13 +1,6 @@
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
-import {
-  booleanAttribute,
-  computed,
-  Directive,
-  input,
-  numberAttribute,
-  output,
-} from '@angular/core';
-import { paginationState, providePaginationState } from './pagination-state';
+import { booleanAttribute, Directive, input, numberAttribute, output } from '@angular/core';
+import { ngpPagination, providePaginationState } from './pagination-state';
 
 /**
  * The `NgpPagination` directive is used to create a pagination control.
@@ -16,14 +9,6 @@ import { paginationState, providePaginationState } from './pagination-state';
   selector: '[ngpPagination]',
   exportAs: 'ngpPagination',
   providers: [providePaginationState()],
-  host: {
-    role: 'navigation',
-    '[attr.data-page]': 'state.page()',
-    '[attr.data-page-count]': 'state.pageCount()',
-    '[attr.data-first-page]': 'firstPage() ? "" : null',
-    '[attr.data-last-page]': 'lastPage() ? "" : null',
-    '[attr.data-disabled]': 'state.disabled() ? "" : null',
-  },
 })
 export class NgpPagination {
   /**
@@ -58,34 +43,21 @@ export class NgpPagination {
   });
 
   /**
-   * Determine if we are on the first page.
-   * @internal
-   */
-  readonly firstPage = computed(() => this.state.page() === 1);
-
-  /**
-   * Determine if we are on the last page.
-   * @internal
-   */
-  readonly lastPage = computed(() => this.state.page() === this.state.pageCount());
-
-  /**
    * The control state for the pagination.
    * @internal
    */
-  protected readonly state = paginationState<NgpPagination>(this);
+  protected readonly state = ngpPagination({
+    page: this.page,
+    pageCount: this.pageCount,
+    disabled: this.disabled,
+    onPageChange: (value: number) => this.pageChange.emit(value),
+  });
 
   /**
    * Go to the specified page.
    * @param page The page to go to.
    */
   goToPage(page: number) {
-    // check if the page is within the bounds of the pagination
-    if (page < 1 || page > this.state.pageCount()) {
-      return;
-    }
-
-    this.state.page.set(page);
-    this.pageChange.emit(page);
+    return this.state.goToPage(page);
   }
 }

--- a/packages/ng-primitives/pagination/src/pagination/pagination.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination.ts
@@ -12,10 +12,20 @@ import { ngpPagination, providePaginationState } from './pagination-state';
 })
 export class NgpPagination {
   /**
-   * The currently selected page.
+   * The currently selected page. Leave unset for uncontrolled usage, where the
+   * internal state is seeded from `defaultPage`.
    */
-  readonly page = input<number, NumberInput>(1, {
+  readonly page = input<number | undefined, NumberInput>(undefined, {
     alias: 'ngpPaginationPage',
+    transform: numberAttribute,
+  });
+
+  /**
+   * The default page for uncontrolled usage.
+   * @default 1
+   */
+  readonly defaultPage = input<number, NumberInput>(1, {
+    alias: 'ngpPaginationDefaultPage',
     transform: numberAttribute,
   });
 
@@ -48,6 +58,7 @@ export class NgpPagination {
    */
   protected readonly state = ngpPagination({
     page: this.page,
+    defaultPage: this.defaultPage,
     pageCount: this.pageCount,
     disabled: this.disabled,
     onPageChange: (value: number) => this.pageChange.emit(value),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #564 

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated pagination to the new `createPrimitive` state pattern, restored uncontrolled navigation with `ngpPaginationDefaultPage`, and kept the element ref internal to each factory.

- **Refactors**
  - Added state factories/tokens and inject/provide helpers for `ngpPagination` and all sub-buttons; exported from `index.ts`.
  - Moved host bindings, ARIA/data attributes, and keyboard/click handlers into state; unified interactions via `ngpButton`.
  - Used `controlledState` for `page`, added `firstPage`/`lastPage`, guarded `goToPage`; pass `defaultPage` directly to `controlledState` as the uncontrolled seed.
  - Removed `elementRef` from returned state and inject it only inside factories.
  - Renamed sub-button `buttonDisabled` to `disabled` (aliases unchanged); directives now delegate to state instances.

- **Bug Fixes**
  - Uncontrolled navigation works when `page` is undefined by seeding from `ngpPaginationDefaultPage`.
  - Pagination buttons re-evaluate `tabindex` when `disabled` changes.

<sup>Written for commit 811c57b5ea19ca96e8c20e308d98fa5eb18b8869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

