### PR TITLE
fix(menu): cancel pending close when pointer enters menu content

### DIFF
--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -543,15 +543,27 @@ export const [
     function setPointerOverContent(isOver: boolean): void {
       pointerOverContent.set(isOver);
 
-      if (!isOver && open() && triggers().includes('hover')) {
-        // Use a small delay to allow pointer to move back to trigger
-        setTimeout(() => {
-          // Only hide if pointer is not over trigger or content
-          if (!isPointerOverMenuArea()) {
-            hide();
-          }
-        }, 50);
+      if (isOver) {
+        // Cancel any pending close when the pointer enters the menu content,
+        // mirroring the onPointerEnter behaviour for the trigger element.
+        // Without this, a pending hideDelay timer started after onPointerLeave
+        // fires would still close the menu even though the pointer has arrived
+        // in the menu content (e.g. after diagonal cursor movement).
+        overlay()?.cancelPendingClose();
+        return;
       }
+
+      if (!open() || !triggers().includes('hover')) {
+        return;
+      }
+
+      // Use a small delay to allow pointer to move back to trigger
+      setTimeout(() => {
+        // Only hide if pointer is not over trigger or content
+        if (!isPointerOverMenuArea()) {
+          hide();
+        }
+      }, 50);
     }
 
     return {

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.test.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.test.ts
@@ -1,7 +1,7 @@
 import { Component, Directive, OnInit } from '@angular/core';
 import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import { NgpTooltip, NgpTooltipTrigger } from 'ng-primitives/tooltip';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from '../index';
 import { injectMenuTriggerState } from './menu-trigger-state';
 
@@ -81,6 +81,46 @@ describe('NgpMenuTrigger', () => {
       expect(screen.getByTestId('menu-b')).toBeInTheDocument();
       // Menu A should be closed
       expect(screen.queryByTestId('menu-a')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('hover trigger', () => {
+    it('should keep the menu open when the pointer moves from the trigger to the menu content', async () => {
+      vi.useFakeTimers();
+
+      await render(
+        `<button [ngpMenuTrigger]="menu" [ngpMenuTriggerOpenTriggers]="['hover']">Open Menu</button>
+
+        <ng-template #menu>
+          <div ngpMenu data-testid="ngp-menu">
+            <button ngpMenuItem>Item 1</button>
+          </div>
+        </ng-template>`,
+        { imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem] },
+      );
+
+      const trigger = screen.getByText('Open Menu');
+
+      // Hover the trigger to open the menu
+      fireEvent.pointerEnter(trigger);
+      await vi.runAllTimersAsync();
+
+      const menu = screen.getByTestId('ngp-menu');
+      expect(menu).toBeInTheDocument();
+
+      // Leave the trigger — starts the 50ms grace-period timer
+      fireEvent.pointerLeave(trigger);
+
+      // Enter the menu content before the grace period expires
+      fireEvent.pointerEnter(menu);
+
+      // Advance well past the grace period and any hideDelay
+      await vi.advanceTimersByTimeAsync(500);
+
+      // Menu must still be open: entering the content should have cancelled the pending close
+      expect(screen.getByTestId('ngp-menu')).toBeInTheDocument();
+
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## Issue

Closes #

## What does this PR implement/fix?

### Problem

When a hover-triggered menu is open and the pointer leaves the trigger, a 50 ms grace-period timer runs. If the timer fires while the pointer is still in transit (e.g. passing briefly over another element during diagonal cursor movement toward the submenu), `hide()` is called, which starts a `hideDelay` timer in the overlay.

If the pointer subsequently enters the menu content, `setPointerOverContent(true)` was only setting a signal — it never called `overlay.cancelPendingClose()` — so the `hideDelay` timer still fired and closed the menu even though the pointer had arrived in the content.

This asymmetry meant diagonal navigation from a trigger to its open submenu was unreliable with any `hideDelay > 0`. Every consumer that set a `hideDelay` for this exact use-case (keeping the menu open during diagonal movement) had to work around it themselves.

### Fix

Mirror the `onPointerEnter` behaviour already present for the trigger element:

```typescript
// onPointerEnter (trigger) — already correct
if (open()) {
  overlay()?.cancelPendingClose();
  return;
}

// setPointerOverContent (content) — was missing the cancel
function setPointerOverContent(isOver: boolean): void {
  pointerOverContent.set(isOver);

  if (isOver) {
    overlay()?.cancelPendingClose(); // ← added
    return;
  }
  // ... existing close logic
}
```

When the pointer enters the menu content, any pending overlay close is now cancelled, keeping the menu open for as long as the pointer remains in the trigger-or-content area.

A test is included that verifies the menu stays open after the pointer moves from the trigger to the content past the grace period.

## Does this PR introduce a breaking change?

- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hover-triggered menus closing when the pointer moves from the trigger into the menu content. We now cancel any pending close on content enter, so menus stay open during diagonal movement even with a non-zero `hideDelay`.

- **Bug Fixes**
  - Call `overlay.cancelPendingClose()` in `setPointerOverContent(true)` and return early; keep the 50 ms grace close only when not over content.
  - Add a test to ensure the menu stays open when moving from trigger to content past the grace period.

<sup>Written for commit c4a0468bb0922224c8f6b3869179af7ac4c08160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

