### PR TITLE
feat(dialog): migrate dialog state

### DIFF
--- a/packages/ng-primitives/dialog/src/dialog-description/dialog-description-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-description/dialog-description-state.ts
@@ -1,0 +1,61 @@
+import { signal, Signal, ElementRef } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, onDestroy } from 'ng-primitives/state';
+import { onChange } from 'ng-primitives/utils';
+import { injectDialogState } from '../dialog/dialog-state';
+
+export interface NgpDialogDescriptionState {
+  /** Access the component's reference. */
+  readonly elementRef: ElementRef;
+  /** The id of the descriptions. */
+  readonly id: Signal<string>;
+  destroy: () => void;
+}
+
+export interface NgpDialogDescriptionProps {
+  /** The id of the descriptions. */
+  readonly id?: Signal<string>;
+}
+
+export const [
+  NgpDialogDescriptionStateToken,
+  ngpDialogDescription,
+  injectDialogDescriptionState,
+  provideDialogDescriptionState,
+] = createPrimitive(
+  'NgpDialogDescription',
+  ({ id = signal<string>('') }: NgpDialogDescriptionProps) => {
+    const elementRef = injectElementRef();
+    const dialogState = injectDialogState();
+
+    // Host binding
+    attrBinding(elementRef, 'id', id);
+
+    // Effects
+    onChange(id, (id, prevId) => {
+      if (prevId) {
+        dialogState().removeDescribedBy(prevId);
+      }
+
+      if (id) {
+        dialogState().setDescribedBy(id);
+      }
+    });
+
+    function destroy(): void {
+      dialogState().removeDescribedBy(id());
+    }
+
+    const state = {
+      elementRef,
+      id,
+      destroy,
+    } satisfies NgpDialogDescriptionState;
+
+    onDestroy(() => {
+      destroy();
+    });
+
+    return state;
+  },
+);

--- a/packages/ng-primitives/dialog/src/dialog-description/dialog-description-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-description/dialog-description-state.ts
@@ -29,7 +29,7 @@ export const [
     const dialogState = injectDialogState();
 
     // Host binding
-    attrBinding(elementRef, 'id', id);
+    attrBinding(elementRef, 'id', () => id());
 
     // Effects
     onChange(id, (id, prevId) => {

--- a/packages/ng-primitives/dialog/src/dialog-description/dialog-description-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-description/dialog-description-state.ts
@@ -1,15 +1,12 @@
-import { signal, Signal, ElementRef } from '@angular/core';
+import { signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, onDestroy } from 'ng-primitives/state';
 import { onChange } from 'ng-primitives/utils';
 import { injectDialogState } from '../dialog/dialog-state';
 
 export interface NgpDialogDescriptionState {
-  /** Access the component's reference. */
-  readonly elementRef: ElementRef;
   /** The id of the descriptions. */
   readonly id: Signal<string>;
-  destroy: () => void;
 }
 
 export interface NgpDialogDescriptionProps {
@@ -42,20 +39,8 @@ export const [
       }
     });
 
-    function destroy(): void {
-      dialogState().removeDescribedBy(id());
-    }
+    onDestroy(() => dialogState().removeDescribedBy(id()));
 
-    const state = {
-      elementRef,
-      id,
-      destroy,
-    } satisfies NgpDialogDescriptionState;
-
-    onDestroy(() => {
-      destroy();
-    });
-
-    return state;
+    return { id } satisfies NgpDialogDescriptionState;
   },
 );

--- a/packages/ng-primitives/dialog/src/dialog-description/dialog-description-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-description/dialog-description-state.ts
@@ -26,7 +26,7 @@ export const [
     const dialogState = injectDialogState();
 
     // Host binding
-    attrBinding(elementRef, 'id', () => id());
+    attrBinding(elementRef, 'id', id);
 
     // Effects
     onChange(id, (id, prevId) => {

--- a/packages/ng-primitives/dialog/src/dialog-description/dialog-description.ts
+++ b/packages/ng-primitives/dialog/src/dialog-description/dialog-description.ts
@@ -1,6 +1,6 @@
 import { Directive, input, OnDestroy } from '@angular/core';
-import { onChange, uniqueId } from 'ng-primitives/utils';
-import { injectDialogState } from '../dialog/dialog-state';
+import { uniqueId } from 'ng-primitives/utils';
+import { ngpDialogDescription } from './dialog-description-state';
 
 @Directive({
   selector: '[ngpDialogDescription]',
@@ -10,25 +10,14 @@ import { injectDialogState } from '../dialog/dialog-state';
   },
 })
 export class NgpDialogDescription implements OnDestroy {
-  /** Access the dialog */
-  private readonly dialog = injectDialogState();
-
   /** The id of the descriptions. */
   readonly id = input<string>(uniqueId('ngp-dialog-description'));
 
-  constructor() {
-    onChange(this.id, (id, prevId) => {
-      if (prevId) {
-        this.dialog().removeDescribedBy(prevId);
-      }
-
-      if (id) {
-        this.dialog().setDescribedBy(id);
-      }
-    });
-  }
+  protected readonly state = ngpDialogDescription({
+    id: this.id,
+  });
 
   ngOnDestroy(): void {
-    this.dialog().removeDescribedBy(this.id());
+    return this.state.destroy();
   }
 }

--- a/packages/ng-primitives/dialog/src/dialog-description/dialog-description.ts
+++ b/packages/ng-primitives/dialog/src/dialog-description/dialog-description.ts
@@ -1,23 +1,16 @@
-import { Directive, input, OnDestroy } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { uniqueId } from 'ng-primitives/utils';
 import { ngpDialogDescription } from './dialog-description-state';
 
 @Directive({
   selector: '[ngpDialogDescription]',
   exportAs: 'ngpDialogDescription',
-  host: {
-    '[id]': 'id()',
-  },
 })
-export class NgpDialogDescription implements OnDestroy {
+export class NgpDialogDescription {
   /** The id of the descriptions. */
   readonly id = input<string>(uniqueId('ngp-dialog-description'));
 
   protected readonly state = ngpDialogDescription({
     id: this.id,
   });
-
-  ngOnDestroy(): void {
-    return this.state.destroy();
-  }
 }

--- a/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay-state.ts
@@ -1,0 +1,108 @@
+import { ElementRef, signal, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { NgpDismissGuard } from 'ng-primitives/portal';
+import { createPrimitive, listener } from 'ng-primitives/state';
+import { injectDialogRef } from '../dialog/dialog-ref';
+
+export interface NgpDialogOverlayState {
+  /** Access component's reference. */
+  readonly elementRef: ElementRef;
+  /**
+   * Whether the dialog should close on backdrop click.
+   * @default `true`
+   */
+  readonly closeOnClick: Signal<NgpDismissGuard<Element> | undefined>;
+}
+
+export interface NgpDialogOverlayProps {
+  /**
+   * Whether the dialog should close on backdrop click.
+   * @default `true`
+   */
+  readonly closeOnClick?: Signal<NgpDismissGuard<Element> | undefined>;
+}
+
+export const [
+  NgpDialogOverlayStateToken,
+  ngpDialogOverlay,
+  injectDialogOverlayState,
+  provideDialogOverlayState,
+] = createPrimitive(
+  'NgpDialogOverlay',
+  ({
+    closeOnClick = signal<NgpDismissGuard<Element> | undefined>(true),
+  }: NgpDialogOverlayProps) => {
+    const elementRef = injectElementRef();
+    const dialogRef = injectDialogRef();
+
+    const startedPointerDownOnOverlay = signal(false);
+
+    // Listener
+    listener(elementRef, 'pointerdown', handleOnPointerDown);
+    listener(elementRef, 'pointercancel', handleOnPointerCancel);
+    listener(elementRef, 'click', handleOnClick);
+
+    function handleOnPointerDown(event: Event): void {
+      startedPointerDownOnOverlay.set(event.target === event.currentTarget);
+    }
+
+    function handleOnPointerCancel(): void {
+      startedPointerDownOnOverlay.set(false);
+    }
+
+    function handleOnClick(event: Event): void {
+      const isOverlayClick = startedPointerDownOnOverlay() && event.target === event.currentTarget;
+
+      handleOnPointerCancel();
+
+      if (!isOverlayClick || dialogRef.disableClose) {
+        return;
+      }
+
+      const guard: NgpDismissGuard<Element> =
+        dialogRef.closeOnOutsideClick ?? closeOnClick() ?? true;
+      evaluateGuard(guard, event.target as Element);
+    }
+
+    function evaluateGuard(guard: NgpDismissGuard<Element>, target: Element): void {
+      if (guard === true) {
+        dialogRef.close(undefined, 'mouse');
+        return;
+      }
+
+      if (guard === false) {
+        return;
+      }
+
+      // Function guard — evaluate sync or async
+      let result: boolean | Promise<boolean>;
+      try {
+        result = guard(target);
+      } catch (error) {
+        console.error('NgpDialogOverlay: dismiss guard threw', error);
+        return;
+      }
+
+      if (typeof result === 'boolean') {
+        if (result) {
+          dialogRef.close(undefined, 'mouse');
+        }
+      } else {
+        result
+          .then(shouldClose => {
+            if (shouldClose) {
+              dialogRef.close(undefined, 'mouse');
+            }
+          })
+          .catch(error => {
+            console.error('NgpDialogOverlay: dismiss guard rejected', error);
+          });
+      }
+    }
+
+    return {
+      elementRef,
+      closeOnClick,
+    } satisfies NgpDialogOverlayState;
+  },
+);

--- a/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay-state.ts
@@ -1,12 +1,10 @@
-import { ElementRef, signal, Signal } from '@angular/core';
+import { signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { NgpDismissGuard } from 'ng-primitives/portal';
 import { createPrimitive, listener } from 'ng-primitives/state';
 import { injectDialogRef } from '../dialog/dialog-ref';
 
 export interface NgpDialogOverlayState {
-  /** Access component's reference. */
-  readonly elementRef: ElementRef;
   /**
    * Whether the dialog should close on backdrop click.
    * @default `true`
@@ -101,7 +99,6 @@ export const [
     }
 
     return {
-      elementRef,
       closeOnClick,
     } satisfies NgpDialogOverlayState;
   },

--- a/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay.ts
+++ b/packages/ng-primitives/dialog/src/dialog-overlay/dialog-overlay.ts
@@ -1,21 +1,15 @@
 import { booleanAttribute, Directive, input } from '@angular/core';
 import { NgpExitAnimation } from 'ng-primitives/internal';
-import { NgpDismissGuard } from 'ng-primitives/portal';
 import { injectDialogRef } from '../dialog/dialog-ref';
+import { ngpDialogOverlay } from './dialog-overlay-state';
 
 @Directive({
   selector: '[ngpDialogOverlay]',
   exportAs: 'ngpDialogOverlay',
   hostDirectives: [NgpExitAnimation],
-  host: {
-    '(pointerdown)': 'onPointerDown($event)',
-    '(click)': 'onClick($event)',
-    '(pointercancel)': 'resetPointerOrigin()',
-  },
 })
 export class NgpDialogOverlay {
-  private readonly dialogRef = injectDialogRef();
-  private startedPointerDownOnOverlay = false;
+  protected readonly dialogRef = injectDialogRef();
 
   /**
    * Whether the dialog should close on backdrop click.
@@ -26,61 +20,7 @@ export class NgpDialogOverlay {
     transform: booleanAttribute,
   });
 
-  protected onPointerDown(event: Event): void {
-    this.startedPointerDownOnOverlay = event.target === event.currentTarget;
-  }
-
-  protected onClick(event: Event): void {
-    const isOverlayClick = this.startedPointerDownOnOverlay && event.target === event.currentTarget;
-
-    this.resetPointerOrigin();
-
-    if (!isOverlayClick || this.dialogRef.disableClose) {
-      return;
-    }
-
-    const guard: NgpDismissGuard<Element> =
-      this.dialogRef.closeOnOutsideClick ?? this.closeOnClick() ?? true;
-    this.evaluateGuard(guard, event.target as Element);
-  }
-
-  private evaluateGuard(guard: NgpDismissGuard<Element>, target: Element): void {
-    if (guard === true) {
-      this.dialogRef.close(undefined, 'mouse');
-      return;
-    }
-
-    if (guard === false) {
-      return;
-    }
-
-    // Function guard — evaluate sync or async
-    let result: boolean | Promise<boolean>;
-    try {
-      result = guard(target);
-    } catch (error) {
-      console.error('NgpDialogOverlay: dismiss guard threw', error);
-      return;
-    }
-
-    if (typeof result === 'boolean') {
-      if (result) {
-        this.dialogRef.close(undefined, 'mouse');
-      }
-    } else {
-      result
-        .then(shouldClose => {
-          if (shouldClose) {
-            this.dialogRef.close(undefined, 'mouse');
-          }
-        })
-        .catch(error => {
-          console.error('NgpDialogOverlay: dismiss guard rejected', error);
-        });
-    }
-  }
-
-  protected resetPointerOrigin(): void {
-    this.startedPointerDownOnOverlay = false;
-  }
+  protected readonly state = ngpDialogOverlay({
+    closeOnClick: this.closeOnClick,
+  });
 }

--- a/packages/ng-primitives/dialog/src/dialog-panel/dialog-panel-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-panel/dialog-panel-state.ts
@@ -1,0 +1,14 @@
+import { createPrimitive } from 'ng-primitives/state';
+
+export interface NgpDialogPanelState {}
+
+export interface NgpDialogPanelProps {}
+
+export const [
+  NgpDialogPanelStateToken,
+  ngpDialogPanel,
+  injectDialogPanelState,
+  provideDialogPanelState,
+] = createPrimitive('NgpDialogPanel', ({}: NgpDialogPanelProps) => {
+  return {} satisfies NgpDialogPanelState;
+});

--- a/packages/ng-primitives/dialog/src/dialog-panel/dialog-panel.ts
+++ b/packages/ng-primitives/dialog/src/dialog-panel/dialog-panel.ts
@@ -1,7 +1,10 @@
 import { Directive } from '@angular/core';
+import { ngpDialogPanel } from './dialog-panel-state';
 
 @Directive({
   selector: '[ngpDialogPanel]',
   exportAs: 'ngpDialogPanel',
 })
-export class NgpDialogPanel {}
+export class NgpDialogPanel {
+  protected readonly state = ngpDialogPanel({});
+}

--- a/packages/ng-primitives/dialog/src/dialog-title/dialog-title-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-title/dialog-title-state.ts
@@ -27,7 +27,7 @@ export const [
   const dialogState = injectDialogState();
 
   // Host binding
-  attrBinding(elementRef, 'id', id);
+  attrBinding(elementRef, 'id', () => id());
 
   // Effects
   onChange(id, (id, prevId) => {

--- a/packages/ng-primitives/dialog/src/dialog-title/dialog-title-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-title/dialog-title-state.ts
@@ -1,0 +1,58 @@
+import { Signal, ElementRef, signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, onDestroy } from 'ng-primitives/state';
+import { onChange } from 'ng-primitives/utils';
+import { injectDialogState } from '../dialog/dialog-state';
+
+export interface NgpDialogTitleState {
+  /** Access the component's reference. */
+  readonly elementRef: ElementRef;
+  /** The id of the title. */
+  readonly id: Signal<string>;
+  destroy: () => void;
+}
+
+export interface NgpDialogTitleProps {
+  /** The id of the title. */
+  readonly id?: Signal<string>;
+}
+
+export const [
+  NgpDialogTitleStateToken,
+  ngpDialogTitle,
+  injectDialogTitleState,
+  provideDialogTitleState,
+] = createPrimitive('NgpDialogTitle', ({ id = signal<string>('') }: NgpDialogTitleProps) => {
+  const elementRef = injectElementRef();
+  const dialogState = injectDialogState();
+
+  // Host binding
+  attrBinding(elementRef, 'id', id);
+
+  // Effects
+  onChange(id, (id, prevId) => {
+    if (prevId) {
+      dialogState().removeLabelledBy(prevId);
+    }
+
+    if (id) {
+      dialogState().setLabelledBy(id);
+    }
+  });
+
+  function destroy(): void {
+    dialogState().removeLabelledBy(id());
+  }
+
+  const state = {
+    elementRef,
+    id,
+    destroy,
+  } satisfies NgpDialogTitleState;
+
+  onDestroy(() => {
+    destroy();
+  });
+
+  return state;
+});

--- a/packages/ng-primitives/dialog/src/dialog-title/dialog-title-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-title/dialog-title-state.ts
@@ -24,7 +24,7 @@ export const [
   const dialogState = injectDialogState();
 
   // Host binding
-  attrBinding(elementRef, 'id', () => id());
+  attrBinding(elementRef, 'id', id);
 
   // Effects
   onChange(id, (id, prevId) => {

--- a/packages/ng-primitives/dialog/src/dialog-title/dialog-title-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-title/dialog-title-state.ts
@@ -1,15 +1,12 @@
-import { Signal, ElementRef, signal } from '@angular/core';
+import { Signal, signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, onDestroy } from 'ng-primitives/state';
 import { onChange } from 'ng-primitives/utils';
 import { injectDialogState } from '../dialog/dialog-state';
 
 export interface NgpDialogTitleState {
-  /** Access the component's reference. */
-  readonly elementRef: ElementRef;
   /** The id of the title. */
   readonly id: Signal<string>;
-  destroy: () => void;
 }
 
 export interface NgpDialogTitleProps {
@@ -40,19 +37,7 @@ export const [
     }
   });
 
-  function destroy(): void {
-    dialogState().removeLabelledBy(id());
-  }
+  onDestroy(() => dialogState().removeLabelledBy(id()));
 
-  const state = {
-    elementRef,
-    id,
-    destroy,
-  } satisfies NgpDialogTitleState;
-
-  onDestroy(() => {
-    destroy();
-  });
-
-  return state;
+  return { id } satisfies NgpDialogTitleState;
 });

--- a/packages/ng-primitives/dialog/src/dialog-title/dialog-title.ts
+++ b/packages/ng-primitives/dialog/src/dialog-title/dialog-title.ts
@@ -1,6 +1,6 @@
 import { Directive, input, OnDestroy } from '@angular/core';
-import { onChange, uniqueId } from 'ng-primitives/utils';
-import { injectDialogState } from '../dialog/dialog-state';
+import { uniqueId } from 'ng-primitives/utils';
+import { ngpDialogTitle } from './dialog-title-state';
 
 @Directive({
   selector: '[ngpDialogTitle]',
@@ -10,25 +10,14 @@ import { injectDialogState } from '../dialog/dialog-state';
   },
 })
 export class NgpDialogTitle implements OnDestroy {
-  /** Access the dialog. */
-  private readonly dialog = injectDialogState();
-
   /** The id of the title. */
   readonly id = input<string>(uniqueId('ngp-dialog-title'));
 
-  constructor() {
-    onChange(this.id, (id, prevId) => {
-      if (prevId) {
-        this.dialog().removeLabelledBy(prevId);
-      }
-
-      if (id) {
-        this.dialog().setLabelledBy(id);
-      }
-    });
-  }
+  protected readonly state = ngpDialogTitle({
+    id: this.id,
+  });
 
   ngOnDestroy(): void {
-    this.dialog().removeLabelledBy(this.id());
+    return this.state.destroy();
   }
 }

--- a/packages/ng-primitives/dialog/src/dialog-title/dialog-title.ts
+++ b/packages/ng-primitives/dialog/src/dialog-title/dialog-title.ts
@@ -1,23 +1,16 @@
-import { Directive, input, OnDestroy } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { uniqueId } from 'ng-primitives/utils';
 import { ngpDialogTitle } from './dialog-title-state';
 
 @Directive({
   selector: '[ngpDialogTitle]',
   exportAs: 'ngpDialogTitle',
-  host: {
-    '[id]': 'id()',
-  },
 })
-export class NgpDialogTitle implements OnDestroy {
+export class NgpDialogTitle {
   /** The id of the title. */
   readonly id = input<string>(uniqueId('ngp-dialog-title'));
 
   protected readonly state = ngpDialogTitle({
     id: this.id,
   });
-
-  ngOnDestroy(): void {
-    return this.state.destroy();
-  }
 }

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger-state.ts
@@ -1,0 +1,96 @@
+import { ElementRef, Signal, TemplateRef, inject, signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { NgpDismissGuard } from 'ng-primitives/portal';
+import { createPrimitive, emitter, listener, StateInjectionOptions } from 'ng-primitives/state';
+import { Observable } from 'rxjs';
+import { NgpDialogRef } from '../dialog/dialog-ref';
+import { NgpDialogContext, NgpDialogManager } from '../dialog/dialog.service';
+
+export interface NgpDialogTriggerState<T> {
+  /** Access the component's reference. */
+  readonly elementRef: ElementRef;
+  /** The template to launch. */
+  readonly template?: Signal<TemplateRef<NgpDialogContext>>;
+  /**
+   * Whether the dialog should close on escape, or a guard function.
+   * @default `true`
+   */
+  readonly closeOnEscape?: Signal<NgpDismissGuard<KeyboardEvent>>;
+  /**
+   * Whether the dialog should close on outside click, or a guard function.
+   * @default `true`
+   */
+  readonly closeOnOutsideClick?: Signal<NgpDismissGuard<Element>>;
+  /** The event that is fired when the closed state changes. */
+  readonly closedChange: Observable<T>;
+}
+
+export interface NgpDialogTriggerProps<T> {
+  /** The template to launch. */
+  readonly template: Signal<TemplateRef<NgpDialogContext>>;
+  /**
+   * Whether the dialog should close on escape, or a guard function.
+   * @default `true`
+   */
+  readonly closeOnEscape?: Signal<NgpDismissGuard<KeyboardEvent>>;
+  /**
+   * Whether the dialog should close on outside click, or a guard function.
+   * @default `true`
+   */
+  readonly closeOnOutsideClick?: Signal<NgpDismissGuard<Element>>;
+  readonly onClosedChange?: (value: T) => void;
+}
+
+export const [
+  NgpDialogTriggerStateToken,
+  ngpDialogTrigger,
+  _injectDialogTriggerState,
+  provideDialogTriggerState,
+] = createPrimitive(
+  'NgpDialogTrigger',
+  <T>({
+    template,
+    closeOnEscape = signal<NgpDismissGuard<KeyboardEvent>>(true),
+    closeOnOutsideClick = signal<NgpDismissGuard<Element>>(true),
+    onClosedChange,
+  }: NgpDialogTriggerProps<T>) => {
+    const elementRef = injectElementRef();
+    const dialogManager = inject(NgpDialogManager);
+
+    const dialogRef = signal<NgpDialogRef | null>(null);
+
+    const closed = emitter<T>();
+
+    // Listener
+    listener(elementRef, 'click', handleClick);
+
+    function handleClick(): void {
+      dialogRef.set(
+        dialogManager.open(template(), {
+          closeOnEscape: closeOnEscape(),
+          closeOnOutsideClick: closeOnOutsideClick(),
+        }),
+      );
+
+      dialogRef()!.closed.subscribe(({ result }) => {
+        onClosedChange?.(result as T);
+        closed.emit(result as T);
+        return dialogRef.set(null);
+      });
+    }
+
+    return {
+      elementRef,
+      template,
+      closeOnEscape,
+      closeOnOutsideClick,
+      closedChange: closed.asObservable(),
+    } satisfies NgpDialogTriggerState<T>;
+  },
+);
+
+export function injectDialogTriggerState<T>(
+  options?: StateInjectionOptions,
+): Signal<NgpDialogTriggerState<T>> {
+  return _injectDialogTriggerState(options) as Signal<NgpDialogTriggerState<T>>;
+}

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger-state.ts
@@ -1,9 +1,9 @@
-import { Signal, TemplateRef, inject, signal } from '@angular/core';
+import { DestroyRef, Signal, TemplateRef, inject, signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { NgpDismissGuard } from 'ng-primitives/portal';
 import { createPrimitive, emitter, listener, StateInjectionOptions } from 'ng-primitives/state';
+import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
 import { Observable } from 'rxjs';
-import { NgpDialogRef } from '../dialog/dialog-ref';
 import { NgpDialogContext, NgpDialogManager } from '../dialog/dialog.service';
 
 export interface NgpDialogTriggerState<T> {
@@ -54,8 +54,7 @@ export const [
   }: NgpDialogTriggerProps<T>) => {
     const elementRef = injectElementRef();
     const dialogManager = inject(NgpDialogManager);
-
-    const dialogRef = signal<NgpDialogRef | null>(null);
+    const destroyRef = inject(DestroyRef);
 
     const closed = emitter<T>();
 
@@ -63,17 +62,14 @@ export const [
     listener(elementRef, 'click', handleClick);
 
     function handleClick(): void {
-      dialogRef.set(
-        dialogManager.open(template(), {
-          closeOnEscape: closeOnEscape(),
-          closeOnOutsideClick: closeOnOutsideClick(),
-        }),
-      );
+      const dialogRef = dialogManager.open(template(), {
+        closeOnEscape: closeOnEscape(),
+        closeOnOutsideClick: closeOnOutsideClick(),
+      });
 
-      dialogRef()!.closed.subscribe(({ result }) => {
+      dialogRef.closed.pipe(safeTakeUntilDestroyed(destroyRef)).subscribe(({ result }) => {
         onClosedChange?.(result as T);
         closed.emit(result as T);
-        return dialogRef.set(null);
       });
     }
 

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger-state.ts
@@ -1,4 +1,4 @@
-import { ElementRef, Signal, TemplateRef, inject, signal } from '@angular/core';
+import { Signal, TemplateRef, inject, signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { NgpDismissGuard } from 'ng-primitives/portal';
 import { createPrimitive, emitter, listener, StateInjectionOptions } from 'ng-primitives/state';
@@ -7,8 +7,6 @@ import { NgpDialogRef } from '../dialog/dialog-ref';
 import { NgpDialogContext, NgpDialogManager } from '../dialog/dialog.service';
 
 export interface NgpDialogTriggerState<T> {
-  /** Access the component's reference. */
-  readonly elementRef: ElementRef;
   /** The template to launch. */
   readonly template?: Signal<TemplateRef<NgpDialogContext>>;
   /**
@@ -80,7 +78,6 @@ export const [
     }
 
     return {
-      elementRef,
       template,
       closeOnEscape,
       closeOnOutsideClick,

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
@@ -1,8 +1,8 @@
-import { Directive, HostListener, inject, input, output, TemplateRef } from '@angular/core';
+import { Directive, input, output, TemplateRef } from '@angular/core';
 import { dismissGuardAttribute, NgpDismissGuard, NgpDismissGuardInput } from 'ng-primitives/portal';
 import { injectDialogConfig } from '../config/dialog-config';
-import { NgpDialogRef } from '../dialog/dialog-ref';
-import { NgpDialogContext, NgpDialogManager } from '../dialog/dialog.service';
+import { NgpDialogContext } from '../dialog/dialog.service';
+import { ngpDialogTrigger } from './dialog-trigger-state';
 
 @Directive({
   selector: '[ngpDialogTrigger]',
@@ -12,16 +12,10 @@ export class NgpDialogTrigger<T = unknown> {
   /** Access the global configuration */
   private readonly config = injectDialogConfig();
 
-  /** Access the dialog manager. */
-  private readonly dialogManager = inject(NgpDialogManager);
-
   /** The template to launch. */
   readonly template = input.required<TemplateRef<NgpDialogContext>>({
     alias: 'ngpDialogTrigger',
   });
-
-  /** Emits whenever the dialog is closed with the given result. */
-  readonly closed = output<T>({ alias: 'ngpDialogTriggerClosed' });
 
   /**
    * Whether the dialog should close on escape, or a guard function.
@@ -47,21 +41,13 @@ export class NgpDialogTrigger<T = unknown> {
     },
   );
 
-  /**
-   * Store the dialog ref.
-   * @internal
-   */
-  private dialogRef: NgpDialogRef | null = null;
+  /** Emits whenever the dialog is closed with the given result. */
+  readonly closed = output<T>({ alias: 'ngpDialogTriggerClosed' });
 
-  @HostListener('click')
-  protected launch(): void {
-    this.dialogRef = this.dialogManager.open(this.template(), {
-      closeOnEscape: this.closeOnEscape(),
-      closeOnOutsideClick: this.closeOnOutsideClick(),
-    });
-    this.dialogRef.closed.subscribe(({ result }) => {
-      this.closed.emit(result as T);
-      return (this.dialogRef = null);
-    });
-  }
+  protected readonly state = ngpDialogTrigger({
+    template: this.template,
+    closeOnEscape: this.closeOnEscape,
+    closeOnOutsideClick: this.closeOnOutsideClick,
+    onClosedChange: this.closed.emit,
+  });
 }

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger.ts
@@ -48,6 +48,6 @@ export class NgpDialogTrigger<T = unknown> {
     template: this.template,
     closeOnEscape: this.closeOnEscape,
     closeOnOutsideClick: this.closeOnOutsideClick,
-    onClosedChange: this.closed.emit,
+    onClosedChange: (value: T) => this.closed.emit(value),
   });
 }

--- a/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
@@ -1,27 +1,110 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpDialog } from './dialog';
+import { ElementRef, signal, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, listener, StateInjectionOptions } from 'ng-primitives/state';
+import { NgpDialogRole } from '../config/dialog-config';
+import { injectDialogRef } from './dialog-ref';
 
-/**
- * The state token  for the Dialog primitive.
- */
-export const NgpDialogStateToken = createStateToken<NgpDialog<any, any>>('Dialog');
+export interface NgpDialogState<T, R> {
+  /** Access the dialog ref */
+  readonly elementRef: ElementRef;
+  /** The id of the dialog */
+  readonly id?: Signal<string>;
+  /** The dialog role. */
+  readonly role?: Signal<NgpDialogRole | undefined>;
+  /** Whether the dialog is a modal. */
+  readonly modal?: Signal<boolean>;
+  destroy: () => void;
+  /** Close the dialog. */
+  close: (result?: R) => void;
+  /** @internal register a labelledby id */
+  setLabelledBy: (id: string) => void;
+  /** @internal register a describedby id */
+  setDescribedBy: (id: string) => void;
+  /** @internal remove a labelledby id */
+  removeLabelledBy: (id: string) => void;
+  /** @internal remove a describedby id */
+  removeDescribedBy: (id: string) => void;
+}
 
-/**
- * Provides the Dialog state.
- */
-export const provideDialogState = createStateProvider(NgpDialogStateToken);
+export interface NgpDialogProps<T, R> {
+  /** The id of the dialog */
+  readonly id?: Signal<string>;
+  /** The dialog role. */
+  readonly role?: Signal<NgpDialogRole | undefined>;
+  /** Whether the dialog is a modal. */
+  readonly modal?: Signal<boolean>;
+}
 
-/**
- * Injects the Dialog state.
- */
-export const injectDialogState = createStateInjector<NgpDialog>(NgpDialogStateToken);
+export const [NgpDialogStateToken, ngpDialog, _injectDialogState, provideDialogState] =
+  createPrimitive(
+    'NgpDialog',
+    <T, R>({
+      id = signal<string>(''),
+      role = signal<NgpDialogRole | undefined>(undefined),
+      modal = signal<boolean>(true),
+    }: NgpDialogProps<T, R>) => {
+      const elementRef = injectElementRef();
+      const dialogRef = injectDialogRef<T, R>();
 
-/**
- * The Dialog state registration function.
- */
-export const dialogState = createState(NgpDialogStateToken);
+      const labelledBy = signal<string[]>([]);
+      const describedBy = signal<string[]>([]);
+
+      // Host binding
+      attrBinding(elementRef, 'tabindex', '-1');
+      attrBinding(elementRef, 'id', () => id());
+      attrBinding(elementRef, 'role', () => role());
+      attrBinding(elementRef, 'aria-modal', () => modal());
+      attrBinding(elementRef, 'aria-labelledby', () => labelledBy().join(' '));
+      attrBinding(elementRef, 'aria-describedby', () => describedBy().join(' '));
+
+      // Listener
+      listener(elementRef, 'click', handleOnClick);
+
+      function destroy(): void {
+        close();
+      }
+
+      function close(result?: R): void {
+        dialogRef.close(result);
+      }
+
+      function handleOnClick(event: Event): void {
+        event.stopPropagation();
+      }
+
+      function setLabelledBy(id: string): void {
+        labelledBy.update(ids => [...ids, id]);
+      }
+
+      function setDescribedBy(id: string): void {
+        describedBy.update(ids => [...ids, id]);
+      }
+
+      function removeLabelledBy(id: string): void {
+        labelledBy.update(ids => ids.filter(i => i !== id));
+      }
+
+      function removeDescribedBy(id: string): void {
+        describedBy.update(ids => ids.filter(i => i !== id));
+      }
+
+      return {
+        elementRef,
+        id,
+        role,
+        modal,
+        destroy,
+        close,
+        setLabelledBy,
+        setDescribedBy,
+        removeLabelledBy,
+        removeDescribedBy,
+      } satisfies NgpDialogState<T, R>;
+    },
+  );
+
+export function injectDialogState<T, R>(
+  options?: StateInjectionOptions,
+): Signal<NgpDialogState<T, R>> {
+  return _injectDialogState(options) as Signal<NgpDialogState<T, R>>;
+}

--- a/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
@@ -4,7 +4,7 @@ import { attrBinding, createPrimitive, listener, StateInjectionOptions } from 'n
 import { NgpDialogRole } from '../config/dialog-config';
 import { injectDialogRef } from './dialog-ref';
 
-export interface NgpDialogState<T, R> {
+export interface NgpDialogState<R> {
   /** Access the dialog ref */
   readonly elementRef: ElementRef;
   /** The id of the dialog */
@@ -26,7 +26,7 @@ export interface NgpDialogState<T, R> {
   removeDescribedBy: (id: string) => void;
 }
 
-export interface NgpDialogProps<T, R> {
+export interface NgpDialogProps {
   /** The id of the dialog */
   readonly id?: Signal<string>;
   /** The dialog role. */
@@ -42,7 +42,7 @@ export const [NgpDialogStateToken, ngpDialog, _injectDialogState, provideDialogS
       id = signal<string>(''),
       role = signal<NgpDialogRole | undefined>(undefined),
       modal = signal<boolean>(true),
-    }: NgpDialogProps<T, R>) => {
+    }: NgpDialogProps) => {
       const elementRef = injectElementRef();
       const dialogRef = injectDialogRef<T, R>();
 
@@ -99,12 +99,10 @@ export const [NgpDialogStateToken, ngpDialog, _injectDialogState, provideDialogS
         setDescribedBy,
         removeLabelledBy,
         removeDescribedBy,
-      } satisfies NgpDialogState<T, R>;
+      } satisfies NgpDialogState<R>;
     },
   );
 
-export function injectDialogState<T, R>(
-  options?: StateInjectionOptions,
-): Signal<NgpDialogState<T, R>> {
-  return _injectDialogState(options) as Signal<NgpDialogState<T, R>>;
+export function injectDialogState<R>(options?: StateInjectionOptions): Signal<NgpDialogState<R>> {
+  return _injectDialogState(options) as Signal<NgpDialogState<R>>;
 }

--- a/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
@@ -1,19 +1,16 @@
-import { ElementRef, signal, Signal } from '@angular/core';
+import { signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive, listener, StateInjectionOptions } from 'ng-primitives/state';
 import { NgpDialogRole } from '../config/dialog-config';
 import { injectDialogRef } from './dialog-ref';
 
 export interface NgpDialogState<R> {
-  /** Access the dialog ref */
-  readonly elementRef: ElementRef;
   /** The id of the dialog */
   readonly id?: Signal<string>;
   /** The dialog role. */
   readonly role?: Signal<NgpDialogRole | undefined>;
   /** Whether the dialog is a modal. */
   readonly modal?: Signal<boolean>;
-  destroy: () => void;
   /** Close the dialog. */
   close: (result?: R) => void;
   /** @internal register a labelledby id */
@@ -60,10 +57,6 @@ export const [NgpDialogStateToken, ngpDialog, _injectDialogState, provideDialogS
       // Listener
       listener(elementRef, 'click', handleOnClick);
 
-      function destroy(): void {
-        close();
-      }
-
       function close(result?: R): void {
         dialogRef.close(result);
       }
@@ -89,11 +82,9 @@ export const [NgpDialogStateToken, ngpDialog, _injectDialogState, provideDialogS
       }
 
       return {
-        elementRef,
         id,
         role,
         modal,
-        destroy,
         close,
         setLabelledBy,
         setDescribedBy,

--- a/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
@@ -54,8 +54,8 @@ export const [NgpDialogStateToken, ngpDialog, _injectDialogState, provideDialogS
       attrBinding(elementRef, 'id', () => id());
       attrBinding(elementRef, 'role', () => role());
       attrBinding(elementRef, 'aria-modal', () => modal());
-      attrBinding(elementRef, 'aria-labelledby', () => labelledBy().join(' '));
-      attrBinding(elementRef, 'aria-describedby', () => describedBy().join(' '));
+      attrBinding(elementRef, 'aria-labelledby', () => labelledBy().join(' ') || null);
+      attrBinding(elementRef, 'aria-describedby', () => describedBy().join(' ') || null);
 
       // Listener
       listener(elementRef, 'click', handleOnClick);

--- a/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
@@ -48,9 +48,9 @@ export const [NgpDialogStateToken, ngpDialog, _injectDialogState, provideDialogS
 
       // Host binding
       attrBinding(elementRef, 'tabindex', '-1');
-      attrBinding(elementRef, 'id', () => id());
-      attrBinding(elementRef, 'role', () => role());
-      attrBinding(elementRef, 'aria-modal', () => modal());
+      attrBinding(elementRef, 'id', id);
+      attrBinding(elementRef, 'role', role);
+      attrBinding(elementRef, 'aria-modal', modal);
       attrBinding(elementRef, 'aria-labelledby', () => labelledBy().join(' ') || null);
       attrBinding(elementRef, 'aria-describedby', () => describedBy().join(' ') || null);
 

--- a/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
@@ -1,6 +1,12 @@
 import { signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive, listener, StateInjectionOptions } from 'ng-primitives/state';
+import {
+  attrBinding,
+  createPrimitive,
+  listener,
+  onDestroy,
+  StateInjectionOptions,
+} from 'ng-primitives/state';
 import { NgpDialogRole } from '../config/dialog-config';
 import { injectDialogRef } from './dialog-ref';
 
@@ -56,6 +62,9 @@ export const [NgpDialogStateToken, ngpDialog, _injectDialogState, provideDialogS
 
       // Listener
       listener(elementRef, 'click', handleOnClick);
+
+      // Close the dialog when the directive is destroyed.
+      onDestroy(() => close());
 
       function close(result?: R): void {
         dialogRef.close(result);

--- a/packages/ng-primitives/dialog/src/dialog/dialog.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Directive, HostListener, input, OnDestroy, signal } from '@angular/core';
+import { booleanAttribute, Directive, input, OnDestroy } from '@angular/core';
 import { NgpFocusTrap } from 'ng-primitives/focus-trap';
 import { NgpExitAnimation } from 'ng-primitives/internal';
 import { uniqueId } from 'ng-primitives/utils';

--- a/packages/ng-primitives/dialog/src/dialog/dialog.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.ts
@@ -1,39 +1,19 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import {
-  booleanAttribute,
-  computed,
-  Directive,
-  HostListener,
-  input,
-  OnDestroy,
-  signal,
-} from '@angular/core';
+import { booleanAttribute, Directive, HostListener, input, OnDestroy, signal } from '@angular/core';
 import { NgpFocusTrap } from 'ng-primitives/focus-trap';
 import { NgpExitAnimation } from 'ng-primitives/internal';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectDialogConfig } from '../config/dialog-config';
-import { injectDialogRef } from './dialog-ref';
-import { dialogState, provideDialogState } from './dialog-state';
+import { ngpDialog, provideDialogState } from './dialog-state';
 
 @Directive({
   selector: '[ngpDialog]',
   exportAs: 'ngpDialog',
   providers: [provideDialogState()],
   hostDirectives: [NgpFocusTrap, NgpExitAnimation],
-  host: {
-    tabindex: '-1',
-    '[id]': 'state.id()',
-    '[attr.role]': 'state.role()',
-    '[attr.aria-modal]': 'state.modal()',
-    '[attr.aria-labelledby]': 'ariaLabelledBy()',
-    '[attr.aria-describedby]': 'ariaDescribedBy()',
-  },
 })
 export class NgpDialog<T = unknown, R = unknown> implements OnDestroy {
   private readonly config = injectDialogConfig();
-
-  /** Access the dialog ref */
-  private readonly dialogRef = injectDialogRef<T, R>();
 
   /** The id of the dialog */
   readonly id = input<string>(uniqueId('ngp-dialog'));
@@ -49,57 +29,39 @@ export class NgpDialog<T = unknown, R = unknown> implements OnDestroy {
     transform: booleanAttribute,
   });
 
-  /** The labelledby ids */
-  protected readonly labelledBy = signal<string[]>([]);
-
-  /** The describedby ids */
-  protected readonly describedBy = signal<string[]>([]);
-
-  /** The aria-labelledby value, omitted when there are no ids to reference. */
-  protected readonly ariaLabelledBy = computed(() =>
-    this.labelledBy().length ? this.labelledBy().join(' ') : null,
-  );
-
-  /** The aria-describedby value, omitted when there are no ids to reference. */
-  protected readonly ariaDescribedBy = computed(() =>
-    this.describedBy().length ? this.describedBy().join(' ') : null,
-  );
-
   /** The dialog state */
-  protected readonly state = dialogState<NgpDialog<T, R>>(this);
+  protected readonly state = ngpDialog<T, R>({
+    id: this.id,
+    role: this.role,
+    modal: this.modal,
+  });
 
   ngOnDestroy(): void {
-    this.close();
+    return this.state.close();
   }
 
   /** Close the dialog. */
   close(result?: R): void {
-    this.dialogRef.close(result);
-  }
-
-  /** Stop click events from propagating to the overlay */
-  @HostListener('click', ['$event'])
-  protected onClick(event: Event): void {
-    event.stopPropagation();
+    return this.state.close(result);
   }
 
   /** @internal register a labelledby id */
   setLabelledBy(id: string): void {
-    this.labelledBy.update(ids => [...ids, id]);
+    return this.state.setLabelledBy(id);
   }
 
   /** @internal register a describedby id */
   setDescribedBy(id: string): void {
-    this.describedBy.update(ids => [...ids, id]);
+    return this.state.setDescribedBy(id);
   }
 
   /** @internal remove a labelledby id */
   removeLabelledBy(id: string): void {
-    this.labelledBy.update(ids => ids.filter(i => i !== id));
+    return this.state.removeLabelledBy(id);
   }
 
   /** @internal remove a describedby id */
   removeDescribedBy(id: string): void {
-    this.describedBy.update(ids => ids.filter(i => i !== id));
+    return this.state.removeDescribedBy(id);
   }
 }

--- a/packages/ng-primitives/dialog/src/dialog/dialog.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Directive, input, OnDestroy } from '@angular/core';
+import { booleanAttribute, Directive, input } from '@angular/core';
 import { NgpFocusTrap } from 'ng-primitives/focus-trap';
 import { NgpExitAnimation } from 'ng-primitives/internal';
 import { uniqueId } from 'ng-primitives/utils';
@@ -12,7 +12,7 @@ import { ngpDialog, provideDialogState } from './dialog-state';
   providers: [provideDialogState()],
   hostDirectives: [NgpFocusTrap, NgpExitAnimation],
 })
-export class NgpDialog<T = unknown, R = unknown> implements OnDestroy {
+export class NgpDialog<T = unknown, R = unknown> {
   private readonly config = injectDialogConfig();
 
   /** The id of the dialog */
@@ -35,10 +35,6 @@ export class NgpDialog<T = unknown, R = unknown> implements OnDestroy {
     role: this.role,
     modal: this.modal,
   });
-
-  ngOnDestroy(): void {
-    return this.state.close();
-  }
 
   /** Close the dialog. */
   close(result?: R): void {

--- a/packages/ng-primitives/dialog/src/index.ts
+++ b/packages/ng-primitives/dialog/src/index.ts
@@ -5,7 +5,6 @@ export { NgpDialogTitle } from './dialog-title/dialog-title';
 export { NgpDialogTrigger } from './dialog-trigger/dialog-trigger';
 export { NgpDialog } from './dialog/dialog';
 export { injectDialogRef, NgpDialogRef } from './dialog/dialog-ref';
-export { injectDialogState, provideDialogState } from './dialog/dialog-state';
 export { NgpDialogContext, NgpDialogManager } from './dialog/dialog.service';
 export {
   NgpDialogDescriptionStateToken,
@@ -47,3 +46,11 @@ export {
   type NgpDialogTriggerState,
   type NgpDialogTriggerProps,
 } from './dialog-trigger/dialog-trigger-state';
+export {
+  NgpDialogStateToken,
+  ngpDialog,
+  injectDialogState,
+  provideDialogState,
+  type NgpDialogState,
+  type NgpDialogProps,
+} from './dialog/dialog-state';

--- a/packages/ng-primitives/dialog/src/index.ts
+++ b/packages/ng-primitives/dialog/src/index.ts
@@ -39,3 +39,11 @@ export {
   type NgpDialogTitleState,
   type NgpDialogTitleProps,
 } from './dialog-title/dialog-title-state';
+export {
+  NgpDialogTriggerStateToken,
+  ngpDialogTrigger,
+  injectDialogTriggerState,
+  provideDialogTriggerState,
+  type NgpDialogTriggerState,
+  type NgpDialogTriggerProps,
+} from './dialog-trigger/dialog-trigger-state';

--- a/packages/ng-primitives/dialog/src/index.ts
+++ b/packages/ng-primitives/dialog/src/index.ts
@@ -15,3 +15,11 @@ export {
   type NgpDialogDescriptionState,
   type NgpDialogDescriptionProps,
 } from './dialog-description/dialog-description-state';
+export {
+  NgpDialogOverlayStateToken,
+  ngpDialogOverlay,
+  injectDialogOverlayState,
+  provideDialogOverlayState,
+  type NgpDialogOverlayState,
+  type NgpDialogOverlayProps,
+} from './dialog-overlay/dialog-overlay-state';

--- a/packages/ng-primitives/dialog/src/index.ts
+++ b/packages/ng-primitives/dialog/src/index.ts
@@ -23,3 +23,11 @@ export {
   type NgpDialogOverlayState,
   type NgpDialogOverlayProps,
 } from './dialog-overlay/dialog-overlay-state';
+export {
+  NgpDialogPanelStateToken,
+  ngpDialogPanel,
+  injectDialogPanelState,
+  provideDialogPanelState,
+  type NgpDialogPanelState,
+  type NgpDialogPanelProps,
+} from './dialog-panel/dialog-panel-state';

--- a/packages/ng-primitives/dialog/src/index.ts
+++ b/packages/ng-primitives/dialog/src/index.ts
@@ -31,3 +31,11 @@ export {
   type NgpDialogPanelState,
   type NgpDialogPanelProps,
 } from './dialog-panel/dialog-panel-state';
+export {
+  NgpDialogTitleStateToken,
+  ngpDialogTitle,
+  injectDialogTitleState,
+  provideDialogTitleState,
+  type NgpDialogTitleState,
+  type NgpDialogTitleProps,
+} from './dialog-title/dialog-title-state';

--- a/packages/ng-primitives/dialog/src/index.ts
+++ b/packages/ng-primitives/dialog/src/index.ts
@@ -7,3 +7,11 @@ export { NgpDialog } from './dialog/dialog';
 export { injectDialogRef, NgpDialogRef } from './dialog/dialog-ref';
 export { injectDialogState, provideDialogState } from './dialog/dialog-state';
 export { NgpDialogContext, NgpDialogManager } from './dialog/dialog.service';
+export {
+  NgpDialogDescriptionStateToken,
+  ngpDialogDescription,
+  injectDialogDescriptionState,
+  provideDialogDescriptionState,
+  type NgpDialogDescriptionState,
+  type NgpDialogDescriptionProps,
+} from './dialog-description/dialog-description-state';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #561 

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Dialog to the new state primitive API, moving logic from directives into injectable state and consolidating ARIA and dismissal behavior. Fixed the trigger closed emit by scoping its subscription to the trigger’s lifetime and moved dialog teardown into state; also omitted empty `aria-labelledby`/`aria-describedby`.

- **Refactors**
  - Converted parts to `createPrimitive` state: `dialog`, `overlay`, `title`, `description`, `trigger`, `panel`.
  - Directives delegate to state via `ngpDialog*`; title/description/dialog state own id and teardown.
  - Centralized ARIA/id bindings and overlay outside-click behavior; pointer-origin checks run in state; signals pass directly to `attrBinding`.
  - Trimmed state contracts to readable inputs plus `close()` and labelled/descr setters.

- **New Features**
  - Exported public state APIs in `index.ts`: tokens, `ngp*` factories, `inject*`, `provide*`, and types for all dialog parts.
  - `injectDialogState<T, R>` is generic and returns a typed `Signal<NgpDialogState<T, R>>`; overlay `closeOnClick` accepts `NgpDismissGuard` (sync or async).
  - Trigger state exposes a `closedChange` observable.

<sup>Written for commit 4f97f32438db331fa6a2289843b4d0e51ae75833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable, state-driven dialog primitives for dialogs, titles, descriptions, panels, overlays, and triggers.
  * Dialog overlays now support `closeOnClick` guards with synchronous or asynchronous evaluation.
  * Added state modules for simplified integration and composition.

* **Improvements**
  * Dialog titles and descriptions now automatically keep `aria-labelledby`/`aria-describedby` relationships in sync.

* **Refactor**
  * Converted key dialog directives from imperative lifecycle handling to declarative state-based wiring, and expanded public exports accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->