### PR TITLE
feat(state): controlled simplified

### DIFF
--- a/STATE_PATTERN_MIGRATION.md
+++ b/STATE_PATTERN_MIGRATION.md
@@ -432,7 +432,7 @@ export const [NgpComponentStateToken, ngpComponent, injectComponentState, provid
 We can also pass in a `setHandler` in order to customize the setter behavior, like closing a tooltip if the trigger become disabled.
 This can be achived by adding the `setHandler` parameter in `StateOptions<T>`.
 
-**The handler is always called after the value change and the new value emission.**
+**The handler is always called after the value change. If `emit` is not `false`, emission occures before the handler is called**
 
 ```typescript
 export const [NgpComponentStateToken, ngpComponent, injectComponentState, provideComponentState] =

--- a/STATE_PATTERN_MIGRATION.md
+++ b/STATE_PATTERN_MIGRATION.md
@@ -402,12 +402,54 @@ Sometimes a state file may need to change the value of a prop internally. In the
 ```typescript
 export const [NgpComponentStateToken, ngpComponent, injectComponentState, provideComponentState] =
   createPrimitive('NgpComponent', ({ value: _value = signal<string>('') }: NgpComponentProps) => {
-    const value = controlled(value);
+    const value = controlled(_value);
     function setValue(newValue: string): void {
       value.set(newValue);
     }
     return { value, setValue };
   });
+```
+
+If we need to have an emitter and a setter, we can use `state` utility to create a writable signal from a prop signal, an emitter and a setter function.
+
+It also can takes in an argument of type `(value: T) => void`, useful when a callback is needed in the directive itself.
+
+```typescript
+export const [NgpComponentStateToken, ngpComponent, injectComponentState, provideComponentState] =
+  createPrimitive(
+    'NgpComponent',
+    ({ value: _value = signal<string>(''), onValueChange }: NgpComponentProps) => {
+      const [value, setValue, valueChanged] = state({
+        value: _value,
+        onChange: onValueChange,
+      });
+
+      return { value, setValue, valueChanged };
+    },
+  );
+```
+
+We can also pass in a `setHandler` in order to customize the setter behavior, like closing a tooltip if the trigger become disabled.
+This can be achived by adding the `setHandler` parameter in `StateOptions<T>`.
+
+**The handler is always called after the value change and the new value emission.**
+
+```typescript
+export const [NgpComponentStateToken, ngpComponent, injectComponentState, provideComponentState] =
+  createPrimitive(
+    'NgpComponent',
+    ({ value: _value = signal<string>(''), onValueChange }: NgpComponentProps) => {
+      const [value, setValue, valueChanged] = state({
+        value: _value,
+        onChange: onValueChange,
+        setHandler: (value: string) => {
+          console.log(value);
+        },
+      });
+
+      return { value, setValue, valueChanged };
+    },
+  );
 ```
 
 ## Composing states

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
@@ -9,9 +9,9 @@ import {
   createPrimitive,
   dataBinding,
   deprecatedSetter,
-  emitter,
   listener,
   SetterOptions,
+  state,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { Observable } from 'rxjs';
@@ -29,6 +29,10 @@ export interface NgpCheckboxState {
    */
   readonly checked: WritableSignal<boolean>;
   /**
+   * The default value of the checked state.
+   */
+  readonly defaultChecked: Signal<boolean>;
+  /**
    * Whether the checkbox is indeterminate.
    */
   readonly indeterminate: WritableSignal<boolean>;
@@ -45,25 +49,25 @@ export interface NgpCheckboxState {
    */
   readonly indeterminateChange: Observable<boolean>;
   /**
-   * Toggle the checkbox value.
-   */
-  toggle(event?: Event): void;
-  /**
    * Update the checked value.
    */
   setChecked(value: boolean, options?: SetterOptions): void;
   /**
    * Set the default checked state.
    */
-  setDefaultChecked(value: boolean): void;
+  setDefaultChecked(value: boolean, options?: SetterOptions): void;
   /**
    * Update the indeterminate value.
    */
-  setIndeterminate(value: boolean): void;
+  setIndeterminate(value: boolean, options?: SetterOptions): void;
   /**
    * Set the disabled value.
    */
-  setDisabled(value: boolean): void;
+  setDisabled(value: boolean, options?: SetterOptions): void;
+  /**
+   * Toggle the checkbox value.
+   */
+  toggle(event?: Event): void;
 }
 
 /**
@@ -104,24 +108,33 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
   createPrimitive(
     'NgpCheckbox',
     ({
-      id = signal(uniqueId('ngp-checkbox')),
+      id: _id = signal(uniqueId('ngp-checkbox')),
       checked: _checked = signal<boolean | undefined>(undefined),
-      defaultChecked: _defaultChecked,
+      defaultChecked: _defaultChecked = signal<boolean>(false),
       indeterminate: _indeterminate = signal(false),
       disabled: _disabled = signal(false),
       onCheckedChange,
       onIndeterminateChange,
     }: NgpCheckboxProps): NgpCheckboxState => {
       const element = injectElementRef();
-      const defaultChecked = controlled(_defaultChecked, false);
+
+      const id = controlled(_id);
+      const [defaultChecked, setDefaultChecked] = state({
+        value: _defaultChecked,
+      });
       const [checked, setChecked, checkedChange] = controlledState({
         value: _checked,
         defaultValue: defaultChecked,
         onChange: onCheckedChange,
       });
-      const indeterminate = controlled(_indeterminate);
-      const disabled = controlled(_disabled);
-      const indeterminateChange = emitter<boolean>();
+      const [indeterminate, setIndeterminate, indeterminateChange] = state({
+        value: _indeterminate,
+        onChange: onIndeterminateChange,
+      });
+      const [disabled, setDisabled] = state({
+        value: _disabled,
+      });
+
       const tabindex = computed(() => (disabled() ? -1 : 0));
 
       // Setup interactions and form control hooks
@@ -130,11 +143,11 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
 
       // Host bindings
       attrBinding(element, 'role', 'checkbox');
-      attrBinding(element, 'aria-checked', () => (indeterminate() ? 'mixed' : checked()));
-      dataBinding(element, 'data-checked', checked);
-      dataBinding(element, 'data-indeterminate', indeterminate);
-      attrBinding(element, 'aria-disabled', disabled);
       attrBinding(element, 'tabindex', () => tabindex().toString());
+      attrBinding(element, 'aria-checked', () => (indeterminate() ? 'mixed' : checked()));
+      attrBinding(element, 'aria-disabled', () => disabled());
+      dataBinding(element, 'data-checked', () => checked());
+      dataBinding(element, 'data-indeterminate', () => indeterminate());
 
       // Event listeners
       listener(element, 'click', event => toggle(event));
@@ -167,28 +180,19 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
         }
       }
 
-      function setIndeterminate(value: boolean): void {
-        indeterminate.set(value);
-        onIndeterminateChange?.(value);
-        indeterminateChange.emit(value);
-      }
-
-      function setDisabled(value: boolean): void {
-        disabled.set(value);
-      }
-
       return {
         id,
+        defaultChecked,
         checked: deprecatedSetter(checked, 'setChecked', setChecked),
-        indeterminate: deprecatedSetter(indeterminate, 'setIndeterminate'),
-        disabled: deprecatedSetter(disabled, 'setDisabled'),
+        indeterminate: deprecatedSetter(indeterminate, 'setIndeterminate', setIndeterminate),
+        disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
         checkedChange,
-        indeterminateChange: indeterminateChange.asObservable(),
-        toggle,
+        indeterminateChange,
         setChecked,
-        setDefaultChecked: defaultChecked.set,
+        setDefaultChecked,
         setIndeterminate,
         setDisabled,
+        toggle,
       } satisfies NgpCheckboxState;
     },
   );

--- a/packages/ng-primitives/state/src/index.ts
+++ b/packages/ng-primitives/state/src/index.ts
@@ -462,6 +462,33 @@ export function controlledState<T>({
   return [resolved.asReadonly() as Signal<T>, set, change.asObservable()];
 }
 
+export interface StateOptions<T> {
+  readonly value: Signal<T | undefined>;
+  readonly onChange?: (value: T) => void;
+  readonly setHandler?: (newValue: T) => void;
+}
+
+export function state<T>({ value, onChange, setHandler }: StateOptions<T>): ControlledState<T> {
+  const change = emitter<T>();
+
+  const internalValue = linkedSignal(() => value());
+
+  function set(newValue: T, options?: SetterOptions): void {
+    if (internalValue() === newValue && options?.emit !== false) return;
+
+    internalValue.set(newValue);
+
+    if (options?.emit !== false) {
+      onChange?.(newValue);
+      change.emit(newValue);
+    }
+
+    setHandler?.(newValue);
+  }
+
+  return [internalValue.asReadonly() as Signal<T>, set, change.asObservable()];
+}
+
 function setAttribute(
   element: ElementRef<HTMLElement>,
   attr: string,

--- a/packages/ng-primitives/state/src/state.test.ts
+++ b/packages/ng-primitives/state/src/state.test.ts
@@ -1,7 +1,8 @@
 import { Component, runInInjectionContext, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { state } from 'ng-primitives/state';
-import { firstValueFrom, take, toArray } from 'rxjs/operators';
+import { firstValueFrom } from 'rxjs';
+import { take, toArray } from 'rxjs/operators';
 
 @Component({ template: '', standalone: true })
 class NoopComponent {}

--- a/packages/ng-primitives/state/src/state.test.ts
+++ b/packages/ng-primitives/state/src/state.test.ts
@@ -1,0 +1,510 @@
+import { Component, runInInjectionContext, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { state } from 'ng-primitives/state';
+import { firstValueFrom, take, toArray } from 'rxjs/operators';
+
+@Component({ template: '', standalone: true })
+class NoopComponent {}
+
+function createState<T>(...args: Parameters<typeof state<T>>) {
+  const fixture = TestBed.createComponent(NoopComponent);
+  const injector = fixture.componentRef.injector;
+  const [value, set, change] = runInInjectionContext(injector, () => state<T>(...args));
+  return { value, set, change };
+}
+
+describe('state', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  describe('initialization', () => {
+    it('should use the defaultValue when value is undefined', () => {
+      const result = createState<boolean>({
+        value: signal(true),
+      });
+      expect(result.value()).toBe(true);
+    });
+
+    it('should handle value being undefined with no defaultValue', () => {
+      const result = createState<boolean>({
+        value: signal(undefined),
+      });
+      expect(result.value()).toBeUndefined();
+    });
+
+    it('should handle non-boolean types', () => {
+      const result = createState<string>({
+        value: signal('hello'),
+      });
+      expect(result.value()).toBe('hello');
+    });
+
+    it('should handle numeric types including zero', () => {
+      const result = createState<number>({
+        value: signal(0),
+      });
+      expect(result.value()).toBe(0);
+    });
+
+    it('should handle null as a valid controlled value', () => {
+      const result = createState<string | null>({
+        value: signal<string | null | undefined>(null),
+      });
+      expect(result.value()).toBeNull();
+    });
+
+    it('should handle empty string as a valid controlled value', () => {
+      const result = createState<string>({
+        value: signal<string | undefined>(''),
+      });
+      expect(result.value()).toBe('');
+    });
+
+    it('should handle false as a valid controlled value', () => {
+      const result = createState<boolean>({
+        value: signal<boolean | undefined>(false),
+      });
+      expect(result.value()).toBe(false);
+    });
+  });
+
+  describe('uncontrolled mode (value is undefined)', () => {
+    it('should update value when set is called', () => {
+      const result = createState<boolean>({
+        value: signal(undefined),
+      });
+
+      result.set(true);
+      expect(result.value()).toBe(true);
+    });
+
+    it('should allow toggling back and forth', () => {
+      const result = createState<boolean>({
+        value: signal(undefined),
+      });
+
+      result.set(true);
+      expect(result.value()).toBe(true);
+
+      result.set(false);
+      expect(result.value()).toBe(false);
+
+      result.set(true);
+      expect(result.value()).toBe(true);
+    });
+
+    it('should work with complex object types', () => {
+      const result = createState<{ x: number; y: number }>({
+        value: signal(undefined),
+      });
+
+      const newValue = { x: 10, y: 20 };
+      result.set(newValue);
+      expect(result.value()).toEqual(newValue);
+    });
+
+    it('should work with array types', () => {
+      const result = createState<string[]>({
+        value: signal(undefined),
+      });
+
+      result.set(['a', 'b']);
+      expect(result.value()).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('controlled mode (value is defined)', () => {
+    it('should always reflect the controlled value', () => {
+      const value = signal<boolean | undefined>(true);
+      const result = createState<boolean>({
+        value,
+      });
+
+      expect(result.value()).toBe(true);
+
+      value.set(false);
+      expect(result.value()).toBe(false);
+
+      value.set(true);
+      expect(result.value()).toBe(true);
+    });
+  });
+
+  describe('onChange callback', () => {
+    it('should call onChange when set is called', () => {
+      const onChange = vi.fn();
+      const result = createState<boolean>({
+        value: signal(undefined),
+        onChange,
+      });
+
+      result.set(true);
+      expect(onChange).toHaveBeenCalledWith(true);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onChange with the new value each time set is called', () => {
+      const onChange = vi.fn();
+      const result = createState<boolean>({
+        value: signal(undefined),
+        onChange,
+      });
+
+      result.set(true);
+      result.set(false);
+      result.set(true);
+
+      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(onChange).toHaveBeenNthCalledWith(1, true);
+      expect(onChange).toHaveBeenNthCalledWith(2, false);
+      expect(onChange).toHaveBeenNthCalledWith(3, true);
+    });
+
+    it('should call onChange in controlled mode so the parent can respond', () => {
+      const onChange = vi.fn();
+      const value = signal<boolean | undefined>(false);
+      const result = createState<boolean>({
+        value,
+        onChange,
+      });
+
+      result.set(true);
+      expect(onChange).toHaveBeenCalledWith(true);
+    });
+
+    it('should not call onChange when controlled value changes externally', () => {
+      const onChange = vi.fn();
+      const value = signal<boolean | undefined>(false);
+      createState<boolean>({
+        value,
+        onChange,
+      });
+
+      value.set(true);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should work without an onChange callback', () => {
+      const result = createState<boolean>({
+        value: signal(undefined),
+      });
+      expect(() => result.set(true)).not.toThrow();
+    });
+
+    it('should call onChange with complex types', () => {
+      const onChange = vi.fn();
+      const result = createState<{ id: number }>({
+        value: signal(undefined),
+        onChange,
+      });
+
+      const newValue = { id: 42 };
+      result.set(newValue);
+      expect(onChange).toHaveBeenCalledWith(newValue);
+    });
+  });
+
+  describe('change observable', () => {
+    it('should emit when set is called', async () => {
+      const result = createState<boolean>({
+        value: signal(undefined),
+      });
+
+      const promise = firstValueFrom(result.change);
+      result.set(true);
+
+      expect(await promise).toBe(true);
+    });
+
+    it('should emit multiple values', async () => {
+      const result = createState<boolean>({
+        value: signal(undefined),
+      });
+
+      const promise = firstValueFrom(result.change.pipe(take(3), toArray()));
+      result.set(true);
+      result.set(false);
+      result.set(true);
+
+      expect(await promise).toEqual([true, false, true]);
+    });
+
+    it('should emit in controlled mode so the parent can respond', async () => {
+      const value = signal<boolean | undefined>(false);
+      const result = createState<boolean>({ value });
+
+      const promise = firstValueFrom(result.change);
+      result.set(true);
+
+      expect(await promise).toBe(true);
+    });
+
+    it('should not emit when controlled value changes externally', () => {
+      const spy = vi.fn();
+      const value = signal<boolean | undefined>(false);
+      const result = createState<boolean>({ value });
+
+      result.change.subscribe(spy);
+      value.set(true);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('priority and precedence', () => {
+    it('should treat null controlled value as a defined value (not fallback to default)', () => {
+      const result = createState<string | null>({
+        value: signal<string | null | undefined>(null),
+      });
+
+      expect(result.value()).toBeNull();
+    });
+
+    it('should treat false controlled value as a defined value', () => {
+      const result = createState<boolean>({
+        value: signal<boolean | undefined>(false),
+      });
+
+      expect(result.value()).toBe(false);
+    });
+
+    it('should treat 0 controlled value as a defined value', () => {
+      const result = createState<number>({
+        value: signal<number | undefined>(0),
+      });
+
+      expect(result.value()).toBe(0);
+    });
+
+    it('should treat empty string controlled value as a defined value', () => {
+      const result = createState<string>({
+        value: signal<string | undefined>(''),
+      });
+
+      expect(result.value()).toBe('');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should not fire onChange when set is called with the same value', () => {
+      const onChange = vi.fn();
+      const result = createState<boolean>({
+        value: signal(undefined),
+        onChange,
+      });
+
+      result.set(true);
+      result.set(true);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle rapid successive set calls', () => {
+      const onChange = vi.fn();
+      const result = createState<number>({
+        value: signal(undefined),
+        onChange,
+      });
+
+      for (let i = 1; i <= 100; i++) {
+        result.set(i);
+      }
+
+      expect(result.value()).toBe(100);
+      expect(onChange).toHaveBeenCalledTimes(100);
+    });
+
+    it('should handle set being called with undefined in a nullable type', () => {
+      const onChange = vi.fn();
+      const result = createState<string | undefined>({
+        value: signal<string | undefined | undefined>('default'),
+        onChange,
+      });
+
+      result.set(undefined);
+      expect(onChange).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should handle controlled value signal updating multiple times', () => {
+      const value = signal<boolean | undefined>(true);
+      const result = createState<boolean>({
+        value,
+      });
+
+      expect(result.value()).toBe(true);
+      value.set(false);
+      expect(result.value()).toBe(false);
+      value.set(true);
+      expect(result.value()).toBe(true);
+    });
+
+    describe('set with emit: false', () => {
+      it('should update internal state but not call onChange', () => {
+        const onChange = vi.fn();
+        const result = createState<boolean>({
+          value: signal(undefined),
+          onChange,
+        });
+
+        result.set(true, { emit: false });
+
+        expect(result.value()).toBe(true);
+        expect(onChange).not.toHaveBeenCalled();
+      });
+
+      it('should update internal state but not emit on the change observable', () => {
+        const spy = vi.fn();
+        const result = createState<boolean>({
+          value: signal(undefined),
+        });
+
+        result.change.subscribe(spy);
+        result.set(true, { emit: false });
+
+        expect(result.value()).toBe(true);
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it('should default to emit: true when options are omitted', () => {
+        const onChange = vi.fn();
+        const result = createState<boolean>({
+          value: signal(undefined),
+          onChange,
+        });
+
+        result.set(true);
+        expect(onChange).toHaveBeenCalledWith(true);
+      });
+
+      it('should respect emit: true explicitly', () => {
+        const onChange = vi.fn();
+        const result = createState<boolean>({
+          value: signal(undefined),
+          onChange,
+        });
+
+        result.set(true, { emit: true });
+        expect(onChange).toHaveBeenCalledWith(true);
+      });
+
+      it('should update internal state in controlled mode even with emit: false', () => {
+        const onChange = vi.fn();
+        const value = signal<boolean | undefined>(false);
+        const result = createState<boolean>({
+          value,
+          onChange,
+        });
+
+        result.set(true, { emit: false });
+
+        expect(result.value()).toBe(true);
+        expect(onChange).not.toHaveBeenCalled();
+      });
+
+      it('should still skip when called with the same value and emit: false', () => {
+        const onChange = vi.fn();
+        const result = createState<boolean>({
+          value: signal(false),
+          onChange,
+        });
+
+        result.set(false, { emit: false });
+        expect(onChange).not.toHaveBeenCalled();
+        expect(result.value()).toBe(false);
+      });
+
+      it('should allow subsequent set with emit:true to fire after emit:false', () => {
+        const onChange = vi.fn();
+        const result = createState<string>({
+          value: signal(undefined),
+          onChange,
+        });
+
+        result.set('b', { emit: false });
+        expect(onChange).not.toHaveBeenCalled();
+        expect(result.value()).toBe('b');
+
+        result.set('c');
+        expect(onChange).toHaveBeenCalledWith('c');
+        expect(result.value()).toBe('c');
+      });
+    });
+  });
+
+  describe('form control integration (set with emit: false)', () => {
+    it('should update the resolved value without calling onChange', () => {
+      const onChange = vi.fn();
+      const result = createState<boolean>({
+        value: signal(undefined),
+        onChange,
+      });
+
+      // Simulate ControlValueAccessor.writeValue — must not trigger onChange
+      result.set(true, { emit: false });
+
+      expect(result.value()).toBe(true);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should not emit on the change observable', () => {
+      const spy = vi.fn();
+      const result = createState<boolean>({
+        value: signal(undefined),
+      });
+
+      result.change.subscribe(spy);
+      result.set(true, { emit: false });
+
+      expect(result.value()).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should allow user interaction (set) after set with emit: false', () => {
+      const onChange = vi.fn();
+      const result = createState<boolean>({
+        value: signal(undefined),
+        onChange,
+      });
+
+      // Form control writes a value
+      result.set(true, { emit: false });
+      expect(result.value()).toBe(true);
+      expect(onChange).not.toHaveBeenCalled();
+
+      // User toggles — should call onChange
+      result.set(false);
+      expect(result.value()).toBe(false);
+      expect(onChange).toHaveBeenCalledWith(false);
+    });
+
+    it('should reflect form control disabled via set with emit: false after user interaction', () => {
+      const onChange = vi.fn();
+      const result = createState<boolean>({
+        value: signal(undefined),
+        onChange,
+      });
+
+      // User interacts
+      result.set(true);
+      expect(onChange).toHaveBeenCalledWith(true);
+
+      // Form control resets via set with emit: false — should not call onChange
+      onChange.mockClear();
+      result.set(false, { emit: false });
+      expect(result.value()).toBe(false);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should handle set with emit: false with the same current value', () => {
+      const onChange = vi.fn();
+      const result = createState<boolean>({
+        value: signal(true),
+        onChange,
+      });
+
+      result.set(true, { emit: false });
+      expect(result.value()).toBe(true);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

Introduce a new state function called `state`, used to simplify `controlled`, `set` and `emitter` usage by creating a wrapper like `controlledState`.

This can be used when a state value must be updated internally, whether or not the user provided a value for the input.

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `state()` in `ng-primitives/state` to unify a value, setter, and change observable, and migrates the checkbox to use it. Updates docs with `state` examples and clarifies emission order; adds comprehensive tests.

- **New Features**
  - Added `state({ value, onChange, setHandler })` returning `[value, set, change]`; `set(value, { emit?: boolean })` emits by default, supports silent updates, and runs `setHandler` after the value change (after emission when `emit !== false`).
  - Works with controlled and uncontrolled values; extensive tests added.

- **Refactors**
  - Updated `ng-primitives/checkbox` to use `state()` for `defaultChecked`, `indeterminate`, and `disabled`; exposes `defaultChecked`; setters accept `SetterOptions`; `indeterminateChange` comes from `state()`.
  - Expanded `STATE_PATTERN_MIGRATION.md` with `state` usage and `setHandler` behavior.

<sup>Written for commit 27574d3a7ca4a72907e58fddde042599980cf38a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

