### PR TITLE
feat(menu): expose container on overlay trigger state

### DIFF
--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
@@ -1,5 +1,13 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
-import { computed, inject, Injector, signal, Signal, ViewContainerRef } from '@angular/core';
+import {
+  computed,
+  inject,
+  Injector,
+  signal,
+  Signal,
+  ViewContainerRef,
+  WritableSignal,
+} from '@angular/core';
 import { Placement } from '@floating-ui/dom';
 import { injectElementRef } from 'ng-primitives/internal';
 import { NgpMenuTriggerStateToken } from 'ng-primitives/menu';
@@ -17,6 +25,7 @@ import {
   controlled,
   createPrimitive,
   dataBinding,
+  deprecatedSetter,
   listener,
   onDestroy,
   StateInjectionOptions,
@@ -35,6 +44,12 @@ export interface NgpContextMenuTriggerState {
   readonly openOrigin: Signal<FocusOrigin>;
 
   /**
+   * The container in which the menu should be attached.
+   * @default document.body
+   */
+  readonly container: WritableSignal<HTMLElement | string | null>;
+
+  /**
    * Show the context menu.
    */
   show(origin?: FocusOrigin): void;
@@ -43,6 +58,12 @@ export interface NgpContextMenuTriggerState {
    * Hide the context menu.
    */
   hide(origin?: FocusOrigin): void;
+
+  /**
+   * Set the container in which the menu should be attached.
+   * @param container - The new container
+   */
+  setContainer(container: HTMLElement | string | null): void;
 
   /**
    * Set whether the pointer is over the menu content.
@@ -114,7 +135,7 @@ export const [
     offset: _offset = signal(2),
     flip: _flip = signal(true),
     context: _context = signal<T>(undefined as T),
-    container,
+    container: _container,
     scrollBehavior,
     shift,
   }: NgpContextMenuTriggerProps<T>) => {
@@ -128,6 +149,7 @@ export const [
     const flip = controlled(_flip);
     const offset = controlled(_offset);
     const context = controlled(_context);
+    const container = controlled(_container, 'body');
 
     // Internal state
     const overlay = signal<NgpOverlay<T> | null>(null);
@@ -265,7 +287,7 @@ export const [
         viewContainerRef,
         injector,
         context,
-        container: container?.(),
+        container: container(),
         offset: offset(),
         flip: flip(),
         shift,
@@ -281,6 +303,10 @@ export const [
       };
 
       overlay.set(createOverlay(config));
+    }
+
+    function setContainer(newContainer: HTMLElement | string | null): void {
+      container.set(newContainer);
     }
 
     function setPointerOverContent(_isOver: boolean): void {
@@ -318,8 +344,10 @@ export const [
     return {
       open,
       openOrigin,
+      container: deprecatedSetter(container, 'setContainer', setContainer),
       show,
       hide,
+      setContainer,
       setPointerOverContent,
     } satisfies NgpContextMenuTriggerState;
   },

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger-state.ts
@@ -60,7 +60,8 @@ export interface NgpContextMenuTriggerState {
   hide(origin?: FocusOrigin): void;
 
   /**
-   * Set the container in which the menu should be attached.
+   * Set the container in which the menu should be attached. Takes effect the
+   * next time the menu is opened; it does not move a menu that is already open.
    * @param container - The new container
    */
   setContainer(container: HTMLElement | string | null): void;

--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger.test.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/context-menu-trigger.test.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Directive, OnInit } from '@angular/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import { describe, expect, it } from 'vitest';
 import {
@@ -11,6 +11,7 @@ import {
   NgpContextMenuSubmenuTrigger,
   NgpContextMenuTrigger,
 } from '../index';
+import { injectContextMenuTriggerState } from './context-menu-trigger-state';
 
 @Component({
   template: `
@@ -841,6 +842,53 @@ describe('NgpContextMenuTrigger', () => {
         expect(document.querySelector('[data-testid="context-menu"]')).not.toBeInTheDocument(),
       );
       expect(document.activeElement).not.toBe(triggerArea);
+    });
+  });
+
+  describe('container', () => {
+    it('should expose container on the injected state so it can be set programmatically', async () => {
+      @Directive({
+        selector: '[setMenuContainer]',
+      })
+      class SetMenuContainerDirective implements OnInit {
+        private readonly trigger = injectContextMenuTriggerState();
+
+        ngOnInit(): void {
+          const host = document.querySelector('#menu-host') as HTMLElement;
+          this.trigger().setContainer(host);
+        }
+      }
+
+      await render(
+        `
+          <div id="menu-host"></div>
+
+          <div [ngpContextMenuTrigger]="menu" setMenuContainer data-testid="trigger-area">
+            Right-click me
+          </div>
+
+          <ng-template #menu>
+            <div ngpContextMenu data-testid="context-menu">
+              <button ngpContextMenuItem>Cut</button>
+            </div>
+          </ng-template>
+        `,
+        {
+          imports: [
+            NgpContextMenuTrigger,
+            NgpContextMenu,
+            NgpContextMenuItem,
+            SetMenuContainerDirective,
+          ],
+        },
+      );
+
+      fireEvent.contextMenu(screen.getByTestId('trigger-area'));
+
+      await waitFor(() => {
+        const container = document.querySelector('#menu-host');
+        expect(container?.querySelector('[ngpContextMenu]')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -61,6 +61,12 @@ export interface NgpMenuTriggerState<T = unknown> {
   readonly flip: WritableSignal<NgpFlip>;
 
   /**
+   * The container in which the menu should be attached.
+   * @default document.body
+   */
+  readonly container: WritableSignal<HTMLElement | string | null>;
+
+  /**
    * The context provided to the menu.
    */
   readonly context: WritableSignal<T>;
@@ -100,6 +106,12 @@ export interface NgpMenuTriggerState<T = unknown> {
    * @param context - The new context
    */
   setContext(context: T): void;
+
+  /**
+   * Set the container in which the menu should be attached.
+   * @param container - The new container
+   */
+  setContainer(container: HTMLElement | string | null): void;
 
   /**
    * Show the menu.
@@ -207,7 +219,7 @@ export const [
     flip: _flip = signal(true),
     shift: _shift = signal(undefined),
     context: _context = signal<T>(undefined as T),
-    container,
+    container: _container,
     scrollBehavior,
     cooldown,
     triggers = signal(['click'] as NgpMenuTriggerType[]),
@@ -227,6 +239,7 @@ export const [
     const shift = controlled(_shift);
     const offset = controlled(_offset);
     const context = controlled(_context);
+    const container = controlled(_container, 'body');
 
     // Internal state
     const overlay = signal<NgpOverlay<T> | null>(null);
@@ -471,7 +484,7 @@ export const [
         viewContainerRef,
         injector,
         context,
-        container: container?.(),
+        container: container(),
         placement: placement,
         offset: offset(),
         flip: flip(),
@@ -518,6 +531,10 @@ export const [
       context.set(newContext);
     }
 
+    function setContainer(newContainer: HTMLElement | string | null): void {
+      container.set(newContainer);
+    }
+
     /**
      * Called by menu content when pointer enters/leaves
      * @internal
@@ -553,8 +570,10 @@ export const [
       setPlacement,
       setOffset,
       setContext,
+      setContainer,
       setPointerOverContent,
       flip,
+      container: deprecatedSetter(container, 'setContainer', setContainer),
     } satisfies NgpMenuTriggerState<T>;
   },
 );

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -108,7 +108,8 @@ export interface NgpMenuTriggerState<T = unknown> {
   setContext(context: T): void;
 
   /**
-   * Set the container in which the menu should be attached.
+   * Set the container in which the menu should be attached. Takes effect the
+   * next time the menu is opened; it does not move a menu that is already open.
    * @param container - The new container
    */
   setContainer(container: HTMLElement | string | null): void;

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.test.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.test.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, Directive, OnInit } from '@angular/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import { NgpTooltip, NgpTooltipTrigger } from 'ng-primitives/tooltip';
 import { describe, expect, it } from 'vitest';
 import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from '../index';
+import { injectMenuTriggerState } from './menu-trigger-state';
 
 describe('NgpMenuTrigger', () => {
   it('should open a menu on click', async () => {
@@ -80,6 +81,73 @@ describe('NgpMenuTrigger', () => {
       expect(screen.getByTestId('menu-b')).toBeInTheDocument();
       // Menu A should be closed
       expect(screen.queryByTestId('menu-a')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('container', () => {
+    it('should attach the menu to a custom container when provided via the input', async () => {
+      await render(
+        `
+          <div id="menu-host"></div>
+
+          <button [ngpMenuTrigger]="menu" ngpMenuTriggerContainer="#menu-host">Open Menu</button>
+
+          <ng-template #menu>
+            <div ngpMenu data-testid="ngp-menu">
+              <button ngpMenuItem>Item 1</button>
+            </div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem],
+        },
+      );
+
+      fireEvent.click(screen.getByText('Open Menu'));
+
+      await waitFor(() => {
+        const container = document.querySelector('#menu-host');
+        expect(container?.querySelector('[ngpMenu]')).toBeInTheDocument();
+      });
+    });
+
+    it('should expose container on the injected state so it can be set programmatically (fixes #782)', async () => {
+      @Directive({
+        selector: '[setMenuContainer]',
+      })
+      class SetMenuContainerDirective implements OnInit {
+        private readonly menuTrigger = injectMenuTriggerState();
+
+        ngOnInit(): void {
+          const host = document.querySelector('#menu-host') as HTMLElement;
+          // container should be settable via the state setter method
+          this.menuTrigger().setContainer(host);
+        }
+      }
+
+      await render(
+        `
+          <div id="menu-host"></div>
+
+          <button [ngpMenuTrigger]="menu" setMenuContainer>Open Menu</button>
+
+          <ng-template #menu>
+            <div ngpMenu data-testid="ngp-menu">
+              <button ngpMenuItem>Item 1</button>
+            </div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem, SetMenuContainerDirective],
+        },
+      );
+
+      fireEvent.click(screen.getByText('Open Menu'));
+
+      await waitFor(() => {
+        const container = document.querySelector('#menu-host');
+        expect(container?.querySelector('[ngpMenu]')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/ng-primitives/navigation-menu/src/navigation-menu-trigger/navigation-menu-trigger-state.ts
+++ b/packages/ng-primitives/navigation-menu/src/navigation-menu-trigger/navigation-menu-trigger-state.ts
@@ -1,6 +1,14 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
 import { Directionality } from '@angular/cdk/bidi';
-import { computed, inject, Injector, signal, Signal, ViewContainerRef } from '@angular/core';
+import {
+  computed,
+  inject,
+  Injector,
+  signal,
+  Signal,
+  ViewContainerRef,
+  WritableSignal,
+} from '@angular/core';
 import { Placement } from '@floating-ui/dom';
 import { injectElementRef } from 'ng-primitives/internal';
 import {
@@ -17,6 +25,7 @@ import {
   controlled,
   createPrimitive,
   dataBinding,
+  deprecatedSetter,
   listener,
   onDestroy,
 } from 'ng-primitives/state';
@@ -58,7 +67,7 @@ export interface NgpNavigationMenuTriggerState {
   /**
    * The container for the content.
    */
-  readonly container: Signal<HTMLElement | string | null>;
+  readonly container: WritableSignal<HTMLElement | string | null>;
 
   /**
    * Whether the content is currently open.
@@ -101,6 +110,12 @@ export interface NgpNavigationMenuTriggerState {
    * @param id The content ID
    */
   setContentId(id: string): void;
+
+  /**
+   * Set the container in which the content should be attached.
+   * @param container The new container
+   */
+  setContainer(container: HTMLElement | string | null): void;
 
   /**
    * Update pointer over content state.
@@ -471,6 +486,10 @@ export const [
       contentId.set(newId);
     }
 
+    function setContainer(newContainer: HTMLElement | string | null): void {
+      container.set(newContainer);
+    }
+
     function setPointerOverContent(isOver: boolean): void {
       isPointerOverContent = isOver;
       if (isOver) {
@@ -501,7 +520,7 @@ export const [
       offset: offset.asReadonly(),
       flip: flip.asReadonly(),
       shift: shift.asReadonly(),
-      container: container.asReadonly(),
+      container: deprecatedSetter(container, 'setContainer', setContainer),
       open,
       id,
       contentId: computed(() => contentId()),
@@ -510,6 +529,7 @@ export const [
       focusFirstContentItem,
       focusLastContentItem,
       setContentId,
+      setContainer,
       setPointerOverContent,
       setFocusInsideContent,
       registerContentFocusFunctions,

--- a/packages/ng-primitives/navigation-menu/src/navigation-menu-trigger/navigation-menu-trigger-state.ts
+++ b/packages/ng-primitives/navigation-menu/src/navigation-menu-trigger/navigation-menu-trigger-state.ts
@@ -112,7 +112,9 @@ export interface NgpNavigationMenuTriggerState {
   setContentId(id: string): void;
 
   /**
-   * Set the container in which the content should be attached.
+   * Set the container in which the content should be attached. Takes effect the
+   * next time the content is opened; it does not move content that is already
+   * open.
    * @param container The new container
    */
   setContainer(container: HTMLElement | string | null): void;

--- a/packages/ng-primitives/navigation-menu/src/navigation-menu.test.ts
+++ b/packages/ng-primitives/navigation-menu/src/navigation-menu.test.ts
@@ -1,4 +1,4 @@
-import { Component, TemplateRef, viewChild } from '@angular/core';
+import { Component, Directive, OnInit, TemplateRef, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -13,6 +13,7 @@ import { NgpNavigationMenuItem } from './navigation-menu-item/navigation-menu-it
 import { NgpNavigationMenuLink } from './navigation-menu-link/navigation-menu-link';
 import { NgpNavigationMenuList } from './navigation-menu-list/navigation-menu-list';
 import { NgpNavigationMenuTrigger } from './navigation-menu-trigger/navigation-menu-trigger';
+import { injectNavigationMenuTriggerState } from './navigation-menu-trigger/navigation-menu-trigger-state';
 import { NgpNavigationMenu } from './navigation-menu/navigation-menu';
 
 @Component({
@@ -1102,6 +1103,70 @@ describe('Navigation Menu Cooldown Behavior', () => {
     await waitFor(() => {
       expect(document.querySelector('[data-testid="content-2"]')).toBeInTheDocument();
       expect(document.querySelector('[data-testid="content-2"]')).toHaveAttribute('data-instant');
+    });
+  });
+});
+
+@Directive({
+  selector: '[setNavMenuContainer]',
+})
+class SetNavMenuContainerDirective implements OnInit {
+  private readonly trigger = injectNavigationMenuTriggerState();
+
+  ngOnInit(): void {
+    const host = document.querySelector('#nav-menu-host') as HTMLElement;
+    this.trigger().setContainer(host);
+  }
+}
+
+@Component({
+  template: `
+    <div id="nav-menu-host"></div>
+
+    <nav ngpNavigationMenu>
+      <ul ngpNavigationMenuList>
+        <li ngpNavigationMenuItem ngpNavigationMenuItemValue="products">
+          <button
+            [ngpNavigationMenuTrigger]="productsContent"
+            setNavMenuContainer
+            data-testid="trigger-products"
+          >
+            Products
+          </button>
+          <ng-template #productsContent>
+            <div ngpNavigationMenuContent data-testid="content-products">
+              <a ngpNavigationMenuContentItem href="#">Product 1</a>
+            </div>
+          </ng-template>
+        </li>
+      </ul>
+    </nav>
+  `,
+  imports: [
+    NgpNavigationMenu,
+    NgpNavigationMenuList,
+    NgpNavigationMenuItem,
+    NgpNavigationMenuTrigger,
+    NgpNavigationMenuContent,
+    NgpNavigationMenuContentItem,
+    SetNavMenuContainerDirective,
+  ],
+})
+class NavMenuContainerComponent {}
+
+describe('Navigation Menu Container', () => {
+  it('should expose container on the injected state so it can be set programmatically', async () => {
+    const { fixture } = await render(NavMenuContainerComponent);
+    const trigger = fixture.debugElement.nativeElement.querySelector(
+      '[data-testid="trigger-products"]',
+    );
+
+    fireEvent.click(trigger);
+    fixture.detectChanges();
+
+    await waitFor(() => {
+      const container = document.querySelector('#nav-menu-host');
+      expect(container?.querySelector('[ngpNavigationMenuContent]')).toBeInTheDocument();
     });
   });
 });

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -25,6 +25,7 @@ import {
   controlled,
   createPrimitive,
   dataBinding,
+  deprecatedSetter,
   listener,
   StateInjectionOptions,
 } from 'ng-primitives/state';
@@ -76,7 +77,7 @@ export interface NgpPopoverTriggerState<T> {
    * Define the container in which the popover should be attached.
    * @default document.body
    */
-  readonly container: Signal<HTMLElement | string | null>;
+  readonly container: WritableSignal<HTMLElement | string | null>;
   /**
    * Define whether the popover should close when clicking outside of it, or a guard function.
    * @default true
@@ -126,6 +127,11 @@ export interface NgpPopoverTriggerState<T> {
   readonly open: Signal<boolean>;
   /** @internal onDestroy callback */
   destroy: () => void;
+  /**
+   * Set the container in which the popover should be attached.
+   * @param container - The new container
+   */
+  setContainer: (container: HTMLElement | string | null) => void;
   /**
    * Show the popover.
    * @returns A promise that resolves when the popover has been shown
@@ -242,7 +248,7 @@ export const [
     hideDelay = signal<number>(0),
     flip = signal<NgpFlip>(true),
     shift = signal<NgpShift>(undefined),
-    container = signal<HTMLElement | string | null>('body'),
+    container: _container,
     closeOnOutsideClick = signal<NgpDismissGuard<Element>>(true),
     closeOnEscape = signal<NgpDismissGuard<KeyboardEvent>>(true),
     scrollBehavior = signal<'reposition' | 'block' | 'close'>('reposition'),
@@ -257,6 +263,7 @@ export const [
     const injector = inject(Injector);
 
     const popover = controlled(_popover);
+    const container = controlled(_container, 'body');
 
     const overlay = signal<NgpOverlay<T> | null>(null);
     const open = computed(() => overlay()?.isOpen() ?? false);
@@ -356,6 +363,10 @@ export const [
       await overlay()?.hide({ origin });
     }
 
+    function setContainer(newContainer: HTMLElement | string | null): void {
+      container.set(newContainer);
+    }
+
     return {
       elementRef,
       popover,
@@ -366,7 +377,7 @@ export const [
       hideDelay,
       flip,
       shift,
-      container,
+      container: deprecatedSetter(container, 'setContainer', setContainer),
       closeOnOutsideClick,
       closeOnEscape,
       scrollBehavior,
@@ -377,6 +388,7 @@ export const [
       overlay,
       open,
       destroy,
+      setContainer,
       show,
       hide,
     } satisfies NgpPopoverTriggerState<T>;

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -128,7 +128,9 @@ export interface NgpPopoverTriggerState<T> {
   /** @internal onDestroy callback */
   destroy: () => void;
   /**
-   * Set the container in which the popover should be attached.
+   * Set the container in which the popover should be attached. Takes effect the
+   * next time the popover is opened; it does not move a popover that is already
+   * open.
    * @param container - The new container
    */
   setContainer: (container: HTMLElement | string | null) => void;

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.test.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.test.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, Directive, OnInit } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
 import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
 import { NgpTooltip, NgpTooltipTrigger, provideTooltipConfig } from 'ng-primitives/tooltip';
 import { describe, expect, it, vi } from 'vitest';
+import { injectPopoverTriggerState } from './popover-trigger-state';
 
 @Component({
   template: `
@@ -554,6 +555,44 @@ describe('NgpPopoverTrigger', () => {
       const popovers = document.querySelectorAll('[ngpPopover]');
       expect(popovers.length).toBe(1);
       expect(popovers[0].textContent).toContain('Popover B');
+    });
+  });
+
+  describe('container', () => {
+    it('should expose container on the injected state so it can be set programmatically', async () => {
+      @Directive({
+        selector: '[setPopoverContainer]',
+      })
+      class SetPopoverContainerDirective implements OnInit {
+        private readonly trigger = injectPopoverTriggerState();
+
+        ngOnInit(): void {
+          const host = document.querySelector('#popover-host') as HTMLElement;
+          this.trigger().setContainer(host);
+        }
+      }
+
+      const { getByRole } = await render(
+        `
+          <div id="popover-host"></div>
+
+          <button [ngpPopoverTrigger]="content" setPopoverContainer>Open Popover</button>
+
+          <ng-template #content>
+            <div ngpPopover>Popover content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpPopoverTrigger, NgpPopover, SetPopoverContainerDirective],
+        },
+      );
+
+      fireEvent.click(getByRole('button'));
+
+      await waitFor(() => {
+        const container = document.querySelector('#popover-host');
+        expect(container?.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
     });
   });
 });

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -47,7 +47,7 @@ export interface NgpSelectState<T> {
   readonly placement: Signal<Placement>;
 
   /** The container for the dropdown. */
-  readonly container: Signal<HTMLElement | string | null>;
+  readonly container: WritableSignal<HTMLElement | string | null>;
 
   /** Whether the dropdown should flip when there is not enough space. Can be a boolean to enable/disable, or an object with padding and fallbackPlacements options. */
   readonly flip: Signal<NgpFlip>;
@@ -229,6 +229,12 @@ export interface NgpSelectState<T> {
   setDisabled(disabled: boolean): void;
 
   /**
+   * Set the container in which the dropdown should be attached.
+   * @param container - The new container
+   */
+  setContainer(container: HTMLElement | string | null): void;
+
+  /**
    * Observable that emits whenever the value changes.
    */
   readonly valueChange: Observable<T | undefined>;
@@ -297,7 +303,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
       disabled: _disabled = signal(false),
       compareWith = signal<(a: T | undefined, b: T | undefined) => boolean>(Object.is),
       placement = signal<Placement>('bottom'),
-      container = signal<HTMLElement | string | null>('body'),
+      container: _container,
       flip = signal<NgpFlip>(true),
       offset = signal<NgpOffset>(0),
       scrollToOption = signal<((index: number) => void) | undefined>(undefined),
@@ -308,6 +314,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
       const elementRef = injectElementRef<HTMLElement>();
       const value = controlled(_value);
       const disabled = controlled(_disabled, false);
+      const container = controlled(_container, 'body');
       const valueChangeEmitter = emitter<T | undefined>();
 
       function setValue(newValue: T | undefined, options?: SetterOptions): void {
@@ -320,6 +327,10 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
 
       function setDisabled(isDisabled: boolean): void {
         disabled.set(isDisabled);
+      }
+
+      function setContainer(newContainer: HTMLElement | string | null): void {
+        container.set(newContainer);
       }
 
       ngpInteractions({
@@ -790,7 +801,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
         disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
         compareWith,
         placement,
-        container,
+        container: deprecatedSetter(container, 'setContainer', setContainer),
         flip,
         offset,
         scrollToOption,
@@ -814,6 +825,7 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
         activatePreviousOption,
         setValue,
         setDisabled,
+        setContainer,
         valueChange: valueChangeEmitter.asObservable(),
         registerPortal,
         registerDropdown,

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -229,7 +229,9 @@ export interface NgpSelectState<T> {
   setDisabled(disabled: boolean): void;
 
   /**
-   * Set the container in which the dropdown should be attached.
+   * Set the container in which the dropdown should be attached. Takes effect the
+   * next time the dropdown is opened; it does not move a dropdown that is already
+   * open.
    * @param container - The new container
    */
   setContainer(container: HTMLElement | string | null): void;

--- a/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
+++ b/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
@@ -1,8 +1,9 @@
-import { Component, signal } from '@angular/core';
+import { Component, Directive, OnInit, signal } from '@angular/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { NgpSelect, NgpSelectDropdown, NgpSelectOption, NgpSelectPortal } from '../../index';
+import { injectSelectState } from '../select-state';
 
 @Component({
   template: `
@@ -1699,6 +1700,59 @@ describe('NgpSelect', () => {
       // Destroy the component — should NOT emit openChange
       fixture.destroy();
       expect(spy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+@Directive({
+  selector: '[setSelectContainer]',
+})
+class SetSelectContainerDirective implements OnInit {
+  private readonly select = injectSelectState();
+
+  ngOnInit(): void {
+    const host = document.querySelector('#select-host') as HTMLElement;
+    this.select().setContainer(host);
+  }
+}
+
+@Component({
+  template: `
+    <div id="select-host"></div>
+
+    <div [(ngpSelectValue)]="value" ngpSelect setSelectContainer data-testid="select">
+      <span data-testid="placeholder">Select an option</span>
+
+      <div *ngpSelectPortal ngpSelectDropdown data-testid="dropdown">
+        @for (option of options; track option) {
+          <div [ngpSelectOptionValue]="option" ngpSelectOption>{{ option }}</div>
+        }
+      </div>
+    </div>
+  `,
+  imports: [
+    NgpSelect,
+    NgpSelectDropdown,
+    NgpSelectOption,
+    NgpSelectPortal,
+    SetSelectContainerDirective,
+  ],
+})
+class SelectContainerComponent {
+  readonly options = ['Apple', 'Banana', 'Cherry'];
+  readonly value = signal<string | undefined>(undefined);
+}
+
+describe('NgpSelect container', () => {
+  it('should expose container on the injected state so it can be set programmatically', async () => {
+    const user = userEvent.setup();
+    await render(SelectContainerComponent);
+
+    await user.click(screen.getByTestId('select'));
+
+    await waitFor(() => {
+      const container = document.querySelector('#select-host');
+      expect(container?.querySelector('[ngpSelectDropdown]')).toBeInTheDocument();
     });
   });
 });

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
@@ -24,6 +24,7 @@ import {
   controlled,
   createPrimitive,
   dataBinding,
+  deprecatedSetter,
   listener,
   StateInjectionOptions,
 } from 'ng-primitives/state';
@@ -80,7 +81,7 @@ export interface NgpTooltipTriggerState<T> {
    * Define the container in which the tooltip should be attached.
    * @default document.body
    */
-  readonly container: Signal<HTMLElement | string | null>;
+  readonly container: WritableSignal<HTMLElement | string | null>;
   /**
    * Define whether the tooltip should only show when the trigger element overflows.
    * @default false
@@ -168,6 +169,11 @@ export interface NgpTooltipTriggerState<T> {
    * Set the tooltip id.
    */
   setTooltipId: (id: string) => void;
+  /**
+   * Set the container in which the tooltip should be attached.
+   * @param container - The new container
+   */
+  setContainer: (container: HTMLElement | string | null) => void;
   /**
    * Called by tooltip content when pointer enters the tooltip.
    * @internal
@@ -294,7 +300,7 @@ export const [
     hideDelay = signal<number>(0),
     flip = signal<NgpFlip>(true),
     shift = signal<NgpShift | undefined>(undefined),
-    container = signal<HTMLElement | string | null>('body'),
+    container: _container,
     showOnOverflow = signal<boolean>(false),
     anchor = signal<HTMLElement | null>(null),
     context = signal<T | undefined>(undefined),
@@ -314,6 +320,7 @@ export const [
     const disposables = injectDisposables();
 
     const tooltip = controlled(_tooltip);
+    const container = controlled(_container, 'body');
 
     const tooltipId = signal<string | undefined>(undefined);
     const triggerHovered = signal<boolean>(false);
@@ -393,6 +400,10 @@ export const [
 
     function setTooltipId(id: string): void {
       tooltipId.set(id);
+    }
+
+    function setContainer(newContainer: HTMLElement | string | null): void {
+      container.set(newContainer);
     }
 
     /**
@@ -608,7 +619,7 @@ export const [
       hideDelay,
       flip,
       shift,
-      container,
+      container: deprecatedSetter(container, 'setContainer', setContainer),
       showOnOverflow,
       anchor,
       context,
@@ -627,6 +638,7 @@ export const [
       show,
       hide,
       setTooltipId,
+      setContainer,
       onTooltipHoverStart,
       onTooltipHoverEnd,
       destroy,

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
@@ -170,7 +170,9 @@ export interface NgpTooltipTriggerState<T> {
    */
   setTooltipId: (id: string) => void;
   /**
-   * Set the container in which the tooltip should be attached.
+   * Set the container in which the tooltip should be attached. Takes effect the
+   * next time the tooltip is shown; it does not move a tooltip that is already
+   * visible.
    * @param container - The new container
    */
   setContainer: (container: HTMLElement | string | null) => void;

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.test.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.test.ts
@@ -1,6 +1,8 @@
+import { Directive, OnInit } from '@angular/core';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
 import { NgpTooltip, NgpTooltipTrigger, provideTooltipConfig } from 'ng-primitives/tooltip';
 import { describe, expect, it, vi, afterEach } from 'vitest';
+import { injectTooltipTriggerState } from './tooltip-trigger-state';
 
 describe('NgpTooltipTrigger', () => {
   afterEach(() => {
@@ -819,6 +821,46 @@ describe('NgpTooltipTrigger', () => {
         `,
         {
           imports: [NgpTooltipTrigger, NgpTooltip],
+        },
+      );
+
+      fireEvent.mouseEnter(getByRole('button'));
+
+      await waitFor(() => {
+        const container = document.querySelector('#tooltip-host');
+        expect(container?.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+    });
+
+    it('should expose container on the injected state so it can be set programmatically', async () => {
+      @Directive({
+        selector: '[setTooltipContainer]',
+      })
+      class SetTooltipContainerDirective implements OnInit {
+        private readonly trigger = injectTooltipTriggerState();
+
+        ngOnInit(): void {
+          const host = document.querySelector('#tooltip-host') as HTMLElement;
+          this.trigger().setContainer(host);
+        }
+      }
+
+      const { getByRole } = await render(
+        `
+          <div id="tooltip-host"></div>
+
+          <button
+            [ngpTooltipTrigger]="content"
+            ngpTooltipTriggerShowDelay="0"
+            setTooltipContainer
+          ></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        {
+          imports: [NgpTooltipTrigger, NgpTooltip, SetTooltipContainerDirective],
         },
       );
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #782

## What does this PR implement/fix?

`injectMenuTriggerState()` returned a state object that omitted `container`, so the menu container could not be read or set programmatically via the injected state - unlike the documented `NgpTooltipTrigger` pattern in the issue.

This PR exposes `container` on the menu trigger state as a writable, input-synced signal (via `controlled`) with a `setContainer()` setter. Direct `.set()` is routed through the setter and deprecated via `deprecatedSetter`, matching the rest of the state API.

While auditing the other overlay-based triggers, the same gap existed elsewhere, so the fix is applied consistently across all of them:

- **context-menu**: `container` was completely absent from the state (identical bug to the menu).
- **tooltip / popover / select / navigation-menu**: `container` was exposed read-only and could not be set programmatically.

Each now exposes a writable, input-synced `container` signal plus a `setContainer()` method, giving a uniform `state().setContainer(...)` API across every overlay trigger.

### Tests

Added a test per primitive that injects the state, calls `setContainer(host)` in `ngOnInit`, opens the overlay, and asserts the content portals into the custom container. Full suite: 1406 passing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a writable, input-synced container on all overlay trigger states and add setContainer(), enabling programmatic control of where overlays render. Fixes missing/readonly container on `menu`, `context-menu`, `tooltip`, `popover`, `select`, and `navigation-menu` to match the documented pattern (fixes #782).

- **New Features**
  - Added writable `container` signal and `setContainer()`; direct `.set()` is routed through the setter and deprecated via `deprecatedSetter`.
  - Behavior: setter takes effect on the next open and defaults to `'body'`; use via injected state (`state().setContainer(host)`).
  - Added tests verifying content portals into a custom host for each primitive.

<sup>Written for commit 3e6d210d381df1f65c73fd7685d7154b37c269a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

