### PR TITLE
feat(listbox): migrate listbox state

### DIFF
--- a/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
+++ b/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
@@ -47,7 +47,7 @@ export class Listbox implements ControlValueAccessor {
   /**
    * Access the listbox state
    */
-  protected readonly state = injectListboxState<NgpListbox<string>>();
+  protected readonly state = injectListboxState<string>();
 
   /**
    * The listbox mode.

--- a/packages/ng-primitives/listbox/src/index.ts
+++ b/packages/ng-primitives/listbox/src/index.ts
@@ -3,7 +3,6 @@ export { NgpListboxOption } from './listbox-option/listbox-option';
 export { NgpListboxSection } from './listbox-section/listbox-section';
 export { NgpListboxTrigger } from './listbox-trigger/listbox-trigger';
 export { NgpListbox } from './listbox/listbox';
-export { injectListboxState, provideListboxState } from './listbox/listbox-state';
 export {
   NgpListboxTriggerStateToken,
   ngpListboxTrigger,
@@ -20,3 +19,27 @@ export {
   type NgpListboxSectionState,
   type NgpListboxSectionProps,
 } from './listbox-section/listbox-section-state';
+export {
+  NgpListboxOptionStateToken,
+  ngpListboxOption,
+  injectListboxOptionState,
+  provideListboxOptionState,
+  type NgpListboxOptionState,
+  type NgpListboxOptionProps,
+} from './listbox-option/listbox-option-state';
+export {
+  NgpListboxHeaderStateToken,
+  ngpListboxHeader,
+  injectListboxHeaderState,
+  provideListboxHeaderState,
+  type NgpListboxHeaderState,
+  type NgpListboxHeaderProps,
+} from './listbox-header/listbox-header-state';
+export {
+  NgpListboxStateToken,
+  ngpListbox,
+  injectListboxState,
+  provideListboxState,
+  type NgpListboxState,
+  type NgpListboxProps,
+} from './listbox/listbox-state';

--- a/packages/ng-primitives/listbox/src/index.ts
+++ b/packages/ng-primitives/listbox/src/index.ts
@@ -12,3 +12,11 @@ export {
   type NgpListboxTriggerState,
   type NgpListboxTriggerProps,
 } from './listbox-trigger/listbox-trigger-state';
+export {
+  NgpListboxSectionStateToken,
+  ngpListboxSection,
+  injectListboxSectionState,
+  provideListboxSectionState,
+  type NgpListboxSectionState,
+  type NgpListboxSectionProps,
+} from './listbox-section/listbox-section-state';

--- a/packages/ng-primitives/listbox/src/index.ts
+++ b/packages/ng-primitives/listbox/src/index.ts
@@ -4,3 +4,11 @@ export { NgpListboxSection } from './listbox-section/listbox-section';
 export { NgpListboxTrigger } from './listbox-trigger/listbox-trigger';
 export { NgpListbox } from './listbox/listbox';
 export { injectListboxState, provideListboxState } from './listbox/listbox-state';
+export {
+  NgpListboxTriggerStateToken,
+  ngpListboxTrigger,
+  injectListboxTriggerState,
+  provideListboxTriggerState,
+  type NgpListboxTriggerState,
+  type NgpListboxTriggerProps,
+} from './listbox-trigger/listbox-trigger-state';

--- a/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
@@ -1,0 +1,33 @@
+import { ElementRef, signal, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+
+export interface NgpListboxHeaderState {
+  /** Access the component's reference. */
+  readonly elementRef: ElementRef;
+  /** The id of the listbox header. */
+  readonly id?: Signal<string>;
+}
+
+export interface NgpListboxHeaderProps {
+  /** The id of the listbox header. */
+  readonly id?: Signal<string>;
+}
+
+export const [
+  NgpListboxHeaderStateToken,
+  ngpListboxHeader,
+  injectListboxHeaderState,
+  provideListboxHeaderState,
+] = createPrimitive('NgpListboxHeader', ({ id = signal<string>('') }: NgpListboxHeaderProps) => {
+  const elementRef = injectElementRef();
+
+  // Host binding
+  attrBinding(elementRef, 'role', 'presentation');
+  attrBinding(elementRef, 'id', () => id());
+
+  return {
+    elementRef,
+    id,
+  } satisfies NgpListboxHeaderState;
+});

--- a/packages/ng-primitives/listbox/src/listbox-header/listbox-header.ts
+++ b/packages/ng-primitives/listbox/src/listbox-header/listbox-header.ts
@@ -1,6 +1,7 @@
 import { Directive, input } from '@angular/core';
 import { NgpHeaderToken } from 'ng-primitives/common';
 import { uniqueId } from 'ng-primitives/utils';
+import { ngpListboxHeader } from './listbox-header-state';
 
 @Directive({
   selector: '[ngpListboxHeader]',
@@ -17,4 +18,8 @@ export class NgpListboxHeader {
    * The id of the listbox header.
    */
   readonly id = input(uniqueId('ngp-listbox-header'));
+
+  protected readonly state = ngpListboxHeader({
+    id: this.id,
+  });
 }

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
@@ -8,7 +8,6 @@ import {
   dataBinding,
   listener,
   onDestroy,
-  StateInjectionOptions,
 } from 'ng-primitives/state';
 import { injectListboxState } from '../listbox/listbox-state';
 

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
@@ -165,7 +165,9 @@ export const [
       optionDisabled,
       active,
       selected,
-      disabled: _disabled(),
+      get disabled(): boolean {
+        return _disabled();
+      },
       _disabled,
       setActiveStyles,
       setInactiveStyles,

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
@@ -1,0 +1,196 @@
+import { FocusOrigin } from '@angular/cdk/a11y';
+import { computed, effect, signal, Signal } from '@angular/core';
+import { ngpInteractions } from 'ng-primitives/interactions';
+import { injectElementRef, onDomRemoval, scrollIntoViewIfNeeded } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  createPrimitive,
+  dataBinding,
+  listener,
+  onDestroy,
+  StateInjectionOptions,
+} from 'ng-primitives/state';
+import { injectListboxState } from '../listbox/listbox-state';
+
+export interface NgpListboxOptionState<T> {
+  /**
+   * The id of the listbox.
+   */
+  readonly id?: Signal<string>;
+  /**
+   * The value of the option.
+   */
+  readonly value: Signal<T>;
+  /**
+   * Whether the option is disabled.
+   */
+  readonly optionDisabled?: Signal<boolean>;
+  /**
+   * Whether the option is active.
+   */
+  readonly active?: Signal<boolean>;
+  /**
+   * @internal
+   * Whether the option is selected.
+   */
+  readonly selected: Signal<boolean | undefined>;
+  /**
+   * @internal
+   * Whether the option is disabled - this is used by the `Highlightable` interface.
+   */
+  disabled: boolean;
+  /**
+   * Whether the option is disabled.
+   */
+  _disabled: Signal<boolean>;
+  /**
+   * @internal
+   * Sets the active state of the option.
+   */
+  setActiveStyles: () => void;
+  /**
+   * @internal
+   * Sets the inactive state of the option.
+   */
+  setInactiveStyles: () => void;
+  /**
+   * @internal
+   * Gets the label of the option, used by the `Highlightable` interface.
+   */
+  getLabel: () => string;
+  /**
+   * @internal
+   * Selects the option.
+   */
+  select: (origin: FocusOrigin) => void;
+  /**
+   * @internal
+   * Activate the current options.
+   */
+  activate: () => void;
+  destroy: () => void;
+}
+
+export interface NgpListboxOptionProps<T> {
+  /**
+   * The id of the listbox.
+   */
+  readonly id?: Signal<string>;
+  /**
+   * The value of the option.
+   */
+  readonly value: Signal<T>;
+  /**
+   * Whether the option is disabled.
+   */
+  readonly optionDisabled?: Signal<boolean>;
+}
+
+export const [
+  NgpListboxOptionStateToken,
+  ngpListboxOption,
+  injectListboxOptionState,
+  provideListboxOptionState,
+] = createPrimitive(
+  'NgpListboxOption',
+  <T>({
+    id = signal<string>(''),
+    value,
+    optionDisabled = signal<boolean>(false),
+  }: NgpListboxOptionProps<T>) => {
+    const elementRef = injectElementRef();
+    const listboxState = injectListboxState<T>();
+
+    const active = signal<boolean>(false);
+    const selected = computed(() => listboxState()?.isSelected(value()));
+
+    const _disabled = computed(() => optionDisabled() || (listboxState()?.disabled() ?? false));
+
+    // Setup interactions
+    ngpInteractions({
+      hover: true,
+      press: true,
+      focusVisible: true,
+      focus: true,
+      disabled: _disabled,
+    });
+
+    // Host binding
+    attrBinding(elementRef, 'role', 'option');
+    attrBinding(elementRef, 'id', () => id());
+    attrBinding(elementRef, 'aria-disabled', () => optionDisabled());
+    dataBinding(elementRef, 'data-disabled', () => (optionDisabled() ? '' : null));
+    dataBinding(elementRef, 'data-active', () =>
+      listboxState()?.isFocused() && active() ? '' : null,
+    );
+    dataBinding(elementRef, 'data-selected', () => (selected() ? '' : null));
+
+    // Listener
+    listener(elementRef, 'mouseenter', activate);
+    listener(elementRef, 'click', () => select('mouse'));
+    listener(elementRef, 'keydown.enter', () => select('keyboard'));
+    listener(elementRef, 'keydown.space', () => select('keyboard'));
+
+    function setActiveStyles(): void {
+      active.set(true);
+      scrollIntoViewIfNeeded(elementRef.nativeElement);
+    }
+
+    function setInactiveStyles(): void {
+      active.set(false);
+    }
+
+    function getLabel(): string {
+      return elementRef.nativeElement.textContent ?? '';
+    }
+
+    function select(origin: FocusOrigin): void {
+      if (_disabled()) {
+        return;
+      }
+
+      listboxState()?.selectOption(value(), origin);
+    }
+
+    function activate(): void {
+      if (_disabled()) {
+        return;
+      }
+
+      listboxState()?.activateOption(value());
+    }
+
+    const state = {
+      id,
+      value,
+      optionDisabled,
+      active,
+      selected,
+      disabled: _disabled(),
+      _disabled,
+      setActiveStyles,
+      setInactiveStyles,
+      getLabel,
+      select,
+      activate,
+      destroy,
+    } satisfies NgpListboxOptionState<T>;
+
+    function destroy(): void {
+      listboxState()?.removeOption(state);
+    }
+
+    onDestroy(() => {
+      destroy();
+    });
+
+    effect(() => listboxState()?.addOption(state));
+
+    onDomRemoval(elementRef.nativeElement, () => {
+      listboxState()?.removeOption(state);
+      setInactiveStyles();
+    });
+
+    return state;
+  },
+);

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option.ts
@@ -1,40 +1,14 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { BooleanInput } from '@angular/cdk/coercion';
-import {
-  booleanAttribute,
-  computed,
-  Directive,
-  effect,
-  input,
-  OnDestroy,
-  signal,
-} from '@angular/core';
-import { ngpInteractions } from 'ng-primitives/interactions';
-import { injectElementRef, onDomRemoval, scrollIntoViewIfNeeded } from 'ng-primitives/internal';
+import { booleanAttribute, Directive, input, OnDestroy } from '@angular/core';
 import { uniqueId } from 'ng-primitives/utils';
-import type { NgpListbox } from '../listbox/listbox';
-import { injectListboxState } from '../listbox/listbox-state';
+import { ngpListboxOption } from './listbox-option-state';
 
 @Directive({
   selector: '[ngpListboxOption]',
   exportAs: 'ngpListboxOption',
-  host: {
-    role: 'option',
-    '[attr.id]': 'id()',
-    '[attr.aria-disabled]': 'optionDisabled()',
-    '[attr.data-active]': 'listbox()?.isFocused() && active() ? "" : undefined',
-    '[attr.data-selected]': 'selected() ? "" : undefined',
-    '[attr.data-disabled]': 'optionDisabled() ? "" : undefined',
-    '(click)': 'select("mouse")',
-    '(mouseenter)': 'activate()',
-    '(keydown.enter)': 'select("keyboard")',
-    '(keydown.space)': 'select("keyboard")',
-  },
 })
 export class NgpListboxOption<T> implements OnDestroy {
-  protected readonly listbox = injectListboxState<NgpListbox<T>>();
-  private readonly elementRef = injectElementRef();
-
   /**
    * The id of the listbox.
    */
@@ -55,55 +29,22 @@ export class NgpListboxOption<T> implements OnDestroy {
     transform: booleanAttribute,
   });
 
-  /**
-   * Whether the option is active.
-   */
-  protected readonly active = signal<boolean>(false);
-
-  /**
-   * @internal
-   * Whether the option is selected.
-   */
-  readonly selected = computed(() => this.listbox()?.isSelected(this.value()));
+  protected readonly state = ngpListboxOption<T>({
+    id: this.id,
+    value: this.value,
+    optionDisabled: this.optionDisabled,
+  });
 
   /**
    * @internal
    * Whether the option is disabled - this is used by the `Highlightable` interface.
    */
   get disabled(): boolean {
-    return this._disabled();
-  }
-
-  /**
-   * Whether the option is disabled.
-   */
-  protected readonly _disabled = computed(
-    () => this.optionDisabled() || (this.listbox()?.disabled() ?? false),
-  );
-
-  constructor() {
-    ngpInteractions({
-      hover: true,
-      press: true,
-      focusVisible: true,
-      focus: true,
-      disabled: this._disabled,
-    });
-
-    // the listbox may not be available when the option is initialized
-    // so we need to add the option when the listbox is available
-    effect(() => this.listbox()?.addOption(this));
-
-    // any time the element is removed from the dom, we need to remove the option from the listbox
-    // and we also want to reset the active state
-    onDomRemoval(this.elementRef.nativeElement, () => {
-      this.listbox()?.removeOption(this);
-      this.setInactiveStyles();
-    });
+    return this.state._disabled();
   }
 
   ngOnDestroy(): void {
-    this.listbox()?.removeOption(this);
+    return this.state.destroy();
   }
 
   /**
@@ -111,8 +52,7 @@ export class NgpListboxOption<T> implements OnDestroy {
    * Sets the active state of the option.
    */
   setActiveStyles(): void {
-    this.active.set(true);
-    scrollIntoViewIfNeeded(this.elementRef.nativeElement);
+    return this.state.setActiveStyles();
   }
 
   /**
@@ -120,7 +60,7 @@ export class NgpListboxOption<T> implements OnDestroy {
    * Sets the inactive state of the option.
    */
   setInactiveStyles(): void {
-    this.active.set(false);
+    return this.state.setInactiveStyles();
   }
 
   /**
@@ -128,7 +68,7 @@ export class NgpListboxOption<T> implements OnDestroy {
    * Gets the label of the option, used by the `Highlightable` interface.
    */
   getLabel(): string {
-    return this.elementRef.nativeElement.textContent ?? '';
+    return this.state.getLabel();
   }
 
   /**
@@ -136,11 +76,7 @@ export class NgpListboxOption<T> implements OnDestroy {
    * Selects the option.
    */
   select(origin: FocusOrigin): void {
-    if (this._disabled()) {
-      return;
-    }
-
-    this.listbox()?.selectOption(this.value(), origin);
+    return this.state.select(origin);
   }
 
   /**
@@ -148,10 +84,6 @@ export class NgpListboxOption<T> implements OnDestroy {
    * Activate the current options.
    */
   activate(): void {
-    if (this._disabled()) {
-      return;
-    }
-
-    this.listbox()?.activateOption(this.value());
+    return this.state.activate();
   }
 }

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option.ts
@@ -37,6 +37,12 @@ export class NgpListboxOption<T> implements OnDestroy {
 
   /**
    * @internal
+   * Whether the option is selected.
+   */
+  readonly selected = this.state.selected;
+
+  /**
+   * @internal
    * Whether the option is disabled - this is used by the `Highlightable` interface.
    */
   get disabled(): boolean {

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
@@ -1,0 +1,39 @@
+import { ElementRef, signal, Signal } from '@angular/core';
+import { NgpHeader } from 'ng-primitives/common';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+
+export interface NgpListboxSectionState {
+  /** Access the comonent's reference. */
+  readonly elementRef: ElementRef;
+}
+
+export interface NgpListboxSectionProps {
+  /**
+   * Access the header of the section if it exists.
+   */
+  readonly header?: Signal<NgpHeader | undefined>;
+}
+
+export const [
+  NgpListboxSectionStateToken,
+  ngpListboxSection,
+  injectListboxSectionState,
+  provideListboxSectionState,
+] = createPrimitive(
+  'NgpListboxSection',
+  ({
+    // TODO: Replace deprecated API
+    header = signal<NgpHeader | undefined>(undefined),
+  }: NgpListboxSectionProps) => {
+    const elementRef = injectElementRef();
+
+    // Host binding
+    attrBinding(elementRef, 'role', 'group');
+    attrBinding(elementRef, 'aria-labelledby', () => header()?.id());
+
+    return {
+      elementRef,
+    } satisfies NgpListboxSectionState;
+  },
+);

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section.ts
@@ -1,5 +1,6 @@
 import { contentChild, Directive } from '@angular/core';
 import { NgpHeaderToken } from 'ng-primitives/common';
+import { ngpListboxSection } from './listbox-section-state';
 
 @Directive({
   selector: '[ngpListboxSection]',
@@ -10,8 +11,13 @@ import { NgpHeaderToken } from 'ng-primitives/common';
   },
 })
 export class NgpListboxSection {
+  // TODO: Replace deprecated API
   /**
    * Access the header of the section if it exists.
    */
   protected readonly header = contentChild(NgpHeaderToken, { descendants: true });
+
+  protected readonly state = ngpListboxSection({
+    header: this.header,
+  });
 }

--- a/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger-state.ts
@@ -1,0 +1,40 @@
+import { ElementRef } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { injectPopoverTriggerState } from 'ng-primitives/popover';
+import { createPrimitive, listener } from 'ng-primitives/state';
+
+export interface NgpListboxTriggerState {
+  /** Access the component's reference. */
+  readonly elementRef: ElementRef;
+  /**
+   * When the up or down arrow key is pressed, open the popover.
+   */
+  onPopover: (event: KeyboardEvent) => void;
+}
+
+export interface NgpListboxTriggerProps {}
+
+export const [
+  NgpListboxTriggerStateToken,
+  ngpListboxTrigger,
+  injectListboxTriggerState,
+  provideListboxTriggerState,
+] = createPrimitive('NgpListboxTrigger', ({}: NgpListboxTriggerProps) => {
+  const elementRef = injectElementRef();
+  const popoverTriggerState = injectPopoverTriggerState();
+
+  // Listener
+  listener(elementRef, 'keydown', handleOnKeydown);
+
+  function handleOnKeydown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      popoverTriggerState().show();
+      event.preventDefault();
+    }
+  }
+
+  return {
+    elementRef,
+    onPopover: handleOnKeydown,
+  } satisfies NgpListboxTriggerState;
+});

--- a/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger.ts
+++ b/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger.ts
@@ -1,24 +1,17 @@
-import { Directive, HostListener } from '@angular/core';
-import { injectPopoverTriggerState } from 'ng-primitives/popover';
+import { Directive } from '@angular/core';
+import { ngpListboxTrigger } from './listbox-trigger-state';
 
 @Directive({
   selector: '[ngpListboxTrigger]',
   exportAs: 'ngpListboxTrigger',
 })
 export class NgpListboxTrigger {
-  /**
-   * There must also be a popover trigger directive associated with this element.
-   */
-  private readonly popoverTrigger = injectPopoverTriggerState();
+  protected readonly state = ngpListboxTrigger({});
 
   /**
    * When the up or down arrow key is pressed, open the popover.
    */
-  @HostListener('keydown', ['$event'])
   openPopover(event: KeyboardEvent) {
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      this.popoverTrigger().show();
-      event.preventDefault();
-    }
+    return this.state.onPopover(event);
   }
 }

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -1,29 +1,278 @@
+import { ActiveDescendantKeyManager, FocusOrigin } from '@angular/cdk/a11y';
+import { computed, DestroyRef, ElementRef, inject, Injector, Signal, signal } from '@angular/core';
+import { NgpSelectionMode } from 'ng-primitives/common';
+import { ngpFocusVisible } from 'ng-primitives/interactions';
+import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
+import { injectPopoverTriggerState } from 'ng-primitives/popover';
 import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
+  attrBinding,
+  controlledState,
+  createPrimitive,
+  deprecatedSetter,
+  listener,
+  StateInjectionOptions,
 } from 'ng-primitives/state';
-import type { NgpListbox } from './listbox';
+import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
+import { Observable } from 'rxjs';
+import { NgpListboxOptionState } from '../listbox-option/listbox-option-state';
 
-/**
- * The state token  for the Listbox primitive.
- */
-export const NgpListboxStateToken = createStateToken<NgpListbox<unknown>>('Listbox');
+export interface NgpListboxState<T> {
+  /** Access the component's reference. */
+  readonly elementRef: ElementRef;
+  /**
+   * The id of the listbox.
+   */
+  readonly id?: Signal<string>;
+  /**
+   * The listbox selection mode.
+   */
+  readonly mode: Signal<NgpSelectionMode>;
+  /**
+   * The listbox selection.
+   */
+  readonly value: Signal<T[]>;
+  /**
+   * The listbox disabled state.
+   */
+  readonly disabled: Signal<boolean>;
+  /**
+   * The comparator function to use when comparing values.
+   * If not provided, strict equality (===) is used.
+   */
+  readonly compareWith: Signal<(a: T, b: T) => boolean>;
+  /**
+   * @internal
+   * Whether the listbox is focused.
+   */
+  readonly isFocused: Signal<boolean>;
+  /**
+   * Emits when the listbox selection changes.
+   */
+  readonly valueChange: Observable<T[]>;
+  /**
+   * @internal
+   * Selects an option in the listbox.
+   */
+  selectOption: (value: T, origin: FocusOrigin) => void;
+  /**
+   * @internal
+   * Determine if an option is selected using the compareWith function.
+   */
+  isSelected: (value: T) => boolean;
+  /**
+   * @internal
+   * Activate an option in the listbox.
+   */
+  activateOption: (value: T) => void;
+  /**
+   * Registers an option with the listbox.
+   * @internal
+   */
+  addOption: (option: NgpListboxOptionState<T>) => void;
+  /**
+   * Deregisters an option with the listbox.
+   * @internal
+   */
+  removeOption: (option: NgpListboxOptionState<T>) => void;
+  onAfterContentInit: () => void;
+  setValue: (value: T[]) => void;
+}
 
-/**
- * Provides the Listbox state.
- */
-export const provideListboxState = createStateProvider(NgpListboxStateToken);
+export interface NgpListboxProps<T> {
+  /**
+   * The id of the listbox.
+   */
+  readonly id?: Signal<string>;
+  /**
+   * The listbox selection mode.
+   */
+  readonly mode?: Signal<NgpSelectionMode>;
+  /**
+   * The listbox selection.
+   */
+  readonly value?: Signal<T[]>;
+  /**
+   * The listbox disabled state.
+   */
+  readonly disabled?: Signal<boolean>;
+  /**
+   * The comparator function to use when comparing values.
+   * If not provided, strict equality (===) is used.
+   */
+  readonly compareWith?: Signal<(a: T, b: T) => boolean>;
+  /**
+   * Emits when the listbox selection changes.
+   */
+  readonly onValueChange?: (value: T[]) => void;
+}
 
-/**
- * Injects the Listbox state.
- */
-export const injectListboxState = createStateInjector<NgpListbox<unknown>>(NgpListboxStateToken, {
-  deferred: true,
-});
+export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideListboxState] =
+  createPrimitive(
+    'NgpListbox',
+    <T>({
+      id = signal<string>(''),
+      mode = signal<NgpSelectionMode>('single'),
+      value: _value = signal<T[]>([]),
+      disabled = signal<boolean>(false),
+      compareWith = signal<(a: T, b: T) => boolean>((a, b) => a === b),
+      onValueChange,
+    }: NgpListboxProps<T>) => {
+      const elementRef = injectElementRef();
+      const injector = inject(Injector);
+      const destroyRef = inject(DestroyRef);
+      const popoverTriggerState = injectPopoverTriggerState({ optional: true });
 
-/**
- * The Listbox state registration function.
- */
-export const listboxState = createState(NgpListboxStateToken);
+      const options = signal<NgpListboxOptionState<T>[]>([]);
+      const activeDescendant = signal<string | undefined>(undefined);
+      const isFocused = signal<boolean>(false);
+      const tabIndex = computed(() => (disabled() ? -1 : 0));
+
+      const [value, setValue, valueChange] = controlledState({
+        value: _value,
+        defaultValue: signal<T[]>([]),
+        onChange: onValueChange,
+      });
+
+      // Setup interactions
+      ngpFocusVisible({ disabled: disabled });
+
+      // Host binding
+      attrBinding(elementRef, 'role', 'listbox');
+      attrBinding(elementRef, 'id', () => id());
+      attrBinding(elementRef, 'tabindex', () => tabIndex());
+      attrBinding(elementRef, 'aria-disabled', () => disabled());
+      attrBinding(elementRef, 'aria-multiselectable', () => mode() === 'multiple');
+      attrBinding(elementRef, 'aria-activedescendant', () => activeDescendant());
+
+      // Listener
+      listener(elementRef, 'focusin', () => isFocused.set(true));
+      listener(elementRef, 'focusout', () => isFocused.set(false));
+      listener(elementRef, 'keydown', onKeydown);
+
+      const keyManager = new ActiveDescendantKeyManager(options, injector);
+
+      function onAfterContentInit(): void {
+        keyManager.withHomeAndEnd().withTypeAhead().withVerticalOrientation();
+
+        keyManager.change
+          .pipe(safeTakeUntilDestroyed(destroyRef))
+          .subscribe(() => activeDescendant.set(keyManager.activeItem?.id?.()));
+
+        // On initialization, set the first selected option as the active descendant if there is one.
+        updateActiveItem();
+
+        // if the options change, update the active item, for example the item that was previously active may have been removed
+        // any time the value changes we should make sure that the active item is updated
+        explicitEffect([options], () => updateActiveItem(), {
+          injector: injector,
+        });
+      }
+
+      function updateActiveItem(): void {
+        const activeItem = keyManager.activeItem;
+        if (activeItem && options().includes(activeItem)) {
+          return;
+        }
+
+        const selectedOption = options().find(o => o.selected());
+
+        if (selectedOption) {
+          keyManager.setActiveItem(selectedOption);
+        } else {
+          keyManager.setFirstItemActive();
+        }
+      }
+
+      function onKeydown(event: KeyboardEvent): void {
+        keyManager.onKeydown(event);
+
+        // if the keydown was enter or space, select the active descendant if there is one
+        if (event.key === 'Enter' || event.key === ' ') {
+          keyManager.activeItem?.select('keyboard');
+        }
+
+        // if this is an arrow key or selection key, prevent the default action to prevent the page from scrolling
+        if (
+          event.key === 'ArrowDown' ||
+          event.key === 'ArrowUp' ||
+          event.key === 'Enter' ||
+          event.key === ' '
+        ) {
+          event.preventDefault();
+        }
+      }
+
+      function selectOption(val: T, origin: FocusOrigin): void {
+        if (mode() === 'single') {
+          const newValue = [val];
+          setValue(newValue);
+        } else {
+          // if the value is already selected, remove it, otherwise add it
+          if (isSelected(val)) {
+            const newValue = value().filter(v => !compareWith()(v, val));
+            setValue(newValue);
+          } else {
+            const newValue = [...value(), val];
+            setValue(newValue);
+          }
+        }
+
+        // Set the active descendant to the selected option.
+        const option = options().find(o => compareWith()(o.value(), val));
+
+        if (option) {
+          keyManager.setActiveItem(option);
+        }
+
+        // If the listbox is within a popover, close the popover on selection if it is not in a multiple selection mode.
+        if (mode() !== 'multiple') {
+          popoverTriggerState()?.hide(origin);
+        }
+      }
+
+      function activateOption(value: T) {
+        const option = options().find(o => compareWith()(o.value(), value));
+
+        if (option) {
+          keyManager.setActiveItem(option);
+        }
+      }
+
+      function addOption(option: NgpListboxOptionState<T>): void {
+        // if the option already exists, do not add it again
+        if (!options().includes(option)) {
+          options.update(options => [...options, option]);
+        }
+      }
+
+      function removeOption(option: NgpListboxOptionState<T>): void {
+        options.update(options => options.filter(o => o !== option));
+      }
+
+      function isSelected(val: T): boolean {
+        return value().some(v => compareWith()(v, val));
+      }
+
+      return {
+        elementRef,
+        id,
+        mode,
+        value: deprecatedSetter(value, 'setValue', setValue),
+        disabled,
+        compareWith,
+        isFocused,
+        valueChange,
+        selectOption,
+        isSelected,
+        activateOption,
+        addOption,
+        removeOption,
+        onAfterContentInit,
+        setValue,
+      } satisfies NgpListboxState<T>;
+    },
+  );
+
+export function injectListboxState<T>(options?: StateInjectionOptions): Signal<NgpListboxState<T>> {
+  return _injectListboxState(options) as Signal<NgpListboxState<T>>;
+}

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -43,7 +43,7 @@ export interface NgpListboxState<T> {
   /**
    * The listbox disabled state.
    */
-  readonly disabled: Signal<boolean>;
+  readonly disabled: WritableSignal<boolean>;
   /**
    * The comparator function to use when comparing values.
    * If not provided, strict equality (===) is used.
@@ -85,6 +85,7 @@ export interface NgpListboxState<T> {
   removeOption: (option: NgpListboxOptionState<T>) => void;
   onAfterContentInit: () => void;
   setValue: (value: T[]) => void;
+  setDisabled: (value: boolean) => void;
 }
 
 export interface NgpListboxProps<T> {
@@ -122,7 +123,7 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       id = signal<string>(''),
       mode = signal<NgpSelectionMode>('single'),
       value: _value = signal<T[]>([]),
-      disabled = signal<boolean>(false),
+      disabled: _disabled = signal<boolean>(false),
       compareWith = signal<(a: T, b: T) => boolean>((a, b) => a === b),
       onValueChange,
     }: NgpListboxProps<T>) => {
@@ -140,6 +141,11 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         value: _value,
         defaultValue: signal<T[]>([]),
         onChange: onValueChange,
+      });
+
+      const [disabled, setDisabled] = controlledState({
+        value: _disabled,
+        defaultValue: signal<boolean>(false),
       });
 
       // Setup interactions
@@ -267,7 +273,7 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         id,
         mode,
         value: deprecatedSetter(value, 'setValue', setValue),
-        disabled,
+        disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
         compareWith,
         isFocused,
         valueChange,
@@ -278,6 +284,7 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         removeOption,
         onAfterContentInit,
         setValue,
+        setDisabled,
       } satisfies NgpListboxState<T>;
     },
   );

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -1,5 +1,14 @@
 import { ActiveDescendantKeyManager, FocusOrigin } from '@angular/cdk/a11y';
-import { computed, DestroyRef, ElementRef, inject, Injector, Signal, signal } from '@angular/core';
+import {
+  computed,
+  DestroyRef,
+  ElementRef,
+  inject,
+  Injector,
+  Signal,
+  signal,
+  WritableSignal,
+} from '@angular/core';
 import { NgpSelectionMode } from 'ng-primitives/common';
 import { ngpFocusVisible } from 'ng-primitives/interactions';
 import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
@@ -30,7 +39,7 @@ export interface NgpListboxState<T> {
   /**
    * The listbox selection.
    */
-  readonly value: Signal<T[]>;
+  readonly value: WritableSignal<T[]>;
   /**
    * The listbox disabled state.
    */

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -178,7 +178,7 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
 
         // if the options change, update the active item, for example the item that was previously active may have been removed
         // any time the value changes we should make sure that the active item is updated
-        explicitEffect([options], () => updateActiveItem(), {
+        explicitEffect([options, value], () => updateActiveItem(), {
           injector: injector,
         });
       }

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -15,10 +15,13 @@ import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
 import { injectPopoverTriggerState } from 'ng-primitives/popover';
 import {
   attrBinding,
+  controlled,
   controlledState,
   createPrimitive,
   deprecatedSetter,
+  emitter,
   listener,
+  SetterOptions,
   StateInjectionOptions,
 } from 'ng-primitives/state';
 import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
@@ -84,7 +87,6 @@ export interface NgpListboxState<T> {
    */
   removeOption: (option: NgpListboxOptionState<T>) => void;
   onAfterContentInit: () => void;
-  setValue: (value: T[]) => void;
   setDisabled: (value: boolean) => void;
 }
 
@@ -137,15 +139,11 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       const isFocused = signal<boolean>(false);
       const tabIndex = computed(() => (disabled() ? -1 : 0));
 
-      const [value, setValue, valueChange] = controlledState({
-        value: _value,
-        defaultValue: signal<T[]>([]),
-        onChange: onValueChange,
-      });
+      const value = controlled(_value);
+      const valueChange = emitter<T[]>();
 
-      const [disabled, setDisabled] = controlledState({
+      const [disabled, setDisabled] = controlledState<boolean>({
         value: _disabled,
-        defaultValue: signal<boolean>(false),
       });
 
       // Setup interactions
@@ -220,15 +218,21 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       function selectOption(val: T, origin: FocusOrigin): void {
         if (mode() === 'single') {
           const newValue = [val];
-          setValue(newValue);
+          value.set(newValue);
+          valueChange.emit(newValue);
+          onValueChange?.(newValue);
         } else {
           // if the value is already selected, remove it, otherwise add it
           if (isSelected(val)) {
             const newValue = value().filter(v => !compareWith()(v, val));
-            setValue(newValue);
+            value.set(newValue);
+            valueChange.emit(newValue);
+            onValueChange?.(newValue);
           } else {
             const newValue = [...value(), val];
-            setValue(newValue);
+            value.set(newValue);
+            valueChange.emit(newValue);
+            onValueChange?.(newValue);
           }
         }
 
@@ -272,18 +276,17 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         elementRef,
         id,
         mode,
-        value: deprecatedSetter(value, 'setValue', setValue),
+        value,
         disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
         compareWith,
         isFocused,
-        valueChange,
+        valueChange: valueChange.asObservable(),
         selectOption,
         isSelected,
         activateOption,
         addOption,
         removeOption,
         onAfterContentInit,
-        setValue,
         setDisabled,
       } satisfies NgpListboxState<T>;
     },

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -21,7 +21,6 @@ import {
   deprecatedSetter,
   emitter,
   listener,
-  SetterOptions,
   StateInjectionOptions,
 } from 'ng-primitives/state';
 import { safeTakeUntilDestroyed } from 'ng-primitives/utils';

--- a/packages/ng-primitives/listbox/src/listbox/listbox.test.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox.test.ts
@@ -261,10 +261,10 @@ describe('NgpListbox', () => {
         { imports, componentProperties: { valueChange } },
       );
       fireEvent.click(container.getByTestId('opt-a'));
-      expect(valueChange).toHaveBeenCalledWith(['a']);
+      await waitFor(() => expect(valueChange).toHaveBeenCalledWith(['a']));
 
       fireEvent.click(container.getByTestId('opt-c'));
-      expect(valueChange).toHaveBeenCalledWith(['a', 'c']);
+      await waitFor(() => expect(valueChange).toHaveBeenCalledWith(['a', 'c']));
     });
   });
 

--- a/packages/ng-primitives/listbox/src/listbox/listbox.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox.ts
@@ -1,57 +1,17 @@
-import { ActiveDescendantKeyManager, FocusOrigin } from '@angular/cdk/a11y';
+import { FocusOrigin } from '@angular/cdk/a11y';
 import { BooleanInput } from '@angular/cdk/coercion';
-import {
-  AfterContentInit,
-  booleanAttribute,
-  computed,
-  DestroyRef,
-  Directive,
-  HostListener,
-  inject,
-  Injector,
-  input,
-  output,
-  signal,
-} from '@angular/core';
+import { AfterContentInit, booleanAttribute, Directive, input, output } from '@angular/core';
 import { NgpSelectionMode } from 'ng-primitives/common';
-import { ngpFocusVisible } from 'ng-primitives/interactions';
-import { explicitEffect } from 'ng-primitives/internal';
-import { injectPopoverTriggerState } from 'ng-primitives/popover';
-import { safeTakeUntilDestroyed, uniqueId } from 'ng-primitives/utils';
-import type { NgpListboxOption } from '../listbox-option/listbox-option';
-import { listboxState, provideListboxState } from './listbox-state';
+import { uniqueId } from 'ng-primitives/utils';
+import { NgpListboxOptionState } from '../listbox-option/listbox-option-state';
+import { ngpListbox, provideListboxState } from './listbox-state';
 
 @Directive({
   selector: '[ngpListbox]',
   exportAs: 'ngpListbox',
   providers: [provideListboxState()],
-  host: {
-    '[id]': 'state.id()',
-    role: 'listbox',
-    '[attr.tabindex]': 'tabindex()',
-    '[attr.aria-disabled]': 'state.disabled()',
-    '[attr.aria-multiselectable]': 'state.mode() === "multiple"',
-    '[attr.aria-activedescendant]': 'activeDescendant()',
-    '(focusin)': 'isFocused.set(true)',
-    '(focusout)': 'isFocused.set(false)',
-  },
 })
 export class NgpListbox<T> implements AfterContentInit {
-  /**
-   * Access the injector.
-   */
-  private readonly injector = inject(Injector);
-
-  /**
-   * Access the destroy ref.
-   */
-  private readonly destroyRef = inject(DestroyRef);
-
-  /**
-   * The listbox may be used within a popover, which we may want to close on selection.
-   */
-  private readonly popoverTrigger = injectPopoverTriggerState({ optional: true });
-
   /**
    * The id of the listbox.
    */
@@ -95,90 +55,19 @@ export class NgpListbox<T> implements AfterContentInit {
   });
 
   /**
-   * The tabindex of the listbox.
-   */
-  protected readonly tabindex = computed(() => (this.state.disabled() ? -1 : 0));
-
-  /**
-   * Access the options in the listbox.
-   */
-  protected readonly options = signal<NgpListboxOption<T>[]>([]);
-
-  /**
-   * The active descendant of the listbox.
-   */
-  protected readonly keyManager = new ActiveDescendantKeyManager(this.options, this.injector);
-
-  /**
-   * Gets the active descendant of the listbox.
-   */
-  protected readonly activeDescendant = signal<string | undefined>(undefined);
-
-  /**
-   * @internal
-   * Whether the listbox is focused.
-   */
-  readonly isFocused = signal(false);
-
-  /**
    * The listbox state
    */
-  protected readonly state = listboxState<NgpListbox<T>>(this);
-
-  constructor() {
-    ngpFocusVisible({ disabled: this.state.disabled });
-  }
+  protected readonly state = ngpListbox({
+    id: this.id,
+    mode: this.mode,
+    value: this.value,
+    disabled: this.disabled,
+    compareWith: this.compareWith,
+    onValueChange: (value: T[]) => this.valueChange.emit(value),
+  });
 
   ngAfterContentInit(): void {
-    this.keyManager.withHomeAndEnd().withTypeAhead().withVerticalOrientation();
-
-    this.keyManager.change
-      .pipe(safeTakeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.activeDescendant.set(this.keyManager.activeItem?.id()));
-
-    // On initialization, set the first selected option as the active descendant if there is one.
-    this.updateActiveItem();
-
-    // if the options change, update the active item, for example the item that was previously active may have been removed
-    // any time the value changes we should make sure that the active item is updated
-    explicitEffect([this.options], () => this.updateActiveItem(), {
-      injector: this.injector,
-    });
-  }
-
-  private updateActiveItem(): void {
-    const activeItem = this.keyManager.activeItem;
-    if (activeItem && this.options().includes(activeItem)) {
-      return;
-    }
-
-    const selectedOption = this.options().find(o => o.selected());
-
-    if (selectedOption) {
-      this.keyManager.setActiveItem(selectedOption);
-    } else {
-      this.keyManager.setFirstItemActive();
-    }
-  }
-
-  @HostListener('keydown', ['$event'])
-  protected onKeydown(event: KeyboardEvent): void {
-    this.keyManager.onKeydown(event);
-
-    // if the keydown was enter or space, select the active descendant if there is one
-    if (event.key === 'Enter' || event.key === ' ') {
-      this.keyManager.activeItem?.select('keyboard');
-    }
-
-    // if this is an arrow key or selection key, prevent the default action to prevent the page from scrolling
-    if (
-      event.key === 'ArrowDown' ||
-      event.key === 'ArrowUp' ||
-      event.key === 'Enter' ||
-      event.key === ' '
-    ) {
-      event.preventDefault();
-    }
+    return this.state.onAfterContentInit();
   }
 
   /**
@@ -186,34 +75,7 @@ export class NgpListbox<T> implements AfterContentInit {
    * Selects an option in the listbox.
    */
   selectOption(value: T, origin: FocusOrigin): void {
-    if (this.state.mode() === 'single') {
-      const newValue = [value];
-      this.state.value.set(newValue);
-      this.valueChange.emit(newValue);
-    } else {
-      // if the value is already selected, remove it, otherwise add it
-      if (this.isSelected(value)) {
-        const newValue = this.state.value().filter(v => !this.state.compareWith()(v, value));
-        this.state.value.set(newValue);
-        this.valueChange.emit(newValue);
-      } else {
-        const newValue = [...this.state.value(), value];
-        this.state.value.set(newValue);
-        this.valueChange.emit(newValue);
-      }
-    }
-
-    // Set the active descendant to the selected option.
-    const option = this.options().find(o => this.state.compareWith()(o.value(), value));
-
-    if (option) {
-      this.keyManager.setActiveItem(option);
-    }
-
-    // If the listbox is within a popover, close the popover on selection if it is not in a multiple selection mode.
-    if (this.state.mode() !== 'multiple') {
-      this.popoverTrigger()?.hide(origin);
-    }
+    return this.state.selectOption(value, origin);
   }
 
   /**
@@ -221,7 +83,7 @@ export class NgpListbox<T> implements AfterContentInit {
    * Determine if an option is selected using the compareWith function.
    */
   isSelected(value: T): boolean {
-    return this.state.value().some(v => this.state.compareWith()(v, value));
+    return this.state.isSelected(value);
   }
 
   /**
@@ -229,29 +91,22 @@ export class NgpListbox<T> implements AfterContentInit {
    * Activate an option in the listbox.
    */
   activateOption(value: T) {
-    const option = this.options().find(o => this.state.compareWith()(o.value(), value));
-
-    if (option) {
-      this.keyManager.setActiveItem(option);
-    }
+    return this.state.activateOption(value);
   }
 
   /**
    * Registers an option with the listbox.
    * @internal
    */
-  addOption(option: NgpListboxOption<T>): void {
-    // if the option already exists, do not add it again
-    if (!this.options().includes(option)) {
-      this.options.update(options => [...options, option]);
-    }
+  addOption(option: NgpListboxOptionState<T>): void {
+    return this.addOption(option);
   }
 
   /**
    * Deregisters an option with the listbox.
    * @internal
    */
-  removeOption(option: NgpListboxOption<T>): void {
-    this.options.update(options => options.filter(o => o !== option));
+  removeOption(option: NgpListboxOptionState<T>): void {
+    return this.state.removeOption(option);
   }
 }


### PR DESCRIPTION
- [ ] Fix tests

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #563 

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Listbox to the new primitive state architecture, moving logic from directives into composable state modules for listbox, option, section, header, and trigger. No breaking changes; ARIA and behavior stay the same.

- **Refactors**
  - Introduced `createPrimitive` state for `listbox`, `listbox-option`, `listbox-section`, `listbox-header`, and `listbox-trigger`, and exported tokens, factories, inject/provide helpers, and types from `index.ts`.
  - Moved host bindings, ARIA, ActiveDescendant key management, focus-visible, and trigger ArrowUp/Down handling into state; single-select still closes the popover.
  - Switched to controlled signals: `value` and `disabled` are WritableSignals; exposed `setDisabled`; `valueChange` remains. Simplified typing to `injectListboxState<T>()` (app updated). Tests now await async `valueChange` with `waitFor`.
  - Applied linting fixes across listbox files.

- **Bug Fixes**
  - Added the missing `explicitEffect` dependency to keep the active item in sync when options or value change.
  - Exposed `selected` as a computed on option state to support template bindings.
  - Fixed handling of `disabled` and `value` so signals and setters update correctly across modes.

<sup>Written for commit 0f7645b7477f9e0f13195735770988ded8fd558d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



