### PR TITLE
fix(tooltip): remove data-disabled binding from tooltip trigger

### DIFF
--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
@@ -40,7 +40,7 @@ export interface NgpTooltipTriggerState<T> {
   /** Access the tooltip template ref. */
   readonly tooltip: WritableSignal<NgpOverlayContent<T> | string | null>;
   /**
-   * Define if the trigger should be disabled. This will prevent the tooltip from being shown or hidden from interactions.
+   * Whether the tooltip is disabled. This allows the tooltip to be enabled or disabled dynamically.
    * @default false
    */
   readonly disabled: Signal<boolean>;
@@ -193,7 +193,7 @@ export interface NgpTooltipTriggerProps<T> {
   /** Access the tooltip template ref. */
   readonly tooltip?: Signal<NgpOverlayContent<T> | string | null>;
   /**
-   * Define if the trigger should be disabled. This will prevent the tooltip from being shown or hidden from interactions.
+   * Whether the tooltip is disabled. This allows the tooltip to be enabled or disabled dynamically.
    * @default false
    */
   readonly disabled?: Signal<boolean>;
@@ -341,7 +341,6 @@ export const [
     // Host binding
     attrBinding(elementRef, 'aria-describedby', () => overlay()?.ariaDescribedBy());
     dataBinding(elementRef, 'data-open', () => (open() ? '' : null));
-    dataBinding(elementRef, 'data-disabled', () => (disabled() ? '' : null));
 
     // Listeners
     listener(elementRef, 'mouseenter', showFromInteraction);

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -46,7 +46,7 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
   });
 
   /**
-   * Define if the trigger should be disabled. This will prevent the tooltip from being shown or hidden from interactions.
+   * Whether the tooltip is disabled. This allows the tooltip to be enabled or disabled dynamically.
    * @default false
    */
   readonly disabled = input<boolean, BooleanInput>(false, {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:



## What does this PR implement/fix?

Removes the `data-disabled` attribute from `ngpTooltipTriggerDisabled`.

The input is intended to enable or disable the tooltip dynamically, not to put the trigger element itself into a disabled state. Adding `data-disabled` could therefore lead to unintended styling or behavior on the trigger.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `data-disabled` host binding from the tooltip trigger so disabling a tooltip no longer sets `data-disabled` on the trigger element. This prevents unintended trigger styles and keeps "disabled" scoped to tooltip behavior.

- **Bug Fixes**
  - Removed `data-disabled` binding from the trigger; `disabled` now only controls tooltip show/hide.
  - Clarified docs/comments that `disabled` is for the tooltip, not the trigger element.

- **Migration**
  - If you styled or checked `[data-disabled]` on tooltip triggers, replace it with:
    - The element’s native `[disabled]` attribute if the control should be disabled.
    - `[data-open]` for open state styling.
    - A custom bound `data-*` attribute if you need a specific marker.

<sup>Written for commit 42776232158d816fc8ea69d9be802544c60c25bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

