### PR TITLE
fix menu transform origin after flip

### DIFF
--- a/apps/components/src/app/pages/reusable-components/toggle-group/toggle-group.ts
+++ b/apps/components/src/app/pages/reusable-components/toggle-group/toggle-group.ts
@@ -55,8 +55,8 @@ export class ToggleGroup implements ControlValueAccessor {
   }
 
   /** Write a new value to the toggle group. */
-  writeValue(value: string[]): void {
-    this.toggleGroup().setValue(value, { emit: false });
+  writeValue(value: string[] | null): void {
+    this.toggleGroup().setValue(value ?? [], { emit: false });
   }
 
   /** Register a callback function to be called when the value changes. */

--- a/packages/ng-primitives/menu/src/menu/menu-positioning.test.ts
+++ b/packages/ng-primitives/menu/src/menu/menu-positioning.test.ts
@@ -98,6 +98,28 @@ class DirectComponentClassMenuComponent {
   readonly menu = WrappedMenuComponent;
 }
 
+@Component({
+  template: `
+    <button
+      [ngpMenuTrigger]="menu"
+      ngpMenuTriggerPlacement="bottom-start"
+      data-testid="flip-trigger"
+      style="position: fixed; top: calc(100vh - 32px); left: 20px; width: 120px; height: 24px"
+    >
+      Open Menu
+    </button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="flip-menu" style="width: 160px; height: 96px">
+        <button ngpMenuItem>Item 1</button>
+        <button ngpMenuItem>Item 2</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem],
+})
+class FlippedMenuComponent {}
+
 /**
  * Helper to open a menu by clicking the trigger.
  * Waits until the menu element has data-placement set, which proves
@@ -170,6 +192,24 @@ describe('Menu outlet element positioning', () => {
       const menuElement = document.querySelector('[data-testid="menu"]');
       expect(menuElement).toBeInTheDocument();
       expect(menuElement?.getAttribute('data-placement')).toBeTruthy();
+    });
+  });
+
+  it('should update transform origin from the flipped placement', async () => {
+    const { fixture } = await render(FlippedMenuComponent);
+    fixture.autoDetectChanges(true);
+
+    const trigger = fixture.debugElement.nativeElement.querySelector(
+      '[data-testid="flip-trigger"]',
+    )!;
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      TestBed.flushEffects();
+      const menu = document.querySelector('[data-testid="flip-menu"]') as HTMLElement | null;
+      expect(menu).toBeInTheDocument();
+      expect(menu?.getAttribute('data-placement')).toBe('top-start');
+      expect(menu?.style.getPropertyValue('--ngp-menu-transform-origin')).toBe('bottom left');
     });
   });
 });

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -946,6 +946,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
 
     // Update final placement signal
     this.finalPlacement.set(position.placement);
+    this.transformOrigin.set(this.getTransformOrigin(position.placement));
 
     // Update arrow position if available
     if (this.arrowElement) {
@@ -1035,8 +1036,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   /**
    * Get the transform origin for the overlay
    */
-  private getTransformOrigin(): string {
-    const placement = this.config.placement?.() ?? 'top';
+  private getTransformOrigin(placement = this.config.placement?.() ?? 'top'): string {
     const basePlacement = placement.split('-')[0]; // Extract "top", "bottom", etc.
     const alignment = placement.split('-')[1]; // Extract "start" or "end"
 

--- a/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group.__fileSuffix@dasherize__.ts.template
@@ -57,8 +57,8 @@ export class ToggleGroup<%= componentSuffix %> implements ControlValueAccessor {
   }
 
   /** Write a new value to the toggle group. */
-  writeValue(value: string[]): void {
-    this.toggleGroup().setValue(value, { emit: false });
+  writeValue(value: string[] | null): void {
+    this.toggleGroup().setValue(value ?? [], { emit: false });
   }
 
   /** Register a callback function to be called when the value changes. */

--- a/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-forms.fixture.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-forms.fixture.ts
@@ -49,8 +49,8 @@ export class ToggleGroup implements ControlValueAccessor {
       .subscribe(value => this.onChange?.(value));
   }
 
-  writeValue(value: string[]): void {
-    this.toggleGroup().setValue(value, { emit: false });
+  writeValue(value: string[] | null): void {
+    this.toggleGroup().setValue(value ?? [], { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<string[]>): void {

--- a/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-forms.test.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-forms.test.ts
@@ -7,33 +7,40 @@ import { ToggleGroup, ToggleGroupItemFixture } from './toggle-group-forms.fixtur
 describe('ToggleGroup (reusable component) — template-driven forms', () => {
   it('binds with [(ngModel)] two-way', async () => {
     const ngModelChange = vi.fn();
-    const { getByTestId, fixture, rerender } = await render(
-      `
-      <app-toggle-group [(ngModel)]="value" (ngModelChange)="ngModelChange($event)">
-        <button app-toggle-group-item data-testid="item-1" value="option-1">1</button>
-        <button app-toggle-group-item data-testid="item-2" value="option-2">2</button>
-      </app-toggle-group>
-      `,
-      {
-        imports: [ToggleGroup, ToggleGroupItemFixture, NgpToggleGroupItem, FormsModule],
-        componentProperties: { value: [] as string[], ngModelChange },
-      },
-    );
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    await fixture.whenStable();
-    const item1 = getByTestId('item-1');
-    expect(item1).not.toHaveAttribute('data-selected');
+    try {
+      const { getByTestId, fixture, rerender } = await render(
+        `
+        <app-toggle-group [(ngModel)]="value" (ngModelChange)="ngModelChange($event)">
+          <button app-toggle-group-item data-testid="item-1" value="option-1">1</button>
+          <button app-toggle-group-item data-testid="item-2" value="option-2">2</button>
+        </app-toggle-group>
+        `,
+        {
+          imports: [ToggleGroup, ToggleGroupItemFixture, NgpToggleGroupItem, FormsModule],
+          componentProperties: { value: [] as string[], ngModelChange },
+        },
+      );
 
-    fireEvent.click(item1);
-    await fixture.whenStable();
-    expect(item1).toHaveAttribute('data-selected');
-    expect(ngModelChange).toHaveBeenCalledTimes(1);
-    expect(ngModelChange).toHaveBeenLastCalledWith(['option-1']);
+      await fixture.whenStable();
+      const item1 = getByTestId('item-1');
+      expect(item1).not.toHaveAttribute('data-selected');
 
-    await rerender({ componentProperties: { value: [], ngModelChange } });
-    await fixture.whenStable();
-    expect(item1).not.toHaveAttribute('data-selected');
-    expect(ngModelChange).toHaveBeenCalledTimes(1);
+      fireEvent.click(item1);
+      await fixture.whenStable();
+      expect(item1).toHaveAttribute('data-selected');
+      expect(ngModelChange).toHaveBeenCalledTimes(1);
+      expect(ngModelChange).toHaveBeenLastCalledWith(['option-1']);
+
+      await rerender({ componentProperties: { value: [], ngModelChange } });
+      await fixture.whenStable();
+      expect(item1).not.toHaveAttribute('data-selected');
+      expect(ngModelChange).toHaveBeenCalledTimes(1);
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #793

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes menu transform origin after a flip so animations start from the correct edge. Also makes toggle group forms null-safe to prevent errors and keep selections in sync.

- **Bug Fixes**
  - Menu: Updated `NgpOverlay` to derive `transformOrigin` from the final placement; added an integration test that forces a flip (`bottom-start` → `top-start`) and asserts `data-placement="top-start"` and `--ngp-menu-transform-origin: bottom left`.
  - Toggle Group: Made `writeValue` accept `string[] | null` and default to `[]`; updated examples, schematics template, and tests to ensure no console errors with null values.

<sup>Written for commit d97cfe76be20455edbdf074d879fe6057b465912. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

