### PR TITLE
fix(menu): focus non-native menu items

### DIFF
--- a/packages/ng-primitives/menu/src/menu/menu-state.ts
+++ b/packages/ng-primitives/menu/src/menu/menu-state.ts
@@ -1,10 +1,12 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { Directionality } from '@angular/cdk/bidi';
-import { computed, inject } from '@angular/core';
+import { afterNextRender, computed, inject, Injector } from '@angular/core';
 import { ngpFocusTrap } from 'ng-primitives/focus-trap';
 import { injectElementRef } from 'ng-primitives/internal';
 import { injectOverlay } from 'ng-primitives/portal';
+import { injectRovingFocusGroupState } from 'ng-primitives/roving-focus';
 import { attrBinding, createPrimitive, listener, styleBinding } from 'ng-primitives/state';
+import { injectDisposables } from 'ng-primitives/utils';
 import { Subject } from 'rxjs';
 import { injectMenuTriggerState } from '../menu-trigger/menu-trigger-state';
 
@@ -29,8 +31,11 @@ export const [NgpMenuStateToken, ngpMenu, injectMenuState, provideMenuState] = c
     const element = injectElementRef();
     const overlay = injectOverlay();
     const directionality = inject(Directionality, { optional: true });
+    const injector = inject(Injector);
+    const disposables = injectDisposables();
     const menuTrigger = injectMenuTriggerState();
     const parentMenu = injectMenuState({ optional: true, skipSelf: true });
+    const rovingFocusGroup = injectRovingFocusGroupState();
 
     // Always trap focus in menus per WAI-ARIA guidelines (Tab should not navigate within menus)
     // Pass the open origin so focus trap uses the correct origin for :focus-visible styling
@@ -38,6 +43,19 @@ export const [NgpMenuStateToken, ngpMenu, injectMenuState, provideMenuState] = c
     ngpFocusTrap({
       focusOrigin: openOrigin,
     });
+
+    afterNextRender(
+      {
+        write: () => {
+          disposables.requestAnimationFrame(() => {
+            if (document.activeElement === element.nativeElement) {
+              rovingFocusGroup()?.activateFirst(openOrigin());
+            }
+          });
+        },
+      },
+      { injector },
+    );
 
     // Register this element as the overlay outlet so floating-ui positions it correctly,
     // even when this directive is on a nested child component rather than the portal root.

--- a/packages/ng-primitives/menu/src/menu/menu.test.ts
+++ b/packages/ng-primitives/menu/src/menu/menu.test.ts
@@ -124,6 +124,21 @@ class TestMenuWithDisabledItemsComponent {
 })
 class TestMenuFocusTrapComponent {}
 
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu">
+        <div ngpMenuItem data-testid="item-1">Item 1</div>
+        <div ngpMenuItem data-testid="item-2">Item 2</div>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem],
+})
+class TestMenuWithDivItemsComponent {}
+
 describe('NgpMenu', () => {
   describe('Focus Trap (WAI-ARIA compliance)', () => {
     // Per WAI-ARIA guidelines, menus should always trap focus (Tab cannot leave menu).
@@ -809,6 +824,25 @@ describe('NgpSubmenuTrigger', () => {
 });
 
 describe('NgpMenuItem', () => {
+  describe('focus management', () => {
+    it('should focus the first item when menu items are not natively focusable', async () => {
+      const { fixture } = await render(TestMenuWithDivItemsComponent);
+      const trigger = fixture.debugElement.nativeElement.querySelector('[data-testid="trigger"]');
+
+      fireEvent.click(trigger);
+      fixture.detectChanges();
+
+      await waitFor(() => {
+        expect(document.querySelector('[data-testid="item-1"]')).toBe(document.activeElement);
+      });
+
+      fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' });
+      fixture.detectChanges();
+
+      expect(document.querySelector('[data-testid="item-2"]')).toBe(document.activeElement);
+    });
+  });
+
   describe('closeAllMenus on selection', () => {
     it('should call closeAllMenus when item is clicked', async () => {
       const { fixture } = await render(TestMenuWithSubmenuComponent);

--- a/packages/ng-primitives/menu/src/menu/menu.ts
+++ b/packages/ng-primitives/menu/src/menu/menu.ts
@@ -5,7 +5,7 @@ import { provideFocusTrapState } from 'ng-primitives/focus-trap';
 import { provideControlContainerIsolation } from 'ng-primitives/portal';
 import { ngpRovingFocusGroup, provideRovingFocusGroupState } from 'ng-primitives/roving-focus';
 import { injectMenuConfig } from '../config/menu-config';
-import { ngpMenu, provideMenuState } from './menu-state';
+import { ngpMenu, NgpMenuState, provideMenuState } from './menu-state';
 
 /**
  * The `NgpMenu` is a container for menu items.
@@ -33,10 +33,11 @@ export class NgpMenu {
     transform: booleanAttribute,
   });
 
-  private readonly state = ngpMenu({ wrap: this.wrap });
+  private readonly state: NgpMenuState;
 
   constructor() {
     ngpRovingFocusGroup({ inherit: false, wrap: this.wrap });
+    this.state = ngpMenu({});
   }
 
   /** @internal Close the menu and any parent menus */


### PR DESCRIPTION
## Summary

Fixes focus for menu items rendered on non-native focusable elements, like `div`.

These items already receive the right `tabindex`, but focus can stay on the menu container when the menu opens. This updates the menu to hand focus to the first roving-focus item after render, while avoiding stealing focus during submenu interactions.

Fixes #800

## Testing

- `.\node_modules\.bin\vitest.CMD --config packages\ng-primitives\vite.config.ts packages\ng-primitives\menu\src\menu\menu.test.ts --run`
- `.\node_modules\.bin\nx.CMD build ng-primitives --excludeTaskDependencies`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes menu focus so `ngpMenuItem` on non-native elements (like `div`) receives focus on open, not the menu container. Prevents focus stealing during submenu interactions.

- **Bug Fixes**
  - After render, if the menu container is focused, return focus to the active roving-focus item (uses `afterNextRender` + `requestAnimationFrame`).
  - Injects roving-focus group state to activate the first item based on `openOrigin`.
  - Adds a test ensuring the first `div`-based item is focused on open and arrow navigation works.

<sup>Written for commit 96f62ff02b5d7576c08b53d1ff2f481251b024eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

