### PR TITLE
feat(tooltip): migrate tooltip state

### DIFF
--- a/packages/ng-primitives/tooltip/src/index.ts
+++ b/packages/ng-primitives/tooltip/src/index.ts
@@ -23,3 +23,11 @@ export {
   type NgpTooltipState,
   type NgpTooltipProps,
 } from './tooltip/tooltip-state';
+export {
+  NgpTooltipTextContentStateToken,
+  ngpTooltipTextContent,
+  injectTooltipTextContentState,
+  provideTooltipTextContentState,
+  type NgpTooltipTextContentState,
+  type NgpTooltipTextContentProps,
+} from './tooltip-text-content/tooltip-text-content-state';

--- a/packages/ng-primitives/tooltip/src/index.ts
+++ b/packages/ng-primitives/tooltip/src/index.ts
@@ -9,11 +9,7 @@ export {
   ngpTooltipArrow,
   provideTooltipArrowState,
 } from './tooltip-arrow/tooltip-arrow-state';
-export { NgpTooltipTrigger, type NgpTooltipPlacement } from './tooltip-trigger/tooltip-trigger';
-export {
-  injectTooltipTriggerState,
-  provideTooltipTriggerState,
-} from './tooltip-trigger/tooltip-trigger-state';
+export { NgpTooltipTrigger } from './tooltip-trigger/tooltip-trigger';
 export { NgpTooltip } from './tooltip/tooltip';
 export {
   NgpTooltipStateToken,
@@ -31,3 +27,12 @@ export {
   type NgpTooltipTextContentState,
   type NgpTooltipTextContentProps,
 } from './tooltip-text-content/tooltip-text-content-state';
+export {
+  NgpTooltipTriggerStateToken,
+  ngpTooltipTrigger,
+  injectTooltipTriggerState,
+  provideTooltipTriggerState,
+  type NgpTooltipTriggerState,
+  type NgpTooltipTriggerProps,
+  type NgpTooltipPlacement,
+} from './tooltip-trigger/tooltip-trigger-state';

--- a/packages/ng-primitives/tooltip/src/index.ts
+++ b/packages/ng-primitives/tooltip/src/index.ts
@@ -15,3 +15,11 @@ export {
   provideTooltipTriggerState,
 } from './tooltip-trigger/tooltip-trigger-state';
 export { NgpTooltip } from './tooltip/tooltip';
+export {
+  NgpTooltipStateToken,
+  ngpTooltip,
+  injectTooltipState,
+  provideTooltipState,
+  type NgpTooltipState,
+  type NgpTooltipProps,
+} from './tooltip/tooltip-state';

--- a/packages/ng-primitives/tooltip/src/tooltip-arrow/tooltip-arrow.test.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-arrow/tooltip-arrow.test.ts
@@ -1,0 +1,62 @@
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpTooltip, NgpTooltipArrow, NgpTooltipTrigger } from 'ng-primitives/tooltip';
+import { afterEach, describe, expect, it } from 'vitest';
+
+describe('NgpTooltipArrow', () => {
+  afterEach(() => {
+    // Overlay content is attached to the document body, not the fixture, so remove
+    // any leftover tooltips between tests.
+    document.querySelectorAll('[ngpTooltip]').forEach(el => el.remove());
+  });
+
+  it('should render the arrow inside the tooltip with a data-placement attribute', async () => {
+    const { getByRole } = await render(
+      `
+        <button [ngpTooltipTrigger]="content" ngpTooltipTriggerShowDelay="0"></button>
+
+        <ng-template #content>
+          <div ngpTooltip>
+            Tooltip content
+            <div ngpTooltipArrow></div>
+          </div>
+        </ng-template>
+      `,
+      {
+        imports: [NgpTooltipTrigger, NgpTooltip, NgpTooltipArrow],
+      },
+    );
+
+    fireEvent.mouseEnter(getByRole('button'));
+
+    // Once positioning settles the arrow reflects the resolved placement.
+    await waitFor(() => {
+      const arrow = document.querySelector('[ngpTooltipArrow]');
+      expect(arrow).toBeInTheDocument();
+      expect(arrow).toHaveAttribute('data-placement');
+    });
+  });
+
+  it('should accept the padding input', async () => {
+    const { getByRole } = await render(
+      `
+        <button [ngpTooltipTrigger]="content" ngpTooltipTriggerShowDelay="0"></button>
+
+        <ng-template #content>
+          <div ngpTooltip>
+            Tooltip content
+            <div ngpTooltipArrow ngpTooltipArrowPadding="8"></div>
+          </div>
+        </ng-template>
+      `,
+      {
+        imports: [NgpTooltipTrigger, NgpTooltip, NgpTooltipArrow],
+      },
+    );
+
+    fireEvent.mouseEnter(getByRole('button'));
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpTooltipArrow]')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ng-primitives/tooltip/src/tooltip-arrow/tooltip-arrow.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-arrow/tooltip-arrow.ts
@@ -17,7 +17,7 @@ export class NgpTooltipArrow {
     transform: numberAttribute,
   });
 
-  private readonly state = ngpTooltipArrow({ padding: this.padding });
+  protected readonly state = ngpTooltipArrow({ padding: this.padding });
 
   /**
    * Set the padding between the arrow and the edges of the tooltip.

--- a/packages/ng-primitives/tooltip/src/tooltip-text-content/tooltip-text-content-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-text-content/tooltip-text-content-state.ts
@@ -1,0 +1,28 @@
+import { ElementRef, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { injectOverlayContext } from 'ng-primitives/portal';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+
+export interface NgpTooltipTextContentState {
+  /** Access the component's context. */
+  readonly elementRef: ElementRef;
+  /** The string content to display. */
+  readonly content: Signal<unknown>;
+}
+
+export interface NgpTooltipTextContentProps {}
+
+export const [
+  NgpTooltipTextContentStateToken,
+  ngpTooltipTextContent,
+  injectTooltipTextContentState,
+  provideTooltipTextContentState,
+] = createPrimitive('NgpTooltipTextContent', ({}: NgpTooltipTextContentProps) => {
+  const elementRef = injectElementRef();
+  const content = injectOverlayContext();
+
+  // Host bindings
+  attrBinding(elementRef, 'ngpTooltip', '');
+
+  return { elementRef, content } satisfies NgpTooltipTextContentState;
+});

--- a/packages/ng-primitives/tooltip/src/tooltip-text-content/tooltip-text-content.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-text-content/tooltip-text-content.ts
@@ -1,13 +1,13 @@
 import { Component } from '@angular/core';
-import { injectOverlayContext } from 'ng-primitives/portal';
 import { NgpTooltip } from '../tooltip/tooltip';
+import { ngpTooltipTextContent } from './tooltip-text-content-state';
 
 /**
  * Internal component for wrapping string content in tooltip portals
  * @internal
  */
 @Component({
-  template: '{{ content() }}',
+  template: '{{ state.content() }}',
   hostDirectives: [NgpTooltip],
   host: {
     // Used only for styling, since the host directive isn’t added to the DOM.
@@ -16,8 +16,5 @@ import { NgpTooltip } from '../tooltip/tooltip';
   },
 })
 export class NgpTooltipTextContentComponent {
-  /**
-   * The string content to display
-   */
-  readonly content = injectOverlayContext();
+  protected readonly state = ngpTooltipTextContent({});
 }

--- a/packages/ng-primitives/tooltip/src/tooltip-text-content/tooltip-text-content.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-text-content/tooltip-text-content.ts
@@ -9,11 +9,6 @@ import { ngpTooltipTextContent } from './tooltip-text-content-state';
 @Component({
   template: '{{ state.content() }}',
   hostDirectives: [NgpTooltip],
-  host: {
-    // Used only for styling, since the host directive isn’t added to the DOM.
-    // This acts as the styling entry point.
-    ngpTooltip: '',
-  },
 })
 export class NgpTooltipTextContentComponent {
   protected readonly state = ngpTooltipTextContent({});

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
@@ -1,30 +1,660 @@
 import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
+  signal,
+  Signal,
+  WritableSignal,
+  Injector,
+  inject,
+  ViewContainerRef,
+  computed,
+  ElementRef,
+} from '@angular/core';
+import { injectElementRef, setupOverflowListener } from 'ng-primitives/internal';
+import {
+  createOverlay,
+  NgpFlip,
+  NgpOffset,
+  NgpOverlay,
+  NgpOverlayConfig,
+  NgpOverlayContent,
+  NgpPosition,
+  NgpShift,
+} from 'ng-primitives/portal';
+import {
+  attrBinding,
+  controlled,
+  createPrimitive,
+  dataBinding,
+  listener,
+  onDestroy,
+  StateInjectionOptions,
 } from 'ng-primitives/state';
-import type { NgpTooltipTrigger } from './tooltip-trigger';
+import { injectDisposables, isString } from 'ng-primitives/utils';
+import { NgpTooltipTextContentComponent } from '../tooltip-text-content/tooltip-text-content';
+import {
+  createTooltipHoverBridgePolygon,
+  isPointInHoverBridgePolygon,
+  TooltipHoverBridgePoint,
+} from './tooltip-hover-bridge';
 
-/**
- * The state token  for the TooltipTrigger primitive.
- */
-export const NgpTooltipTriggerStateToken =
-  createStateToken<NgpTooltipTrigger<unknown>>('TooltipTrigger');
+export interface NgpTooltipTriggerState<T> {
+  /** Access the tooltip template ref. */
+  readonly tooltip: WritableSignal<NgpOverlayContent<T> | string | null>;
+  /**
+   * Define if the trigger should be disabled. This will prevent the tooltip from being shown or hidden from interactions.
+   * @default false
+   */
+  readonly disabled: Signal<boolean>;
+  /**
+   * Define the placement of the tooltip relative to the trigger.
+   * @default 'top'
+   */
+  readonly placement: Signal<NgpTooltipPlacement>;
+  /**
+   * Define the offset of the tooltip relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
+   * @default 0
+   */
+  readonly offset: Signal<NgpOffset>;
+  /**
+   * Define the delay before the tooltip is displayed.
+   * @default 500
+   */
+  readonly showDelay: Signal<number>;
+  /**
+   * Define the delay before the tooltip is hidden.
+   * @default 0
+   */
+  readonly hideDelay: Signal<number>;
+  /**
+   * Define whether the tooltip should flip when there is not enough space for the tooltip.
+   * Can be a boolean to enable/disable, or an object with padding and fallbackPlacements options.
+   * @default true
+   */
+  readonly flip: Signal<NgpFlip>;
+  /**
+   * Configure shift behavior to keep the tooltip in view.
+   * Can be a boolean to enable/disable, or an object with padding and limiter options.
+   * @default undefined (enabled by default in overlay)
+   */
+  readonly shift: Signal<NgpShift>;
+  /**
+   * Define the container in which the tooltip should be attached.
+   * @default document.body
+   */
+  readonly container: Signal<HTMLElement | string | null>;
+  /**
+   * Define whether the tooltip should only show when the trigger element overflows.
+   * @default false
+   */
+  readonly showOnOverflow: Signal<boolean>;
+  /**
+   * Define an anchor element for positioning the tooltip.
+   * If provided, the tooltip will be positioned relative to this element instead of the trigger.
+   */
+  readonly anchor: Signal<HTMLElement | null>;
+  /**
+   * Provide context to the tooltip. This can be used to pass data to the tooltip content.
+   */
+  readonly context: Signal<T | undefined>;
+  /**
+   * Define whether to use the text content of the trigger element as the tooltip content.
+   * When enabled, the tooltip will display the text content of the trigger element.
+   * @default true
+   */
+  readonly useTextContent: Signal<boolean>;
+  /**
+   * Define whether to track the trigger element position on every animation frame.
+   * Useful for moving elements like slider thumbs.
+   * @default false
+   */
+  readonly trackPosition: Signal<boolean>;
+  /**
+   * Programmatic position for the tooltip. When provided, the tooltip
+   * will be positioned at these coordinates instead of the trigger element.
+   * Use with trackPosition="true" for smooth cursor following.
+   */
+  readonly position: Signal<NgpPosition | null>;
+  /**
+   * Defines how the tooltip behaves when the window is scrolled.
+   * @default 'reposition'
+   */
+  readonly scrollBehavior: Signal<'reposition' | 'close'>;
+  /**
+   * Define the cooldown duration in milliseconds.
+   * When moving from one tooltip to another within this duration,
+   * the showDelay is skipped for the new tooltip.
+   * @default 300
+   */
+  readonly cooldown: Signal<number>;
+  /**
+   * Whether hovering tooltip content keeps the tooltip open.
+   * @default false
+   */
+  readonly hoverableContent: Signal<boolean>;
+  /**
+   * The overlay that manages the tooltip
+   * @internal
+   */
+  readonly overlay: WritableSignal<NgpOverlay<T | string> | null>;
+  /**
+   * The unique id of the tooltip.
+   */
+  readonly tooltipId: Signal<string | undefined>;
+  /**
+   * The open state of the tooltip.
+   * @internal
+   */
+  readonly open: Signal<boolean>;
+  /**
+   * Determine if the trigger element has overflow.
+   */
+  readonly hasOverflow: Signal<boolean>;
+  /**
+   * Tracks whether pointer is currently over tooltip content.
+   */
+  readonly contentHovered: Signal<boolean>;
+  /**
+   * Current pointer grace polygon used while crossing trigger -> tooltip.
+   */
+  readonly hoverBridgePolygon: Signal<TooltipHoverBridgePoint[] | null>;
+  /**
+   * Show the tooltip programmatically (skips cooldown so multiple tooltips can coexist).
+   */
+  show: () => void;
+  /**
+   * Hide the tooltip.
+   */
+  hide: () => void;
+  /**
+   * Set the tooltip id.
+   */
+  setTooltipId: (id: string) => void;
+  /**
+   * Called by tooltip content when pointer enters the tooltip.
+   * @internal
+   */
+  onTooltipHoverStart: () => void;
+  /**
+   * Called by tooltip content when pointer leaves the tooltip.
+   * @internal
+   */
+  onTooltipHoverEnd: () => void;
+  destroy: () => void;
+}
 
-/**
- * Provides the TooltipTrigger state.
- */
-export const provideTooltipTriggerState = createStateProvider(NgpTooltipTriggerStateToken);
+export interface NgpTooltipTriggerProps<T> {
+  /** Access the tooltip template ref. */
+  readonly tooltip: Signal<NgpOverlayContent<T> | string | null>;
+  /**
+   * Define if the trigger should be disabled. This will prevent the tooltip from being shown or hidden from interactions.
+   * @default false
+   */
+  readonly disabled: Signal<boolean>;
+  /**
+   * Define the placement of the tooltip relative to the trigger.
+   * @default 'top'
+   */
+  readonly placement: Signal<NgpTooltipPlacement>;
+  /**
+   * Define the offset of the tooltip relative to the trigger.
+   * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
+   * @default 0
+   */
+  readonly offset: Signal<NgpOffset>;
+  /**
+   * Define the delay before the tooltip is displayed.
+   * @default 500
+   */
+  readonly showDelay: Signal<number>;
+  /**
+   * Define the delay before the tooltip is hidden.
+   * @default 0
+   */
+  readonly hideDelay: Signal<number>;
+  /**
+   * Define whether the tooltip should flip when there is not enough space for the tooltip.
+   * Can be a boolean to enable/disable, or an object with padding and fallbackPlacements options.
+   * @default true
+   */
+  readonly flip: Signal<NgpFlip>;
+  /**
+   * Configure shift behavior to keep the tooltip in view.
+   * Can be a boolean to enable/disable, or an object with padding and limiter options.
+   * @default undefined (enabled by default in overlay)
+   */
+  readonly shift: Signal<NgpShift>;
+  /**
+   * Define the container in which the tooltip should be attached.
+   * @default document.body
+   */
+  readonly container: Signal<HTMLElement | string | null>;
+  /**
+   * Define whether the tooltip should only show when the trigger element overflows.
+   * @default false
+   */
+  readonly showOnOverflow: Signal<boolean>;
+  /**
+   * Define an anchor element for positioning the tooltip.
+   * If provided, the tooltip will be positioned relative to this element instead of the trigger.
+   */
+  readonly anchor: Signal<HTMLElement | null>;
+  /**
+   * Provide context to the tooltip. This can be used to pass data to the tooltip content.
+   */
+  readonly context: Signal<T | undefined>;
+  /**
+   * Define whether to use the text content of the trigger element as the tooltip content.
+   * When enabled, the tooltip will display the text content of the trigger element.
+   * @default true
+   */
+  readonly useTextContent: Signal<boolean>;
+  /**
+   * Define whether to track the trigger element position on every animation frame.
+   * Useful for moving elements like slider thumbs.
+   * @default false
+   */
+  readonly trackPosition: Signal<boolean>;
+  /**
+   * Programmatic position for the tooltip. When provided, the tooltip
+   * will be positioned at these coordinates instead of the trigger element.
+   * Use with trackPosition="true" for smooth cursor following.
+   */
+  readonly position: Signal<NgpPosition | null>;
+  /**
+   * Defines how the tooltip behaves when the window is scrolled.
+   * @default 'reposition'
+   */
+  readonly scrollBehavior: Signal<'reposition' | 'close'>;
+  /**
+   * Define the cooldown duration in milliseconds.
+   * When moving from one tooltip to another within this duration,
+   * the showDelay is skipped for the new tooltip.
+   * @default 300
+   */
+  readonly cooldown: Signal<number>;
+  /**
+   * Whether hovering tooltip content keeps the tooltip open.
+   * @default false
+   */
+  readonly hoverableContent: Signal<boolean>;
+}
 
-/**
- * Injects the TooltipTrigger state.
- */
-export const injectTooltipTriggerState = createStateInjector<NgpTooltipTrigger<unknown>>(
+export const [
   NgpTooltipTriggerStateToken,
+  ngpTooltipTrigger,
+  _injectTooltipTriggerState,
+  provideTooltipTriggerState,
+] = createPrimitive(
+  'NgpTooltipTrigger',
+  <T>({
+    tooltip: _tooltip = signal<NgpOverlayContent<T> | string | null>(null),
+    disabled = signal<boolean>(false),
+    placement = signal<NgpTooltipPlacement>('top'),
+    offset = signal<NgpOffset>(0),
+    showDelay = signal<number>(500),
+    hideDelay = signal<number>(0),
+    flip = signal<NgpFlip>(true),
+    shift = signal<NgpShift | undefined>(undefined),
+    container = signal<HTMLElement | string | null>('body'),
+    showOnOverflow = signal<boolean>(false),
+    anchor = signal<HTMLElement | null>(null),
+    context = signal<T | undefined>(undefined),
+    useTextContent = signal<boolean>(true),
+    trackPosition = signal<boolean>(false),
+    position = signal<NgpPosition | null>(null),
+    scrollBehavior = signal<'reposition' | 'close'>('reposition'),
+    cooldown = signal<number>(300),
+    hoverableContent = signal<boolean>(false),
+  }: NgpTooltipTriggerProps<T>) => {
+    const HOVER_BRIDGE_TIMEOUT_MS = 150;
+    const elementRef = injectElementRef();
+    const injector = inject(Injector);
+    const viewContainerRef = inject(ViewContainerRef);
+    const trigger = inject(ElementRef<HTMLElement>);
+    const tooltipTriggerState = injectTooltipTriggerState<T>();
+    const disposables = injectDisposables();
+
+    const tooltip = controlled(_tooltip);
+
+    const tooltipId = signal<string | undefined>(undefined);
+    const triggerHovered = signal<boolean>(false);
+    const contentHovered = signal<boolean>(false);
+    const hoverBridgePolygon = signal<TooltipHoverBridgePoint[] | null>(null);
+    const overlay = signal<NgpOverlay<T | string> | null>(null);
+    const hasOverflow = setupOverflowListener(trigger.nativeElement, {
+      disabled: computed(() => !showOnOverflow()),
+    });
+
+    let removePointerMoveListener: (() => void) | undefined = undefined;
+    let clearHoverBridgeTimeout: (() => void) | undefined = undefined;
+
+    const open = computed(() => overlay()?.isOpen() ?? false);
+
+    // Host binding
+    attrBinding(elementRef, 'aria-describedby', () => overlay()?.ariaDescribedBy());
+    dataBinding(elementRef, 'data-open', () => (open() ? '' : null));
+    dataBinding(elementRef, 'data-disabled', () => (disabled() ? '' : null));
+
+    // Listeners
+    listener(elementRef, 'mouseenter', showFromInteraction);
+    listener(elementRef, 'focus', showFromInteraction);
+    listener(elementRef, 'mouseleave', hideFromInteraction);
+    listener(elementRef, 'blur', () => hideFromInteraction());
+
+    function destroy(): void {
+      clearHoverBridge();
+      overlay()?.destroy();
+    }
+
+    function show(): void {
+      performShow(true);
+    }
+
+    function hide(): void {
+      clearHoverBridge();
+      overlay()?.hide();
+    }
+
+    /**
+     * Show the tooltip from an interaction (respects disabled state, uses cooldown).
+     * @internal
+     */
+    function showFromInteraction(): void {
+      if (tooltipTriggerState().disabled()) {
+        return;
+      }
+      triggerHovered.set(true);
+      clearHoverBridge();
+      performShow(false);
+    }
+
+    /**
+     * Shared show logic.
+     * @param skipCooldown When true, skip cooldown registration so multiple tooltips can coexist.
+     */
+    function performShow(skipCooldown: boolean): void {
+      // If already open, cancel any pending close
+      if (open()) {
+        overlay()?.cancelPendingClose();
+        return;
+      }
+
+      // if we should only show when there is overflow, check if the trigger has overflow
+      if (tooltipTriggerState().showOnOverflow() && !hasOverflow()) {
+        return;
+      }
+
+      // Create the overlay if it doesn't exist yet
+      if (!overlay()) {
+        createOverlayInstance();
+      }
+
+      overlay()?.show({ skipCooldown });
+    }
+
+    function setTooltipId(id: string): void {
+      tooltipId.set(id);
+    }
+
+    /**
+     * Hide the tooltip from an interaction (respects disabled state).
+     * @internal
+     */
+    function hideFromInteraction(event?: MouseEvent): void {
+      if (tooltipTriggerState().disabled()) {
+        return;
+      }
+
+      triggerHovered.set(false);
+
+      // Blur should close regardless of hover bridge or tooltip hover state.
+      if (!event) {
+        contentHovered.set(false);
+        clearHoverBridge();
+        hide();
+        return;
+      }
+
+      if (!tooltipTriggerState().hoverableContent()) {
+        hide();
+        return;
+      }
+
+      const tooltipElement = overlay()?.getElements()[0];
+      if (!tooltipElement) {
+        hide();
+        return;
+      }
+
+      const polygon = createTooltipHoverBridgePolygon({
+        triggerRect: trigger.nativeElement.getBoundingClientRect(),
+        tooltipRect: tooltipElement.getBoundingClientRect(),
+        exitPoint: { x: event.clientX, y: event.clientY },
+      });
+
+      if (!polygon) {
+        hide();
+        return;
+      }
+
+      hoverBridgePolygon.set(polygon);
+      overlay()?.cancelPendingClose();
+      registerPointerMoveListener();
+      scheduleHoverBridgeCloseFallback();
+    }
+
+    /**
+     * Called by tooltip content when pointer enters the tooltip.
+     * @internal
+     */
+    function onTooltipHoverStart(): void {
+      if (tooltipTriggerState().disabled() || !tooltipTriggerState().hoverableContent()) {
+        return;
+      }
+
+      contentHovered.set(true);
+      clearHoverBridge();
+      overlay()?.cancelPendingClose();
+    }
+
+    /**
+     * Called by tooltip content when pointer leaves the tooltip.
+     * @internal
+     */
+    function onTooltipHoverEnd(): void {
+      if (tooltipTriggerState().disabled() || !tooltipTriggerState().hoverableContent()) {
+        return;
+      }
+
+      contentHovered.set(false);
+
+      if (!triggerHovered()) {
+        hide();
+      }
+    }
+
+    /**
+     * Create the overlay that will contain the tooltip
+     */
+    function createOverlayInstance(): void {
+      // Determine the content and context based on useTextContent setting
+      const shouldUseTextContent = tooltipTriggerState().useTextContent();
+      let content = tooltip();
+      let context: Signal<T | string | undefined> = tooltipTriggerState().context;
+
+      if (!content) {
+        if (!shouldUseTextContent) {
+          if (ngDevMode) {
+            console.error(
+              '[ngpTooltipTrigger]: Tooltip must be a string, TemplateRef, or ComponentType. Alternatively, set useTextContent to true if none is provided.',
+            );
+          }
+
+          return;
+        }
+
+        const textContent = trigger.nativeElement.textContent?.trim() || '';
+        if (ngDevMode && !textContent) {
+          console.warn(
+            '[ngpTooltipTrigger]: useTextContent is enabled but trigger element has no text content',
+          );
+          return;
+        }
+        content = NgpTooltipTextContentComponent;
+        context = signal(textContent);
+      } else if (isString(content)) {
+        context = signal(content);
+        content = NgpTooltipTextContentComponent;
+      }
+
+      // Create config for the overlay
+      const config: NgpOverlayConfig<T | string> = {
+        content,
+        triggerElement: trigger.nativeElement,
+        anchorElement: anchor(),
+        injector: injector,
+        context,
+        container: container(),
+        placement: placement,
+        offset: offset(),
+        flip: flip(),
+        shift: shift(),
+        showDelay: showDelay(),
+        hideDelay: hideDelay(),
+        closeOnEscape: true,
+        closeOnOutsideClick: true,
+        viewContainerRef: viewContainerRef,
+        trackPosition: trackPosition(),
+        position: position,
+        scrollBehaviour: scrollBehavior(),
+        overlayType: 'tooltip',
+        cooldown: cooldown(),
+      };
+
+      // Create the overlay instance
+      overlay.set(createOverlay(config));
+    }
+
+    /**
+     * Register document-level pointer tracking while crossing trigger -> tooltip.
+     * @internal
+     */
+    function registerPointerMoveListener(): void {
+      if (removePointerMoveListener) {
+        return;
+      }
+
+      const cleanup = disposables.addEventListener(
+        document,
+        'pointermove' as keyof HTMLElementEventMap,
+        ((event: PointerEvent): void => {
+          if (triggerHovered() || contentHovered() || !hoverBridgePolygon()) {
+            clearHoverBridge();
+            return;
+          }
+
+          const inBridge = isPointInHoverBridgePolygon(
+            { x: event.clientX, y: event.clientY },
+            hoverBridgePolygon()!,
+          );
+
+          if (!inBridge) {
+            clearHoverBridge();
+            hide();
+          }
+        }) as EventListener,
+        true,
+      );
+
+      removePointerMoveListener = () => {
+        cleanup();
+        removePointerMoveListener = undefined;
+      };
+    }
+
+    /**
+     * Clear hover bridge state and global listeners.
+     * @internal
+     */
+    function clearHoverBridge(): void {
+      hoverBridgePolygon.set(null);
+      clearHoverBridgeTimeout?.();
+      clearHoverBridgeTimeout = undefined;
+      removePointerMoveListener?.();
+    }
+
+    /**
+     * Close if pointer leaves trigger and does not move into tooltip soon enough.
+     * @internal
+     */
+    function scheduleHoverBridgeCloseFallback(): void {
+      clearHoverBridgeTimeout?.();
+
+      clearHoverBridgeTimeout = disposables.setTimeout(() => {
+        clearHoverBridgeTimeout = undefined;
+
+        if (!triggerHovered() && !contentHovered() && hoverBridgePolygon()) {
+          clearHoverBridge();
+          hide();
+        }
+      }, HOVER_BRIDGE_TIMEOUT_MS);
+    }
+
+    const state = {
+      tooltip,
+      disabled,
+      placement,
+      offset,
+      showDelay,
+      hideDelay,
+      flip,
+      shift,
+      container,
+      showOnOverflow,
+      anchor,
+      context,
+      useTextContent,
+      trackPosition,
+      position,
+      scrollBehavior,
+      cooldown,
+      hoverableContent,
+      overlay,
+      tooltipId,
+      open,
+      hasOverflow,
+      contentHovered,
+      hoverBridgePolygon,
+      show,
+      hide,
+      setTooltipId,
+      onTooltipHoverStart,
+      onTooltipHoverEnd,
+      destroy,
+    } satisfies NgpTooltipTriggerState<T>;
+
+    onDestroy(destroy);
+
+    return state;
+  },
 );
 
-/**
- * The TooltipTrigger state registration function.
- */
-export const tooltipTriggerState = createState(NgpTooltipTriggerStateToken);
+export function injectTooltipTriggerState<T>(
+  options?: StateInjectionOptions,
+): Signal<NgpTooltipTriggerState<T>> {
+  return _injectTooltipTriggerState(options) as Signal<NgpTooltipTriggerState<T>>;
+}
+
+export type NgpTooltipPlacement =
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left'
+  | 'top-start'
+  | 'top-end'
+  | 'right-start'
+  | 'right-end'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left-start'
+  | 'left-end';

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
@@ -25,7 +25,6 @@ import {
   createPrimitive,
   dataBinding,
   listener,
-  onDestroy,
   StateInjectionOptions,
 } from 'ng-primitives/state';
 import { injectDisposables, isString } from 'ng-primitives/utils';
@@ -184,99 +183,99 @@ export interface NgpTooltipTriggerState<T> {
 
 export interface NgpTooltipTriggerProps<T> {
   /** Access the tooltip template ref. */
-  readonly tooltip: Signal<NgpOverlayContent<T> | string | null>;
+  readonly tooltip?: Signal<NgpOverlayContent<T> | string | null>;
   /**
    * Define if the trigger should be disabled. This will prevent the tooltip from being shown or hidden from interactions.
    * @default false
    */
-  readonly disabled: Signal<boolean>;
+  readonly disabled?: Signal<boolean>;
   /**
    * Define the placement of the tooltip relative to the trigger.
    * @default 'top'
    */
-  readonly placement: Signal<NgpTooltipPlacement>;
+  readonly placement?: Signal<NgpTooltipPlacement>;
   /**
    * Define the offset of the tooltip relative to the trigger.
    * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
    * @default 0
    */
-  readonly offset: Signal<NgpOffset>;
+  readonly offset?: Signal<NgpOffset>;
   /**
    * Define the delay before the tooltip is displayed.
    * @default 500
    */
-  readonly showDelay: Signal<number>;
+  readonly showDelay?: Signal<number>;
   /**
    * Define the delay before the tooltip is hidden.
    * @default 0
    */
-  readonly hideDelay: Signal<number>;
+  readonly hideDelay?: Signal<number>;
   /**
    * Define whether the tooltip should flip when there is not enough space for the tooltip.
    * Can be a boolean to enable/disable, or an object with padding and fallbackPlacements options.
    * @default true
    */
-  readonly flip: Signal<NgpFlip>;
+  readonly flip?: Signal<NgpFlip>;
   /**
    * Configure shift behavior to keep the tooltip in view.
    * Can be a boolean to enable/disable, or an object with padding and limiter options.
    * @default undefined (enabled by default in overlay)
    */
-  readonly shift: Signal<NgpShift>;
+  readonly shift?: Signal<NgpShift>;
   /**
    * Define the container in which the tooltip should be attached.
    * @default document.body
    */
-  readonly container: Signal<HTMLElement | string | null>;
+  readonly container?: Signal<HTMLElement | string | null>;
   /**
    * Define whether the tooltip should only show when the trigger element overflows.
    * @default false
    */
-  readonly showOnOverflow: Signal<boolean>;
+  readonly showOnOverflow?: Signal<boolean>;
   /**
    * Define an anchor element for positioning the tooltip.
    * If provided, the tooltip will be positioned relative to this element instead of the trigger.
    */
-  readonly anchor: Signal<HTMLElement | null>;
+  readonly anchor?: Signal<HTMLElement | null>;
   /**
    * Provide context to the tooltip. This can be used to pass data to the tooltip content.
    */
-  readonly context: Signal<T | undefined>;
+  readonly context?: Signal<T | undefined>;
   /**
    * Define whether to use the text content of the trigger element as the tooltip content.
    * When enabled, the tooltip will display the text content of the trigger element.
    * @default true
    */
-  readonly useTextContent: Signal<boolean>;
+  readonly useTextContent?: Signal<boolean>;
   /**
    * Define whether to track the trigger element position on every animation frame.
    * Useful for moving elements like slider thumbs.
    * @default false
    */
-  readonly trackPosition: Signal<boolean>;
+  readonly trackPosition?: Signal<boolean>;
   /**
    * Programmatic position for the tooltip. When provided, the tooltip
    * will be positioned at these coordinates instead of the trigger element.
    * Use with trackPosition="true" for smooth cursor following.
    */
-  readonly position: Signal<NgpPosition | null>;
+  readonly position?: Signal<NgpPosition | null>;
   /**
    * Defines how the tooltip behaves when the window is scrolled.
    * @default 'reposition'
    */
-  readonly scrollBehavior: Signal<'reposition' | 'close'>;
+  readonly scrollBehavior?: Signal<'reposition' | 'close'>;
   /**
    * Define the cooldown duration in milliseconds.
    * When moving from one tooltip to another within this duration,
    * the showDelay is skipped for the new tooltip.
    * @default 300
    */
-  readonly cooldown: Signal<number>;
+  readonly cooldown?: Signal<number>;
   /**
    * Whether hovering tooltip content keeps the tooltip open.
    * @default false
    */
-  readonly hoverableContent: Signal<boolean>;
+  readonly hoverableContent?: Signal<boolean>;
 }
 
 export const [
@@ -632,8 +631,6 @@ export const [
       onTooltipHoverEnd,
       destroy,
     } satisfies NgpTooltipTriggerState<T>;
-
-    onDestroy(destroy);
 
     return state;
   },

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.test.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.test.ts
@@ -6,6 +6,7 @@ describe('NgpTooltipTrigger', () => {
   afterEach(() => {
     // Clean up any remaining tooltips from DOM between tests
     document.querySelectorAll('[ngpTooltip]').forEach(el => el.remove());
+    vi.useRealTimers();
   });
 
   it('should destroy the overlay when the trigger is destroyed', async () => {
@@ -60,6 +61,61 @@ describe('NgpTooltipTrigger', () => {
       const tooltip = document.querySelector('[ngpTooltip]');
       expect(tooltip).toBeInTheDocument();
       expect(tooltip?.getAttribute('data-placement')).toBeTruthy();
+    });
+  });
+
+  describe('id / aria-describedby', () => {
+    it('should give the tooltip a generated id and link the trigger via aria-describedby', async () => {
+      const { getByRole } = await render(
+        `
+          <button [ngpTooltipTrigger]="content"></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      // The tooltip must have a real, generated id (not empty) and the trigger
+      // must describe it for assistive technology.
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement | null;
+        const id = tooltip?.getAttribute('id');
+        expect(id).toBeTruthy();
+        expect(trigger.getAttribute('aria-describedby')).toBe(id);
+      });
+    });
+
+    it('should use a consumer-provided id over the generated one', async () => {
+      const { getByRole } = await render(
+        `
+          <button [ngpTooltipTrigger]="content"></button>
+
+          <ng-template #content>
+            <div ngpTooltip id="custom-tooltip-id">Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      // A bound id must win over the seeded generated id, and aria-describedby
+      // must follow it.
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement | null;
+        expect(tooltip?.getAttribute('id')).toBe('custom-tooltip-id');
+        expect(trigger.getAttribute('aria-describedby')).toBe('custom-tooltip-id');
+      });
     });
   });
 
@@ -630,6 +686,242 @@ describe('NgpTooltipTrigger', () => {
 
       await waitFor(() => {
         expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('showDelay / hideDelay', () => {
+    it('should wait for showDelay before showing the tooltip', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const { getByRole } = await render(
+        `
+          <button [ngpTooltipTrigger]="content" ngpTooltipTriggerShowDelay="200"></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      fireEvent.mouseEnter(getByRole('button'));
+
+      // Before the delay elapses the tooltip must not be present.
+      vi.advanceTimersByTime(150);
+      expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+
+      // Once the delay passes it appears.
+      vi.advanceTimersByTime(100);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+    });
+
+    it('should wait for hideDelay before hiding the tooltip', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const { getByRole } = await render(
+        `
+          <button
+            [ngpTooltipTrigger]="content"
+            ngpTooltipTriggerShowDelay="0"
+            ngpTooltipTriggerHideDelay="200"
+          ></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      const trigger = getByRole('button');
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+
+      fireEvent.mouseLeave(trigger);
+
+      // Before the hide delay elapses the tooltip is still present.
+      vi.advanceTimersByTime(150);
+      expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+
+      // Once the delay passes it is removed.
+      vi.advanceTimersByTime(100);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('cooldown', () => {
+    it('should show a second tooltip instantly (data-instant) while another tooltip is active', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+
+      const { getByTestId } = await render(
+        `
+          <button data-testid="trigger-a" [ngpTooltipTrigger]="contentA" ngpTooltipTriggerShowDelay="300"></button>
+          <button data-testid="trigger-b" [ngpTooltipTrigger]="contentB" ngpTooltipTriggerShowDelay="300"></button>
+
+          <ng-template #contentA>
+            <div ngpTooltip data-testid="tooltip-a">Tooltip A</div>
+          </ng-template>
+          <ng-template #contentB>
+            <div ngpTooltip data-testid="tooltip-b">Tooltip B</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      // Show the first tooltip, which respects its own 300ms show delay.
+      fireEvent.mouseEnter(getByTestId('trigger-a'));
+      vi.advanceTimersByTime(300);
+      await waitFor(() => {
+        expect(document.querySelector('[data-testid="tooltip-a"]')).toBeInTheDocument();
+      });
+
+      // With a tooltip already active, hovering the second trigger shows it
+      // instantly - the 300ms delay is skipped and data-instant is applied.
+      fireEvent.mouseEnter(getByTestId('trigger-b'));
+      vi.advanceTimersByTime(1);
+      await waitFor(() => {
+        const tooltipB = document.querySelector('[data-testid="tooltip-b"]');
+        expect(tooltipB).toBeInTheDocument();
+        expect(tooltipB).toHaveAttribute('data-instant');
+      });
+    });
+  });
+
+  describe('container', () => {
+    it('should attach the tooltip to a custom container when provided', async () => {
+      const { getByRole } = await render(
+        `
+          <div id="tooltip-host"></div>
+
+          <button
+            [ngpTooltipTrigger]="content"
+            ngpTooltipTriggerShowDelay="0"
+            ngpTooltipTriggerContainer="#tooltip-host"
+          ></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      fireEvent.mouseEnter(getByRole('button'));
+
+      await waitFor(() => {
+        const container = document.querySelector('#tooltip-host');
+        expect(container?.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('offset / flip / shift config', () => {
+    it('should accept the offset input', async () => {
+      const { getByRole } = await render(
+        `
+          <button
+            [ngpTooltipTrigger]="content"
+            ngpTooltipTriggerShowDelay="0"
+            ngpTooltipTriggerOffset="8"
+          ></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      fireEvent.mouseEnter(getByRole('button'));
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+    });
+
+    it('should accept the flip input', async () => {
+      const { getByRole } = await render(
+        `
+          <button
+            [ngpTooltipTrigger]="content"
+            ngpTooltipTriggerShowDelay="0"
+            ngpTooltipTriggerFlip="false"
+          ></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      fireEvent.mouseEnter(getByRole('button'));
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+    });
+
+    it('should accept the shift input', async () => {
+      const { getByRole } = await render(
+        `
+          <button
+            [ngpTooltipTrigger]="content"
+            ngpTooltipTriggerShowDelay="0"
+            ngpTooltipTriggerShift="true"
+          ></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      fireEvent.mouseEnter(getByRole('button'));
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('text content styling', () => {
+    it('should apply the ngpTooltip styling attribute to string-content tooltips', async () => {
+      const { getByRole } = await render(`<button ngpTooltipTrigger>Button text</button>`, {
+        imports: [NgpTooltipTrigger, NgpTooltip],
+      });
+
+      fireEvent.mouseEnter(getByRole('button'));
+
+      // String content is wrapped in an internal component whose host carries the
+      // ngpTooltip styling attribute (the consumer's copy-paste styling hook).
+      await waitFor(() => {
+        const tooltip = document.querySelector('[role="tooltip"]');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip).toHaveAttribute('ngpTooltip');
       });
     });
   });

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -1,44 +1,25 @@
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
-import {
-  booleanAttribute,
-  computed,
-  Directive,
-  ElementRef,
-  inject,
-  Injector,
-  input,
-  numberAttribute,
-  OnDestroy,
-  Signal,
-  signal,
-  ViewContainerRef,
-} from '@angular/core';
-import { setupOverflowListener } from 'ng-primitives/internal';
+import { booleanAttribute, Directive, input, numberAttribute, OnDestroy } from '@angular/core';
 import {
   coerceFlip,
   coerceOffset,
   coerceShift,
-  createOverlay,
   NgpFlip,
   NgpFlipInput,
   NgpOffset,
   NgpOffsetInput,
-  NgpOverlay,
-  NgpOverlayConfig,
   NgpOverlayContent,
   NgpPosition,
   NgpShift,
   NgpShiftInput,
 } from 'ng-primitives/portal';
-import { injectDisposables, isString } from 'ng-primitives/utils';
+import { isString } from 'ng-primitives/utils';
 import { injectTooltipConfig } from '../config/tooltip-config';
-import { NgpTooltipTextContentComponent } from '../tooltip-text-content/tooltip-text-content';
 import {
-  createTooltipHoverBridgePolygon,
-  isPointInHoverBridgePolygon,
-  TooltipHoverBridgePoint,
-} from './tooltip-hover-bridge';
-import { provideTooltipTriggerState, tooltipTriggerState } from './tooltip-trigger-state';
+  NgpTooltipPlacement,
+  ngpTooltipTrigger,
+  provideTooltipTriggerState,
+} from './tooltip-trigger-state';
 
 type TooltipInput<T> = NgpOverlayContent<T> | string | null | undefined;
 
@@ -49,46 +30,12 @@ type TooltipInput<T> = NgpOverlayContent<T> | string | null | undefined;
   selector: '[ngpTooltipTrigger]',
   exportAs: 'ngpTooltipTrigger',
   providers: [provideTooltipTriggerState({ inherit: false })],
-  host: {
-    '[attr.data-open]': 'open() ? "" : null',
-    '[attr.data-disabled]': 'state.disabled() ? "" : null',
-    '[attr.aria-describedby]': 'overlay()?.ariaDescribedBy()',
-    '(mouseenter)': 'showFromInteraction()',
-    '(mouseleave)': 'hideFromInteraction($event)',
-    '(focus)': 'showFromInteraction()',
-    '(blur)': 'hideFromInteraction()',
-  },
 })
 export class NgpTooltipTrigger<T = null> implements OnDestroy {
-  /**
-   * Maximum time allowed to cross from trigger to tooltip without pointer movement.
-   */
-  private static readonly HOVER_BRIDGE_TIMEOUT_MS = 150;
-
-  /**
-   * Access the trigger element
-   */
-  private readonly trigger = inject(ElementRef<HTMLElement>);
-
-  /**
-   * Access the injector.
-   */
-  private readonly injector = inject(Injector);
-
-  /**
-   * Access the view container reference.
-   */
-  private readonly viewContainerRef = inject(ViewContainerRef);
-
   /**
    * Access the global tooltip configuration.
    */
   private readonly config = injectTooltipConfig();
-
-  /**
-   * Disposables for managing event listeners and timers with automatic teardown.
-   */
-  private readonly disposables = injectDisposables();
 
   /**
    * Access the tooltip template ref.
@@ -250,167 +197,43 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
     transform: booleanAttribute,
   });
 
-  /**
-   * The overlay that manages the tooltip
-   * @internal
-   */
-  readonly overlay = signal<NgpOverlay<T | string> | null>(null);
-
-  /**
-   * The unique id of the tooltip.
-   */
-  readonly tooltipId = signal<string | undefined>(undefined);
-
-  /**
-   * The open state of the tooltip.
-   * @internal
-   */
-  readonly open = computed(() => this.overlay()?.isOpen() ?? false);
-
-  /**
-   * Determine if the trigger element has overflow.
-   */
-  private readonly hasOverflow: Signal<boolean>;
-
-  /**
-   * Tracks whether pointer is currently over trigger.
-   */
-  private triggerHovered = false;
-
-  /**
-   * Tracks whether pointer is currently over tooltip content.
-   */
-  private contentHovered = false;
-
-  /**
-   * Current pointer grace polygon used while crossing trigger -> tooltip.
-   */
-  private hoverBridgePolygon: TooltipHoverBridgePoint[] | null = null;
-
-  /**
-   * Cleanup callback for the document pointermove listener.
-   */
-  private removePointerMoveListener?: () => void;
-
-  /**
-   * Cleanup callback for the hover bridge timeout.
-   */
-  private clearHoverBridgeTimeout?: () => void;
-
-  /**
-   * Store the state of the tooltip.
-   * @internal
-   */
-  readonly state = tooltipTriggerState<NgpTooltipTrigger<T>>(this);
-
-  constructor() {
-    this.hasOverflow = setupOverflowListener(this.trigger.nativeElement, {
-      disabled: computed(() => !this.state.showOnOverflow()),
-    });
-  }
+  protected readonly state = ngpTooltipTrigger({
+    tooltip: this.tooltip,
+    disabled: this.disabled,
+    placement: this.placement,
+    offset: this.offset,
+    showDelay: this.showDelay,
+    hideDelay: this.hideDelay,
+    flip: this.flip,
+    shift: this.shift,
+    container: this.container,
+    showOnOverflow: this.showOnOverflow,
+    anchor: this.anchor,
+    context: this.context,
+    useTextContent: this.useTextContent,
+    trackPosition: this.trackPosition,
+    position: this.position,
+    scrollBehavior: this.scrollBehavior,
+    cooldown: this.cooldown,
+    hoverableContent: this.hoverableContent,
+  });
 
   ngOnDestroy(): void {
-    this.clearHoverBridge();
-    this.overlay()?.destroy();
+    return this.state.destroy();
   }
 
   /**
    * Show the tooltip programmatically (skips cooldown so multiple tooltips can coexist).
    */
   show(): void {
-    this.performShow(true);
+    return this.state.show();
   }
 
   /**
    * Hide the tooltip.
    */
   hide(): void {
-    this.clearHoverBridge();
-    this.overlay()?.hide();
-  }
-
-  /**
-   * Show the tooltip from an interaction (respects disabled state, uses cooldown).
-   * @internal
-   */
-  protected showFromInteraction(): void {
-    if (this.state.disabled()) {
-      return;
-    }
-    this.triggerHovered = true;
-    this.clearHoverBridge();
-    this.performShow(false);
-  }
-
-  /**
-   * Shared show logic.
-   * @param skipCooldown When true, skip cooldown registration so multiple tooltips can coexist.
-   */
-  private performShow(skipCooldown: boolean): void {
-    // If already open, cancel any pending close
-    if (this.open()) {
-      this.overlay()?.cancelPendingClose();
-      return;
-    }
-
-    // if we should only show when there is overflow, check if the trigger has overflow
-    if (this.state.showOnOverflow() && !this.hasOverflow()) {
-      return;
-    }
-
-    // Create the overlay if it doesn't exist yet
-    if (!this.overlay()) {
-      this.createOverlay();
-    }
-
-    this.overlay()?.show({ skipCooldown });
-  }
-
-  /**
-   * Hide the tooltip from an interaction (respects disabled state).
-   * @internal
-   */
-  protected hideFromInteraction(event?: MouseEvent): void {
-    if (this.state.disabled()) {
-      return;
-    }
-
-    this.triggerHovered = false;
-
-    // Blur should close regardless of hover bridge or tooltip hover state.
-    if (!event) {
-      this.contentHovered = false;
-      this.clearHoverBridge();
-      this.hide();
-      return;
-    }
-
-    if (!this.state.hoverableContent()) {
-      this.hide();
-      return;
-    }
-
-    const tooltipElement = this.overlay()?.getElements()[0];
-    if (!tooltipElement) {
-      this.hide();
-      return;
-    }
-
-    const polygon = createTooltipHoverBridgePolygon({
-      triggerRect: this.trigger.nativeElement.getBoundingClientRect(),
-      tooltipRect: tooltipElement.getBoundingClientRect(),
-      exitPoint: { x: event.clientX, y: event.clientY },
-    });
-
-    if (!polygon) {
-      this.hide();
-      return;
-    }
-
-    this.hoverBridgePolygon = polygon;
-    this.overlay()?.cancelPendingClose();
-    this.registerPointerMoveListener();
-    this.scheduleHoverBridgeCloseFallback();
+    return this.state.hide();
   }
 
   /**
@@ -418,13 +241,7 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
    * @internal
    */
   onTooltipHoverStart(): void {
-    if (this.state.disabled() || !this.state.hoverableContent()) {
-      return;
-    }
-
-    this.contentHovered = true;
-    this.clearHoverBridge();
-    this.overlay()?.cancelPendingClose();
+    return this.state.onTooltipHoverStart();
   }
 
   /**
@@ -432,159 +249,13 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
    * @internal
    */
   onTooltipHoverEnd(): void {
-    if (this.state.disabled() || !this.state.hoverableContent()) {
-      return;
-    }
-
-    this.contentHovered = false;
-
-    if (!this.triggerHovered) {
-      this.hide();
-    }
-  }
-
-  /**
-   * Create the overlay that will contain the tooltip
-   */
-  private createOverlay(): void {
-    // Determine the content and context based on useTextContent setting
-    const shouldUseTextContent = this.state.useTextContent();
-    let content = this.state.tooltip();
-    let context: Signal<T | string | undefined> = this.state.context;
-
-    if (!content) {
-      if (!shouldUseTextContent) {
-        if (ngDevMode) {
-          console.error(
-            '[ngpTooltipTrigger]: Tooltip must be a string, TemplateRef, or ComponentType. Alternatively, set useTextContent to true if none is provided.',
-          );
-        }
-
-        return;
-      }
-
-      const textContent = this.trigger.nativeElement.textContent?.trim() || '';
-      if (ngDevMode && !textContent) {
-        console.warn(
-          '[ngpTooltipTrigger]: useTextContent is enabled but trigger element has no text content',
-        );
-        return;
-      }
-      content = NgpTooltipTextContentComponent;
-      context = signal(textContent);
-    } else if (isString(content)) {
-      context = signal(content);
-      content = NgpTooltipTextContentComponent;
-    }
-
-    // Create config for the overlay
-    const config: NgpOverlayConfig<T | string> = {
-      content,
-      triggerElement: this.trigger.nativeElement,
-      anchorElement: this.state.anchor(),
-      injector: this.injector,
-      context,
-      container: this.state.container(),
-      placement: this.state.placement,
-      offset: this.state.offset(),
-      flip: this.state.flip(),
-      shift: this.state.shift(),
-      showDelay: this.state.showDelay(),
-      hideDelay: this.state.hideDelay(),
-      closeOnEscape: true,
-      closeOnOutsideClick: true,
-      viewContainerRef: this.viewContainerRef,
-      trackPosition: this.state.trackPosition(),
-      position: this.state.position,
-      scrollBehaviour: this.state.scrollBehavior(),
-      overlayType: 'tooltip',
-      cooldown: this.state.cooldown(),
-    };
-
-    // Create the overlay instance
-    this.overlay.set(createOverlay(config));
+    return this.state.onTooltipHoverEnd();
   }
 
   /**
    * Set the tooltip id.
    */
   setTooltipId(id: string): void {
-    this.tooltipId.set(id);
-  }
-
-  /**
-   * Register document-level pointer tracking while crossing trigger -> tooltip.
-   */
-  private registerPointerMoveListener(): void {
-    if (this.removePointerMoveListener) {
-      return;
-    }
-
-    const cleanup = this.disposables.addEventListener(
-      document,
-      'pointermove' as keyof HTMLElementEventMap,
-      ((event: PointerEvent): void => {
-        if (this.triggerHovered || this.contentHovered || !this.hoverBridgePolygon) {
-          this.clearHoverBridge();
-          return;
-        }
-
-        const inBridge = isPointInHoverBridgePolygon(
-          { x: event.clientX, y: event.clientY },
-          this.hoverBridgePolygon,
-        );
-
-        if (!inBridge) {
-          this.clearHoverBridge();
-          this.hide();
-        }
-      }) as EventListener,
-      true,
-    );
-
-    this.removePointerMoveListener = () => {
-      cleanup();
-      this.removePointerMoveListener = undefined;
-    };
-  }
-
-  /**
-   * Clear hover bridge state and global listeners.
-   */
-  private clearHoverBridge(): void {
-    this.hoverBridgePolygon = null;
-    this.clearHoverBridgeTimeout?.();
-    this.clearHoverBridgeTimeout = undefined;
-    this.removePointerMoveListener?.();
-  }
-
-  /**
-   * Close if pointer leaves trigger and does not move into tooltip soon enough.
-   */
-  private scheduleHoverBridgeCloseFallback(): void {
-    this.clearHoverBridgeTimeout?.();
-
-    this.clearHoverBridgeTimeout = this.disposables.setTimeout(() => {
-      this.clearHoverBridgeTimeout = undefined;
-
-      if (!this.triggerHovered && !this.contentHovered && this.hoverBridgePolygon) {
-        this.clearHoverBridge();
-        this.hide();
-      }
-    }, NgpTooltipTrigger.HOVER_BRIDGE_TIMEOUT_MS);
+    return this.state.setTooltipId(id);
   }
 }
-
-export type NgpTooltipPlacement =
-  | 'top'
-  | 'right'
-  | 'bottom'
-  | 'left'
-  | 'top-start'
-  | 'top-end'
-  | 'right-start'
-  | 'right-end'
-  | 'bottom-start'
-  | 'bottom-end'
-  | 'left-start'
-  | 'left-end';

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -32,7 +32,7 @@ import {
 } from 'ng-primitives/portal';
 import { injectDisposables, isString } from 'ng-primitives/utils';
 import { injectTooltipConfig } from '../config/tooltip-config';
-import { NgpTooltipTextContentComponent } from '../tooltip-text-content/tooltip-text-content.component';
+import { NgpTooltipTextContentComponent } from '../tooltip-text-content/tooltip-text-content';
 import {
   createTooltipHoverBridgePolygon,
   isPointInHoverBridgePolygon,

--- a/packages/ng-primitives/tooltip/src/tooltip/tooltip-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip/tooltip-state.ts
@@ -20,7 +20,7 @@ export interface NgpTooltipState {
 
 export interface NgpTooltipProps {
   /** The unique id of the tooltip. */
-  readonly id: Signal<string>;
+  readonly id?: Signal<string>;
 }
 
 export const [NgpTooltipStateToken, ngpTooltip, injectTooltipState, provideTooltipState] =
@@ -29,7 +29,13 @@ export const [NgpTooltipStateToken, ngpTooltip, injectTooltipState, provideToolt
     const tooltipTriggerState = injectTooltipTriggerState();
     const overlay = injectOverlay();
 
-    const id = controlled(_id, overlay.id());
+    const id = controlled(_id);
+
+    // Seed the id with the overlay's generated unique id so the tooltip has a
+    // valid id (and the trigger a valid aria-describedby) when none is provided.
+    // `controlled` returns a linkedSignal, so this is only a transient default:
+    // if a consumer binds `id`, that source change supersedes this seed.
+    id.set(overlay.id());
 
     // Setup interactions
     ngpHover({

--- a/packages/ng-primitives/tooltip/src/tooltip/tooltip-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip/tooltip-state.ts
@@ -1,0 +1,59 @@
+import { ElementRef, Signal, signal } from '@angular/core';
+import { ngpHover } from 'ng-primitives/interactions';
+import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
+import { injectOverlay } from 'ng-primitives/portal';
+import {
+  attrBinding,
+  controlled,
+  createPrimitive,
+  dataBinding,
+  styleBinding,
+} from 'ng-primitives/state';
+import { injectTooltipTriggerState } from '../tooltip-trigger/tooltip-trigger-state';
+
+export interface NgpTooltipState {
+  /** Access the element's reference. */
+  readonly elementRef: ElementRef;
+  /** The unique id of the tooltip. */
+  readonly id: Signal<string>;
+}
+
+export interface NgpTooltipProps {
+  /** The unique id of the tooltip. */
+  readonly id: Signal<string>;
+}
+
+export const [NgpTooltipStateToken, ngpTooltip, injectTooltipState, provideTooltipState] =
+  createPrimitive('NgpTooltip', ({ id: _id = signal<string>('') }: NgpTooltipProps) => {
+    const elementRef = injectElementRef();
+    const tooltipTriggerState = injectTooltipTriggerState();
+    const overlay = injectOverlay();
+
+    const id = controlled(_id, overlay.id());
+
+    // Setup interactions
+    ngpHover({
+      onHoverStart: () => tooltipTriggerState().onTooltipHoverStart(),
+      onHoverEnd: () => tooltipTriggerState().onTooltipHoverEnd(),
+    });
+
+    // Host binding
+    attrBinding(elementRef, 'role', 'tooltip');
+    attrBinding(elementRef, 'id', () => id());
+    dataBinding(elementRef, 'data-overlay', '');
+    dataBinding(elementRef, 'data-placement', () => overlay.finalPlacement()?.toString() ?? null);
+    styleBinding(elementRef, 'left.px', () => overlay.position().x ?? null);
+    styleBinding(elementRef, 'top.px', () => overlay.position().y ?? null);
+    styleBinding(elementRef, '--ngp-tooltip-trigger-width.px', () => overlay.triggerWidth());
+    styleBinding(elementRef, '--ngp-tooltip-transform-origin', () => overlay.transformOrigin());
+    styleBinding(elementRef, '--ngp-tooltip-available-width.px', () => overlay.availableWidth());
+    styleBinding(elementRef, '--ngp-tooltip-available-height.px', () => overlay.availableHeight());
+
+    // Effects
+    explicitEffect([id], ([id]) => overlay.id.set(id));
+
+    return {
+      elementRef,
+      id,
+    } satisfies NgpTooltipState;
+  });

--- a/packages/ng-primitives/tooltip/src/tooltip/tooltip.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip/tooltip.ts
@@ -1,8 +1,5 @@
 import { Directive, input } from '@angular/core';
-import { ngpHover } from 'ng-primitives/interactions';
-import { explicitEffect } from 'ng-primitives/internal';
-import { injectOverlay } from 'ng-primitives/portal';
-import { injectTooltipTriggerState } from '../tooltip-trigger/tooltip-trigger-state';
+import { ngpTooltip } from './tooltip-state';
 
 /**
  * Apply the `ngpTooltip` directive to an element that represents the tooltip. This typically would be a `div` inside an `ng-template`.
@@ -10,42 +7,14 @@ import { injectTooltipTriggerState } from '../tooltip-trigger/tooltip-trigger-st
 @Directive({
   selector: '[ngpTooltip]',
   exportAs: 'ngpTooltip',
-  host: {
-    role: 'tooltip',
-    '[id]': 'id()',
-    '[style.left.px]': 'overlay.position().x',
-    '[style.top.px]': 'overlay.position().y',
-    '[style.--ngp-tooltip-trigger-width.px]': 'overlay.triggerWidth()',
-    '[style.--ngp-tooltip-transform-origin]': 'overlay.transformOrigin()',
-    '[style.--ngp-tooltip-available-width.px]': 'overlay.availableWidth()',
-    '[style.--ngp-tooltip-available-height.px]': 'overlay.availableHeight()',
-    '[attr.data-placement]': 'overlay.finalPlacement()',
-    'data-overlay': '',
-  },
 })
 export class NgpTooltip {
   /**
-   * Access the overlay.
-   */
-  protected readonly overlay = injectOverlay();
-
-  /**
-   * Access the tooltip trigger state.
-   */
-  private readonly tooltipTrigger = injectTooltipTriggerState();
-
-  /**
    * The unique id of the tooltip.
    */
-  readonly id = input(this.overlay.id());
+  readonly id = input('');
 
-  constructor() {
-    explicitEffect([this.id], ([id]) => this.overlay.id.set(id));
-
-    // if the mouse moves over the tooltip, we want to keep it open
-    ngpHover({
-      onHoverStart: () => this.tooltipTrigger().onTooltipHoverStart(),
-      onHoverEnd: () => this.tooltipTrigger().onTooltipHoverEnd(),
-    });
-  }
+  protected readonly state = ngpTooltip({
+    id: this.id,
+  });
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #566 

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Tooltip to primitive-based state APIs and fixed generated id/aria-describedby so tooltips link accessibly by default. Aligns with #566.

- **Refactors**
  - Added `tooltip/tooltip-state.ts` with `NgpTooltipStateToken`, `ngpTooltip`, `injectTooltipState`, `provideTooltipState`; `NgpTooltip` now delegates to state and seeds its id from the overlay.
  - Added `tooltip-text-content/tooltip-text-content-state.ts` and wrapper; reads overlay context and applies the `ngpTooltip` styling attribute for string content.
  - Rebuilt trigger as `ngpTooltipTrigger` state with overlay creation, overflow tracking, hover-bridge, `aria-describedby`/data bindings, and optional props like `container`, `cooldown`, `useTextContent`, `trackPosition`, and `position`. Simplified `NgpTooltipTrigger` to delegate to state.
  - Updated root exports to include new state tokens/types; `NgpTooltipPlacement` is now exported from `tooltip-trigger-state`.
  - Made `NgpTooltipArrow` state field protected; added tests for arrow, id/aria-describedby, delays, cooldown, container, offset/flip/shift, and text-content styling.

- **Bug Fixes**
  - Restored generated tooltip id seeding so triggers get a valid `aria-describedby` when no id is provided; aligned state props to be optional and removed redundant internal destroy.

<sup>Written for commit 24b51138a1da26d07a9e5757b606c4c22e5b4b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

