### PR TITLE
fix(docs):  #774 fix combobox demo filter

### DIFF
--- a/apps/documentation/src/app/examples/combobox/combobox-custom-option.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-custom-option.example.ts
@@ -25,12 +25,12 @@ import {
   template: `
     <div
       [(ngpComboboxValue)]="value"
-      (ngpComboboxValueChange)="filter.set($event ?? '')"
+      (ngpComboboxValueChange)="onValueChange($event)"
       (ngpComboboxOpenChange)="resetOnClose($event)"
       ngpCombobox
     >
       <input
-        [value]="filter()"
+        [value]="inputValue()"
         (input)="onFilterChange($event)"
         placeholder="Select an option"
         ngpComboboxInput
@@ -224,6 +224,9 @@ export default class ComboboxCustomOptionExample {
   /** The selected value. */
   readonly value = signal<string | undefined>(undefined);
 
+  /** The input value. */
+  readonly inputValue = signal<string>('');
+
   /** The filter value. */
   readonly filter = signal<string>('');
 
@@ -234,7 +237,13 @@ export default class ComboboxCustomOptionExample {
 
   protected onFilterChange(event: Event): void {
     const input = event.target as HTMLInputElement;
+    this.inputValue.set(input.value);
     this.filter.set(input.value);
+  }
+
+  protected onValueChange(value: string | undefined): void {
+    this.inputValue.set(value ?? '');
+    this.filter.set('');
   }
 
   protected resetOnClose(open: boolean): void {
@@ -243,18 +252,21 @@ export default class ComboboxCustomOptionExample {
       return;
     }
 
-    // if the filter value is empty, set the value to undefined
-    if (this.filter() === '') {
+    // if the input value is empty, set the value to undefined
+    if (this.inputValue() === '') {
       this.value.set(undefined);
     } else {
-      // otherwise set the filter value to the selected value
-      this.filter.set(this.value() ?? '');
+      // otherwise set the input value to the selected value
+      this.inputValue.set(this.value() ?? '');
     }
+
+    this.filter.set('');
   }
 
   /** Clear the selection. */
   clear(): void {
     this.value.set(undefined);
+    this.inputValue.set('');
     this.filter.set('');
   }
 }

--- a/apps/documentation/src/app/examples/combobox/combobox-virtual.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-virtual.example.ts
@@ -28,12 +28,12 @@ import {
       [(ngpComboboxValue)]="value"
       [ngpComboboxScrollToOption]="scrollToOption"
       [ngpComboboxOptions]="filteredOptions()"
-      (ngpComboboxValueChange)="filter.set($event)"
+      (ngpComboboxValueChange)="onValueChange($event)"
       (ngpComboboxOpenChange)="resetOnClose($event)"
       ngpCombobox
     >
       <input
-        [value]="filter()"
+        [value]="inputValue()"
         (input)="onFilterChange($event)"
         placeholder="Select from 10,000 options"
         ngpComboboxInput
@@ -239,6 +239,9 @@ export default class ComboboxVirtualExample {
   /** The selected value. */
   readonly value = signal<string | undefined>(undefined);
 
+  /** The input value. */
+  readonly inputValue = signal<string>('');
+
   /** The filter value. */
   readonly filter = signal<string>('');
 
@@ -265,7 +268,13 @@ export default class ComboboxVirtualExample {
 
   protected onFilterChange(event: Event): void {
     const input = event.target as HTMLInputElement;
+    this.inputValue.set(input.value);
     this.filter.set(input.value);
+  }
+
+  protected onValueChange(value: string | undefined): void {
+    this.inputValue.set(value ?? '');
+    this.filter.set('');
   }
 
   protected resetOnClose(open: boolean): void {
@@ -274,13 +283,15 @@ export default class ComboboxVirtualExample {
       return;
     }
 
-    // if the filter value is empty, set the value to undefined
-    if (this.filter() === '') {
+    // if the input value is empty, set the value to undefined
+    if (this.inputValue() === '') {
       this.value.set(undefined);
     } else {
-      // otherwise set the filter value to the selected value
-      this.filter.set(this.value() ?? '');
+      // otherwise set the input value to the selected value
+      this.inputValue.set(this.value() ?? '');
     }
+
+    this.filter.set('');
   }
 }
 

--- a/apps/documentation/src/app/examples/combobox/combobox.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox.example.ts
@@ -25,12 +25,12 @@ import {
   template: `
     <div
       [(ngpComboboxValue)]="value"
-      (ngpComboboxValueChange)="filter.set($event)"
+      (ngpComboboxValueChange)="onValueChange($event)"
       (ngpComboboxOpenChange)="resetOnClose($event)"
       ngpCombobox
     >
       <input
-        [value]="filter()"
+        [value]="inputValue()"
         (input)="onFilterChange($event)"
         placeholder="Select an option"
         ngpComboboxInput
@@ -207,6 +207,9 @@ export default class ComboboxExample {
   /** The selected value. */
   readonly value = signal<string | undefined>(undefined);
 
+  /** The input value. */
+  readonly inputValue = signal<string>('');
+
   /** The filter value. */
   readonly filter = signal<string>('');
 
@@ -217,7 +220,13 @@ export default class ComboboxExample {
 
   protected onFilterChange(event: Event): void {
     const input = event.target as HTMLInputElement;
+    this.inputValue.set(input.value);
     this.filter.set(input.value);
+  }
+
+  protected onValueChange(value: string | undefined): void {
+    this.inputValue.set(value ?? '');
+    this.filter.set('');
   }
 
   protected resetOnClose(open: boolean): void {
@@ -226,12 +235,14 @@ export default class ComboboxExample {
       return;
     }
 
-    // if the filter value is empty, set the value to undefined
-    if (this.filter() === '') {
+    // if the input value is empty, set the value to undefined
+    if (this.inputValue() === '') {
       this.value.set(undefined);
     } else {
-      // otherwise set the filter value to the selected value
-      this.filter.set(this.value() ?? '');
+      // otherwise set the input value to the selected value
+      this.inputValue.set(this.value() ?? '');
     }
+
+    this.filter.set('');
   }
 }

--- a/apps/documentation/src/app/examples/combobox/combobox.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox.tailwind.example.ts
@@ -26,13 +26,13 @@ import {
     <div
       class="relative box-border flex h-[2.125rem] w-[300px] items-center justify-between rounded-lg border border-gray-200 bg-white transition-colors focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-500 dark:border-gray-700 dark:bg-transparent dark:focus-within:outline-blue-400"
       [(ngpComboboxValue)]="value"
-      (ngpComboboxValueChange)="filter.set($event)"
+      (ngpComboboxValueChange)="onValueChange($event)"
       (ngpComboboxOpenChange)="resetOnClose($event)"
       ngpCombobox
     >
       <input
         class="font-inherit h-full flex-1 border-none bg-transparent px-4 text-[14px] text-gray-900 outline-hidden focus:ring-0 dark:bg-transparent dark:text-gray-100"
-        [value]="filter()"
+        [value]="inputValue()"
         (input)="onFilterChange($event)"
         placeholder="Select an option"
         ngpComboboxInput
@@ -91,6 +91,9 @@ export default class ComboboxExample {
   /** The selected value. */
   readonly value = signal<string | undefined>(undefined);
 
+  /** The input value. */
+  readonly inputValue = signal<string>('');
+
   /** The filter value. */
   readonly filter = signal<string>('');
 
@@ -101,7 +104,13 @@ export default class ComboboxExample {
 
   protected onFilterChange(event: Event): void {
     const input = event.target as HTMLInputElement;
+    this.inputValue.set(input.value);
     this.filter.set(input.value);
+  }
+
+  protected onValueChange(value: string | undefined): void {
+    this.inputValue.set(value ?? '');
+    this.filter.set('');
   }
 
   protected resetOnClose(open: boolean): void {
@@ -110,12 +119,14 @@ export default class ComboboxExample {
       return;
     }
 
-    // if the filter value is empty, set the value to undefined
-    if (this.filter() === '') {
+    // if the input value is empty, set the value to undefined
+    if (this.inputValue() === '') {
       this.value.set(undefined);
     } else {
-      // otherwise set the filter value to the selected value
-      this.filter.set(this.value() ?? '');
+      // otherwise set the input value to the selected value
+      this.inputValue.set(this.value() ?? '');
     }
+
+    this.filter.set('');
   }
 }


### PR DESCRIPTION
Closes #774

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:


## Issue

Closes #774 

## What does this PR implement/fix?

Fixes the combobox documentation examples so reopening a combobox after selecting a value no longer filters the option list immediately.
The examples now keep the displayed input value separate from the active filter query. Selecting an option fills the input and clears the filter, while typing still filters options as expected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the combobox docs demos so reopening after a selection doesn’t auto-filter the list, and ensures the filter always resets on close. Addresses #774 by separating the displayed input text from the active filter query.

- **Bug Fixes**
  - Introduced `inputValue` separate from `filter` in default, Tailwind, virtual, and custom-option demos; inputs bind to `inputValue`, and typing updates both.
  - Selection sets `inputValue` and clears `filter`; on close, always clear `filter` and either clear the selection if the input is empty or sync `inputValue` to the selected value (via `onValueChange` and a unified `resetOnClose`).

<sup>Written for commit d81578174337cc44a39939597c15ed16306a8414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

