### PR TITLE
fix(select,combobox): validate active descendant when options change while open

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox/combobox.test.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.test.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  Directive,
   TemplateRef,
   ViewContainerRef,
   forwardRef,
@@ -25,6 +26,14 @@ import { NgpComboboxInput } from '../combobox-input/combobox-input';
 import { NgpComboboxOption } from '../combobox-option/combobox-option';
 import { NgpComboboxPortal } from '../combobox-portal/combobox-portal';
 import { NgpCombobox } from './combobox';
+import { injectComboboxState } from './combobox-state';
+
+@Directive({
+  selector: '[captureComboboxState]',
+})
+class CaptureComboboxStateDirective {
+  readonly state = injectComboboxState();
+}
 
 @Component({
   imports: [
@@ -88,6 +97,44 @@ class TestComponent {
 
   onOpenChange(event: boolean) {
     this.open = event;
+  }
+}
+
+@Component({
+  imports: [
+    NgpCombobox,
+    NgpComboboxDropdown,
+    NgpComboboxInput,
+    NgpComboboxOption,
+    CaptureComboboxStateDirective,
+  ],
+  template: `
+    <div captureComboboxState ngpCombobox>
+      <input ngpComboboxInput />
+
+      <div ngpComboboxDropdown>
+        @for (option of filteredOptions(); track option) {
+          <div
+            [ngpComboboxOptionValue]="option"
+            [attr.data-testid]="'closed-option-' + option"
+            ngpComboboxOption
+          >
+            {{ option }}
+          </div>
+        }
+      </div>
+    </div>
+  `,
+})
+class ClosedOptionsComboboxComponent {
+  readonly comboboxState = viewChild.required(CaptureComboboxStateDirective);
+  filter = '';
+  options = ['Apple', 'Banana', 'Cherry'];
+
+  filteredOptions() {
+    return this.filter
+      ? this.options.filter(option => option.toLowerCase().includes(this.filter.toLowerCase()))
+      : this.options;
   }
 }
 
@@ -209,6 +256,79 @@ describe('NgpCombobox', () => {
     // Only Elderberry should be visible
     expect(screen.getByText('Elderberry')).toBeInTheDocument();
     expect(screen.queryByText('Apple')).not.toBeInTheDocument();
+  });
+
+  it('should validate aria-activedescendant when the active option is filtered out while open', async () => {
+    const { fixture } = await render(TestComponent);
+
+    const input = screen.getByRole('combobox');
+    input.focus();
+
+    await userEvent.keyboard('{arrowdown}');
+    await waitFor(() => {
+      expect(screen.getByText('Apple')).toHaveAttribute('data-active');
+    });
+
+    await userEvent.keyboard('{arrowdown}{arrowdown}');
+    await waitFor(() => {
+      expect(screen.getByText('Cherry')).toHaveAttribute('data-active');
+    });
+
+    const staleId = screen.getByText('Cherry').id;
+
+    fireEvent.input(input, { target: { value: 'App' } });
+    fixture.detectChanges();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Cherry')).not.toBeInTheDocument();
+
+      const appleOption = screen.getByText('Apple');
+      const activeId = input.getAttribute('aria-activedescendant');
+      expect(activeId).toBe(appleOption.id);
+      expect(document.getElementById(activeId as string)).toBe(appleOption);
+    });
+    expect(document.getElementById(staleId)).toBeNull();
+  });
+
+  it('should clear aria-activedescendant when filtering to no options while open', async () => {
+    const { fixture } = await render(TestComponent);
+
+    const input = screen.getByRole('combobox');
+    input.focus();
+
+    await userEvent.keyboard('{arrowdown}{arrowdown}');
+    await waitFor(() => {
+      expect(screen.getByText('Banana')).toHaveAttribute('data-active');
+    });
+
+    const staleId = screen.getByText('Banana').id;
+
+    fireEvent.input(input, { target: { value: 'zzz' } });
+    fixture.detectChanges();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-message')).toBeInTheDocument();
+      expect(input).not.toHaveAttribute('aria-activedescendant');
+    });
+    expect(document.getElementById(staleId)).toBeNull();
+  });
+
+  it('should not validate changed options while closed', async () => {
+    const { fixture } = await render(ClosedOptionsComboboxComponent);
+    const component = fixture.componentInstance;
+    const state = component.comboboxState().state();
+
+    expect(state.open()).toBe(false);
+    state.activeDescendantManager.activateByIndex(2);
+    expect(state.activeDescendantManager.index()).toBe(2);
+
+    component.filter = 'App';
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(screen.queryByTestId('closed-option-Cherry')).not.toBeInTheDocument();
+    expect(state.open()).toBe(false);
+    expect(state.activeDescendantManager.index()).toBe(2);
   });
 
   it('should display "No options found" when filter has no matches', async () => {

--- a/packages/ng-primitives/combobox/src/combobox/combobox.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.ts
@@ -3,12 +3,14 @@ import {
   booleanAttribute,
   computed,
   Directive,
+  effect,
   HostListener,
   inject,
   Injector,
   input,
   output,
   signal,
+  untracked,
 } from '@angular/core';
 import { activeDescendantManager } from 'ng-primitives/a11y';
 import { ngpInteractions } from 'ng-primitives/interactions';
@@ -249,6 +251,14 @@ export class NgpCombobox {
   protected readonly state = comboboxState<NgpCombobox>(this);
 
   constructor() {
+    effect(() => {
+      this.sortedOptions();
+
+      if (this.open()) {
+        untracked(() => this.activeDescendantManager.validate());
+      }
+    });
+
     ngpInteractions({
       focus: true,
       focusWithin: true,

--- a/packages/ng-primitives/combobox/src/combobox/combobox.ts
+++ b/packages/ng-primitives/combobox/src/combobox/combobox.ts
@@ -251,8 +251,11 @@ export class NgpCombobox {
   protected readonly state = comboboxState<NgpCombobox>(this);
 
   constructor() {
+    // When the visible (or virtual) options change while open, revalidate so the
+    // active index can't point at a removed option and leave a stale aria-activedescendant.
     effect(() => {
       this.sortedOptions();
+      this.state.allOptions();
 
       if (this.open()) {
         untracked(() => this.activeDescendantManager.validate());

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -386,8 +386,11 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
         },
       });
 
+      // When the visible (or virtual) options change while open, revalidate so the
+      // active index can't point at a removed option and leave a stale aria-activedescendant.
       effect(() => {
         sortedOptions();
+        allOptions();
 
         if (open()) {
           untracked(() => activeDescendantManagerInstance.validate());

--- a/packages/ng-primitives/select/src/select/select-state.ts
+++ b/packages/ng-primitives/select/src/select/select-state.ts
@@ -1,4 +1,12 @@
-import { computed, ElementRef, Signal, signal, WritableSignal } from '@angular/core';
+import {
+  computed,
+  effect,
+  ElementRef,
+  Signal,
+  signal,
+  untracked,
+  WritableSignal,
+} from '@angular/core';
 import type { Placement } from '@floating-ui/dom';
 import { activeDescendantManager } from 'ng-primitives/a11y';
 import { ngpFormControl } from 'ng-primitives/form-field';
@@ -376,6 +384,14 @@ export const [NgpSelectStateToken, ngpSelect, _injectSelectState, provideSelectS
 
           scrollTo(index);
         },
+      });
+
+      effect(() => {
+        sortedOptions();
+
+        if (open()) {
+          untracked(() => activeDescendantManagerInstance.validate());
+        }
       });
 
       // Host bindings

--- a/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
+++ b/packages/ng-primitives/select/src/select/tests/select-primitive.test.ts
@@ -1,4 +1,4 @@
-import { Component, Directive, OnInit, signal } from '@angular/core';
+import { Component, Directive, OnInit, signal, viewChild } from '@angular/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, afterEach } from 'vitest';
@@ -138,6 +138,89 @@ class TestActivatedOutputComponent {
   onClearActivated(): void {
     this.clearActivatedCount++;
     this.value.set(undefined);
+  }
+}
+
+@Directive({
+  selector: '[captureFilteredSelectState]',
+})
+class CaptureFilteredSelectStateDirective {
+  readonly state = injectSelectState<string>();
+}
+
+@Component({
+  template: `
+    <div
+      [(ngpSelectValue)]="value"
+      captureFilteredSelectState
+      ngpSelect
+      data-testid="filtered-select"
+    >
+      <span>{{ value() || 'Select an option' }}</span>
+
+      <div *ngpSelectPortal ngpSelectDropdown data-testid="filtered-dropdown">
+        @for (option of filteredOptions(); track option) {
+          <div
+            [ngpSelectOptionValue]="option"
+            [attr.data-testid]="'filtered-option-' + option"
+            ngpSelectOption
+          >
+            {{ option }}
+          </div>
+        } @empty {
+          <div data-testid="filtered-empty">No options found</div>
+        }
+      </div>
+    </div>
+  `,
+  imports: [
+    NgpSelect,
+    NgpSelectDropdown,
+    NgpSelectOption,
+    NgpSelectPortal,
+    CaptureFilteredSelectStateDirective,
+  ],
+})
+class FilteredSelectComponent {
+  readonly value = signal<string | undefined>(undefined);
+  readonly selectState = viewChild.required(CaptureFilteredSelectStateDirective);
+  filter = '';
+  options = ['Apple', 'Banana', 'Cherry', 'Dragon Fruit'];
+
+  filteredOptions() {
+    return this.filter
+      ? this.options.filter(option => option.toLowerCase().includes(this.filter.toLowerCase()))
+      : this.options;
+  }
+}
+
+@Component({
+  template: `
+    <div captureFilteredSelectState ngpSelect data-testid="closed-filtered-select">
+      <div ngpSelectDropdown>
+        @for (option of filteredOptions(); track option) {
+          <div
+            [ngpSelectOptionValue]="option"
+            [attr.data-testid]="'closed-option-' + option"
+            ngpSelectOption
+          >
+            {{ option }}
+          </div>
+        }
+      </div>
+    </div>
+  `,
+  imports: [NgpSelect, NgpSelectDropdown, NgpSelectOption, CaptureFilteredSelectStateDirective],
+})
+class ClosedOptionsSelectComponent {
+  readonly selectState = viewChild.required(CaptureFilteredSelectStateDirective);
+  filter = '';
+  options = ['Apple', 'Banana', 'Cherry'];
+
+  filteredOptions() {
+    return this.filter
+      ? this.options.filter(option => option.toLowerCase().includes(this.filter.toLowerCase()))
+      : this.options;
   }
 }
 
@@ -652,6 +735,84 @@ describe('NgpSelect', () => {
       const optionId = appleOption.getAttribute('id');
       expect(optionId).toBeTruthy();
       expect(select).toHaveAttribute('aria-activedescendant', optionId);
+    });
+
+    it('should validate aria-activedescendant when the active option is filtered out while open', async () => {
+      const user = userEvent.setup();
+      const { fixture } = await render(FilteredSelectComponent);
+      const component = fixture.componentInstance;
+
+      const select = screen.getByTestId('filtered-select');
+      await user.click(select);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('filtered-option-Apple')).toHaveAttribute('data-active', '');
+      });
+
+      fireEvent.keyDown(select, { key: 'ArrowDown' });
+      fireEvent.keyDown(select, { key: 'ArrowDown' });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('filtered-option-Cherry')).toHaveAttribute('data-active', '');
+      });
+
+      const staleId = screen.getByTestId('filtered-option-Cherry').id;
+
+      component.filter = 'App';
+      fixture.detectChanges();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('filtered-option-Cherry')).not.toBeInTheDocument();
+
+        const appleOption = screen.getByTestId('filtered-option-Apple');
+        const activeId = select.getAttribute('aria-activedescendant');
+        expect(activeId).toBe(appleOption.id);
+        expect(document.getElementById(activeId as string)).toBe(appleOption);
+      });
+      expect(document.getElementById(staleId)).toBeNull();
+    });
+
+    it('should clear aria-activedescendant when filtering to no options while open', async () => {
+      const user = userEvent.setup();
+      const { fixture } = await render(FilteredSelectComponent);
+      const component = fixture.componentInstance;
+
+      const select = screen.getByTestId('filtered-select');
+      await user.click(select);
+
+      fireEvent.keyDown(select, { key: 'ArrowDown' });
+      await waitFor(() => {
+        expect(screen.getByTestId('filtered-option-Banana')).toHaveAttribute('data-active', '');
+      });
+
+      const staleId = screen.getByTestId('filtered-option-Banana').id;
+
+      component.filter = 'zzz';
+      fixture.detectChanges();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('filtered-empty')).toBeInTheDocument();
+        expect(select).not.toHaveAttribute('aria-activedescendant');
+      });
+      expect(document.getElementById(staleId)).toBeNull();
+    });
+
+    it('should not validate changed options while closed', async () => {
+      const { fixture } = await render(ClosedOptionsSelectComponent);
+      const component = fixture.componentInstance;
+      const state = component.selectState().state();
+
+      expect(state.open()).toBe(false);
+      state.activeDescendantManager.activateByIndex(2);
+      expect(state.activeDescendantManager.index()).toBe(2);
+
+      component.filter = 'App';
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(screen.queryByTestId('closed-option-Cherry')).not.toBeInTheDocument();
+      expect(state.open()).toBe(false);
+      expect(state.activeDescendantManager.index()).toBe(2);
     });
 
     it('should set aria-selected on selected options', async () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #775

## What does this PR implement/fix?

When filtering options while a Select or Combobox dropdown is open, the currently active option can be removed from the DOM. The active-descendant manager keeps its previous active index, so `aria-activedescendant` ends up pointing at an element id that no longer exists, which breaks screen-reader announcement and keyboard navigation. As noted in the issue, this affects `ngpCombobox` as well as Select.

The `activeDescendantManager` already exposes a `validate()` method whose documented purpose is exactly "any time the item list changes, check if the active index is still valid", but it was never invoked when the options list changed while the dropdown was open.

This PR adds an open-only reactive effect in both `combobox.ts` and `select-state.ts` that observes the sorted options signal and calls `activeDescendantManager.validate()` when `open()` is true, clamping the active index back into the valid range (or onto the first enabled option) whenever options are added or removed. The `validate()` call is wrapped in `untracked()` so it does not register the manager's own internal signals as effect dependencies. Closed dropdowns are deliberately left untouched, so validating a closed list never reactivates options. The change uses only the existing public `validate()` API, so no change to `active-descendant.ts` was needed, and it is symmetric across the two components so Select and Combobox behave identically.

Tests added to `combobox.test.ts` and `select-primitive.test.ts` cover: the active option being filtered out while open (asserts `aria-activedescendant` references a still-rendered option and the stale id is gone), filtering down to zero matching options while open (asserts no stale `aria-activedescendant` and no error), and options changing while the dropdown is closed (asserts `validate()` is not triggered and the active index is untouched).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an a11y bug where filtering or virtual list changes while a `NgpSelect` or `NgpCombobox` is open could leave `aria-activedescendant` pointing to a removed option, breaking screen reader and keyboard navigation. Revalidates the active descendant whenever visible or backing option lists change to meet #775.

- **Bug Fixes**
  - Revalidate the active index when `sortedOptions()` or `allOptions()` change while open.
  - Use `activeDescendantManager.validate()` wrapped in `untracked()`; keep closed lists untouched.
  - Keep `aria-activedescendant` in sync, clamping to the first enabled option or clearing when empty; add tests for Select and Combobox, including virtual list scenarios.

<sup>Written for commit 698be7ae91eda8fefa963fc2a7b1dcad04ddfbbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

