### PR TITLE
feat(submenu): support setContainer/container on submenu trigger

### DIFF
--- a/packages/ng-primitives/menu/src/submenu-trigger/submenu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/submenu-trigger/submenu-trigger-state.ts
@@ -61,6 +61,12 @@ export interface NgpSubmenuTriggerState {
   readonly flip: WritableSignal<NgpFlip>;
 
   /**
+   * The container in which the menu should be attached.
+   * @default document.body
+   */
+  readonly container: WritableSignal<HTMLElement | string | null>;
+
+  /**
    * The focus origin used to open the submenu.
    * Used by the submenu's focus trap for :focus-visible styling.
    * @internal
@@ -116,6 +122,13 @@ export interface NgpSubmenuTriggerState {
   setFlip(shouldFlip: NgpFlip): void;
 
   /**
+   * Set the container in which the menu should be attached. Takes effect the
+   * next time the menu is opened; it does not move a menu that is already open.
+   * @param container - The new container
+   */
+  setContainer(container: HTMLElement | string | null): void;
+
+  /**
    * Focus the trigger element.
    * @param origin - The focus origin
    */
@@ -151,6 +164,10 @@ export interface NgpSubmenuTriggerProps<T = unknown> {
    * Whether the menu should flip when there is not enough space.
    */
   readonly flip?: Signal<NgpFlip>;
+  /**
+   * The container in which the menu should be attached.
+   */
+  readonly container?: Signal<HTMLElement | string | null>;
 }
 
 export const [
@@ -166,6 +183,7 @@ export const [
     placement: _placement = signal('right-start'),
     offset: _offset = signal(0),
     flip: _flip = signal(true),
+    container: _container,
   }: NgpSubmenuTriggerProps<T>) => {
     const element = injectElementRef();
     const injector = inject(Injector);
@@ -179,6 +197,7 @@ export const [
     const placement = controlled(_placement);
     const flip = controlled(_flip);
     const offset = controlled(_offset);
+    const container = controlled(_container, 'body');
 
     const overlay = signal<NgpOverlay<T> | null>(null);
     const open = computed(() => overlay()?.isOpen() ?? false);
@@ -271,6 +290,7 @@ export const [
         content: menuContent,
         triggerElement: element.nativeElement,
         injector,
+        container: container(),
         placement,
         offset: offset(),
         flip: flip(),
@@ -338,6 +358,10 @@ export const [
       flip.set(shouldFlip);
     }
 
+    function setContainer(newContainer: HTMLElement | string | null): void {
+      container.set(newContainer);
+    }
+
     function focus(origin: FocusOrigin): void {
       focusMonitor.focusVia(element.nativeElement, origin, { preventScroll: true });
     }
@@ -366,8 +390,10 @@ export const [
       setFlip,
       setPlacement,
       setOffset,
+      setContainer,
       focus,
       setPointerOverContent,
+      container: deprecatedSetter(container, 'setContainer', setContainer),
     } satisfies NgpSubmenuTriggerState;
   },
 );

--- a/packages/ng-primitives/menu/src/submenu-trigger/submenu-trigger.test.ts
+++ b/packages/ng-primitives/menu/src/submenu-trigger/submenu-trigger.test.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Directive, OnInit } from '@angular/core';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
 import { NgpOverlay } from 'ng-primitives/portal';
 import { describe, expect, it, vi } from 'vitest';
@@ -6,6 +6,7 @@ import { NgpMenuItem } from '../menu-item/menu-item';
 import { NgpMenuTrigger } from '../menu-trigger/menu-trigger';
 import { NgpMenu } from '../menu/menu';
 import { NgpSubmenuTrigger } from './submenu-trigger';
+import { injectSubmenuTriggerState } from './submenu-trigger-state';
 
 @Component({
   template: `
@@ -86,6 +87,77 @@ class TestSubmenuNoFlipComponent {}
 class TestSubmenuPlacementComponent {
   placement: string = 'right-start';
 }
+
+@Component({
+  template: `
+    <div id="submenu-host"></div>
+
+    <button [ngpMenuTrigger]="menu" data-testid="root-trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="root-menu">
+        <button
+          [ngpSubmenuTrigger]="submenu"
+          ngpSubmenuTriggerContainer="#submenu-host"
+          ngpMenuItem
+          data-testid="submenu-trigger"
+        >
+          Open Submenu
+        </button>
+      </div>
+    </ng-template>
+
+    <ng-template #submenu>
+      <div ngpMenu data-testid="submenu">
+        <button ngpMenuItem data-testid="submenu-item-1">Submenu Item 1</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem, NgpSubmenuTrigger],
+})
+class TestSubmenuContainerComponent {}
+
+@Directive({
+  selector: '[setSubmenuContainer]',
+})
+class SetSubmenuContainerDirective implements OnInit {
+  private readonly submenuTrigger = injectSubmenuTriggerState();
+
+  ngOnInit(): void {
+    const host = document.querySelector('#submenu-host') as HTMLElement;
+    // container should be settable via the state setter method
+    this.submenuTrigger().setContainer(host);
+  }
+}
+
+@Component({
+  template: `
+    <div id="submenu-host"></div>
+
+    <button [ngpMenuTrigger]="menu" data-testid="root-trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="root-menu">
+        <button
+          [ngpSubmenuTrigger]="submenu"
+          setSubmenuContainer
+          ngpMenuItem
+          data-testid="submenu-trigger"
+        >
+          Open Submenu
+        </button>
+      </div>
+    </ng-template>
+
+    <ng-template #submenu>
+      <div ngpMenu data-testid="submenu">
+        <button ngpMenuItem data-testid="submenu-item-1">Submenu Item 1</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem, NgpSubmenuTrigger, SetSubmenuContainerDirective],
+})
+class TestSubmenuSetContainerComponent {}
 
 /**
  * Helper to open the root menu and submenu.
@@ -444,6 +516,28 @@ describe('NgpSubmenuTrigger viewport awareness', () => {
         const submenu = document.querySelector('[data-testid="submenu"]');
         expect(submenu).toBeInTheDocument();
         expect(submenu?.getAttribute('data-placement')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('container', () => {
+    it('should attach the submenu to a custom container when provided via the input (fixes #792)', async () => {
+      const { fixture } = await render(TestSubmenuContainerComponent);
+      await openMenuAndSubmenu(fixture);
+
+      await waitFor(() => {
+        const container = document.querySelector('#submenu-host');
+        expect(container?.querySelector('[ngpMenu]')).toBeInTheDocument();
+      });
+    });
+
+    it('should expose container on the injected state so it can be set programmatically (fixes #792)', async () => {
+      const { fixture } = await render(TestSubmenuSetContainerComponent);
+      await openMenuAndSubmenu(fixture);
+
+      await waitFor(() => {
+        const container = document.querySelector('#submenu-host');
+        expect(container?.querySelector('[ngpMenu]')).toBeInTheDocument();
       });
     });
   });

--- a/packages/ng-primitives/menu/src/submenu-trigger/submenu-trigger.ts
+++ b/packages/ng-primitives/menu/src/submenu-trigger/submenu-trigger.ts
@@ -74,6 +74,14 @@ export class NgpSubmenuTrigger<T = unknown> {
   });
 
   /**
+   * Define the container in which the menu should be attached.
+   * @default document.body
+   */
+  readonly container = input<HTMLElement | string | null>(null, {
+    alias: 'ngpSubmenuTriggerContainer',
+  });
+
+  /**
    * Access the menu trigger state.
    */
   private readonly state = ngpSubmenuTrigger<T>({
@@ -82,6 +90,7 @@ export class NgpSubmenuTrigger<T = unknown> {
     placement: this.placement,
     offset: this.offset,
     flip: this.flip,
+    container: this.container,
   });
 
   /**


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (API docs are generated from the JSDoc added here; no example page changes needed)

## PR Type

- [x] Feature

## Issue

Closes #792

## What does this PR implement/fix?

### Summary

Adds `setContainer` / `container` support to `NgpSubmenuTrigger`, bringing it to parity with `NgpMenuTrigger`. Submenu content can now be portaled into a custom container instead of always defaulting to `document.body`.

- New `ngpSubmenuTriggerContainer` input on the `NgpSubmenuTrigger` directive.
- New `container` writable signal and `setContainer()` method on the submenu trigger state (with the same deprecated direct-setter shape used by `menu-trigger-state.ts`).
- The container is now threaded into the submenu's `NgpOverlayConfig`, which previously omitted it.

### Why this matters (ref #792)

Submenu content was portaled into a container that always defaulted to `document.body`, so component- or segment-scoped CSS could not reach the rendered submenu and styling had to be declared globally. `NgpMenuTrigger` already exposes this via a `container` input and a `setContainer()` method, but `NgpSubmenuTrigger` did not. The maintainer confirmed on 2026-06-19 that the gap was real and still unfixed (an earlier release was thought to cover it, then corrected). This change mirrors the existing menu-trigger implementation exactly and is additive and bounded to the one primitive.

### Testing

- Added a `container` test group to `submenu-trigger.test.ts`:
  - Attaches the submenu to a custom container supplied via the `ngpSubmenuTriggerContainer` input.
  - Sets the container programmatically through the injected state's `setContainer()` method.
- `nx test ng-primitives` — all tests pass (submenu-trigger suite: 9 tests).
- `nx lint ng-primitives` — clean (0 errors).
- `nx build ng-primitives` — builds successfully.

## Does this PR introduce a breaking change?

- [x] No

Fixes #792


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `container`/`setContainer` support to `NgpSubmenuTrigger` so submenus can render into a custom container (not just `document.body`), matching `NgpMenuTrigger`. This enables component-scoped styles to apply; fixes #792.

- New Features
  - Added `ngpSubmenuTriggerContainer` input on `NgpSubmenuTrigger`.
  - Exposed `container` writable signal and `setContainer()` on the submenu trigger state (with the deprecated direct-setter alias).
  - Threaded `container` into `NgpOverlayConfig` so the portal attaches to the provided element or selector.

<sup>Written for commit 46e27455b0f15a548f8d96ef624b41767d9b122c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

