### PR TITLE
fix(portal): don't evict ancestor overlays when registering a nested overlay

### DIFF
--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.test.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.test.ts
@@ -558,6 +558,110 @@ describe('NgpPopoverTrigger', () => {
     });
   });
 
+  describe('nested popovers', () => {
+    @Component({
+      template: `
+        <button [ngpPopoverTrigger]="outer" data-testid="outer-trigger">Open panel</button>
+
+        <ng-template #outer>
+          <div ngpPopover data-testid="outer-popover">
+            <button [ngpPopoverTrigger]="inner" data-testid="inner-trigger">Open calendar</button>
+          </div>
+        </ng-template>
+
+        <ng-template #inner>
+          <div ngpPopover data-testid="inner-popover">Inner content</div>
+        </ng-template>
+      `,
+      imports: [NgpPopoverTrigger, NgpPopover],
+    })
+    class NestedPopoverComponent {}
+
+    it('should keep the outer popover open when opening a popover nested inside it', async () => {
+      const { getByTestId } = await render(NestedPopoverComponent);
+
+      // Open the outer popover
+      fireEvent.click(getByTestId('outer-trigger'));
+
+      await waitFor(() => {
+        expect(document.querySelector('[data-testid="outer-popover"]')).toBeInTheDocument();
+      });
+
+      // Click the trigger that lives inside the outer popover content. The inner popover
+      // shares the same overlay type ('popover'), but as a descendant it must not evict
+      // its ancestor.
+      const innerTrigger = document.querySelector(
+        '[data-testid="inner-trigger"]',
+      ) as HTMLElement;
+      fireEvent.click(innerTrigger);
+
+      await waitFor(() => {
+        // The inner popover should open
+        expect(document.querySelector('[data-testid="inner-popover"]')).toBeInTheDocument();
+      });
+
+      // The outer popover must remain open — it is an ancestor and must not be evicted.
+      expect(document.querySelector('[data-testid="outer-popover"]')).toBeInTheDocument();
+    });
+
+    it('should restore the outer popover as the active overlay after the nested popover closes', async () => {
+      @Component({
+        template: `
+          <button [ngpPopoverTrigger]="outer" data-testid="outer-trigger">Open panel</button>
+          <button [ngpPopoverTrigger]="sibling" data-testid="sibling-trigger">Open sibling</button>
+
+          <ng-template #outer>
+            <div ngpPopover data-testid="outer-popover">
+              <button [ngpPopoverTrigger]="inner" data-testid="inner-trigger">Open nested</button>
+            </div>
+          </ng-template>
+
+          <ng-template #inner>
+            <div ngpPopover data-testid="inner-popover">Inner content</div>
+          </ng-template>
+
+          <ng-template #sibling>
+            <div ngpPopover data-testid="sibling-popover">Sibling content</div>
+          </ng-template>
+        `,
+        imports: [NgpPopoverTrigger, NgpPopover],
+      })
+      class NestedThenSiblingComponent {}
+
+      const { getByTestId } = await render(NestedThenSiblingComponent);
+
+      // Open outer, then the nested popover inside it.
+      fireEvent.click(getByTestId('outer-trigger'));
+      await waitFor(() => {
+        expect(document.querySelector('[data-testid="outer-popover"]')).toBeInTheDocument();
+      });
+
+      const innerTrigger = document.querySelector(
+        '[data-testid="inner-trigger"]',
+      ) as HTMLElement;
+      fireEvent.click(innerTrigger);
+      await waitFor(() => {
+        expect(document.querySelector('[data-testid="inner-popover"]')).toBeInTheDocument();
+      });
+
+      // Close just the nested popover by clicking its trigger again.
+      fireEvent.click(innerTrigger);
+      await waitFor(() => {
+        expect(document.querySelector('[data-testid="inner-popover"]')).not.toBeInTheDocument();
+        expect(document.querySelector('[data-testid="outer-popover"]')).toBeInTheDocument();
+      });
+
+      // Opening an unrelated sibling popover should still evict the outer popover
+      // (the one-popover-at-a-time rule for siblings is preserved).
+      fireEvent.mouseUp(getByTestId('sibling-trigger'));
+      fireEvent.click(getByTestId('sibling-trigger'));
+      await waitFor(() => {
+        expect(document.querySelector('[data-testid="sibling-popover"]')).toBeInTheDocument();
+        expect(document.querySelector('[data-testid="outer-popover"]')).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe('container', () => {
     it('should expose container on the injected state so it can be set programmatically', async () => {
       @Directive({

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.test.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.test.ts
@@ -590,9 +590,7 @@ describe('NgpPopoverTrigger', () => {
       // Click the trigger that lives inside the outer popover content. The inner popover
       // shares the same overlay type ('popover'), but as a descendant it must not evict
       // its ancestor.
-      const innerTrigger = document.querySelector(
-        '[data-testid="inner-trigger"]',
-      ) as HTMLElement;
+      const innerTrigger = document.querySelector('[data-testid="inner-trigger"]') as HTMLElement;
       fireEvent.click(innerTrigger);
 
       await waitFor(() => {
@@ -636,9 +634,7 @@ describe('NgpPopoverTrigger', () => {
         expect(document.querySelector('[data-testid="outer-popover"]')).toBeInTheDocument();
       });
 
-      const innerTrigger = document.querySelector(
-        '[data-testid="inner-trigger"]',
-      ) as HTMLElement;
+      const innerTrigger = document.querySelector('[data-testid="inner-trigger"]') as HTMLElement;
       fireEvent.click(innerTrigger);
       await waitFor(() => {
         expect(document.querySelector('[data-testid="inner-popover"]')).toBeInTheDocument();

--- a/packages/ng-primitives/portal/src/overlay-cooldown.test.ts
+++ b/packages/ng-primitives/portal/src/overlay-cooldown.test.ts
@@ -1,0 +1,151 @@
+import { signal } from '@angular/core';
+import { describe, expect, it, vi } from 'vitest';
+import { CooldownOverlay, NgpOverlayCooldownManager } from './overlay-cooldown';
+
+/**
+ * A lightweight CooldownOverlay used to exercise the manager without the full
+ * NgpOverlay. Ancestry is modelled with an explicit `parent` reference, mirroring
+ * NgpOverlay's injected parent overlay chain.
+ */
+class FakeOverlay implements CooldownOverlay {
+  parent: FakeOverlay | null = null;
+  readonly instantTransition = signal(false);
+  readonly hideImmediate = vi.fn();
+
+  constructor(parent: FakeOverlay | null = null) {
+    this.parent = parent;
+  }
+
+  isDescendantOf(other: CooldownOverlay): boolean {
+    let current: FakeOverlay | null = this.parent;
+    while (current) {
+      if (current === other) {
+        return true;
+      }
+      current = current.parent;
+    }
+    return false;
+  }
+}
+
+describe('NgpOverlayCooldownManager', () => {
+  it('evicts a previously active overlay of the same type (sibling switch)', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const a = new FakeOverlay();
+    const b = new FakeOverlay();
+
+    manager.registerActive('popover', a, 0);
+    manager.registerActive('popover', b, 0);
+
+    expect(a.hideImmediate).toHaveBeenCalledTimes(1);
+    expect(b.hideImmediate).not.toHaveBeenCalled();
+    expect(manager.hasActiveOverlay('popover')).toBe(true);
+  });
+
+  it('does not evict an ancestor overlay when a nested overlay registers', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const outer = new FakeOverlay();
+    const inner = new FakeOverlay(outer);
+
+    manager.registerActive('popover', outer, 0);
+    manager.registerActive('popover', inner, 0);
+
+    expect(outer.hideImmediate).not.toHaveBeenCalled();
+    expect(inner.hideImmediate).not.toHaveBeenCalled();
+    expect(manager.hasActiveOverlay('popover')).toBe(true);
+  });
+
+  it('restores the ancestor as active after the nested overlay unregisters', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const outer = new FakeOverlay();
+    const inner = new FakeOverlay(outer);
+    const sibling = new FakeOverlay();
+
+    manager.registerActive('popover', outer, 0);
+    manager.registerActive('popover', inner, 0);
+
+    // The nested overlay closes, leaving the ancestor active.
+    manager.unregisterActive('popover', inner);
+    expect(manager.hasActiveOverlay('popover')).toBe(true);
+
+    // Opening an unrelated sibling now evicts the ancestor (one-per-type for peers).
+    manager.registerActive('popover', sibling, 0);
+    expect(outer.hideImmediate).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts every non-ancestor overlay above the nearest ancestor on the stack', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const outer = new FakeOverlay();
+    const inner = new FakeOverlay(outer);
+    // A second overlay nested directly in `outer` (a sibling of `inner`).
+    const innerSibling = new FakeOverlay(outer);
+
+    manager.registerActive('popover', outer, 0);
+    manager.registerActive('popover', inner, 0);
+    manager.registerActive('popover', innerSibling, 0);
+
+    // `inner` is a peer of `innerSibling`, so it is evicted; `outer` is their
+    // shared ancestor and stays open.
+    expect(inner.hideImmediate).toHaveBeenCalledTimes(1);
+    expect(outer.hideImmediate).not.toHaveBeenCalled();
+  });
+
+  it('keeps overlays of different types independent', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const popover = new FakeOverlay();
+    const tooltip = new FakeOverlay();
+
+    manager.registerActive('popover', popover, 0);
+    manager.registerActive('tooltip', tooltip, 0);
+
+    expect(popover.hideImmediate).not.toHaveBeenCalled();
+    expect(tooltip.hideImmediate).not.toHaveBeenCalled();
+    expect(manager.hasActiveOverlay('popover')).toBe(true);
+    expect(manager.hasActiveOverlay('tooltip')).toBe(true);
+  });
+
+  it('marks the evicted overlay as an instant transition when cooldown is active', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const a = new FakeOverlay();
+    const b = new FakeOverlay();
+
+    manager.registerActive('tooltip', a, 300);
+    manager.registerActive('tooltip', b, 300);
+
+    expect(a.instantTransition()).toBe(true);
+    expect(a.hideImmediate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mark an instant transition when cooldown is disabled', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const a = new FakeOverlay();
+    const b = new FakeOverlay();
+
+    manager.registerActive('tooltip', a, 0);
+    manager.registerActive('tooltip', b, 0);
+
+    expect(a.instantTransition()).toBe(false);
+  });
+
+  it('reports no active overlay once the last overlay unregisters', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const a = new FakeOverlay();
+
+    manager.registerActive('popover', a, 0);
+    expect(manager.hasActiveOverlay('popover')).toBe(true);
+
+    manager.unregisterActive('popover', a);
+    expect(manager.hasActiveOverlay('popover')).toBe(false);
+  });
+
+  it('treats re-registering the active overlay as a no-op', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const a = new FakeOverlay();
+
+    manager.registerActive('popover', a, 0);
+    manager.registerActive('popover', a, 0);
+
+    expect(a.hideImmediate).not.toHaveBeenCalled();
+    expect(manager.hasActiveOverlay('popover')).toBe(true);
+  });
+});

--- a/packages/ng-primitives/portal/src/overlay-cooldown.test.ts
+++ b/packages/ng-primitives/portal/src/overlay-cooldown.test.ts
@@ -148,4 +148,53 @@ describe('NgpOverlayCooldownManager', () => {
     expect(a.hideImmediate).not.toHaveBeenCalled();
     expect(manager.hasActiveOverlay('popover')).toBe(true);
   });
+
+  it('does not evict an active descendant when its ancestor re-registers', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const outer = new FakeOverlay();
+    const inner = new FakeOverlay(outer);
+    const sibling = new FakeOverlay();
+
+    manager.registerActive('popover', outer, 0);
+    manager.registerActive('popover', inner, 0);
+
+    // The ancestor starts closing and is removed from the stack while its portal
+    // content is still available for the exit animation.
+    manager.unregisterActive('popover', outer);
+
+    // If that ancestor's destruction is cancelled, it re-registers while the
+    // descendant is still active and must not evict the descendant.
+    manager.registerActive('popover', outer, 0);
+
+    expect(inner.hideImmediate).not.toHaveBeenCalled();
+    expect(outer.hideImmediate).not.toHaveBeenCalled();
+    expect(manager.hasActiveOverlay('popover')).toBe(true);
+
+    // Sibling replacement should still evict the active descendant and ancestor.
+    manager.registerActive('popover', sibling, 0);
+
+    expect(inner.hideImmediate).toHaveBeenCalledTimes(1);
+    expect(outer.hideImmediate).toHaveBeenCalledTimes(1);
+    expect(sibling.hideImmediate).not.toHaveBeenCalled();
+  });
+
+  it('treats re-registering an ancestor with an active descendant as a no-op', () => {
+    const manager = new NgpOverlayCooldownManager();
+    const outer = new FakeOverlay();
+    const inner = new FakeOverlay(outer);
+    const sibling = new FakeOverlay();
+
+    manager.registerActive('popover', outer, 0);
+    manager.registerActive('popover', inner, 0);
+    manager.registerActive('popover', outer, 0);
+
+    expect(inner.hideImmediate).not.toHaveBeenCalled();
+    expect(outer.hideImmediate).not.toHaveBeenCalled();
+
+    manager.registerActive('popover', sibling, 0);
+
+    expect(inner.hideImmediate).toHaveBeenCalledTimes(1);
+    expect(outer.hideImmediate).toHaveBeenCalledTimes(1);
+    expect(sibling.hideImmediate).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ng-primitives/portal/src/overlay-cooldown.ts
+++ b/packages/ng-primitives/portal/src/overlay-cooldown.ts
@@ -5,6 +5,12 @@ export interface CooldownOverlay {
   hideImmediate(): void;
   /** Optional signal to mark the transition as instant due to cooldown */
   instantTransition?: WritableSignal<boolean>;
+  /**
+   * Optional check for whether this overlay is a descendant of the given overlay
+   * (i.e. its trigger is rendered within the other overlay's content). Used to
+   * keep an ancestor open when a nested overlay of the same type is activated.
+   */
+  isDescendantOf?(other: CooldownOverlay): boolean;
 }
 
 /**
@@ -17,7 +23,14 @@ export interface CooldownOverlay {
 @Injectable({ providedIn: 'root' })
 export class NgpOverlayCooldownManager {
   private readonly lastCloseTimestamps = new Map<string, number>();
-  private readonly activeOverlays = new Map<string, CooldownOverlay>();
+  /**
+   * Active overlays per type, stored as a stack ordered oldest-first / topmost-last.
+   * Most types only ever hold a single overlay, but when an overlay is nested inside
+   * another of the same type (e.g. a popover whose trigger lives inside another
+   * popover) the child is pushed on top of its ancestor instead of evicting it.
+   * Closing the child then restores the ancestor as the active overlay.
+   */
+  private readonly activeOverlays = new Map<string, CooldownOverlay[]>();
 
   /**
    * Record the close timestamp for an overlay type.
@@ -43,25 +56,44 @@ export class NgpOverlayCooldownManager {
 
   /**
    * Register an overlay as active for its type.
-   * Any existing overlay of the same type will be closed immediately.
+   *
+   * Any existing overlay of the same type is closed immediately so that only one
+   * overlay of each type is open at a time - *unless* it is an ancestor of the
+   * overlay being registered. A nested overlay (its trigger rendered inside an
+   * ancestor overlay's content) is stacked on top of its ancestor instead of
+   * evicting it, allowing legitimate nesting to coexist while sibling overlays
+   * still replace one another.
+   *
    * @param overlayType The type identifier for the overlay group
    * @param overlay The overlay instance
    * @param cooldown The cooldown duration - if > 0, enables instant transitions
    */
   registerActive(overlayType: string, overlay: CooldownOverlay, cooldown: number): void {
-    const existing = this.activeOverlays.get(overlayType);
+    const stack = this.activeOverlays.get(overlayType) ?? [];
 
-    // If there's an existing overlay of the same type, close it immediately.
-    // This ensures only one overlay of each type is open at a time.
-    if (existing && existing !== overlay) {
+    // Evict overlays from the top of the stack until we reach the overlay itself
+    // or one of its ancestors (or the stack empties). Ancestors are preserved so
+    // nested same-type overlays can coexist; peers are closed immediately.
+    while (stack.length > 0) {
+      const top = stack[stack.length - 1];
+      if (top === overlay || overlay.isDescendantOf?.(top)) {
+        break;
+      }
+      stack.pop();
       // Enable instant transition only if cooldown is active
       if (cooldown > 0) {
-        existing.instantTransition?.set(true);
+        top.instantTransition?.set(true);
       }
-      existing.hideImmediate();
+      top.hideImmediate();
     }
 
-    this.activeOverlays.set(overlayType, overlay);
+    // Push as the topmost active overlay, avoiding a duplicate entry if it is
+    // already there (e.g. re-registering after a cancelled destruction).
+    if (stack[stack.length - 1] !== overlay) {
+      stack.push(overlay);
+    }
+
+    this.activeOverlays.set(overlayType, stack);
   }
 
   /**
@@ -70,7 +102,17 @@ export class NgpOverlayCooldownManager {
    * @param overlay The overlay instance to remove
    */
   unregisterActive(overlayType: string, overlay: CooldownOverlay): void {
-    if (this.activeOverlays.get(overlayType) === overlay) {
+    const stack = this.activeOverlays.get(overlayType);
+    if (!stack) {
+      return;
+    }
+
+    const index = stack.indexOf(overlay);
+    if (index !== -1) {
+      stack.splice(index, 1);
+    }
+
+    if (stack.length === 0) {
       this.activeOverlays.delete(overlayType);
     }
   }
@@ -81,6 +123,7 @@ export class NgpOverlayCooldownManager {
    * @returns true if there's an active overlay, false otherwise
    */
   hasActiveOverlay(overlayType: string): boolean {
-    return this.activeOverlays.has(overlayType);
+    const stack = this.activeOverlays.get(overlayType);
+    return stack !== undefined && stack.length > 0;
   }
 }

--- a/packages/ng-primitives/portal/src/overlay-cooldown.ts
+++ b/packages/ng-primitives/portal/src/overlay-cooldown.ts
@@ -71,13 +71,23 @@ export class NgpOverlayCooldownManager {
   registerActive(overlayType: string, overlay: CooldownOverlay, cooldown: number): void {
     const stack = this.activeOverlays.get(overlayType) ?? [];
 
+    if (stack.includes(overlay)) {
+      return;
+    }
+
     // Evict overlays from the top of the stack until we reach the overlay itself
     // or one of its ancestors (or the stack empties). Ancestors are preserved so
     // nested same-type overlays can coexist; peers are closed immediately.
     while (stack.length > 0) {
       const top = stack[stack.length - 1];
-      if (top === overlay || overlay.isDescendantOf?.(top)) {
+      if (overlay.isDescendantOf?.(top)) {
         break;
+      }
+      if (top.isDescendantOf?.(overlay)) {
+        const firstDescendantIndex = stack.findIndex(entry => entry.isDescendantOf?.(overlay));
+        stack.splice(firstDescendantIndex, 0, overlay);
+        this.activeOverlays.set(overlayType, stack);
+        return;
       }
       stack.pop();
       // Enable instant transition only if cooldown is active

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -715,6 +715,28 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   }
 
   /**
+   * Determine whether this overlay is a descendant of the given overlay - i.e.
+   * its trigger is rendered within the other overlay's content. Walks the parent
+   * overlay chain established through dependency injection.
+   *
+   * Used by the cooldown manager to avoid evicting an ancestor overlay when a
+   * nested overlay of the same type is activated.
+   * @internal
+   */
+  isDescendantOf(other: CooldownOverlay): boolean {
+    let current: NgpOverlay | null = this.parentOverlay;
+
+    while (current) {
+      if (current === other) {
+        return true;
+      }
+      current = current.parentOverlay;
+    }
+
+    return false;
+  }
+
+  /**
    * Check if the event path includes any child overlay elements (recursively).
    * @internal
    */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — not applicable; this restores the intended nesting behaviour and changes no public API or documented behaviour.

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #789

## What does this PR implement/fix?

When a popover's trigger is rendered **inside** another popover's content, opening the inner popover immediately closed the outer one and the inner one never appeared.

### Root cause

Both overlays share `overlayType: 'popover'`, so `NgpOverlayCooldownManager.registerActive()` enforced "one overlay per type" by evicting the previously-active overlay:

```ts
const existing = this.activeOverlays.get(overlayType);
if (existing && existing !== overlay) {
  if (cooldown > 0) existing.instantTransition?.set(true);
  existing.hideImmediate(); // <- closes the ancestor
}
```

When the inner popover opened, `existing` was its **ancestor** (the outer popover). `hideImmediate()` tore down the outer popover's content view — which contains the inner trigger — so the inner popover was destroyed before it could render. This affected any two same-type overlays in an ancestor/descendant relationship (e.g. a popover opened from inside a dialog-as-popover).

### Fix

`NgpOverlayCooldownManager` now tracks a **per-type stack** instead of a single active slot:

- On `registerActive`, it evicts entries from the top of the stack **only while the top is not an ancestor** of the overlay being registered, then pushes the new overlay. A nested overlay therefore stacks on top of its ancestor instead of evicting it.
- Sibling overlays of the same type still replace one another, so the existing "one popover/tooltip/menu at a time" behaviour (and the tooltip→tooltip cooldown) is preserved.
- `unregisterActive` removes the overlay from anywhere in its stack, so closing a nested overlay **restores its ancestor** as the active overlay — a subsequently-opened sibling still evicts the ancestor correctly.

Ancestry is resolved by a new `NgpOverlay.isDescendantOf()` helper that walks the parent-overlay chain already established through dependency injection (the same chain `parentId` uses for the outside-click dismissal cascade), so no new plumbing is introduced. The internal `CooldownOverlay` interface gains an optional `isDescendantOf?()` (it is not part of the public API).

The `cancelDestruction()` re-registration path is covered: by the time it re-registers, the overlay has already been removed from the stack, so it re-stacks beneath any still-open descendant ancestors correctly.

### Tests

- `popover-trigger.test.ts` — integration tests: opening a popover nested inside another keeps the ancestor open and shows both; closing the nested popover restores the ancestor as active so a later sibling still evicts it.
- `overlay-cooldown.test.ts` (new) — unit tests for the stack: sibling eviction, ancestor preservation, restoration after a nested close, per-type independence, instant-transition flag on cooldown, and no-op re-registration.

All `portal`, `popover`, `tooltip`, `menu`, `context-menu`, and `navigation-menu` tests pass (281 tests), along with `nx lint ng-primitives` and `nx build ng-primitives`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nested same‑type overlays so opening an inner overlay no longer closes its ancestor. Nested overlays stack; siblings still replace each other. Closes #789.

- **Bug Fixes**
  - Use a per‑type stack in `NgpOverlayCooldownManager` to keep ancestors when registering descendants; peers still evict. Handles ancestor re‑registration without evicting an active descendant.
  - Preserve cooldown behavior (evicted overlays get instant transitions when cooldown > 0).
  - Add `NgpOverlay.isDescendantOf()` and expand tests for nested stacking, ancestor restoration, and edge cases.

<sup>Written for commit 024fcdfbb920c1b1853f52bb85c873a66e266121. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

