### PR TITLE
Correct comparison logic datepicker

### DIFF
--- a/packages/ng-primitives/date-picker/src/date-picker-row-render/date-picker-row-render.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker-row-render/date-picker-row-render.ts
@@ -76,7 +76,7 @@ export class NgpDatePickerRowRender<T> implements OnDestroy {
     });
 
     // collect all the days to display.
-    while (firstDay <= lastDay) {
+    while (this.dateAdapter.compare(firstDay, lastDay) <= 0) {
       days.push(firstDay);
       firstDay = this.dateAdapter.add(firstDay, { days: 1 });
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #795 

## What does this PR implement/fix?

Correct comparison logic in NgpDatePickerRowRender using the current date adapater

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes day generation in the date picker row renderer by using the active date adapter for comparisons. Ensures correct ranges for all adapters and avoids edge-case loops. Closes #795.

- **Bug Fixes**
  - Use `this.dateAdapter.compare` instead of direct `<=` when iterating days in `NgpDatePickerRowRender`.

<sup>Written for commit 1f2059bab0821dc8941feff9f71bc6dea96611c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

