### PR TITLE
fix(utils): release DestroyRef registrations when disposables are cleaned up

### DIFF
--- a/packages/ng-primitives/utils/src/helpers/disposables.test.ts
+++ b/packages/ng-primitives/utils/src/helpers/disposables.test.ts
@@ -1,0 +1,218 @@
+import {
+  createEnvironmentInjector,
+  EnvironmentInjector,
+  runInInjectionContext,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { injectDisposables } from './disposables';
+
+/**
+ * inject(DestroyRef) in an environment context resolves to the injector itself
+ * (Angular ignores user providers for DestroyRef), so to observe registrations
+ * we wrap a real child environment injector's onDestroy. The wrapper tracks
+ * which callbacks are still registered while delegating to the real
+ * implementation, so destroy() behaviour stays authentic.
+ */
+function setup() {
+  const env = createEnvironmentInjector([], TestBed.inject(EnvironmentInjector));
+  const registrations = new Set<() => void>();
+  const originalOnDestroy = env.onDestroy.bind(env);
+
+  vi.spyOn(env, 'onDestroy').mockImplementation((callback: () => void) => {
+    registrations.add(callback);
+    const unregister = originalOnDestroy(callback);
+    return () => {
+      registrations.delete(callback);
+      unregister();
+    };
+  });
+
+  const disposables = runInInjectionContext(env, () => injectDisposables());
+
+  // injectDisposables registers one callback of its own (the isDestroyed flag).
+  const baseline = registrations.size;
+
+  return {
+    disposables,
+    baseline,
+    get size() {
+      return registrations.size;
+    },
+    destroy: () => env.destroy(),
+  };
+}
+
+describe('injectDisposables', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('setTimeout', () => {
+    it('releases its destroy registration once the timeout fires', () => {
+      vi.useFakeTimers();
+      const ctx = setup();
+      const callback = vi.fn();
+
+      ctx.disposables.setTimeout(callback, 100);
+      expect(ctx.size).toBe(ctx.baseline + 1);
+
+      vi.advanceTimersByTime(100);
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(ctx.size).toBe(ctx.baseline);
+    });
+
+    it('releases its destroy registration when cleared early', () => {
+      vi.useFakeTimers();
+      const ctx = setup();
+      const callback = vi.fn();
+
+      const cleanup = ctx.disposables.setTimeout(callback, 100);
+      cleanup();
+
+      expect(ctx.size).toBe(ctx.baseline);
+      vi.advanceTimersByTime(100);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('does not accumulate registrations across repeated schedule/clear cycles', () => {
+      vi.useFakeTimers();
+      const ctx = setup();
+
+      let cleanup: () => void = () => void 0;
+      for (let i = 0; i < 50; i++) {
+        cleanup();
+        cleanup = ctx.disposables.setTimeout(() => void 0, 100);
+      }
+
+      expect(ctx.size).toBe(ctx.baseline + 1);
+    });
+
+    it('is idempotent when the cleanup is called multiple times', () => {
+      vi.useFakeTimers();
+      const ctx = setup();
+
+      const cleanup = ctx.disposables.setTimeout(() => void 0, 100);
+      cleanup();
+      cleanup();
+
+      expect(ctx.size).toBe(ctx.baseline);
+    });
+
+    it('still clears a pending timeout on destroy', () => {
+      vi.useFakeTimers();
+      const ctx = setup();
+      const callback = vi.fn();
+
+      ctx.disposables.setTimeout(callback, 100);
+      ctx.destroy();
+
+      vi.advanceTimersByTime(100);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('does not schedule or register after destroy', () => {
+      vi.useFakeTimers();
+      const ctx = setup();
+      const callback = vi.fn();
+
+      ctx.destroy();
+      const sizeAfterDestroy = ctx.size;
+      ctx.disposables.setTimeout(callback, 100);
+
+      expect(ctx.size).toBe(sizeAfterDestroy);
+      vi.advanceTimersByTime(100);
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setInterval', () => {
+    it('releases its destroy registration when cleared', () => {
+      vi.useFakeTimers();
+      const ctx = setup();
+      const callback = vi.fn();
+
+      const cleanup = ctx.disposables.setInterval(callback, 100);
+      vi.advanceTimersByTime(300);
+      expect(callback).toHaveBeenCalledTimes(3);
+
+      cleanup();
+      expect(ctx.size).toBe(ctx.baseline);
+
+      vi.advanceTimersByTime(300);
+      expect(callback).toHaveBeenCalledTimes(3);
+    });
+
+    it('still stops the interval on destroy', () => {
+      vi.useFakeTimers();
+      const ctx = setup();
+      const callback = vi.fn();
+
+      ctx.disposables.setInterval(callback, 100);
+      ctx.destroy();
+
+      vi.advanceTimersByTime(300);
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addEventListener', () => {
+    it('releases its destroy registration when the listener is removed', () => {
+      const ctx = setup();
+      const target = document.createElement('div');
+      const listener = vi.fn();
+
+      const cleanup = ctx.disposables.addEventListener(target, 'click', listener);
+      expect(ctx.size).toBe(ctx.baseline + 1);
+
+      target.dispatchEvent(new MouseEvent('click'));
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      cleanup();
+      expect(ctx.size).toBe(ctx.baseline);
+
+      target.dispatchEvent(new MouseEvent('click'));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('still removes the listener on destroy', () => {
+      const ctx = setup();
+      const target = document.createElement('div');
+      const listener = vi.fn();
+
+      ctx.disposables.addEventListener(target, 'click', listener);
+      ctx.destroy();
+
+      target.dispatchEvent(new MouseEvent('click'));
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('requestAnimationFrame', () => {
+    it('releases its destroy registration once the frame fires', async () => {
+      const ctx = setup();
+      const callback = vi.fn();
+
+      ctx.disposables.requestAnimationFrame(callback);
+      expect(ctx.size).toBe(ctx.baseline + 1);
+
+      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(ctx.size).toBe(ctx.baseline);
+    });
+
+    it('releases its destroy registration when cancelled early', async () => {
+      const ctx = setup();
+      const callback = vi.fn();
+
+      const cleanup = ctx.disposables.requestAnimationFrame(callback);
+      cleanup();
+
+      expect(ctx.size).toBe(ctx.baseline);
+
+      await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ng-primitives/utils/src/helpers/disposables.ts
+++ b/packages/ng-primitives/utils/src/helpers/disposables.ts
@@ -4,6 +4,11 @@ import { DestroyRef, inject } from '@angular/core';
  * Disposable functions are a way to manage timers, intervals, and event listeners
  * that should be cleared when a component is destroyed.
  *
+ * Each disposable releases its DestroyRef registration as soon as the resource
+ * is gone (the timer fires or the returned cleanup runs), so repeated calls -
+ * e.g. rescheduling a timeout on every pointermove - don't accumulate destroy
+ * callbacks for the lifetime of the host.
+ *
  * This is heavily inspired by Headless UI disposables:
  * https://github.com/tailwindlabs/headlessui/blob/main/packages/%40headlessui-react/src/utils/disposables.ts
  */
@@ -26,20 +31,23 @@ export function injectDisposables() {
         return () => {};
       }
 
-      const id = setTimeout(callback, delay);
-      const cleanup = () => clearTimeout(id);
-      destroyRef.onDestroy(cleanup);
-      return cleanup;
+      const id = setTimeout(() => {
+        unregister();
+        callback();
+      }, delay);
+      const unregister = destroyRef.onDestroy(() => clearTimeout(id));
+      return () => {
+        clearTimeout(id);
+        unregister();
+      };
     },
     /**
-     * Set an interval that will be cleared when the component is destroyed.
-     * @param callback The callback to execute
-     * @param delay The delay before the callback is executed
-     * @param target
-     * @param type
-     * @param listener
-     * @param options
-     * @returns A function to clear the interval
+     * Add an event listener that will be removed when the component is destroyed.
+     * @param target The event target
+     * @param type The event type
+     * @param listener The event listener
+     * @param options The event listener options
+     * @returns A function to remove the event listener
      */
     addEventListener: <K extends keyof HTMLElementEventMap>(
       target: EventTarget,
@@ -54,15 +62,18 @@ export function injectDisposables() {
       }
 
       target.addEventListener(type, listener as EventListenerOrEventListenerObject, options);
-      const cleanup = () =>
+      const unregister = destroyRef.onDestroy(() =>
+        target.removeEventListener(type, listener as EventListenerOrEventListenerObject, options),
+      );
+      return () => {
         target.removeEventListener(type, listener as EventListenerOrEventListenerObject, options);
-      destroyRef.onDestroy(cleanup);
-      return cleanup;
+        unregister();
+      };
     },
     /**
      * Set an interval that will be cleared when the component is destroyed.
      * @param callback The callback to execute
-     * @param delay The delay before the callback is executed
+     * @param delay The delay between executions
      * @returns A function to clear the interval
      */
     setInterval: (callback: () => void, delay: number) => {
@@ -72,9 +83,11 @@ export function injectDisposables() {
       }
 
       const id = setInterval(callback, delay);
-      const cleanup = () => clearInterval(id);
-      destroyRef.onDestroy(cleanup);
-      return cleanup;
+      const unregister = destroyRef.onDestroy(() => clearInterval(id));
+      return () => {
+        clearInterval(id);
+        unregister();
+      };
     },
     /**
      * Set a requestAnimationFrame that will be cleared when the component is destroyed.
@@ -87,10 +100,15 @@ export function injectDisposables() {
         return () => {};
       }
 
-      const id = requestAnimationFrame(callback);
-      const cleanup = () => cancelAnimationFrame(id);
-      destroyRef.onDestroy(cleanup);
-      return cleanup;
+      const id = requestAnimationFrame(time => {
+        unregister();
+        callback(time);
+      });
+      const unregister = destroyRef.onDestroy(() => cancelAnimationFrame(id));
+      return () => {
+        cancelAnimationFrame(id);
+        unregister();
+      };
     },
   };
 }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated - internal utility, no public API or docs surface changed

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #
<!-- Follow-up noted in #802 review discussion. -->

## What does this PR implement/fix?

`injectDisposables` registered a `DestroyRef.onDestroy` cleanup for every `setTimeout` / `setInterval` / `addEventListener` / `requestAnimationFrame` call and discarded the unregister function Angular returns, so each call leaked one registration for the lifetime of the host. Hot paths that reschedule per event - e.g. the hover-bridge idle fallback in #802 rescheduling on every pointermove, or overlays re-adding document listeners per interaction - accumulated unbounded dead callbacks on long-lived pages.

Each disposable now captures the unregister function from `onDestroy` and calls it when the resource is released naturally (the timer or animation frame fires) or via the returned cleanup function. Destroy-time behaviour is unchanged: pending timers, intervals, listeners and frames are still torn down when the host is destroyed, and the returned cleanups remain idempotent (`clearTimeout` / `removeEventListener` / Angular's unregister all tolerate repeat calls).

Written test-first: the new `disposables.test.ts` wraps a real child `EnvironmentInjector`'s `onDestroy` to count live registrations (Angular resolves `DestroyRef` to the injector itself and ignores user providers, so a mock can't be injected). The 8 leak assertions fail against the previous implementation; the 4 destroy-behaviour tests pass before and after, pinning that nothing regressed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a memory leak in `injectDisposables` by unregistering `DestroyRef.onDestroy` callbacks when timers, listeners, or frames are cleared or have fired. Prevents accumulating dead destroy callbacks on long‑lived hosts while keeping destroy-time teardown unchanged.

- **Bug Fixes**
  - Captures the `onDestroy` unregister and invokes it on natural completion or cleanup for `setTimeout`, `setInterval`, `addEventListener`, and `requestAnimationFrame`.
  - Ensures repeated schedule/clear cycles don’t grow registrations; cleanups are idempotent and destroy-time behavior is unchanged.
  - Adds tests that fail on the previous leak and verify destroy behavior remains intact.

<sup>Written for commit 0bfd5caa4f8e4a9e0fb5bb89a8ff46c8837757ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

