### PR TITLE
fix(combobox): reflect form control status without an input

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox/combobox.test.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.test.ts
@@ -1,5 +1,20 @@
-import { Component, TemplateRef, ViewContainerRef, inject, viewChild } from '@angular/core';
+import {
+  Component,
+  TemplateRef,
+  ViewContainerRef,
+  forwardRef,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ControlValueAccessor,
+  FormControl,
+  NG_VALUE_ACCESSOR,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import { userEvent } from '@testing-library/user-event';
 import { NgpDialog, NgpDialogContext, NgpDialogManager } from 'ng-primitives/dialog';
@@ -2253,5 +2268,131 @@ describe('NgpCombobox inside NgpDialog', () => {
     fireEvent.input(input, { target: { value: 'App' } });
 
     expect(input.value).toBe('App');
+  });
+});
+
+/**
+ * A reusable component that wraps the combobox and exposes it as a form control via a
+ * ControlValueAccessor. This mirrors how consumers integrate the combobox with Angular forms -
+ * the NgControl lives on the wrapper element, not on the inner combobox primitives.
+ */
+@Component({
+  selector: 'app-combobox-with-input',
+  imports: [
+    NgpCombobox,
+    NgpComboboxButton,
+    NgpComboboxDropdown,
+    NgpComboboxInput,
+    NgpComboboxPortal,
+  ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ComboboxWithInputWrapper),
+      multi: true,
+    },
+  ],
+  template: `
+    <div
+      [ngpComboboxValue]="value()"
+      (ngpComboboxValueChange)="value.set($event)"
+      ngpCombobox
+      data-testid="combobox"
+    >
+      <input ngpComboboxInput data-testid="combobox-input" />
+      <button ngpComboboxButton>▼</button>
+      <div *ngpComboboxPortal ngpComboboxDropdown></div>
+    </div>
+  `,
+})
+class ComboboxWithInputWrapper implements ControlValueAccessor {
+  readonly value = signal<string | undefined>(undefined);
+  writeValue(value: string | undefined): void {
+    this.value.set(value);
+  }
+  registerOnChange(): void {}
+  registerOnTouched(): void {}
+}
+
+/**
+ * The same as above, but without an `ngpComboboxInput`. The combobox host itself is the focusable
+ * element. The control status must still be reflected on the combobox element.
+ */
+@Component({
+  selector: 'app-combobox-without-input',
+  imports: [NgpCombobox, NgpComboboxButton, NgpComboboxDropdown, NgpComboboxPortal],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ComboboxWithoutInputWrapper),
+      multi: true,
+    },
+  ],
+  template: `
+    <div
+      [ngpComboboxValue]="value()"
+      (ngpComboboxValueChange)="value.set($event)"
+      ngpCombobox
+      data-testid="combobox"
+    >
+      <button ngpComboboxButton>▼</button>
+      <div *ngpComboboxPortal ngpComboboxDropdown></div>
+    </div>
+  `,
+})
+class ComboboxWithoutInputWrapper implements ControlValueAccessor {
+  readonly value = signal<string | undefined>(undefined);
+  writeValue(value: string | undefined): void {
+    this.value.set(value);
+  }
+  registerOnChange(): void {}
+  registerOnTouched(): void {}
+}
+
+describe('NgpCombobox form control status', () => {
+  @Component({
+    imports: [ComboboxWithInputWrapper, ReactiveFormsModule],
+    template: `
+      <app-combobox-with-input [formControl]="control" />
+    `,
+  })
+  class WithInputHost {
+    readonly control = new FormControl('', Validators.required);
+  }
+
+  @Component({
+    imports: [ComboboxWithoutInputWrapper, ReactiveFormsModule],
+    template: `
+      <app-combobox-without-input [formControl]="control" />
+    `,
+  })
+  class WithoutInputHost {
+    readonly control = new FormControl('', Validators.required);
+  }
+
+  it('should apply data-invalid to the combobox when the form control is invalid', async () => {
+    await render(WithInputHost);
+
+    const combobox = screen.getByTestId('combobox');
+    expect(combobox).toHaveAttribute('data-invalid');
+    expect(combobox).not.toHaveAttribute('data-valid');
+  });
+
+  it('should apply data-invalid to the combobox without an input when the form control is invalid', async () => {
+    await render(WithoutInputHost);
+
+    const combobox = screen.getByTestId('combobox');
+    expect(combobox).toHaveAttribute('data-invalid');
+    expect(combobox).not.toHaveAttribute('data-valid');
+  });
+
+  it('should apply data-valid to the combobox without an input when the form control is valid', async () => {
+    const { fixture } = await render(WithoutInputHost);
+    fixture.componentInstance.control.setValue('a value');
+    fixture.detectChanges();
+
+    const combobox = screen.getByTestId('combobox');
+    expect(combobox).toHaveAttribute('data-valid');
+    expect(combobox).not.toHaveAttribute('data-invalid');
   });
 });

--- a/packages/ng-primitives/combobox/src/combobox/combobox.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.ts
@@ -21,6 +21,7 @@ import {
   NgpOffset,
   NgpOffsetInput,
 } from 'ng-primitives/portal';
+import { controlStatus } from 'ng-primitives/utils';
 import type { NgpComboboxButton } from '../combobox-button/combobox-button';
 import type { NgpComboboxDropdown } from '../combobox-dropdown/combobox-dropdown';
 import type { NgpComboboxInput } from '../combobox-input/combobox-input';
@@ -228,8 +229,21 @@ export class NgpCombobox {
     },
   });
 
-  /** The control status */
-  protected readonly controlStatus = computed(() => this.input()?.controlStatus());
+  /**
+   * The form control status of the combobox host element itself. When the combobox is used as a
+   * form control (e.g. via a `ControlValueAccessor` wrapper) the `NgControl` lives on an ancestor
+   * element, so this resolves it even when there is no `ngpComboboxInput`.
+   */
+  private readonly hostControlStatus = controlStatus();
+
+  /**
+   * The control status. When an input is present it can resolve the associated `NgControl` (whether
+   * the control is on the input itself or an ancestor), so we use its status. Otherwise we fall back
+   * to the combobox host's own control status so an input-less combobox still reflects validity.
+   */
+  protected readonly controlStatus = computed(() =>
+    this.input() ? this.input()?.controlStatus() : this.hostControlStatus(),
+  );
 
   /** The state of the combobox. */
   protected readonly state = comboboxState<NgpCombobox>(this);


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## Issue

Closes #781

## What does this PR implement/fix?

The combobox derived its form-control status **solely** from the child `ngpComboboxInput`:

```ts
protected readonly controlStatus = computed(() => this.input()?.controlStatus());
```

When a combobox has **no `ngpComboboxInput`** (a valid configuration where the combobox host itself is the focusable element), `this.input()` is always `undefined`, so `data-invalid` / `data-valid` / `data-touched` / etc. were **never** applied to the `[ngpCombobox]` element - even when the combobox is used as a form control (via a `ControlValueAccessor` wrapper) with, say, a `required` validator. This was inconsistent with `ngpInput`, which reflects its own control status.

### Fix

The combobox now reads its **own** host `NgControl` status (which resolves a `ControlValueAccessor` wrapper ancestor's control) and falls back to it when there's no input:

```ts
private readonly hostControlStatus = controlStatus();

protected readonly controlStatus = computed(() =>
  this.input() ? this.input()?.controlStatus() : this.hostControlStatus(),
);
```

When an input is present it can already resolve the associated control (whether on itself or an ancestor), so its status remains authoritative - existing behaviour is preserved with no regression.

### Verification

- New `NgpCombobox form control status` tests cover the input-less path (previously broken) and guard the with-input path against regression. All 77 combobox tests pass; lint and build are green.
- Confirmed in a real zoneless browser that an input-less combobox now exposes `data-invalid` at form opening.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes combobox validity reflection when there is no `ngpComboboxInput`, so `data-valid`/`data-invalid` are correctly applied on the `[ngpCombobox]` host. Aligns behavior with `ngpInput` and supports wrappers using a `ControlValueAccessor`.

- **Bug Fixes**
  - Fallback to the host `NgControl` via `controlStatus()` when no input is present; keep input status as source when available.
  - Added tests for with-input and input-less comboboxes to verify `data-valid`/`data-invalid` behavior.

<sup>Written for commit b40ba361bd7afa6f142c85b74e31bdfda16b44af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

