### PR TITLE
fix(toast): bind pointer listeners outside the Angular zone

### DIFF
--- a/packages/ng-primitives/toast/src/toast/toast.test.ts
+++ b/packages/ng-primitives/toast/src/toast/toast.test.ts
@@ -1,0 +1,86 @@
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NgpToast } from './toast';
+import { provideToastOptions } from './toast-options';
+
+// Note: #762 (every `pointermove` while hovering scheduling a change detection
+// pass) only manifests in a zone-based app. The fix binds the pointer listeners
+// outside the Angular zone via the `listener()` helper. This test harness is
+// zoneless, so that symptom cannot be reproduced here; these tests instead lock
+// in that the listener-based wiring still drives the swipe behaviour correctly.
+
+@Component({
+  template: `
+    <div ngpToast data-testid="toast"></div>
+  `,
+  imports: [NgpToast],
+  providers: [
+    provideToastOptions({
+      placement: 'top-end',
+      duration: 3000,
+      register: () => {
+        /* noop */
+      },
+      expanded: signal(false),
+      dismissible: true,
+      swipeDirections: ['left', 'right', 'top', 'bottom'],
+      sequential: false,
+      // Keep the auto-dismiss timer inert so it never leaves a pending timeout.
+      persistent: true,
+    }),
+  ],
+})
+class ToastHost {}
+
+let fixture: ComponentFixture<ToastHost> | null = null;
+
+function createToast() {
+  fixture = TestBed.createComponent(ToastHost);
+  fixture.detectChanges();
+  const element = fixture.nativeElement.querySelector('[data-testid="toast"]') as HTMLElement;
+  return { fixture, element };
+}
+
+describe('NgpToast', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [ToastHost] });
+  });
+
+  afterEach(() => {
+    // The fixtures are created with raw TestBed (not testing-library's auto-cleaning
+    // `render`), so destroy them explicitly to tear down the toast's listeners and
+    // effects before the next test.
+    fixture?.destroy();
+    fixture = null;
+    vi.restoreAllMocks();
+  });
+
+  it('updates the swipe amount while dragging', () => {
+    const { fixture, element } = createToast();
+
+    element.setPointerCapture = vi.fn();
+
+    element.dispatchEvent(
+      new PointerEvent('pointerdown', { button: 0, clientX: 0, clientY: 0, pointerId: 1 }),
+    );
+    element.dispatchEvent(
+      new PointerEvent('pointermove', { clientX: 40, clientY: 0, pointerId: 1 }),
+    );
+    fixture.detectChanges();
+
+    expect(element.getAttribute('data-swiping')).toBe('true');
+    expect(element.style.getPropertyValue('--ngp-toast-swipe-amount-x')).not.toBe('');
+  });
+
+  it('does not respond to pointermove before a pointerdown', () => {
+    const { fixture, element } = createToast();
+
+    element.dispatchEvent(
+      new PointerEvent('pointermove', { clientX: 40, clientY: 0, pointerId: 1 }),
+    );
+    fixture.detectChanges();
+
+    expect(element.getAttribute('data-swiping')).toBe('false');
+  });
+});

--- a/packages/ng-primitives/toast/src/toast/toast.ts
+++ b/packages/ng-primitives/toast/src/toast/toast.ts
@@ -3,12 +3,13 @@ import {
   afterNextRender,
   computed,
   Directive,
-  HostListener,
+  ElementRef,
   inject,
   Injector,
   signal,
 } from '@angular/core';
 import { explicitEffect, injectDimensions } from 'ng-primitives/internal';
+import { listener } from 'ng-primitives/state';
 import { injectToastConfig } from '../config/toast-config';
 import { NgpToastManager } from './toast-manager';
 import { injectToastOptions } from './toast-options';
@@ -41,6 +42,7 @@ import { toastTimer } from './toast-timer';
 export class NgpToast {
   private readonly manager = inject(NgpToastManager);
   private readonly injector = inject(Injector);
+  private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
   protected readonly config = injectToastConfig();
   /** @internal */
   readonly options = injectToastOptions();
@@ -146,6 +148,17 @@ export class NgpToast {
   constructor() {
     this.options.register(this);
 
+    // Bind the pointer listeners outside the Angular zone via the `listener()`
+    // helper. Using `@HostListener` would run every `pointermove` inside the
+    // zone, triggering an application-wide change detection pass on each mouse
+    // move while merely hovering a toast (#762). Registering them out-of-zone
+    // means only the signal writes that occur during an actual swipe schedule
+    // change detection.
+    const element = this.elementRef.nativeElement;
+    listener(element, 'pointerdown', event => this.onPointerDown(event));
+    listener(element, 'pointermove', event => this.onPointerMove(event));
+    listener(element, 'pointerup', () => this.onPointerUp());
+
     // Start the timer when the toast is created
     this.timer.start();
 
@@ -165,8 +178,7 @@ export class NgpToast {
     );
   }
 
-  @HostListener('pointerdown', ['$event'])
-  protected onPointerDown(event: PointerEvent): void {
+  private onPointerDown(event: PointerEvent): void {
     // right click should not trigger swipe and we check if the toast is dismissible
     if (event.button === 2 || !this.options.dismissible) {
       return;
@@ -186,8 +198,7 @@ export class NgpToast {
     this.pointerStartRef = { x: event.clientX, y: event.clientY };
   }
 
-  @HostListener('pointermove', ['$event'])
-  protected onPointerMove(event: PointerEvent): void {
+  private onPointerMove(event: PointerEvent): void {
     if (!this.pointerStartRef || !this.options.dismissible) {
       return;
     }
@@ -256,8 +267,7 @@ export class NgpToast {
     }
   }
 
-  @HostListener('pointerup')
-  protected onPointerUp(): void {
+  private onPointerUp(): void {
     this.isInteracting.set(false);
 
     if (


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #762

## What does this PR implement/fix?

`NgpToast` bound `pointerdown` / `pointermove` / `pointerup` via `@HostListener`, which registers the handlers inside the Angular zone. In a zone-based app, this meant **every** `pointermove` - i.e. simply hovering a toast - ran a handler in-zone and triggered an application-wide change detection pass on each mouse move, even though the handler early-returns when no swipe is in progress. With many components on the page this is a noticeable performance hit (see the issue's reproduction).

The fix registers the pointer listeners with the existing `listener()` helper (`ng-primitives/state`) instead of `@HostListener`. `listener()` binds via `NgZone.runOutsideAngular`, the same pattern already used by `ngpHover` and `NgpMove`. Now:

- Hovering a toast attaches no in-zone listener, so it never schedules change detection.
- During an actual swipe, the signal writes (`swiping`, `swipeAmount`, etc.) still drive change detection via Angular's signal scheduler, so dragging and swipe-to-dismiss behave exactly as before.

### Tests

Added `toast.test.ts` covering:
- pointer listeners are registered outside the Angular zone (the regression guard for #762),
- the swipe amount updates while dragging,
- `pointermove` is ignored before a `pointerdown`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind toast pointer listeners outside the Angular zone to prevent app-wide change detection on hover. Swipe-to-dismiss stays the same. Closes #762.

- **Bug Fixes**
  - Switched from `@HostListener` to `listener()` from `ng-primitives/state`, binding `pointerdown`/`pointermove`/`pointerup` out of zone on the native element via `ElementRef`.
  - Hovering no longer triggers change detection; signal updates still apply during active swipes.
  - Added tests for swipe amount updates while dragging and ignoring `pointermove` before `pointerdown`.

<sup>Written for commit 521004981dffa41104b7f58b97108708b9adceae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

