### PR TITLE
fix(toggle-group): expose aria-pressed toggle buttons in multiple-select groups

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/toggle-group.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toggle-group.md
@@ -111,7 +111,7 @@ bootstrapApplication(AppComponent, {
 
 ## Accessibility
 
-The toggle group uses `role="group"` on the container and `role="radio"` with `aria-checked` on each item. Keyboard navigation follows the roving tabindex pattern.
+The toggle group uses `role="group"` on the container. In a single-select group each item uses `role="radio"` with `aria-checked`; in a multiple-select group the items are toggle buttons exposing `aria-pressed` instead. Keyboard navigation follows the roving tabindex pattern.
 
 ### Keyboard Interactions
 

--- a/packages/ng-primitives/toggle-group/src/toggle-group-item/toggle-group-item-state.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group-item/toggle-group-item-state.ts
@@ -43,9 +43,16 @@ export const [
     // Whether the item is selected.
     const selected = computed(() => toggleGroup()?.isSelected(value()!) ?? false);
 
+    // Whether the item belongs to a multiple-select toggle group.
+    const multiple = computed(() => toggleGroup()?.type() === 'multiple');
+
     // Host bindings
-    attrBinding(element, 'role', 'radio');
-    attrBinding(element, 'aria-checked', selected);
+    // In a single-select group the items behave like radio buttons, while in a
+    // multiple-select group they are independent toggle buttons exposing
+    // aria-pressed, matching the standalone toggle primitive.
+    attrBinding(element, 'role', () => (multiple() ? null : 'radio'));
+    attrBinding(element, 'aria-checked', () => (multiple() ? null : selected()));
+    attrBinding(element, 'aria-pressed', () => (multiple() ? selected() : null));
     dataBinding(element, 'data-selected', selected);
     attrBinding(element, 'aria-disabled', disabled);
     dataBinding(element, 'data-disabled', disabled);

--- a/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-primitive.test.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-primitive.test.ts
@@ -57,6 +57,32 @@ describe('NgpToggleGroup', () => {
       expect(group).toHaveAttribute('data-orientation', 'horizontal');
     });
 
+    it('should expose radio semantics on items', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpToggleGroup>
+          <div data-testid="toggle-item-1" ngpToggleGroupItem ngpToggleGroupItemValue="option-1"></div>
+          <div data-testid="toggle-item-2" ngpToggleGroupItem ngpToggleGroupItemValue="option-2"></div>
+        </div>
+        `,
+        {
+          imports: [NgpToggleGroup, NgpToggleGroupItem],
+        },
+      );
+
+      const item1 = getByTestId('toggle-item-1');
+      const item2 = getByTestId('toggle-item-2');
+      expect(item1).toHaveAttribute('role', 'radio');
+      expect(item1).toHaveAttribute('aria-checked', 'false');
+      expect(item1).not.toHaveAttribute('aria-pressed');
+
+      fireEvent.click(item1);
+
+      expect(item1).toHaveAttribute('aria-checked', 'true');
+      expect(item1).not.toHaveAttribute('aria-pressed');
+      expect(item2).toHaveAttribute('aria-checked', 'false');
+    });
+
     it('should allow deselection', async () => {
       const { getByTestId } = await render(
         `
@@ -151,6 +177,34 @@ describe('NgpToggleGroup', () => {
       const group = getByRole('group');
       expect(group).toHaveAttribute('data-type', 'multiple');
       expect(group).toHaveAttribute('data-orientation', 'horizontal');
+    });
+
+    it('should expose toggle button semantics on items', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpToggleGroup ngpToggleGroupType="multiple">
+          <div data-testid="toggle-item-1" ngpToggleGroupItem ngpToggleGroupItemValue="option-1"></div>
+          <div data-testid="toggle-item-2" ngpToggleGroupItem ngpToggleGroupItemValue="option-2"></div>
+        </div>
+        `,
+        {
+          imports: [NgpToggleGroup, NgpToggleGroupItem],
+        },
+      );
+
+      const item1 = getByTestId('toggle-item-1');
+      const item2 = getByTestId('toggle-item-2');
+      expect(item1).not.toHaveAttribute('role');
+      expect(item1).not.toHaveAttribute('aria-checked');
+      expect(item1).toHaveAttribute('aria-pressed', 'false');
+
+      fireEvent.click(item1);
+      fireEvent.click(item2);
+
+      expect(item1).toHaveAttribute('aria-pressed', 'true');
+      expect(item2).toHaveAttribute('aria-pressed', 'true');
+      expect(item1).not.toHaveAttribute('role');
+      expect(item1).not.toHaveAttribute('aria-checked');
     });
 
     it('should allow multiple selections', async () => {

--- a/packages/ng-primitives/toggle-group/src/toggle-group/toggle-group-state.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/toggle-group-state.ts
@@ -39,6 +39,11 @@ export interface NgpToggleGroupState<T = string> {
   readonly orientation: WritableSignal<NgpOrientation>;
 
   /**
+   * The type of the toggle group, whether only one item can be selected or multiple.
+   */
+  readonly type: Signal<'single' | 'multiple'>;
+
+  /**
    * Select a value in the toggle group.
    */
   select(selection: T): void;
@@ -242,6 +247,7 @@ export const [
       toggle,
       value: deprecatedSetter(value, 'setValue', setValue),
       orientation: deprecatedSetter(orientation, 'setOrientation', setOrientation),
+      type,
       setValue,
       setDefaultValue: defaultValue.set,
       setDisabled,


### PR DESCRIPTION
Closes #813

## Problem

`NgpToggleGroupItem` hardcodes `role="radio"` and `aria-checked` regardless of the group's `ngpToggleGroupType`. For a `type="multiple"` group this announces the options as mutually exclusive radios to assistive technology, even though selections are independent.

Reproduction (from the issue): https://stackblitz.com/edit/q9jalwpl?file=src%2Fmain.ts

## Fix

Items now derive their semantics from the group type, matching the pattern used by Radix UI's ToggleGroup and React Aria's ToggleButtonGroup:

- `type="single"` (unchanged): items expose `role="radio"` + `aria-checked`.
- `type="multiple"`: items keep their native role and expose `aria-pressed` instead — the same semantics as the standalone `NgpToggle` primitive.

To support this, `NgpToggleGroupState` now exposes the group's `type` as a readonly signal, and the item binds `role`/`aria-checked`/`aria-pressed` reactively so a runtime `type` change stays correct.

## Changes

- `toggle-group-state.ts`: expose `type: Signal<'single' | 'multiple'>` on `NgpToggleGroupState`.
- `toggle-group-item-state.ts`: derive `role`, `aria-checked`, and `aria-pressed` from the group type.
- `toggle-group-primitive.test.ts`: new assertions for radio semantics (single) and toggle-button semantics (multiple), including after selection changes.
- `toggle-group.md`: document the per-mode accessibility semantics.

## Notes

This is technically an observable DOM change for multiple-select groups (consumers styling `[role="radio"]` or querying `aria-checked` on multiple-type items would be affected), but the previous attributes misrepresented the widget to screen readers, so I've treated it as a bug fix.
