### PR TITLE
fix(state): apply host bindings during change detection to avoid first-paint flash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,10 @@ See `.claude/rules/` for detailed coding standards:
 
 For code review, use the `ngp-code-review` skill — it consolidates these rules with the custom workspace lint rules, test conventions, and PR checklist.
 
+### Comments
+
+Keep comments short and dense. Explain _why_ (the non-obvious reason, edge case, or constraint), never _what_ the code already says. Prefer one line; only go longer when the rationale genuinely needs it, and stay terse. Don't restate the code, narrate steps, or recap history ("previously we…"). Cut a comment if the code is self-explanatory.
+
 ## Package Management
 
 - Uses pnpm with workspace configuration

--- a/packages/ng-primitives/button/src/button/button.test.ts
+++ b/packages/ng-primitives/button/src/button/button.test.ts
@@ -1,5 +1,6 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
 import { Component, Input } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { fireEvent, render } from '@testing-library/angular';
 import { NgpButton } from 'ng-primitives/button';
 import { describe, expect, it } from 'vitest';
@@ -14,7 +15,29 @@ class ButtonHost {
   @Input() isDisabled = false;
 }
 
+@Component({
+  imports: [NgpButton],
+  template: `
+    <button [disabled]="true" ngpButton>Test</button>
+  `,
+})
+class InitiallyDisabledButtonHost {}
+
 describe('NgpButton', () => {
+  it('should set the disabled state during the initial change detection (no flash on navigation)', () => {
+    // Flash regression: an initially-disabled button must reflect disabled
+    // during the CD that creates it, not in the deferred afterRender phase
+    // (which paints it enabled for a frame on zoneless client-nav). We use the
+    // CDRef directly (not the fixture, which also flushes afterRender) so the
+    // assertion fails if the binding only lands after a render frame.
+    const fixture = TestBed.createComponent(InitiallyDisabledButtonHost);
+    fixture.changeDetectorRef.detectChanges();
+
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    expect(button.hasAttribute('disabled')).toBe(true);
+    expect(button.hasAttribute('data-disabled')).toBe(true);
+  });
+
   it('should set the disabled attribute when disabled', async () => {
     const container = await render(`<button ngpButton [disabled]="true"></button>`, {
       imports: [NgpButton],

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger.test.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger.test.ts
@@ -207,6 +207,9 @@ async function openContextMenu() {
     const menu = screen.getByTestId('context-menu');
     expect(menu).toBeInTheDocument();
     expect(menu).toHaveAttribute('data-focus-trap');
+    // data-focus-trap lands synchronously now, before the trap moves focus
+    // (a post-render hook), so also wait for focus to land in the menu.
+    expect(menu.contains(document.activeElement)).toBe(true);
   });
 }
 

--- a/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap.test.ts
+++ b/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap.test.ts
@@ -1,7 +1,8 @@
 import { FocusMonitor, InteractivityChecker } from '@angular/cdk/a11y';
 import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { fireEvent, render } from '@testing-library/angular';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpRovingFocusGroup, NgpRovingFocusItem } from 'ng-primitives/roving-focus';
 import { describe, expect, it, vi } from 'vitest';
 import { NgpFocusTrap } from './focus-trap';
 
@@ -77,6 +78,20 @@ class TestNestedFocusTrapsComponent {
   `,
 })
 class TestFocusTrapWithNegativeTabIndexComponent {}
+
+@Component({
+  selector: 'test-focus-trap-roving',
+  imports: [NgpFocusTrap, NgpRovingFocusGroup, NgpRovingFocusItem],
+  template: `
+    <div ngpFocusTrap data-testid="focus-trap">
+      <div ngpRovingFocusGroup>
+        <button ngpRovingFocusItem data-testid="roving-1">One</button>
+        <button ngpRovingFocusItem data-testid="roving-2">Two</button>
+      </div>
+    </div>
+  `,
+})
+class TestFocusTrapWithRovingComponent {}
 
 @Component({
   selector: 'test-focus-trap-cdk-overlay',
@@ -206,6 +221,16 @@ describe('NgpFocusTrap', () => {
 
       // Test passes if no errors are thrown
       expect(focusTrap).toBeInTheDocument();
+    });
+
+    it('should focus the active item of a roving-focus group on open', async () => {
+      // Roving focus marks only the active (first) item tabindex="0"; the rest
+      // are -1. The trap must still focus the active item on open. Guards the
+      // trap against assuming every item is tabbable.
+      const container = await render(TestFocusTrapWithRovingComponent);
+
+      await waitFor(() => expect(container.getByTestId('roving-1')).toHaveFocus());
+      expect(container.getByTestId('roving-2')).toHaveAttribute('tabindex', '-1');
     });
 
     it('should not interfere when disabled', async () => {

--- a/packages/ng-primitives/roving-focus/src/roving-focus-group/roving-focus-group.test.ts
+++ b/packages/ng-primitives/roving-focus/src/roving-focus-group/roving-focus-group.test.ts
@@ -1,10 +1,37 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
 import { NgpRovingFocusGroup, NgpRovingFocusItem } from 'ng-primitives/roving-focus';
 import { describe, expect, it } from 'vitest';
 
 const imports = [NgpRovingFocusGroup, NgpRovingFocusItem];
 
+@Component({
+  imports,
+  template: `
+    <div ngpRovingFocusGroup>
+      <button ngpRovingFocusItem data-testid="item-1">One</button>
+      <button ngpRovingFocusItem data-testid="item-2">Two</button>
+    </div>
+  `,
+})
+class RovingFocusHost {}
+
 describe('NgpRovingFocusGroup', () => {
+  it('should make the active item tabbable during the initial change detection', () => {
+    // The active (first) item must be tabindex="0" during CD - not deferred to
+    // the post-render phase - so a focus trap focusing the group on open finds
+    // it tabbable. Drive CD directly (the fixture also flushes afterRender), so
+    // this fails if the active item only becomes tabbable a frame later.
+    const fixture = TestBed.createComponent(RovingFocusHost);
+    fixture.changeDetectorRef.detectChanges();
+
+    const item = (id: string): HTMLElement =>
+      fixture.nativeElement.querySelector(`[data-testid="${id}"]`);
+    expect(item('item-1').getAttribute('tabindex')).toBe('0');
+    expect(item('item-2').getAttribute('tabindex')).toBe('-1');
+  });
+
   it('should initialise correctly', async () => {
     const container = await render(`<div ngpRovingFocusGroup></div>`, {
       imports: [NgpRovingFocusGroup],

--- a/packages/ng-primitives/roving-focus/src/roving-focus-item/roving-focus-item-state.ts
+++ b/packages/ng-primitives/roving-focus/src/roving-focus-item/roving-focus-item-state.ts
@@ -1,7 +1,7 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
 import { computed, effect, ElementRef, inject, signal, Signal, untracked } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive, listener } from 'ng-primitives/state';
+import { attrBinding, createPrimitive, listener, onDestroy } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectRovingFocusGroupState } from '../roving-focus-group/roving-focus-group-state';
 
@@ -95,15 +95,23 @@ export const [
       element,
     };
 
-    // Projected items may construct before the parent populates the shared group signal,
-    // so register reactively once it becomes available.
-    // See https://github.com/ng-primitives/ng-primitives/issues/735
-    effect(onCleanup => {
-      const groupState = group();
-      if (!groupState) return;
-      untracked(() => groupState.register(state));
-      onCleanup(() => groupState.unregister(state));
-    });
+    // Register synchronously when the group is available so its activeItem (and
+    // thus this item's tabindex) is set before the host bindings flush - this
+    // keeps the active item tabbable when a focus trap focuses it on open.
+    // Projected items can construct before the group signal is populated, so
+    // fall back to reactive registration. See #735.
+    const groupState = group();
+    if (groupState) {
+      groupState.register(state);
+      onDestroy(() => groupState.unregister(state));
+    } else {
+      effect(onCleanup => {
+        const deferred = group();
+        if (!deferred) return;
+        untracked(() => deferred.register(state));
+        onCleanup(() => deferred.unregister(state));
+      });
+    }
 
     return state satisfies NgpRovingFocusItemState;
   },

--- a/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
+++ b/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
@@ -650,7 +650,8 @@ describe('NgpSelect', () => {
       const appleOption = screen.getByTestId('option-Apple');
       const optionId = appleOption.getAttribute('id');
       expect(optionId).toBeTruthy();
-      expect(select).toHaveAttribute('aria-activedescendant', optionId);
+      // aria-activedescendant lands in the post-render phase, a tick after data-active.
+      await waitFor(() => expect(select).toHaveAttribute('aria-activedescendant', optionId));
     });
 
     it('should set aria-selected on selected options', async () => {

--- a/packages/ng-primitives/state/src/index.ts
+++ b/packages/ng-primitives/state/src/index.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @angular-eslint/no-uncalled-signals */
 import { coerceElement } from '@angular/cdk/coercion';
-import { isPlatformBrowser } from '@angular/common';
 import {
   afterRenderEffect,
   ChangeDetectorRef,
@@ -19,11 +18,11 @@ import {
   isSignal,
   linkedSignal,
   NgZone,
-  PLATFORM_ID,
   ProviderToken,
   runInInjectionContext,
   signal,
   Signal,
+  untracked,
   WritableSignal,
 } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
@@ -497,7 +496,7 @@ export function attrBinding(
     return;
   }
 
-  isomorphicEffect(() => {
+  bindingEffect(() => {
     const valueResult = value();
     setAttribute(element, attr, valueResult?.toString() ?? null);
   });
@@ -539,7 +538,7 @@ export function styleBinding(
   style: string,
   value: (() => string | number | null) | string | number | null,
 ): void {
-  isomorphicEffect(() => {
+  bindingEffect(() => {
     const styleValue = typeof value === 'function' ? value() : value;
     // we should look for units in the style name, just like Angular does e.g. width.px
     const styleUnit = getStyleUnit(style);
@@ -562,7 +561,7 @@ export function dataBinding(
     throw new Error(`dataBinding: attribute "${attr}" must start with "data-"`);
   }
 
-  isomorphicEffect(() => {
+  bindingEffect(() => {
     let valueResult = typeof value === 'function' ? value() : value;
 
     if (valueResult === false) {
@@ -721,14 +720,21 @@ export function emitter<T>({
   });
 }
 
-function isomorphicEffect(callback: () => void): void {
-  const injector = inject(Injector);
-  const platformId = injector.get(PLATFORM_ID);
-
-  if (isPlatformBrowser(platformId)) {
-    afterRenderEffect(() => callback());
-  } else {
-    // On the server, we just run the effect immediately
-    effect(() => callback());
-  }
+/**
+ * Reflects state onto the host element (attribute/data-attribute/style).
+ *
+ * Written twice: a one-shot `untracked` effect applies the initial value during
+ * change detection so the first paint isn't stale (without it `afterRenderEffect`
+ * defers it a frame, and a zoneless client-nav paints e.g. a disabled button
+ * enabled for one frame); `afterRenderEffect` applies later updates in the
+ * post-render phase overlays/portals/roving-focus rely on. On the server
+ * `afterRenderEffect` is a no-op, so the one-shot is what ships the value in SSR.
+ *
+ * Bindings thus land during CD, so anything ordering-sensitive must cope - e.g.
+ * roving focus registers items synchronously so the active item is tabbable
+ * before a focus trap focuses it.
+ */
+function bindingEffect(callback: () => void): void {
+  afterRenderEffect(() => callback());
+  effect(() => untracked(() => callback()));
 }

--- a/packages/ng-primitives/toggle-group/src/toggle-group/toggle-group-state.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/toggle-group-state.ts
@@ -205,7 +205,8 @@ export const [
     }
 
     function setValue(newValue: string[], options?: SetterOptions): void {
-      setValueInternal(newValue, options);
+      // Forms write null on reset; coerce to [] so array reads stay safe.
+      setValueInternal(newValue ?? [], options);
     }
 
     function setDisabled(isDisabled: boolean): void {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated — N/A (internal binding-timing fix; no public API or example surface)

## PR Type

- [x] Bugfix

## What does this PR implement/fix?

Host bindings (`attrBinding`/`dataBinding`/`styleBinding`) were applied via `afterRenderEffect`, which defers the first application to the frame after the element is created. In a zoneless app, client-side navigation painted the element in its default state for one frame before the binding landed - e.g. an initially-disabled button flashing from its enabled colour into the disabled colour.

`bindingEffect` now also applies the initial value synchronously during change detection (a dependency-free `untracked` effect), so the first paint is already correct; `afterRenderEffect` still handles reactive updates. SSR is unaffected (`afterRenderEffect` is a no-op on the server, so the synchronous effect ships the value).

Because `tabindex` now lands during change detection, roving-focus items register synchronously so the active item is tabbable before a focus trap focuses it on open - the focus trap itself is unchanged. Toggle-group coerces a null value (forms reset) to an empty array so the synchronous read stays safe.

Tests added: synchronous disabled binding (button), roving-focus active tabindex during CD, and a focus-trap focusing a roving-focus group.

## Does this PR introduce a breaking change?

- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a first-paint flash by applying host attribute/data/style bindings during change detection instead of after render. Prevents disabled buttons and roving-focus tabbability from flashing on client navigation; SSR unaffected.

- **Bug Fixes**
  - Host bindings: new `bindingEffect` sets the initial value during CD and keeps reactive updates after render for `attrBinding`/`dataBinding`/`styleBinding` in `ng-primitives/state`.
  - Roving focus: items register synchronously in `ng-primitives/roving-focus` so the active item is tabbable before a `focus-trap` moves focus.
  - `toggle-group`: coerce `null` to `[]` on write to keep reads safe with the earlier binding timing.

<sup>Written for commit f316882bf61ac5f8fba66623dcf4190fa2622cfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

