### PR TITLE
feat(select): add ngpSelectInput for option filtering (#694)

### DIFF
--- a/apps/documentation/src/app/examples/select/select-input.example.ts
+++ b/apps/documentation/src/app/examples/select/select-input.example.ts
@@ -14,68 +14,32 @@ import {
   imports: [NgpSelect, NgpSelectDropdown, NgpSelectInput, NgpSelectOption, NgpSelectPortal, NgIcon],
   providers: [provideIcons({ heroChevronDown })],
   template: `
-    <div class="select-examples">
-      <!-- Layout A: the input lives inside the dropdown, above a scrollable list -->
-      <div class="select-field">
-        <span class="select-label">Search inside the dropdown</span>
+    <div class="select-field">
+      <span class="select-label">Searchable select</span>
 
-        <div [(ngpSelectValue)]="valueA" (ngpSelectOpenChange)="onOpenA($event)" ngpSelect>
-          @if (valueA(); as value) {
-            <span class="select-value">{{ value }}</span>
-          } @else {
-            <span class="select-placeholder">Select an option</span>
-          }
-          <ng-icon name="heroChevronDown" />
+      <div [(ngpSelectValue)]="value" (ngpSelectOpenChange)="onOpen($event)" ngpSelect>
+        @if (value(); as selected) {
+          <span class="select-value">{{ selected }}</span>
+        } @else {
+          <span class="select-placeholder">Select an option</span>
+        }
+        <ng-icon name="heroChevronDown" />
 
-          <div *ngpSelectPortal ngpSelectDropdown>
-            <input
-              [value]="searchA()"
-              (input)="onSearchA($event)"
-              ngpSelectInput
-              placeholder="Search…"
-            />
-            <div class="select-scrollable">
-              @for (option of filteredOptionsA(); track option) {
-                <div [ngpSelectOptionValue]="option" ngpSelectOption>
-                  {{ option }}
-                </div>
-              } @empty {
-                <div class="empty-message">No options found</div>
-              }
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Layout B: the input replaces the trigger value while the dropdown is open -->
-      <div class="select-field">
-        <span class="select-label">Search in the trigger</span>
-
-        <div [(ngpSelectValue)]="valueB" (ngpSelectOpenChange)="onOpenB($event)" ngpSelect>
-          @if (openB()) {
-            <input
-              [value]="searchB()"
-              (input)="onSearchB($event)"
-              ngpSelectInput
-              placeholder="Search…"
-            />
-          } @else if (valueB(); as value) {
-            <span class="select-value">{{ value }}</span>
-          } @else {
-            <span class="select-placeholder">Select an option</span>
-          }
-          <ng-icon name="heroChevronDown" />
-
-          <div *ngpSelectPortal ngpSelectDropdown>
-            <div class="select-scrollable">
-              @for (option of filteredOptionsB(); track option) {
-                <div [ngpSelectOptionValue]="option" ngpSelectOption>
-                  {{ option }}
-                </div>
-              } @empty {
-                <div class="empty-message">No options found</div>
-              }
-            </div>
+        <div *ngpSelectPortal ngpSelectDropdown>
+          <input
+            [value]="search()"
+            (input)="onSearch($event)"
+            ngpSelectInput
+            placeholder="Search…"
+          />
+          <div class="select-scrollable">
+            @for (option of filteredOptions(); track option) {
+              <div [ngpSelectOptionValue]="option" ngpSelectOption>
+                {{ option }}
+              </div>
+            } @empty {
+              <div class="empty-message">No options found</div>
+            }
           </div>
         </div>
       </div>
@@ -286,42 +250,19 @@ export default class SelectInputExample {
     'Strickland',
   ];
 
-  // Layout A — search inside the dropdown
-  readonly valueA = signal<string | undefined>(undefined);
-  readonly searchA = signal<string>('');
-  protected readonly filteredOptionsA = computed(() =>
-    this.options.filter(option => option.toLowerCase().includes(this.searchA().toLowerCase())),
+  readonly value = signal<string | undefined>(undefined);
+  readonly search = signal<string>('');
+  protected readonly filteredOptions = computed(() =>
+    this.options.filter(option => option.toLowerCase().includes(this.search().toLowerCase())),
   );
 
-  // Layout B — search replaces the trigger when open
-  readonly valueB = signal<string | undefined>(undefined);
-  readonly searchB = signal<string>('');
-  readonly openB = signal<boolean>(false);
-  protected readonly filteredOptionsB = computed(() =>
-    this.options.filter(option => option.toLowerCase().includes(this.searchB().toLowerCase())),
-  );
-
-  protected onSearchA(event: Event): void {
-    this.searchA.set((event.target as HTMLInputElement).value);
+  protected onSearch(event: Event): void {
+    this.search.set((event.target as HTMLInputElement).value);
   }
 
-  protected onOpenA(open: boolean): void {
-    // reset the filter once the dropdown closes
+  protected onOpen(open: boolean): void {
     if (!open) {
-      this.searchA.set('');
-    }
-  }
-
-  protected onSearchB(event: Event): void {
-    this.searchB.set((event.target as HTMLInputElement).value);
-  }
-
-  protected onOpenB(open: boolean): void {
-    this.openB.set(open);
-
-    // reset the filter once the dropdown closes
-    if (!open) {
-      this.searchB.set('');
+      this.search.set('');
     }
   }
 }

--- a/apps/documentation/src/app/examples/select/select-input.example.ts
+++ b/apps/documentation/src/app/examples/select/select-input.example.ts
@@ -5,13 +5,22 @@ import {
   NgpSelect,
   NgpSelectDropdown,
   NgpSelectInput,
+  NgpSelectList,
   NgpSelectOption,
   NgpSelectPortal,
 } from 'ng-primitives/select';
 
 @Component({
   selector: 'app-select-input',
-  imports: [NgpSelect, NgpSelectDropdown, NgpSelectInput, NgpSelectOption, NgpSelectPortal, NgIcon],
+  imports: [
+    NgpSelect,
+    NgpSelectDropdown,
+    NgpSelectInput,
+    NgpSelectList,
+    NgpSelectOption,
+    NgpSelectPortal,
+    NgIcon,
+  ],
   providers: [provideIcons({ heroChevronDown })],
   template: `
     <div class="select-field">
@@ -25,7 +34,7 @@ import {
         }
         <ng-icon name="heroChevronDown" />
 
-        <div *ngpSelectPortal ngpSelectDropdown>
+        <div *ngpSelectPortal ngpSelectDropdown aria-label="Searchable select">
           <input
             [value]="search()"
             (input)="onSearch($event)"
@@ -33,7 +42,7 @@ import {
             placeholder="Search…"
             aria-labelledby="select-search-label"
           />
-          <div class="select-scrollable">
+          <div class="select-scrollable" ngpSelectList>
             @for (option of filteredOptions(); track option) {
               <div [ngpSelectOptionValue]="option" ngpSelectOption>
                 {{ option }}

--- a/apps/documentation/src/app/examples/select/select-input.example.ts
+++ b/apps/documentation/src/app/examples/select/select-input.example.ts
@@ -1,0 +1,327 @@
+import { Component, computed, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDown } from '@ng-icons/heroicons/outline';
+import {
+  NgpSelect,
+  NgpSelectDropdown,
+  NgpSelectInput,
+  NgpSelectOption,
+  NgpSelectPortal,
+} from 'ng-primitives/select';
+
+@Component({
+  selector: 'app-select-input',
+  imports: [NgpSelect, NgpSelectDropdown, NgpSelectInput, NgpSelectOption, NgpSelectPortal, NgIcon],
+  providers: [provideIcons({ heroChevronDown })],
+  template: `
+    <div class="select-examples">
+      <!-- Layout A: the input lives inside the dropdown, above a scrollable list -->
+      <div class="select-field">
+        <span class="select-label">Search inside the dropdown</span>
+
+        <div [(ngpSelectValue)]="valueA" (ngpSelectOpenChange)="onOpenA($event)" ngpSelect>
+          @if (valueA(); as value) {
+            <span class="select-value">{{ value }}</span>
+          } @else {
+            <span class="select-placeholder">Select an option</span>
+          }
+          <ng-icon name="heroChevronDown" />
+
+          <div *ngpSelectPortal ngpSelectDropdown>
+            <input
+              [value]="searchA()"
+              (input)="onSearchA($event)"
+              ngpSelectInput
+              placeholder="Search…"
+            />
+            <div class="select-scrollable">
+              @for (option of filteredOptionsA(); track option) {
+                <div [ngpSelectOptionValue]="option" ngpSelectOption>
+                  {{ option }}
+                </div>
+              } @empty {
+                <div class="empty-message">No options found</div>
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Layout B: the input replaces the trigger value while the dropdown is open -->
+      <div class="select-field">
+        <span class="select-label">Search in the trigger</span>
+
+        <div [(ngpSelectValue)]="valueB" (ngpSelectOpenChange)="onOpenB($event)" ngpSelect>
+          @if (openB()) {
+            <input
+              [value]="searchB()"
+              (input)="onSearchB($event)"
+              ngpSelectInput
+              placeholder="Search…"
+            />
+          } @else if (valueB(); as value) {
+            <span class="select-value">{{ value }}</span>
+          } @else {
+            <span class="select-placeholder">Select an option</span>
+          }
+          <ng-icon name="heroChevronDown" />
+
+          <div *ngpSelectPortal ngpSelectDropdown>
+            <div class="select-scrollable">
+              @for (option of filteredOptionsB(); track option) {
+                <div [ngpSelectOptionValue]="option" ngpSelectOption>
+                  {{ option }}
+                </div>
+              } @empty {
+                <div class="empty-message">No options found</div>
+              }
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    .select-examples {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .select-field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .select-label {
+      font-size: 13px;
+      font-weight: 510;
+      letter-spacing: -0.011em;
+      color: var(--ngp-text-secondary);
+    }
+
+    [ngpSelect] {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      height: 2.125rem;
+      width: 300px;
+      border-radius: 0.5rem;
+      border: none;
+      background-color: var(--ngp-background);
+      box-shadow: var(--ngp-input-shadow);
+      box-sizing: border-box;
+    }
+
+    [ngpSelect][data-focus] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    .select-value,
+    .select-placeholder {
+      display: flex;
+      align-items: center;
+      flex: 1;
+      padding: 0 16px;
+      background-color: transparent;
+      color: var(--ngp-text-primary);
+      font-family: inherit;
+      font-size: 14px;
+      height: 100%;
+    }
+
+    .select-placeholder {
+      color: var(--ngp-text-secondary);
+    }
+
+    [ngpSelectInput] {
+      flex: 1;
+      min-width: 0;
+      padding: 0 16px;
+      border: none;
+      background-color: transparent;
+      color: var(--ngp-text-primary);
+      font-family: inherit;
+      font-size: 14px;
+      height: 100%;
+      outline: none;
+    }
+
+    [ngpSelectInput]::placeholder {
+      color: var(--ngp-text-tertiary);
+    }
+
+    ng-icon {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      height: 100%;
+      margin-inline: 8px;
+      font-size: 14px;
+      color: var(--ngp-text-primary);
+    }
+
+    [ngpSelectDropdown] {
+      background-color: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      padding: 0;
+      border-radius: 0.75rem;
+      outline: none;
+      position: absolute;
+      overflow: hidden;
+      animation: select-input-show 0.1s ease-out;
+      width: var(--ngp-select-width);
+      box-shadow: var(--ngp-shadow-lg);
+      box-sizing: border-box;
+      margin-top: 4px;
+      z-index: 1001;
+    }
+
+    [ngpSelectDropdown][data-exit] {
+      animation: select-input-hide 0.1s ease-out;
+    }
+
+    /* Search field pinned at the top of the dropdown (layout A) */
+    [ngpSelectDropdown] > [ngpSelectInput] {
+      width: 100%;
+      flex: none;
+      height: 2.25rem;
+      padding: 0 0.75rem;
+      border-bottom: 1px solid var(--ngp-border);
+    }
+
+    [ngpSelectDropdown] > [ngpSelectInput][data-focus-visible] {
+      border-bottom-color: var(--ngp-focus-ring);
+      box-shadow: inset 0 -1px 0 0 var(--ngp-focus-ring);
+    }
+
+    .select-scrollable {
+      max-height: 200px;
+      overflow-y: auto;
+      padding: 0.25rem;
+    }
+
+    [ngpSelectOption] {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.375rem 0.75rem;
+      cursor: pointer;
+      border-radius: 0.5rem;
+      width: 100%;
+      height: 2.125rem;
+      font-size: 14px;
+      color: var(--ngp-text-primary);
+      box-sizing: border-box;
+    }
+
+    [ngpSelectOption][data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpSelectOption][data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpSelectOption][data-active] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpSelectOption][data-selected] {
+      color: var(--ngp-primary);
+      font-weight: 510;
+    }
+
+    .empty-message {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 0.5rem;
+      color: var(--ngp-text-secondary);
+      font-size: 14px;
+      font-weight: 510;
+      text-align: center;
+    }
+
+    @keyframes select-input-show {
+      0% {
+        opacity: 0;
+        transform: translateY(-10px) scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    @keyframes select-input-hide {
+      0% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: translateY(-10px) scale(0.9);
+      }
+    }
+  `,
+})
+export default class SelectInputExample {
+  /** The options for the select. */
+  readonly options: string[] = [
+    'Marty McFly',
+    'Doc Brown',
+    'Biff Tannen',
+    'George McFly',
+    'Jennifer Parker',
+    'Emmett Brown',
+    'Einstein',
+    'Clara Clayton',
+    'Needles',
+    'Goldie Wilson',
+    'Marvin Berry',
+    'Lorraine Baines',
+    'Strickland',
+  ];
+
+  // Layout A — search inside the dropdown
+  readonly valueA = signal<string | undefined>(undefined);
+  readonly searchA = signal<string>('');
+  protected readonly filteredOptionsA = computed(() =>
+    this.options.filter(option => option.toLowerCase().includes(this.searchA().toLowerCase())),
+  );
+
+  // Layout B — search replaces the trigger when open
+  readonly valueB = signal<string | undefined>(undefined);
+  readonly searchB = signal<string>('');
+  readonly openB = signal<boolean>(false);
+  protected readonly filteredOptionsB = computed(() =>
+    this.options.filter(option => option.toLowerCase().includes(this.searchB().toLowerCase())),
+  );
+
+  protected onSearchA(event: Event): void {
+    this.searchA.set((event.target as HTMLInputElement).value);
+  }
+
+  protected onOpenA(open: boolean): void {
+    // reset the filter once the dropdown closes
+    if (!open) {
+      this.searchA.set('');
+    }
+  }
+
+  protected onSearchB(event: Event): void {
+    this.searchB.set((event.target as HTMLInputElement).value);
+  }
+
+  protected onOpenB(open: boolean): void {
+    this.openB.set(open);
+
+    // reset the filter once the dropdown closes
+    if (!open) {
+      this.searchB.set('');
+    }
+  }
+}

--- a/apps/documentation/src/app/examples/select/select-input.example.ts
+++ b/apps/documentation/src/app/examples/select/select-input.example.ts
@@ -15,7 +15,7 @@ import {
   providers: [provideIcons({ heroChevronDown })],
   template: `
     <div class="select-field">
-      <span class="select-label">Searchable select</span>
+      <span class="select-label" id="select-search-label">Searchable select</span>
 
       <div [(ngpSelectValue)]="value" (ngpSelectOpenChange)="onOpen($event)" ngpSelect>
         @if (value(); as selected) {
@@ -31,6 +31,7 @@ import {
             (input)="onSearch($event)"
             ngpSelectInput
             placeholder="Search…"
+            aria-labelledby="select-search-label"
           />
           <div class="select-scrollable">
             @for (option of filteredOptions(); track option) {

--- a/apps/documentation/src/app/examples/select/select-input.example.ts
+++ b/apps/documentation/src/app/examples/select/select-input.example.ts
@@ -26,7 +26,12 @@ import {
     <div class="select-field">
       <span class="select-label" id="select-search-label">Searchable select</span>
 
-      <div [(ngpSelectValue)]="value" (ngpSelectOpenChange)="onOpen($event)" ngpSelect>
+      <div
+        [(ngpSelectValue)]="value"
+        (ngpSelectOpenChange)="onOpen($event)"
+        ngpSelect
+        aria-labelledby="select-search-label"
+      >
         @if (value(); as selected) {
           <span class="select-value">{{ selected }}</span>
         } @else {
@@ -56,12 +61,6 @@ import {
     </div>
   `,
   styles: `
-    .select-examples {
-      display: flex;
-      flex-direction: column;
-      gap: 24px;
-    }
-
     .select-field {
       display: flex;
       flex-direction: column;
@@ -110,21 +109,29 @@ import {
       color: var(--ngp-text-secondary);
     }
 
+    /* Search field pinned at the top of the dropdown */
     [ngpSelectInput] {
-      flex: 1;
+      width: 100%;
       min-width: 0;
-      padding: 0 16px;
+      height: 2.25rem;
+      padding: 0 0.75rem;
       border: none;
+      border-bottom: 1px solid var(--ngp-border);
       background-color: transparent;
       color: var(--ngp-text-primary);
       font-family: inherit;
       font-size: 14px;
-      height: 100%;
       outline: none;
+      box-sizing: border-box;
     }
 
     [ngpSelectInput]::placeholder {
       color: var(--ngp-text-tertiary);
+    }
+
+    [ngpSelectInput][data-focus-visible] {
+      border-bottom-color: var(--ngp-focus-ring);
+      box-shadow: inset 0 -1px 0 0 var(--ngp-focus-ring);
     }
 
     ng-icon {
@@ -155,20 +162,6 @@ import {
 
     [ngpSelectDropdown][data-exit] {
       animation: select-input-hide 0.1s ease-out;
-    }
-
-    /* Search field pinned at the top of the dropdown (layout A) */
-    [ngpSelectDropdown] > [ngpSelectInput] {
-      width: 100%;
-      flex: none;
-      height: 2.25rem;
-      padding: 0 0.75rem;
-      border-bottom: 1px solid var(--ngp-border);
-    }
-
-    [ngpSelectDropdown] > [ngpSelectInput][data-focus-visible] {
-      border-bottom-color: var(--ngp-focus-ring);
-      box-shadow: inset 0 -1px 0 0 var(--ngp-focus-ring);
     }
 
     .select-scrollable {

--- a/apps/documentation/src/app/examples/select/select-input.example.ts
+++ b/apps/documentation/src/app/examples/select/select-input.example.ts
@@ -42,7 +42,7 @@ import {
             placeholder="Search…"
             aria-labelledby="select-search-label"
           />
-          <div class="select-scrollable" ngpSelectList>
+          <div class="select-scrollable" ngpSelectList aria-label="Options">
             @for (option of filteredOptions(); track option) {
               <div [ngpSelectOptionValue]="option" ngpSelectOption>
                 {{ option }}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -78,7 +78,7 @@ You can customize the offset using either a simple number or an object for more 
 
 ### Searchable Select
 
-Add an `input[ngpSelectInput]` to let the user filter the options by typing. The input can live inside the dropdown or replace the trigger value while the dropdown is open. Filtering itself is left to you — bind the input's `(input)` event to a signal and filter the rendered options.
+Add an `input[ngpSelectInput]` to let the user filter the options by typing. Filtering is left to the consumer — bind the input's (input) event to a signal and filter the rendered options.
 
 <docs-example name="select-input"></docs-example>
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -76,6 +76,12 @@ You can customize the offset using either a simple number or an object for more 
 </div>
 ```
 
+### Searchable Select
+
+Add an `input[ngpSelectInput]` to let the user filter the options by typing. The input can live inside the dropdown or replace the trigger value while the dropdown is open. Filtering itself is left to you — bind the input's `(input)` event to a signal and filter the rendered options.
+
+<docs-example name="select-input"></docs-example>
+
 ### Select Form Field
 
 The select can be used within a form field for better integration with form controls.

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -203,7 +203,7 @@ bootstrapApplication(AppComponent, {
 
 The select primitive follows the [WAI-ARIA Combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/). The trigger uses `role="combobox"` with `aria-expanded` and `aria-controls`. The dropdown uses `role="listbox"` and options use `role="option"` with `aria-selected`. Focus is managed using `aria-activedescendant`.
 
-When a search input (`ngpSelectInput`) is used, the combobox semantics move to the input, which receives focus when the dropdown opens. The dropdown becomes a `dialog` wrapping the input and an `ngpSelectList` (`role="listbox"`), and the input drives the options via `aria-activedescendant` and `aria-controls`.
+When a search input (`ngpSelectInput`) is used, the combobox semantics move to the input, which receives focus when the dropdown opens. The dropdown becomes a `dialog` wrapping the input and an `ngpSelectList` (`role="listbox"`), and the input drives the options via `aria-activedescendant` and `aria-controls`. Naming is left to the consumer, so add an `aria-label` (or `aria-labelledby`) to both the dropdown dialog and the list.
 
 ### Keyboard Interactions
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -213,3 +213,5 @@ When a search input (`ngpSelectInput`) is used, the combobox semantics move to t
 - <kbd>ArrowUp</kbd>: Open the dropdown or move to the previous option.
 - <kbd>Home</kbd>: Move to the first option.
 - <kbd>End</kbd>: Move to the last option.
+
+When a search input (`ngpSelectInput`) has focus, <kbd>Home</kbd> and <kbd>End</kbd> keep their text editing behaviour and move the caret within the search term. <kbd>Space</kbd> types a space rather than toggling the dropdown.

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -76,12 +76,6 @@ You can customize the offset using either a simple number or an object for more 
 </div>
 ```
 
-### Searchable Select
-
-Add an `input[ngpSelectInput]` to let the user filter the options by typing. Filtering is left to the consumer — bind the input's (input) event to a signal and filter the rendered options.
-
-<docs-example name="select-input"></docs-example>
-
 ### Select Form Field
 
 The select can be used within a form field for better integration with form controls.
@@ -118,6 +112,12 @@ Options without a value do not perform any selection by default. You can use thi
 
 <docs-example name="select-custom-option"></docs-example>
 
+### Searchable Select
+
+Add `ngpSelectInput` inside the dropdown to provide a search field. Filtering is left to the consumer. Wrap the options in `ngpSelectList` to keep the accessibility tree valid.
+
+<docs-example name="select-input"></docs-example>
+
 ## API Reference
 
 The following directives are available to import from the `ng-primitives/select` package:
@@ -151,6 +151,18 @@ The following directives are available to import from the `ng-primitives/select`
 <api-docs name="NgpSelectOption"></api-docs>
 
 <api-reference-props name="NgpSelectOption"></api-reference-props>
+
+### NgpSelectInput
+
+<api-docs name="NgpSelectInput"></api-docs>
+
+<api-reference-props name="NgpSelectInput"></api-reference-props>
+
+### NgpSelectList
+
+<api-docs name="NgpSelectList"></api-docs>
+
+<api-reference-props name="NgpSelectList"></api-reference-props>
 
 ### NgpNativeSelect
 
@@ -190,6 +202,8 @@ bootstrapApplication(AppComponent, {
 ## Accessibility
 
 The select primitive follows the [WAI-ARIA Combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/). The trigger uses `role="combobox"` with `aria-expanded` and `aria-controls`. The dropdown uses `role="listbox"` and options use `role="option"` with `aria-selected`. Focus is managed using `aria-activedescendant`.
+
+When a search input (`ngpSelectInput`) is used, the combobox semantics move to the input, which receives focus when the dropdown opens. The dropdown becomes a `dialog` wrapping the input and an `ngpSelectList` (`role="listbox"`), and the input drives the options via `aria-activedescendant` and `aria-controls`.
 
 ### Keyboard Interactions
 

--- a/packages/ng-primitives/internal/src/utilities/scrolling.ts
+++ b/packages/ng-primitives/internal/src/utilities/scrolling.ts
@@ -17,15 +17,26 @@ export function scrollIntoViewIfNeeded(element: HTMLElement): void {
   const parentRect = scrollableAncestor.getBoundingClientRect();
   const elementRect = element.getBoundingClientRect();
 
+  // getBoundingClientRect reports visual pixels, so a transform scaling the container shrinks
+  // the distances it returns, while scrollTop and scrollLeft are layout pixels. Dividing by the
+  // container's current scale converts one into the other. Without this, an overlay that opens
+  // with a scaled entrance animation scrolls short and leaves the target option clipped.
+  const scaleY = scrollableAncestor.offsetHeight
+    ? parentRect.height / scrollableAncestor.offsetHeight
+    : 1;
+  const scaleX = scrollableAncestor.offsetWidth
+    ? parentRect.width / scrollableAncestor.offsetWidth
+    : 1;
+
   if (elementRect.top < parentRect.top) {
-    scrollableAncestor.scrollTop -= parentRect.top - elementRect.top;
+    scrollableAncestor.scrollTop -= (parentRect.top - elementRect.top) / scaleY;
   } else if (elementRect.bottom > parentRect.bottom) {
-    scrollableAncestor.scrollTop += elementRect.bottom - parentRect.bottom;
+    scrollableAncestor.scrollTop += (elementRect.bottom - parentRect.bottom) / scaleY;
   }
 
   if (elementRect.left < parentRect.left) {
-    scrollableAncestor.scrollLeft -= parentRect.left - elementRect.left;
+    scrollableAncestor.scrollLeft -= (parentRect.left - elementRect.left) / scaleX;
   } else if (elementRect.right > parentRect.right) {
-    scrollableAncestor.scrollLeft += elementRect.right - parentRect.right;
+    scrollableAncestor.scrollLeft += (elementRect.right - parentRect.right) / scaleX;
   }
 }

--- a/packages/ng-primitives/select/src/index.ts
+++ b/packages/ng-primitives/select/src/index.ts
@@ -18,6 +18,13 @@ export {
   NgpSelectInputStateToken,
   provideSelectInputState,
 } from './select-input/select-input-state';
+export { NgpSelectList } from './select-list/select-list';
+export {
+  injectSelectListState,
+  ngpSelectList,
+  NgpSelectListStateToken,
+  provideSelectListState,
+} from './select-list/select-list-state';
 export { NgpSelectOption } from './select-option/select-option';
 export {
   injectSelectOptionState,

--- a/packages/ng-primitives/select/src/index.ts
+++ b/packages/ng-primitives/select/src/index.ts
@@ -11,6 +11,13 @@ export {
   NgpSelectDropdownStateToken,
   provideSelectDropdownState,
 } from './select-dropdown/select-dropdown-state';
+export { NgpSelectInput } from './select-input/select-input';
+export {
+  injectSelectInputState,
+  ngpSelectInput,
+  NgpSelectInputStateToken,
+  provideSelectInputState,
+} from './select-input/select-input-state';
 export { NgpSelectOption } from './select-option/select-option';
 export {
   injectSelectOptionState,

--- a/packages/ng-primitives/select/src/select-dropdown/select-dropdown-state.ts
+++ b/packages/ng-primitives/select/src/select-dropdown/select-dropdown-state.ts
@@ -37,7 +37,9 @@ export const [
 
     const selectDimensions = observeResize(() => selectState().elementRef.nativeElement);
     // Host bindings
-    attrBinding(elementRef, 'role', 'listbox');
+    // When a dedicated ngpSelectList owns the options, the dropdown becomes a dialog
+    // wrapping the input + listbox; otherwise the dropdown is itself the listbox.
+    attrBinding(elementRef, 'role', () => (selectState().list() ? 'dialog' : 'listbox'));
     attrBinding(elementRef, 'id', _id);
     styleBinding(elementRef, 'left.px', () => selectState().overlay()?.position()?.x ?? null);
     styleBinding(elementRef, 'top.px', () => selectState().overlay()?.position()?.y ?? null);

--- a/packages/ng-primitives/select/src/select-input/select-input-state.ts
+++ b/packages/ng-primitives/select/src/select-input/select-input-state.ts
@@ -1,0 +1,197 @@
+import { afterNextRender, ElementRef, inject, Injector, Signal, signal } from '@angular/core';
+import { ngpInteractions } from 'ng-primitives/interactions';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  createPrimitive,
+  dataBinding,
+  listener,
+  onDestroy,
+  StateInjectionOptions,
+} from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { injectSelectState } from '../select/select-state';
+
+export interface NgpSelectInputState {
+  /**
+   * @internal Access the element reference.
+   */
+  readonly elementRef: ElementRef<HTMLInputElement>;
+
+  /** The id of the input. */
+  readonly id: Signal<string>;
+
+  /**
+   * Focus the input field.
+   * @internal
+   */
+  focus(): void;
+}
+
+export interface NgpSelectInputProps {
+  /** The id of the input. */
+  readonly id?: Signal<string>;
+}
+
+export const [
+  NgpSelectInputStateToken,
+  ngpSelectInput,
+  _injectSelectInputState,
+  provideSelectInputState,
+] = createPrimitive(
+  'NgpSelectInput',
+  ({ id = signal(uniqueId('ngp-select-input')) }: NgpSelectInputProps) => {
+    const elementRef = injectElementRef<HTMLInputElement>();
+    const selectState = injectSelectState();
+    const injector = inject(Injector);
+
+    ngpInteractions({
+      focus: true,
+      hover: true,
+      press: true,
+      disabled: selectState().disabled,
+    });
+
+    // Static host bindings
+    attrBinding(elementRef, 'role', 'searchbox');
+    attrBinding(elementRef, 'type', 'text');
+    attrBinding(elementRef, 'autocomplete', 'off');
+    attrBinding(elementRef, 'autocorrect', 'off');
+    attrBinding(elementRef, 'spellcheck', 'false');
+    attrBinding(elementRef, 'id', id);
+
+    // Dynamic host bindings
+    attrBinding(elementRef, 'disabled', () => (selectState().disabled() ? '' : null));
+    dataBinding(elementRef, 'data-open', () => (selectState().open() ? '' : null));
+    dataBinding(elementRef, 'data-disabled', () => (selectState().disabled() ? '' : null));
+    dataBinding(elementRef, 'data-multiple', () => (selectState().multiple() ? '' : null));
+
+    // Event listeners
+    listener(elementRef, 'keydown', handleKeydown);
+    listener(elementRef, 'blur', onBlur);
+
+    /** Handle keydown events for accessibility. */
+    function handleKeydown(event: KeyboardEvent): void {
+      switch (event.key) {
+        case 'ArrowDown':
+          if (selectState().open()) {
+            selectState().activateNextOption();
+          } else {
+            selectState().openDropdown();
+          }
+          event.preventDefault();
+          break;
+        case 'ArrowUp':
+          if (selectState().open()) {
+            selectState().activatePreviousOption();
+          } else {
+            selectState().openDropdown();
+            selectState().activeDescendantManager.last();
+          }
+          event.preventDefault();
+          break;
+        case 'Home':
+          if (selectState().open()) {
+            selectState().activeDescendantManager.first({ origin: 'keyboard' });
+          }
+          event.preventDefault();
+          break;
+        case 'End':
+          if (selectState().open()) {
+            selectState().activeDescendantManager.last({ origin: 'keyboard' });
+          }
+          event.preventDefault();
+          break;
+        case 'Enter':
+          if (selectState().open()) {
+            const activeId = selectState().activeDescendantManager.id();
+
+            if (activeId) {
+              const option = selectState()
+                .sortedOptions()
+                .find(opt => opt.id() === activeId);
+              option?.select();
+            }
+
+            // if a single selection closed the dropdown, return focus to the trigger
+            if (!selectState().open()) {
+              selectState().focus();
+            }
+          }
+          event.preventDefault();
+          break;
+        case 'Escape':
+          selectState().closeDropdown();
+          selectState().focus();
+          event.preventDefault();
+          break;
+        case 'Backspace':
+          // if the input is not empty then open the dropdown
+          if (elementRef.nativeElement.value.length > 0) {
+            selectState().openDropdown();
+          }
+          break;
+        default:
+          // Ignore keys with length > 1 (e.g., 'Shift', 'ArrowLeft', etc.)
+          // and control/meta key combos (e.g., Ctrl+C)
+          if (
+            event.key !== 'Unidentified' &&
+            (event.key.length > 1 || event.ctrlKey || event.metaKey || event.altKey)
+          ) {
+            return;
+          }
+
+          // if this was a character key, we want to open the dropdown
+          selectState().openDropdown();
+      }
+    }
+
+    function onBlur(event: FocusEvent): void {
+      const relatedTarget = event.relatedTarget as HTMLElement;
+
+      // if the blur was caused by focus moving into the dropdown, don't close
+      if (
+        relatedTarget &&
+        selectState().dropdown()?.elementRef.nativeElement.contains(relatedTarget)
+      ) {
+        return;
+      }
+
+      // if the blur was caused by focus moving to the select trigger, don't close
+      if (relatedTarget && selectState().elementRef.nativeElement.contains(relatedTarget)) {
+        return;
+      }
+
+      selectState().closeDropdown();
+    }
+
+    /**
+     * Focus the input field.
+     * @internal
+     */
+    function focus(): void {
+      elementRef.nativeElement.focus({ preventScroll: true });
+    }
+
+    const state = {
+      elementRef,
+      id,
+      focus,
+    } satisfies NgpSelectInputState;
+
+    selectState().registerInput(state);
+
+    // when the input is rendered (e.g. the dropdown opened), move focus to it
+    afterNextRender(() => focus(), { injector });
+
+    onDestroy(() => selectState().unregisterInput(state));
+
+    return state;
+  },
+);
+
+export function injectSelectInputState(
+  options?: StateInjectionOptions,
+): Signal<NgpSelectInputState> {
+  return _injectSelectInputState(options) as Signal<NgpSelectInputState>;
+}

--- a/packages/ng-primitives/select/src/select-input/select-input-state.ts
+++ b/packages/ng-primitives/select/src/select-input/select-input-state.ts
@@ -53,14 +53,22 @@ export const [
     });
 
     // Static host bindings
-    attrBinding(elementRef, 'role', 'searchbox');
+    attrBinding(elementRef, 'role', 'combobox');
     attrBinding(elementRef, 'type', 'text');
     attrBinding(elementRef, 'autocomplete', 'off');
     attrBinding(elementRef, 'autocorrect', 'off');
     attrBinding(elementRef, 'spellcheck', 'false');
+    attrBinding(elementRef, 'aria-autocomplete', 'list');
     attrBinding(elementRef, 'id', id);
 
     // Dynamic host bindings
+    attrBinding(elementRef, 'aria-expanded', () => selectState().open());
+    attrBinding(elementRef, 'aria-controls', () =>
+      selectState().open() ? selectState().dropdown()?.id() : undefined,
+    );
+    attrBinding(elementRef, 'aria-activedescendant', () =>
+      selectState().activeDescendantManager.id(),
+    );
     attrBinding(elementRef, 'disabled', () => (selectState().disabled() ? '' : null));
     dataBinding(elementRef, 'data-open', () => (selectState().open() ? '' : null));
     dataBinding(elementRef, 'data-disabled', () => (selectState().disabled() ? '' : null));

--- a/packages/ng-primitives/select/src/select-input/select-input-state.ts
+++ b/packages/ng-primitives/select/src/select-input/select-input-state.ts
@@ -63,9 +63,12 @@ export const [
 
     // Dynamic host bindings
     attrBinding(elementRef, 'aria-expanded', () => selectState().open());
-    attrBinding(elementRef, 'aria-controls', () =>
-      selectState().open() ? selectState().dropdown()?.id() : undefined,
-    );
+    attrBinding(elementRef, 'aria-controls', () => {
+      if (!selectState().open()) {
+        return undefined;
+      }
+      return selectState().list()?.id() ?? selectState().dropdown()?.id();
+    });
     attrBinding(elementRef, 'aria-activedescendant', () =>
       selectState().activeDescendantManager.id(),
     );
@@ -121,8 +124,7 @@ export const [
               option?.select();
             }
 
-            // if a single selection closed the dropdown, return focus to the trigger
-            if (!selectState().open()) {
+            if (!selectState().multiple()) {
               selectState().focus();
             }
           }
@@ -189,8 +191,19 @@ export const [
 
     selectState().registerInput(state);
 
-    // when the input is rendered (e.g. the dropdown opened), move focus to it
-    afterNextRender(() => focus(), { injector });
+    // when the input is rendered (e.g. the dropdown opened), move focus to it.
+    afterNextRender(
+      () => {
+        focus();
+
+        if (ngDevMode && !selectState().list()) {
+          console.error(
+            '[ngpSelectInput]: When using ngpSelectInput, the options must be wrapped in an element with the ngpSelectList directive (role="listbox"). Without it the input (role="combobox") is nested inside the listbox, which is invalid.',
+          );
+        }
+      },
+      { injector },
+    );
 
     onDestroy(() => selectState().unregisterInput(state));
 

--- a/packages/ng-primitives/select/src/select-input/select-input-state.ts
+++ b/packages/ng-primitives/select/src/select-input/select-input-state.ts
@@ -102,16 +102,10 @@ export const [
           event.preventDefault();
           break;
         case 'Home':
-          if (selectState().open()) {
-            selectState().activeDescendantManager.first({ origin: 'keyboard' });
-          }
-          event.preventDefault();
+          // let the caret move within the search term
           break;
         case 'End':
-          if (selectState().open()) {
-            selectState().activeDescendantManager.last({ origin: 'keyboard' });
-          }
-          event.preventDefault();
+          // let the caret move within the search term
           break;
         case 'Enter':
           if (selectState().open()) {

--- a/packages/ng-primitives/select/src/select-input/select-input-state.ts
+++ b/packages/ng-primitives/select/src/select-input/select-input-state.ts
@@ -70,7 +70,7 @@ export const [
       return selectState().list()?.id() ?? selectState().dropdown()?.id();
     });
     attrBinding(elementRef, 'aria-activedescendant', () =>
-      selectState().activeDescendantManager.id(),
+      selectState().open() ? selectState().activeDescendantManager.id() : undefined,
     );
     attrBinding(elementRef, 'disabled', () => (selectState().disabled() ? '' : null));
     dataBinding(elementRef, 'data-open', () => (selectState().open() ? '' : null));
@@ -191,15 +191,29 @@ export const [
 
     selectState().registerInput(state);
 
-    // when the input is rendered (e.g. the dropdown opened), move focus to it.
     afterNextRender(
       () => {
-        focus();
+        if (ngDevMode) {
+          const insideDropdown = selectState()
+            .dropdown()
+            ?.elementRef.nativeElement.contains(elementRef.nativeElement);
 
-        if (ngDevMode && !selectState().list()) {
-          console.error(
-            '[ngpSelectInput]: When using ngpSelectInput, the options must be wrapped in an element with the ngpSelectList directive (role="listbox"). Without it the input (role="combobox") is nested inside the listbox, which is invalid.',
-          );
+          if (!insideDropdown) {
+            console.error(
+              '[ngpSelectInput]: The input must be placed inside the element with the ngpSelectDropdown directive. For an editable trigger, use ngpCombobox instead.',
+            );
+          }
+
+          if (!selectState().list()) {
+            console.error(
+              '[ngpSelectInput]: When using ngpSelectInput, the options must be wrapped in an element with the ngpSelectList directive (role="listbox"). Without it the input (role="combobox") is nested inside the listbox, which is invalid.',
+            );
+          }
+        }
+
+        // the input is only rendered once the dropdown has opened, so move focus to it.
+        if (selectState().open()) {
+          focus();
         }
       },
       { injector },

--- a/packages/ng-primitives/select/src/select-input/select-input-state.ts
+++ b/packages/ng-primitives/select/src/select-input/select-input-state.ts
@@ -96,8 +96,7 @@ export const [
           if (selectState().open()) {
             selectState().activatePreviousOption();
           } else {
-            selectState().openDropdown();
-            selectState().activeDescendantManager.last();
+            void selectState().openDropdown({ activate: 'last' });
           }
           event.preventDefault();
           break;

--- a/packages/ng-primitives/select/src/select-input/select-input-state.ts
+++ b/packages/ng-primitives/select/src/select-input/select-input-state.ts
@@ -81,23 +81,22 @@ export const [
     listener(elementRef, 'keydown', handleKeydown);
     listener(elementRef, 'blur', onBlur);
 
-    /** Handle keydown events for accessibility. */
+    /**
+     * Handle keydown events for accessibility.
+     *
+     * The input lives inside the dropdown, so it only exists while the dropdown is open and
+     * only ever receives a key while it is. Nothing here needs to open the dropdown, and any
+     * closed-state branch would be unreachable: the overlay reports itself open for the whole
+     * exit animation and the view is gone by the time it reports otherwise.
+     */
     function handleKeydown(event: KeyboardEvent): void {
       switch (event.key) {
         case 'ArrowDown':
-          if (selectState().open()) {
-            selectState().activateNextOption();
-          } else {
-            selectState().openDropdown();
-          }
+          selectState().activateNextOption();
           event.preventDefault();
           break;
         case 'ArrowUp':
-          if (selectState().open()) {
-            selectState().activatePreviousOption();
-          } else {
-            void selectState().openDropdown({ activate: 'last' });
-          }
+          selectState().activatePreviousOption();
           event.preventDefault();
           break;
         case 'Home':
@@ -106,46 +105,28 @@ export const [
         case 'End':
           // let the caret move within the search term
           break;
-        case 'Enter':
-          if (selectState().open()) {
-            const activeId = selectState().activeDescendantManager.id();
+        case 'Enter': {
+          const activeId = selectState().activeDescendantManager.id();
 
-            if (activeId) {
-              const option = selectState()
-                .sortedOptions()
-                .find(opt => opt.id() === activeId);
-              option?.select();
-            }
-
-            if (!selectState().multiple()) {
-              selectState().focus();
-            }
+          if (activeId) {
+            const option = selectState()
+              .sortedOptions()
+              .find(opt => opt.id() === activeId);
+            option?.select();
           }
+
+          if (!selectState().multiple()) {
+            selectState().focus();
+          }
+
           event.preventDefault();
           break;
+        }
         case 'Escape':
           selectState().closeDropdown();
           selectState().focus();
           event.preventDefault();
           break;
-        case 'Backspace':
-          // if the input is not empty then open the dropdown
-          if (elementRef.nativeElement.value.length > 0) {
-            selectState().openDropdown();
-          }
-          break;
-        default:
-          // Ignore keys with length > 1 (e.g., 'Shift', 'ArrowLeft', etc.)
-          // and control/meta key combos (e.g., Ctrl+C)
-          if (
-            event.key !== 'Unidentified' &&
-            (event.key.length > 1 || event.ctrlKey || event.metaKey || event.altKey)
-          ) {
-            return;
-          }
-
-          // if this was a character key, we want to open the dropdown
-          selectState().openDropdown();
       }
     }
 

--- a/packages/ng-primitives/select/src/select-input/select-input.ts
+++ b/packages/ng-primitives/select/src/select-input/select-input.ts
@@ -1,0 +1,25 @@
+import { Directive, input } from '@angular/core';
+import { uniqueId } from 'ng-primitives/utils';
+import { ngpSelectInput } from './select-input-state';
+
+@Directive({
+  selector: 'input[ngpSelectInput]',
+  exportAs: 'ngpSelectInput',
+})
+export class NgpSelectInput {
+  /** The id of the input. */
+  readonly id = input<string>(uniqueId('ngp-select-input'));
+
+  /** Access the select input state. */
+  protected readonly state = ngpSelectInput({
+    id: this.id,
+  });
+
+  /**
+   * Focus the input field.
+   * @internal
+   */
+  focus(): void {
+    this.state.focus();
+  }
+}

--- a/packages/ng-primitives/select/src/select-list/select-list-state.ts
+++ b/packages/ng-primitives/select/src/select-list/select-list-state.ts
@@ -1,0 +1,57 @@
+import { ElementRef, Signal, signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  createPrimitive,
+  onDestroy,
+  StateInjectionOptions,
+} from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { injectSelectState } from '../select/select-state';
+
+export interface NgpSelectListState {
+  /**
+   * @internal Access the element reference.
+   */
+  readonly elementRef: ElementRef<HTMLElement>;
+
+  /** The id of the list. */
+  readonly id: Signal<string>;
+}
+
+export interface NgpSelectListProps {
+  /** The id of the list. */
+  readonly id?: Signal<string>;
+}
+
+export const [
+  NgpSelectListStateToken,
+  ngpSelectList,
+  _injectSelectListState,
+  provideSelectListState,
+] = createPrimitive(
+  'NgpSelectList',
+  ({ id: _id = signal(uniqueId('ngp-select-list')) }: NgpSelectListProps) => {
+    const elementRef = injectElementRef<HTMLElement>();
+    const selectState = injectSelectState();
+
+    // Host bindings
+    attrBinding(elementRef, 'role', 'listbox');
+    attrBinding(elementRef, 'id', _id);
+
+    const state = {
+      elementRef,
+      id: _id,
+    } satisfies NgpSelectListState;
+
+    selectState().registerList(state);
+
+    onDestroy(() => selectState().unregisterList(state));
+
+    return state;
+  },
+);
+
+export function injectSelectListState(options?: StateInjectionOptions): Signal<NgpSelectListState> {
+  return _injectSelectListState(options) as Signal<NgpSelectListState>;
+}

--- a/packages/ng-primitives/select/src/select-list/select-list.ts
+++ b/packages/ng-primitives/select/src/select-list/select-list.ts
@@ -1,0 +1,18 @@
+import { Directive, input } from '@angular/core';
+import { uniqueId } from 'ng-primitives/utils';
+import { ngpSelectList } from './select-list-state';
+
+@Directive({
+  selector: '[ngpSelectList]',
+  exportAs: 'ngpSelectList',
+})
+export class NgpSelectList {
+  /** The id of the list. */
+  readonly id = input<string>(uniqueId('ngp-select-list'));
+
+  constructor() {
+    ngpSelectList({
+      id: this.id,
+    });
+  }
+}

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -28,6 +28,7 @@ import { uniqueId } from 'ng-primitives/utils';
 import { Observable } from 'rxjs';
 import type { NgpSelectDropdownState } from '../select-dropdown/select-dropdown-state';
 import type { NgpSelectInputState } from '../select-input/select-input-state';
+import type { NgpSelectListState } from '../select-list/select-list-state';
 import type { NgpSelectOptionState } from '../select-option/select-option-state';
 import { NgpSelectPortalState } from '../select-portal/select-portal-state';
 
@@ -99,6 +100,13 @@ export interface NgpSelectState<T> {
    * @internal
    */
   readonly input: WritableSignal<NgpSelectInputState | undefined>;
+
+  /**
+   * Store the select list, when a dedicated listbox wraps the options
+   * (e.g. when the popup also contains a filter input).
+   * @internal
+   */
+  readonly list: WritableSignal<NgpSelectListState | undefined>;
 
   /**
    * Store the select options.
@@ -223,6 +231,20 @@ export interface NgpSelectState<T> {
    * @internal
    */
   unregisterInput(input: NgpSelectInputState): void;
+
+  /**
+   * Register the list with the select.
+   * @param list The list to register.
+   * @internal
+   */
+  registerList(list: NgpSelectListState): void;
+
+  /**
+   * Unregister the list from the select.
+   * @param list The list to unregister.
+   * @internal
+   */
+  unregisterList(list: NgpSelectListState): void;
 
   /**
    * Register an option with the select.
@@ -377,6 +399,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
       const portal = signal<NgpSelectPortalState | undefined>(undefined);
       const dropdown = signal<NgpSelectDropdownState | undefined>(undefined);
       const input = signal<NgpSelectInputState | undefined>(undefined);
+      const list = signal<NgpSelectListState | undefined>(undefined);
       const options = signal<NgpSelectOptionState[]>([]);
 
       const overlay = computed(() => portal()?.overlay());
@@ -761,6 +784,26 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
       }
 
       /**
+       * Register the list with the select.
+       * @param listInstance The list to register.
+       * @internal
+       */
+      function registerList(listInstance: NgpSelectListState): void {
+        list.set(listInstance);
+      }
+
+      /**
+       * Unregister the list from the select.
+       * @param listInstance The list to unregister.
+       * @internal
+       */
+      function unregisterList(listInstance: NgpSelectListState): void {
+        if (list() === listInstance) {
+          list.set(undefined);
+        }
+      }
+
+      /**
        * Register an option with the select.
        * @param option The option to register.
        * @internal
@@ -902,6 +945,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
         portal,
         dropdown,
         input,
+        list,
         options,
         overlay,
         open,
@@ -925,6 +969,8 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
         registerDropdown,
         registerInput,
         unregisterInput,
+        registerList,
+        unregisterList,
         registerOption,
         unregisterOption,
         focus,

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -420,9 +420,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
       });
 
       // Host bindings
-      // When no input is registered, select is the combobox; when input exists, input is the combobox.
       attrBinding(elementRef, 'role', () => (input() ? null : 'combobox'));
-      attrBinding(elementRef, 'aria-haspopup', 'dialog');
       attrBinding(elementRef, 'id', id);
       attrBinding(elementRef, 'aria-expanded', () => (input() ? undefined : open()));
       attrBinding(elementRef, 'aria-controls', () =>

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -447,7 +447,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
       attrBinding(elementRef, 'id', id);
       attrBinding(elementRef, 'aria-expanded', () => (input() ? undefined : open()));
       attrBinding(elementRef, 'aria-controls', () =>
-        input() ? undefined : open() ? dropdown()?.id() : undefined,
+        input() ? undefined : open() ? (list()?.id() ?? dropdown()?.id()) : undefined,
       );
       attrBinding(elementRef, 'aria-activedescendant', () =>
         input() ? undefined : open() ? activeDescendantManagerInstance.id() : undefined,
@@ -466,14 +466,13 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
       listener(elementRef, 'blur', onBlur);
 
       function onClick(event: MouseEvent): void {
-        // if the click originated from the input, let the input keep focus
-        // (clicking it should not toggle the dropdown closed when it is placed
-        // inside the select element)
+        // if the click originated from the input, let the input keep focus. the event only
+        // reaches us when the dropdown is rendered into a container inside the select element.
         if (event.target === input()?.elementRef.nativeElement) {
           return;
         }
 
-        toggleDropdown();
+        void toggleDropdown();
       }
 
       /**
@@ -831,8 +830,8 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
 
       /** Handle keydown events for accessibility. */
       function handleKeydown(event: KeyboardEvent): void {
-        // if the event originated from the input element, let the input handle it
-        // (the event bubbles up when the input is placed inside the select element)
+        // if the event originated from the input element, let the input handle it. the event only
+        // bubbles here when the dropdown is rendered into a container inside the select element.
         if (event.target === input()?.elementRef.nativeElement) {
           return;
         }
@@ -842,7 +841,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
             if (open()) {
               activateNextOption();
             } else {
-              openDropdown();
+              void openDropdown();
             }
             event.preventDefault();
             break;
@@ -850,7 +849,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
             if (open()) {
               activatePreviousOption();
             } else {
-              openDropdown();
+              void openDropdown();
               activeDescendantManagerInstance.last();
             }
             event.preventDefault();
@@ -876,12 +875,12 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
                 option?.select();
               }
             } else {
-              openDropdown();
+              void openDropdown();
             }
             event.preventDefault();
             break;
           case ' ':
-            toggleDropdown();
+            void toggleDropdown();
             event.preventDefault();
             break;
         }
@@ -895,8 +894,8 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
           return;
         }
 
-        // if the blur was caused by focus moving to the input, don't close
-        // (the input may be placed inside the select element)
+        // if the blur was caused by focus moving to the input, don't close. opening the
+        // dropdown moves focus from the trigger to the input, which blurs the trigger.
         if (relatedTarget === input()?.elementRef.nativeElement) {
           return;
         }

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -420,12 +420,16 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
       });
 
       // Host bindings
-      attrBinding(elementRef, 'role', 'combobox');
+      // When no input is registered, select is the combobox; when input exists, input is the combobox.
+      attrBinding(elementRef, 'role', () => (input() ? null : 'combobox'));
+      attrBinding(elementRef, 'aria-haspopup', 'dialog');
       attrBinding(elementRef, 'id', id);
-      attrBinding(elementRef, 'aria-expanded', () => open());
-      attrBinding(elementRef, 'aria-controls', () => (open() ? dropdown()?.id() : undefined));
+      attrBinding(elementRef, 'aria-expanded', () => (input() ? undefined : open()));
+      attrBinding(elementRef, 'aria-controls', () =>
+        input() ? undefined : open() ? dropdown()?.id() : undefined,
+      );
       attrBinding(elementRef, 'aria-activedescendant', () =>
-        open() ? activeDescendantManagerInstance.id() : undefined,
+        input() ? undefined : open() ? activeDescendantManagerInstance.id() : undefined,
       );
       attrBinding(elementRef, 'tabindex', () => {
         if (input() || disabled()) return -1;

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -523,10 +523,19 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
         // by the caller would run before any option has registered, and would then be
         // overwritten when this function resumes.
         if (options?.activate === 'last') {
+          // reset first so the index stays at -1 when there is nothing to activate, rather than
+          // keeping the 0 it starts on
+          activeDescendantManagerInstance.reset();
           activeDescendantManagerInstance.last();
+
+          const activeIndex = activeDescendantManagerInstance.index();
+
           // the manager scrolls through a callback that bails out until the overlay has been
           // positioned, which has not happened yet, so scroll here like the selected branch does
-          scrollTo(activeDescendantManagerInstance.index());
+          if (activeIndex !== -1) {
+            scrollTo(activeIndex);
+          }
+
           return;
         }
 

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -27,6 +27,7 @@ import {
 import { uniqueId } from 'ng-primitives/utils';
 import { Observable } from 'rxjs';
 import type { NgpSelectDropdownState } from '../select-dropdown/select-dropdown-state';
+import type { NgpSelectInputState } from '../select-input/select-input-state';
 import type { NgpSelectOptionState } from '../select-option/select-option-state';
 import { NgpSelectPortalState } from '../select-portal/select-portal-state';
 
@@ -92,6 +93,12 @@ export interface NgpSelectState<T> {
    * @internal
    */
   readonly dropdown: WritableSignal<NgpSelectDropdownState | undefined>;
+
+  /**
+   * Store the select input, when one is used to filter the options.
+   * @internal
+   */
+  readonly input: WritableSignal<NgpSelectInputState | undefined>;
 
   /**
    * Store the select options.
@@ -202,6 +209,20 @@ export interface NgpSelectState<T> {
    * @internal
    */
   registerDropdown(dropdown: NgpSelectDropdownState): void;
+
+  /**
+   * Register the input with the select.
+   * @param input The input to register.
+   * @internal
+   */
+  registerInput(input: NgpSelectInputState): void;
+
+  /**
+   * Unregister the input from the select.
+   * @param input The input to unregister.
+   * @internal
+   */
+  unregisterInput(input: NgpSelectInputState): void;
 
   /**
    * Register an option with the select.
@@ -355,6 +376,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
 
       const portal = signal<NgpSelectPortalState | undefined>(undefined);
       const dropdown = signal<NgpSelectDropdownState | undefined>(undefined);
+      const input = signal<NgpSelectInputState | undefined>(undefined);
       const options = signal<NgpSelectOptionState[]>([]);
 
       const overlay = computed(() => portal()?.overlay());
@@ -400,20 +422,34 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
       // Host bindings
       attrBinding(elementRef, 'role', 'combobox');
       attrBinding(elementRef, 'id', id);
-      attrBinding(elementRef, 'aria-expanded', open);
+      attrBinding(elementRef, 'aria-expanded', () => open());
       attrBinding(elementRef, 'aria-controls', () => (open() ? dropdown()?.id() : undefined));
       attrBinding(elementRef, 'aria-activedescendant', () =>
         open() ? activeDescendantManagerInstance.id() : undefined,
       );
-      attrBinding(elementRef, 'tabindex', () => (disabled() ? -1 : 0));
+      attrBinding(elementRef, 'tabindex', () => {
+        if (input() || disabled()) return -1;
+        return 0;
+      });
       dataBinding(elementRef, 'data-open', () => (open() ? '' : null));
       dataBinding(elementRef, 'data-disabled', () => (disabled() ? '' : null));
       dataBinding(elementRef, 'data-multiple', () => (multiple() ? '' : null));
 
       // Event listeners
-      listener(elementRef, 'click', () => void toggleDropdown());
+      listener(elementRef, 'click', onClick);
       listener(elementRef, 'keydown', handleKeydown);
       listener(elementRef, 'blur', onBlur);
+
+      function onClick(event: MouseEvent): void {
+        // if the click originated from the input, let the input keep focus
+        // (clicking it should not toggle the dropdown closed when it is placed
+        // inside the select element)
+        if (event.target === input()?.elementRef.nativeElement) {
+          return;
+        }
+
+        toggleDropdown();
+      }
 
       /**
        * Open the dropdown.
@@ -426,6 +462,8 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
 
         onOpenChange?.(true);
         await portal()?.show();
+
+        input()?.focus();
 
         let selectedOptionIdx = -1;
 
@@ -701,6 +739,26 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
       }
 
       /**
+       * Register the input with the select.
+       * @param inputInstance The input to register.
+       * @internal
+       */
+      function registerInput(inputInstance: NgpSelectInputState): void {
+        input.set(inputInstance);
+      }
+
+      /**
+       * Unregister the input from the select.
+       * @param inputInstance The input to unregister.
+       * @internal
+       */
+      function unregisterInput(inputInstance: NgpSelectInputState): void {
+        if (input() === inputInstance) {
+          input.set(undefined);
+        }
+      }
+
+      /**
        * Register an option with the select.
        * @param option The option to register.
        * @internal
@@ -728,12 +786,18 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
 
       /** Handle keydown events for accessibility. */
       function handleKeydown(event: KeyboardEvent): void {
+        // if the event originated from the input element, let the input handle it
+        // (the event bubbles up when the input is placed inside the select element)
+        if (event.target === input()?.elementRef.nativeElement) {
+          return;
+        }
+
         switch (event.key) {
           case 'ArrowDown':
             if (open()) {
               activateNextOption();
             } else {
-              void openDropdown();
+              openDropdown();
             }
             event.preventDefault();
             break;
@@ -741,7 +805,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
             if (open()) {
               activatePreviousOption();
             } else {
-              void openDropdown();
+              openDropdown();
               activeDescendantManagerInstance.last();
             }
             event.preventDefault();
@@ -767,12 +831,12 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
                 option?.select();
               }
             } else {
-              void openDropdown();
+              openDropdown();
             }
             event.preventDefault();
             break;
           case ' ':
-            void toggleDropdown();
+            toggleDropdown();
             event.preventDefault();
             break;
         }
@@ -783,6 +847,12 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
 
         // if the blur was caused by focus moving to the dropdown, don't close
         if (relatedTarget && dropdown()?.elementRef.nativeElement.contains(relatedTarget)) {
+          return;
+        }
+
+        // if the blur was caused by focus moving to the input, don't close
+        // (the input may be placed inside the select element)
+        if (relatedTarget === input()?.elementRef.nativeElement) {
           return;
         }
 
@@ -829,6 +899,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
         allOptions,
         portal,
         dropdown,
+        input,
         options,
         overlay,
         open,
@@ -850,6 +921,8 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
         valueChange: valueChangeEmitter.asObservable(),
         registerPortal,
         registerDropdown,
+        registerInput,
+        unregisterInput,
         registerOption,
         unregisterOption,
         focus,

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -32,6 +32,14 @@ import type { NgpSelectListState } from '../select-list/select-list-state';
 import type { NgpSelectOptionState } from '../select-option/select-option-state';
 import { NgpSelectPortalState } from '../select-portal/select-portal-state';
 
+export interface NgpSelectOpenOptions {
+  /**
+   * Which option to activate once the dropdown has opened and its options have registered.
+   * A selected option always wins over this preference. Defaults to `'first'`.
+   */
+  readonly activate?: 'first' | 'last';
+}
+
 export interface NgpSelectState<T> {
   /**
    * @internal Access the select element.
@@ -142,7 +150,7 @@ export interface NgpSelectState<T> {
    * Open the dropdown.
    * @internal
    */
-  openDropdown(): Promise<void>;
+  openDropdown(options?: NgpSelectOpenOptions): Promise<void>;
 
   /**
    * Close the dropdown.
@@ -479,7 +487,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
        * Open the dropdown.
        * @internal
        */
-      async function openDropdown(): Promise<void> {
+      async function openDropdown(options?: NgpSelectOpenOptions): Promise<void> {
         if (disabled() || open()) {
           return;
         }
@@ -510,7 +518,18 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
           return;
         }
 
-        // activate the selected option or the first option
+        // nothing is selected, so honour the caller's preference. this must happen here rather
+        // than at the call site: openDropdown suspends on the portal, so an activation queued
+        // by the caller would run before any option has registered, and would then be
+        // overwritten when this function resumes.
+        if (options?.activate === 'last') {
+          activeDescendantManagerInstance.last();
+          // the manager scrolls through a callback that bails out until the overlay has been
+          // positioned, which has not happened yet, so scroll here like the selected branch does
+          scrollTo(activeDescendantManagerInstance.index());
+          return;
+        }
+
         activeDescendantManagerInstance.first();
       }
 
@@ -849,8 +868,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
             if (open()) {
               activatePreviousOption();
             } else {
-              void openDropdown();
-              activeDescendantManagerInstance.last();
+              void openDropdown({ activate: 'last' });
             }
             event.preventDefault();
             break;

--- a/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
+++ b/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
@@ -1,8 +1,14 @@
-import { Component, Directive, OnInit, signal, viewChild } from '@angular/core';
+import { Component, computed, Directive, OnInit, signal, viewChild } from '@angular/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { NgpSelect, NgpSelectDropdown, NgpSelectOption, NgpSelectPortal } from '../../index';
+import {
+  NgpSelect,
+  NgpSelectDropdown,
+  NgpSelectInput,
+  NgpSelectOption,
+  NgpSelectPortal,
+} from '../../index';
 import { injectSelectState } from '../select-state';
 
 @Component({
@@ -1861,6 +1867,177 @@ describe('NgpSelect', () => {
       // Destroy the component — should NOT emit openChange
       fixture.destroy();
       expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('NgpSelectInput', () => {
+    @Component({
+      template: `
+        <div
+          [(ngpSelectValue)]="value"
+          (ngpSelectOpenChange)="onOpenChange($event)"
+          ngpSelect
+          data-testid="select-with-input"
+        >
+          @if (value(); as val) {
+            <span data-testid="selected-value">{{ val }}</span>
+          } @else {
+            <span data-testid="placeholder">Select an option</span>
+          }
+
+          <div *ngpSelectPortal ngpSelectDropdown data-testid="dropdown">
+            <input
+              [value]="search()"
+              (input)="onSearch($event)"
+              ngpSelectInput
+              placeholder="Search..."
+              data-testid="select-input"
+            />
+            <div class="options-container">
+              @for (option of filteredOptions(); track option) {
+                <div
+                  [ngpSelectOptionValue]="option"
+                  [attr.data-testid]="'option-' + option"
+                  ngpSelectOption
+                >
+                  {{ option }}
+                </div>
+              } @empty {
+                <div data-testid="empty">No options found</div>
+              }
+            </div>
+          </div>
+        </div>
+      `,
+      imports: [NgpSelect, NgpSelectDropdown, NgpSelectInput, NgpSelectOption, NgpSelectPortal],
+      styles: `
+        .options-container {
+          max-height: 200px;
+          overflow-y: auto;
+        }
+      `,
+    })
+    class TestSelectInputComponent {
+      readonly options = ['Apple', 'Banana', 'Cherry', 'Dragon Fruit'];
+      readonly value = signal<string | undefined>(undefined);
+      readonly search = signal<string>('');
+
+      protected readonly filteredOptions = computed(() =>
+        this.options.filter(option => option.toLowerCase().includes(this.search().toLowerCase())),
+      );
+
+      protected onSearch(event: Event): void {
+        this.search.set((event.target as HTMLInputElement).value);
+      }
+
+      protected onOpenChange(open: boolean): void {
+        if (!open) {
+          this.search.set('');
+        }
+      }
+    }
+
+    it('should render input inside dropdown', async () => {
+      await render(TestSelectInputComponent);
+      const select = screen.getByTestId('select-with-input');
+
+      fireEvent.click(select);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('select-input')).toBeInTheDocument();
+      });
+    });
+
+    it('should focus input on dropdown open', async () => {
+      await render(TestSelectInputComponent);
+      const select = screen.getByTestId('select-with-input');
+
+      fireEvent.click(select);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('select-input')).toHaveFocus();
+      });
+    });
+
+    it('should click option to select', async () => {
+      const { fixture } = await render(TestSelectInputComponent);
+      const component = fixture.componentInstance;
+      const select = screen.getByTestId('select-with-input');
+      const user = userEvent.setup();
+
+      fireEvent.click(select);
+
+      const option = await screen.findByTestId('option-Banana');
+      await user.click(option);
+
+      await waitFor(() => {
+        expect(component.value()).toBe('Banana');
+      });
+    });
+
+    it('should reset search when dropdown closes', async () => {
+      const { fixture } = await render(TestSelectInputComponent);
+      const component = fixture.componentInstance;
+      const select = screen.getByTestId('select-with-input');
+      const user = userEvent.setup();
+
+      fireEvent.click(select);
+
+      const input = await screen.findByTestId('select-input');
+      await user.type(input, 'test');
+
+      expect(component.search()).toBe('test');
+
+      // Click outside to close
+      await user.click(document.body);
+
+      await waitFor(() => {
+        expect(component.search()).toBe('');
+      });
+    });
+
+    it('should have combobox role on select trigger when closed', async () => {
+      await render(TestSelectInputComponent);
+      const select = screen.getByTestId('select-with-input');
+
+      expect(select).toHaveAttribute('role', 'combobox');
+      expect(select).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('should transfer combobox role to input when opened', async () => {
+      await render(TestSelectInputComponent);
+      const select = screen.getByTestId('select-with-input');
+
+      fireEvent.click(select);
+
+      const input = await screen.findByTestId('select-input');
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('role', 'combobox');
+        expect(input).toHaveAttribute('aria-expanded', 'true');
+        expect(input).toHaveAttribute('aria-autocomplete', 'list');
+        expect(input).toHaveAttribute('aria-controls');
+      });
+    });
+
+    it('should restore combobox role to select when input closes', async () => {
+      await render(TestSelectInputComponent);
+      const select = screen.getByTestId('select-with-input');
+      const user = userEvent.setup();
+
+      fireEvent.click(select);
+
+      const input = await screen.findByTestId('select-input');
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('role', 'combobox');
+      });
+
+      await user.click(document.body);
+
+      await waitFor(() => {
+        expect(select).toHaveAttribute('role', 'combobox');
+      });
     });
   });
 });

--- a/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
+++ b/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
@@ -440,6 +440,43 @@ describe('NgpSelect', () => {
       });
     });
 
+    it('should not scroll when ArrowUp opens a dropdown with no activatable option', async () => {
+      const scrollToOption = vi.fn();
+
+      @Component({
+        template: `
+          <div
+            [(ngpSelectValue)]="value"
+            [ngpSelectScrollToOption]="scrollToOption"
+            ngpSelect
+            data-testid="empty-select"
+          >
+            <span data-testid="placeholder">Select an option</span>
+
+            <div *ngpSelectPortal ngpSelectDropdown data-testid="dropdown"></div>
+          </div>
+        `,
+        imports: [NgpSelect, NgpSelectDropdown, NgpSelectPortal],
+      })
+      class TestEmptySelectComponent {
+        readonly value = signal<string | undefined>(undefined);
+        readonly scrollToOption = scrollToOption;
+      }
+
+      await render(TestEmptySelectComponent);
+
+      const select = screen.getByTestId('empty-select');
+      select.focus();
+
+      fireEvent.keyDown(select, { key: 'ArrowUp' });
+
+      await waitFor(() => {
+        expect(select).toHaveAttribute('aria-expanded', 'true');
+      });
+
+      expect(scrollToOption).not.toHaveBeenCalled();
+    });
+
     it('should keep the selected option active when ArrowUp opens the dropdown', async () => {
       const { fixture } = await render(TestSelectComponent);
       fixture.componentInstance.value.set('Banana');

--- a/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
+++ b/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
@@ -358,6 +358,102 @@ describe('NgpSelect', () => {
       });
     });
 
+    it('should activate the last option when ArrowUp opens the dropdown', async () => {
+      await render(TestSelectComponent);
+
+      const select = screen.getByTestId('select');
+      select.focus();
+
+      fireEvent.keyDown(select, { key: 'ArrowUp' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('option-Cherry')).toHaveAttribute('data-active', '');
+      });
+    });
+
+    it('should scroll the last option into view when ArrowUp opens the dropdown', async () => {
+      @Component({
+        template: `
+          <div [(ngpSelectValue)]="value" ngpSelect data-testid="scrollable-select">
+            <span data-testid="placeholder">Select an option</span>
+
+            <div *ngpSelectPortal ngpSelectDropdown data-testid="dropdown">
+              <div class="scrollable" data-testid="scrollable">
+                @for (option of options; track option) {
+                  <div
+                    [ngpSelectOptionValue]="option"
+                    [attr.data-testid]="'option-' + option"
+                    ngpSelectOption
+                  >
+                    {{ option }}
+                  </div>
+                }
+              </div>
+            </div>
+          </div>
+        `,
+        imports: [NgpSelect, NgpSelectDropdown, NgpSelectOption, NgpSelectPortal],
+        styles: `
+          /* the docs examples open the dropdown with an entrance animation that starts at
+             scale(0.9). a static transform stands in for it so the assertion does not depend
+             on where the animation happens to be when the scroll runs */
+          [ngpSelectDropdown] {
+            overflow: hidden;
+            transform: scale(0.9);
+          }
+
+          .scrollable {
+            max-height: 100px;
+            overflow-y: auto;
+          }
+
+          [ngpSelectOption] {
+            height: 30px;
+          }
+        `,
+      })
+      class TestScrollableSelectComponent {
+        readonly options = Array.from({ length: 20 }, (_, index) => `Option${index}`);
+        readonly value = signal<string | undefined>(undefined);
+      }
+
+      await render(TestScrollableSelectComponent);
+
+      const select = screen.getByTestId('scrollable-select');
+      select.focus();
+
+      fireEvent.keyDown(select, { key: 'ArrowUp' });
+
+      const scrollable = await screen.findByTestId('scrollable');
+
+      await waitFor(() => {
+        const lastOption = screen.getByTestId('option-Option19');
+        expect(lastOption).toHaveAttribute('data-active', '');
+
+        // compare both rects in the same coordinate space: the option sits inside the scroll
+        // container, so the transform applies to both and cancels out
+        const optionRect = lastOption.getBoundingClientRect();
+        const scrollableRect = scrollable.getBoundingClientRect();
+
+        expect(optionRect.bottom).toBeLessThanOrEqual(scrollableRect.bottom + 0.5);
+        expect(optionRect.top).toBeGreaterThanOrEqual(scrollableRect.top - 0.5);
+      });
+    });
+
+    it('should keep the selected option active when ArrowUp opens the dropdown', async () => {
+      const { fixture } = await render(TestSelectComponent);
+      fixture.componentInstance.value.set('Banana');
+
+      const select = screen.getByTestId('select');
+      select.focus();
+
+      fireEvent.keyDown(select, { key: 'ArrowUp' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('option-Banana')).toHaveAttribute('data-active', '');
+      });
+    });
+
     it('should open dropdown when Enter is pressed', async () => {
       await render(TestSelectComponent);
 

--- a/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
+++ b/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
@@ -235,7 +235,7 @@ describe('NgpSelect', () => {
   afterEach(() => {
     // the dropdown should be removed from the DOM after each test
     // to avoid interference with other tests - it may linger due to waiting for animations
-    document.querySelectorAll('[ngpselectdropdown]').forEach(dropdown => dropdown.remove());
+    document.querySelectorAll('[ngpSelectDropdown]').forEach(dropdown => dropdown.remove());
   });
 
   describe('Basic functionality', () => {
@@ -1989,7 +1989,7 @@ describe('NgpSelect', () => {
       fireEvent.click(select);
 
       const input = await screen.findByTestId('select-input');
-      await user.type(input, 'test');
+      fireEvent.input(input, { target: { value: 'test' } });
 
       expect(component.search()).toBe('test');
 
@@ -2065,6 +2065,160 @@ describe('NgpSelect', () => {
 
         await waitFor(() => {
           expect(screen.getByTestId('options-list')).toHaveAttribute('role', 'listbox');
+        });
+      });
+
+      it('should point aria-controls at the list rather than the dropdown', async () => {
+        await render(TestSelectInputComponent);
+        const select = screen.getByTestId('select-with-input');
+
+        fireEvent.click(select);
+
+        const input = await screen.findByTestId('select-input');
+        const list = screen.getByTestId('options-list');
+
+        await waitFor(() => {
+          expect(input).toHaveAttribute('aria-controls', list.getAttribute('id')!);
+        });
+      });
+
+      it('should point the trigger aria-controls at the list when there is no input', async () => {
+        @Component({
+          template: `
+            <div [(ngpSelectValue)]="value" ngpSelect data-testid="select-with-list">
+              <span data-testid="placeholder">Select an option</span>
+
+              <div *ngpSelectPortal ngpSelectDropdown data-testid="dropdown">
+                <div ngpSelectList data-testid="options-list">
+                  @for (option of options; track option) {
+                    <div [ngpSelectOptionValue]="option" ngpSelectOption>{{ option }}</div>
+                  }
+                </div>
+              </div>
+            </div>
+          `,
+          imports: [NgpSelect, NgpSelectDropdown, NgpSelectList, NgpSelectOption, NgpSelectPortal],
+        })
+        class TestSelectListOnlyComponent {
+          readonly options = ['Apple', 'Banana'];
+          readonly value = signal<string | undefined>(undefined);
+        }
+
+        await render(TestSelectListOnlyComponent);
+        const select = screen.getByTestId('select-with-list');
+
+        fireEvent.click(select);
+
+        const list = await screen.findByTestId('options-list');
+
+        await waitFor(() => {
+          expect(select).toHaveAttribute('aria-controls', list.getAttribute('id')!);
+        });
+      });
+    });
+
+    describe('Keyboard navigation from the input', () => {
+      it('should navigate through options with arrow keys', async () => {
+        await render(TestSelectInputComponent);
+        const select = screen.getByTestId('select-with-input');
+
+        fireEvent.click(select);
+
+        const input = await screen.findByTestId('select-input');
+
+        await waitFor(() => {
+          expect(screen.getByTestId('option-Apple')).toHaveAttribute('data-active', '');
+        });
+
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+        await waitFor(() => {
+          expect(screen.getByTestId('option-Banana')).toHaveAttribute('data-active', '');
+        });
+
+        fireEvent.keyDown(input, { key: 'ArrowUp' });
+        await waitFor(() => {
+          expect(screen.getByTestId('option-Apple')).toHaveAttribute('data-active', '');
+        });
+      });
+
+      it('should keep aria-activedescendant in sync with the active option', async () => {
+        await render(TestSelectInputComponent);
+        const select = screen.getByTestId('select-with-input');
+
+        fireEvent.click(select);
+
+        const input = await screen.findByTestId('select-input');
+
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+        await waitFor(() => {
+          const banana = screen.getByTestId('option-Banana');
+          expect(banana).toHaveAttribute('data-active', '');
+          expect(input).toHaveAttribute('aria-activedescendant', banana.getAttribute('id')!);
+        });
+      });
+
+      it('should select the active option when Enter is pressed', async () => {
+        const { fixture } = await render(TestSelectInputComponent);
+        const component = fixture.componentInstance;
+        const select = screen.getByTestId('select-with-input');
+
+        fireEvent.click(select);
+
+        const input = await screen.findByTestId('select-input');
+
+        await waitFor(() => {
+          expect(screen.getByTestId('option-Apple')).toHaveAttribute('data-active', '');
+        });
+
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+        await waitFor(() => {
+          expect(screen.getByTestId('option-Banana')).toHaveAttribute('data-active', '');
+        });
+
+        fireEvent.keyDown(input, { key: 'Enter' });
+
+        await waitFor(() => {
+          expect(component.value()).toBe('Banana');
+        });
+      });
+
+      it('should close the dropdown and return focus to the trigger when Escape is pressed', async () => {
+        await render(TestSelectInputComponent);
+        const select = screen.getByTestId('select-with-input');
+
+        fireEvent.click(select);
+
+        const input = await screen.findByTestId('select-input');
+        fireEvent.keyDown(input, { key: 'Escape' });
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('select-input')).not.toBeInTheDocument();
+          expect(select).toHaveFocus();
+        });
+      });
+
+      it('should move the active option onto a rendered option when filtering removes the active one', async () => {
+        await render(TestSelectInputComponent);
+        const select = screen.getByTestId('select-with-input');
+
+        fireEvent.click(select);
+
+        const input = await screen.findByTestId('select-input');
+
+        await waitFor(() => {
+          expect(screen.getByTestId('option-Apple')).toHaveAttribute('data-active', '');
+        });
+
+        // filter Apple out, the active descendant must not point at a removed option
+        fireEvent.input(input, { target: { value: 'an' } });
+
+        await waitFor(() => {
+          expect(screen.queryByTestId('option-Apple')).not.toBeInTheDocument();
+
+          const activeId = input.getAttribute('aria-activedescendant');
+          expect(activeId).toBeTruthy();
+          expect(document.getElementById(activeId!)).toBeInTheDocument();
         });
       });
     });

--- a/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
+++ b/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
@@ -2183,6 +2183,27 @@ describe('NgpSelect', () => {
         });
       });
 
+      it('should leave Home and End to the browser so the caret can move', async () => {
+        await render(TestSelectInputComponent);
+        const select = screen.getByTestId('select-with-input');
+
+        fireEvent.click(select);
+
+        const input = await screen.findByTestId('select-input');
+
+        fireEvent.keyDown(input, { key: 'ArrowDown' });
+        await waitFor(() => {
+          expect(screen.getByTestId('option-Banana')).toHaveAttribute('data-active', '');
+        });
+
+        // the input is an editable combobox, so Home and End are text editing keys and
+        // must not be consumed for option navigation
+        expect(fireEvent.keyDown(input, { key: 'Home' })).toBe(true);
+        expect(fireEvent.keyDown(input, { key: 'End' })).toBe(true);
+
+        expect(screen.getByTestId('option-Banana')).toHaveAttribute('data-active', '');
+      });
+
       it('should close the dropdown and return focus to the trigger when Escape is pressed', async () => {
         await render(TestSelectInputComponent);
         const select = screen.getByTestId('select-with-input');

--- a/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
+++ b/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
@@ -6,6 +6,7 @@ import {
   NgpSelect,
   NgpSelectDropdown,
   NgpSelectInput,
+  NgpSelectList,
   NgpSelectOption,
   NgpSelectPortal,
 } from '../../index';
@@ -234,10 +235,7 @@ describe('NgpSelect', () => {
   afterEach(() => {
     // the dropdown should be removed from the DOM after each test
     // to avoid interference with other tests - it may linger due to waiting for animations
-    const dropdown = screen.queryByRole('listbox');
-    if (dropdown) {
-      dropdown.remove();
-    }
+    document.querySelectorAll('[ngpselectdropdown]').forEach(dropdown => dropdown.remove());
   });
 
   describe('Basic functionality', () => {
@@ -1893,7 +1891,7 @@ describe('NgpSelect', () => {
               placeholder="Search..."
               data-testid="select-input"
             />
-            <div class="options-container">
+            <div class="options-container" ngpSelectList data-testid="options-list">
               @for (option of filteredOptions(); track option) {
                 <div
                   [ngpSelectOptionValue]="option"
@@ -1909,7 +1907,14 @@ describe('NgpSelect', () => {
           </div>
         </div>
       `,
-      imports: [NgpSelect, NgpSelectDropdown, NgpSelectInput, NgpSelectOption, NgpSelectPortal],
+      imports: [
+        NgpSelect,
+        NgpSelectDropdown,
+        NgpSelectInput,
+        NgpSelectList,
+        NgpSelectOption,
+        NgpSelectPortal,
+      ],
       styles: `
         .options-container {
           max-height: 200px;
@@ -2037,6 +2042,30 @@ describe('NgpSelect', () => {
 
       await waitFor(() => {
         expect(select).toHaveAttribute('role', 'combobox');
+      });
+    });
+
+    describe('ARIA roles with ngpSelectList', () => {
+      it('should give dropdown role=dialog when ngpSelectList is present', async () => {
+        await render(TestSelectInputComponent);
+        const select = screen.getByTestId('select-with-input');
+
+        fireEvent.click(select);
+
+        await waitFor(() => {
+          expect(screen.getByTestId('dropdown')).toHaveAttribute('role', 'dialog');
+        });
+      });
+
+      it('should give ngpSelectList element role=listbox', async () => {
+        await render(TestSelectInputComponent);
+        const select = screen.getByTestId('select-with-input');
+
+        fireEvent.click(select);
+
+        await waitFor(() => {
+          expect(screen.getByTestId('options-list')).toHaveAttribute('role', 'listbox');
+        });
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?


- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:


## Issue

Closes #694 

## What does this PR implement/fix?

Adds NgpSelectInput (input[ngpSelectInput]), a search input directive for the select primitive. Consumers place it inside the dropdown or the trigger to filter options by typing. Filtering is consumer-driven, no matching logic in the primitive.


https://github.com/user-attachments/assets/4dd39d00-c216-4177-bae0-36543b333e2f


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `NgpSelectInput` and `NgpSelectList` to `ng-primitives/select` to make Select searchable with correct ARIA. The input takes focus and the combobox role; when a list is present the dropdown becomes a dialog that wraps the input and the listbox.

- **New Features**
  - Added `input[ngpSelectInput]` with combobox semantics. Focuses on open; Arrow keys navigate; Enter selects; Escape closes; Home/End move the caret. Dev-only errors enforce placement inside `ngpSelectDropdown` and require an `ngpSelectList`.
  - Added `[ngpSelectList]` (`role="listbox"`) to wrap options. With it, `ngpSelectDropdown` uses `role="dialog"`. When an input is present the trigger drops combobox ARIA and `tabindex`; without an input, the trigger’s `aria-controls` points to the list.

- **Bug Fixes**
  - ArrowUp on a closed select opens with the last option active; no scroll is issued when nothing can be activated; scrolling now accounts for scaled containers so activated options are fully visible.
  - Tightened ARIA: trigger never references a dialog; `aria-haspopup` removed; `aria-activedescendant` is only set while open.
  - Simplified input key handling and focus: removed unreachable open paths; the input only exists while open and receives focus on open.
  - Improved example labeling and docs on naming the dropdown and list; expanded tests for input keyboard/ARIA and scrolling behavior.

<sup>Written for commit f03ee274149d6b0b489b9cc9a193b8c711d24195. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added searchable select support with filtering, empty states, selection display and keyboard navigation.
  * Added configurable select input and list components with focus management and accessible combobox, listbox and dialog behaviour.
  * Added search reset on close and improved interaction handling.

* **Bug Fixes**
  * Improved option activation and scrolling behaviour.

* **Documentation**
  * Added searchable select examples, API references and accessibility guidance, including keyboard semantics.

* **Tests**
  * Added coverage for focus, selection, searching, roles and accessible interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->