### PR TITLE
fix(pagination): restore keyboard activation

### DIFF
--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
@@ -69,7 +69,7 @@ export const [
     }
 
     function handleKeydown(event: KeyboardEvent): void {
-      if (event.key !== 'Enter' && event.key !== ' ') {
+      if (event.repeat || (event.key !== 'Enter' && event.key !== ' ')) {
         return;
       }
 

--- a/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-button/pagination-button-state.ts
@@ -58,8 +58,7 @@ export const [
 
     // Listeners
     listener(elementRef, 'click', goToPage);
-    listener(elementRef, 'keydown.space', handleOnEnter);
-    listener(elementRef, 'keydown.enter', handleOnEnter);
+    listener(elementRef, 'keydown', handleKeydown);
 
     function goToPage(): void {
       if (disabled()) {
@@ -69,7 +68,11 @@ export const [
       paginationState().goToPage(page());
     }
 
-    function handleOnEnter(event: Event): void {
+    function handleKeydown(event: KeyboardEvent): void {
+      if (event.key !== 'Enter' && event.key !== ' ') {
+        return;
+      }
+
       event.preventDefault();
       event.stopPropagation();
       goToPage();

--- a/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
@@ -57,7 +57,7 @@ export const [
     }
 
     function handleKeydown(event: KeyboardEvent): void {
-      if (event.key !== 'Enter' && event.key !== ' ') {
+      if (event.repeat || (event.key !== 'Enter' && event.key !== ' ')) {
         return;
       }
 

--- a/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-first/pagination-first-state.ts
@@ -46,8 +46,7 @@ export const [
 
     // Listener
     listener(elementRef, 'click', goToFirstPage);
-    listener(elementRef, 'keydown.enter', handleOnEnter);
-    listener(elementRef, 'keydown.space', handleOnEnter);
+    listener(elementRef, 'keydown', handleKeydown);
 
     function goToFirstPage(): void {
       if (disabled()) {
@@ -57,7 +56,11 @@ export const [
       paginationState().goToPage(1);
     }
 
-    function handleOnEnter(event: Event): void {
+    function handleKeydown(event: KeyboardEvent): void {
+      if (event.key !== 'Enter' && event.key !== ' ') {
+        return;
+      }
+
       event.preventDefault();
       event.stopPropagation();
       goToFirstPage();

--- a/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
@@ -51,7 +51,7 @@ export const [
     }
 
     function handleKeydown(event: KeyboardEvent): void {
-      if (event.key !== 'Enter' && event.key !== ' ') {
+      if (event.repeat || (event.key !== 'Enter' && event.key !== ' ')) {
         return;
       }
 

--- a/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-last/pagination-last-state.ts
@@ -40,8 +40,7 @@ export const [
 
     // Listener
     listener(elementRef, 'click', goToLastPage);
-    listener(elementRef, 'keydown.enter', handleOnEnter);
-    listener(elementRef, 'keydown.space', handleOnEnter);
+    listener(elementRef, 'keydown', handleKeydown);
 
     function goToLastPage(): void {
       if (disabled()) {
@@ -51,7 +50,11 @@ export const [
       paginationState().goToPage(paginationState().pageCount());
     }
 
-    function handleOnEnter(event: Event): void {
+    function handleKeydown(event: KeyboardEvent): void {
+      if (event.key !== 'Enter' && event.key !== ' ') {
+        return;
+      }
+
       event.preventDefault();
       event.stopPropagation();
       goToLastPage();

--- a/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
@@ -40,8 +40,7 @@ export const [
 
     // Listener
     listener(elementRef, 'click', goToNextPage);
-    listener(elementRef, 'keydown.enter', handleOnEnter);
-    listener(elementRef, 'keydown.space', handleOnEnter);
+    listener(elementRef, 'keydown', handleKeydown);
 
     function goToNextPage(): void {
       if (disabled()) {
@@ -51,7 +50,11 @@ export const [
       paginationState().goToPage(paginationState().page() + 1);
     }
 
-    function handleOnEnter(event: Event): void {
+    function handleKeydown(event: KeyboardEvent): void {
+      if (event.key !== 'Enter' && event.key !== ' ') {
+        return;
+      }
+
       event.preventDefault();
       event.stopPropagation();
       goToNextPage();

--- a/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-next/pagination-next-state.ts
@@ -51,7 +51,7 @@ export const [
     }
 
     function handleKeydown(event: KeyboardEvent): void {
-      if (event.key !== 'Enter' && event.key !== ' ') {
+      if (event.repeat || (event.key !== 'Enter' && event.key !== ' ')) {
         return;
       }
 

--- a/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
@@ -57,8 +57,13 @@ export const [
     }
 
     function handleKeydown(event: KeyboardEvent): void {
+      if (event.repeat) {
+        return;
+      }
+
       if (event.key !== 'Enter' && event.key !== ' ') {
         return;
+      }
       }
 
       event.preventDefault();

--- a/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
@@ -57,13 +57,8 @@ export const [
     }
 
     function handleKeydown(event: KeyboardEvent): void {
-      if (event.repeat) {
+      if (event.repeat || (event.key !== 'Enter' && event.key !== ' ')) {
         return;
-      }
-
-      if (event.key !== 'Enter' && event.key !== ' ') {
-        return;
-      }
       }
 
       event.preventDefault();

--- a/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination-previous/pagination-previous-state.ts
@@ -46,8 +46,7 @@ export const [
 
     // Listener
     listener(elementRef, 'click', goToPreviousPage);
-    listener(elementRef, 'keydown.enter', handleOnEnter);
-    listener(elementRef, 'keydown.space', handleOnEnter);
+    listener(elementRef, 'keydown', handleKeydown);
 
     function goToPreviousPage(): void {
       if (disabled()) {
@@ -57,7 +56,11 @@ export const [
       paginationState().goToPage(paginationState().page() - 1);
     }
 
-    function handleOnEnter(event: Event): void {
+    function handleKeydown(event: KeyboardEvent): void {
+      if (event.key !== 'Enter' && event.key !== ' ') {
+        return;
+      }
+
       event.preventDefault();
       event.stopPropagation();
       goToPreviousPage();

--- a/packages/ng-primitives/pagination/src/pagination/pagination.test.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination.test.ts
@@ -131,6 +131,25 @@ describe('NgpPagination', () => {
     expect(pagination).toHaveAttribute('data-page', '5');
   });
 
+  it('should ignore repeated keydown events', async () => {
+    const { getByRole, getByTestId } = await render(
+      `<div ngpPagination [(ngpPaginationPage)]="page" [ngpPaginationPageCount]="5">
+        <a data-testid="previous-page-button" ngpPaginationPrevious>Previous</a>
+      </div>`,
+      {
+        imports: [NgpPagination, NgpPaginationPrevious],
+        componentProperties: { page: 3 },
+      },
+    );
+    const pagination = getByRole('navigation');
+    const previous = getByTestId('previous-page-button');
+    expect(pagination).toHaveAttribute('data-page', '3');
+
+    fireEvent.keyDown(previous, { key: 'Enter' });
+    fireEvent.keyDown(previous, { key: 'Enter', repeat: true });
+    expect(pagination).toHaveAttribute('data-page', '2');
+  });
+
   it('should not emit pageChange or update page if goToPage is called with out-of-bounds value', async () => {
     const { getByRole, getByTestId } = await render(
       `<div ngpPagination [(ngpPaginationPage)]="page" [ngpPaginationPageCount]="2">

--- a/packages/ng-primitives/pagination/src/pagination/pagination.test.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination.test.ts
@@ -91,6 +91,46 @@ describe('NgpPagination', () => {
     expect(pagination).not.toHaveAttribute('data-last-page');
   });
 
+  it('should navigate with Enter and Space keydown events on non-button controls', async () => {
+    const { getByRole, getByTestId } = await render(
+      `<div ngpPagination [(ngpPaginationPage)]="page" [ngpPaginationPageCount]="5">
+        <a data-testid="first-page-button" ngpPaginationFirst>First</a>
+        <a data-testid="previous-page-button" ngpPaginationPrevious>Previous</a>
+        <a data-testid="go-to-page-4" ngpPaginationButton ngpPaginationButtonPage="4">Go to Page 4</a>
+        <a data-testid="next-page-button" ngpPaginationNext>Next</a>
+        <a data-testid="last-page-button" ngpPaginationLast>Last</a>
+      </div>`,
+      {
+        imports: [
+          NgpPagination,
+          NgpPaginationButton,
+          NgpPaginationFirst,
+          NgpPaginationLast,
+          NgpPaginationNext,
+          NgpPaginationPrevious,
+        ],
+        componentProperties: { page: 3 },
+      },
+    );
+    const pagination = getByRole('navigation');
+    expect(pagination).toHaveAttribute('data-page', '3');
+
+    fireEvent.keyDown(getByTestId('first-page-button'), { key: 'Enter' });
+    expect(pagination).toHaveAttribute('data-page', '1');
+
+    fireEvent.keyDown(getByTestId('next-page-button'), { key: 'Enter' });
+    expect(pagination).toHaveAttribute('data-page', '2');
+
+    fireEvent.keyDown(getByTestId('go-to-page-4'), { key: ' ' });
+    expect(pagination).toHaveAttribute('data-page', '4');
+
+    fireEvent.keyDown(getByTestId('previous-page-button'), { key: ' ' });
+    expect(pagination).toHaveAttribute('data-page', '3');
+
+    fireEvent.keyDown(getByTestId('last-page-button'), { key: 'Enter' });
+    expect(pagination).toHaveAttribute('data-page', '5');
+  });
+
   it('should not emit pageChange or update page if goToPage is called with out-of-bounds value', async () => {
     const { getByRole, getByTestId } = await render(
       `<div ngpPagination [(ngpPaginationPage)]="page" [ngpPaginationPageCount]="2">


### PR DESCRIPTION
## Summary

Fixes keyboard activation for pagination controls.

The pagination state code was passing `keydown.enter` and `keydown.space` to the shared `listener()` helper. Since that helper uses native `addEventListener`, those event names are treated as literal DOM events and never fire.

This updates the pagination controls to listen for a normal `keydown` event and check for Enter/Space inside the handler.

Fixes #804

## Testing

- `.\node_modules\.bin\vitest.CMD --config packages\ng-primitives\vite.config.ts packages\ng-primitives\pagination\src\pagination\pagination.test.ts --run`
- `.\node_modules\.bin\nx.CMD build ng-primitives --excludeTaskDependencies`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores keyboard activation for pagination by listening to a normal keydown and handling Enter/Space. Adds a repeat guard across all controls to prevent multi-navigation and fixes keyboard use on non-button controls. Fixes #804.

- **Bug Fixes**
  - Replace 'keydown.enter'/'keydown.space' with 'keydown' + key check in all pagination state modules.
  - Prevent default and stop propagation before navigation.
  - Ignore repeated keydown events on first/prev/next/last and page buttons.
  - Add tests for Enter/Space on anchor controls and repeated keydown.

<sup>Written for commit a5d1ff25584643df44cee0c04790cb23ccd29c67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

