### PR TITLE
fix(date-time): align date adapters and expand contract coverage

### DIFF
--- a/packages/ng-primitives/date-time-date-fns/src/date-fns-date-adapter/date-fns-date-adapter.ts
+++ b/packages/ng-primitives/date-time-date-fns/src/date-fns-date-adapter/date-fns-date-adapter.ts
@@ -47,7 +47,8 @@ export class NgpDateFnsDateAdapter implements NgpDateAdapter<Date> {
   set(date: Date, values: NgpDateUnits): Date {
     return setOnDate(date, {
       year: values.year,
-      month: values.month !== undefined ? values.month - 1 : undefined,
+      // `getMonth` and the native adapter use a 0-11 month, so `set` takes the same range.
+      month: values.month,
       date: values.day,
       hours: values.hour,
       minutes: values.minute,

--- a/packages/ng-primitives/date-time-luxon/src/luxon-date-adapter/luxon-date-adapter.ts
+++ b/packages/ng-primitives/date-time-luxon/src/luxon-date-adapter/luxon-date-adapter.ts
@@ -7,7 +7,9 @@ export class NgpLuxonDateAdapter implements NgpDateAdapter<DateTime> {
   }
 
   set(date: DateTime, values: NgpDateUnits) {
-    return date.set(values);
+    // The adapter uses a 0-11 month (matching the native adapter), but Luxon is 1-12.
+    const { month, ...rest } = values;
+    return date.set(month !== undefined ? { ...rest, month: month + 1 } : rest);
   }
 
   add(date: DateTime, duration: NgpDuration) {
@@ -57,7 +59,8 @@ export class NgpLuxonDateAdapter implements NgpDateAdapter<DateTime> {
   }
 
   getMonth(date: DateTime): number {
-    return date.month;
+    // Luxon is 1-12; the adapter contract uses a 0-11 month (matching the native adapter).
+    return date.month - 1;
   }
 
   getDate(date: DateTime): number {
@@ -101,6 +104,22 @@ export class NgpLuxonDateAdapter implements NgpDateAdapter<DateTime> {
   }
 
   create(values: NgpDateUnits) {
-    return DateTime.fromObject(values);
+    // Match the native adapter: unspecified units default to the current date/time
+    // (month uses a truthy check, so 0 falls back to now like `new Date(...)`).
+    const now = DateTime.now();
+    const month = values.month || now.month;
+    const day = values.day ?? now.day;
+
+    // Build from a valid anchor and apply the units as durations so out-of-range
+    // values roll over like the native Date constructor (e.g. month 13 -> next
+    // January, day 0 -> last day of the previous month).
+    return DateTime.fromObject({ year: values.year ?? now.year, month: 1, day: 1 }).plus({
+      months: month - 1,
+      days: day - 1,
+      hours: values.hour ?? now.hour,
+      minutes: values.minute ?? now.minute,
+      seconds: values.second ?? now.second,
+      milliseconds: values.millisecond ?? now.millisecond,
+    });
   }
 }

--- a/packages/ng-primitives/date-time/src/date-adapter/date-adapter.ts
+++ b/packages/ng-primitives/date-time/src/date-adapter/date-adapter.ts
@@ -69,7 +69,8 @@ export interface NgpDateAdapter<T> {
   getYear(date: T): number;
 
   /**
-   * Get the month.
+   * Get the month as a zero-based number (0-11, January = 0). This matches the
+   * range accepted by `set`, so `set(date, { month: getMonth(other) })` round-trips.
    */
   getMonth(date: T): number;
 

--- a/packages/ng-primitives/date-time/src/date-adapter/date-adapter.ts
+++ b/packages/ng-primitives/date-time/src/date-adapter/date-adapter.ts
@@ -4,7 +4,9 @@
  */
 export interface NgpDateAdapter<T> {
   /**
-   * Create a new date time object.
+   * Create a new date time object. Here `month` is one-based (1-12), matching
+   * the `NgpDateUnits` documentation. Note this differs from `set` and
+   * `getMonth`, which use a zero-based month (0-11).
    */
   create(values: NgpDateUnits): T;
 
@@ -14,7 +16,10 @@ export interface NgpDateAdapter<T> {
   now(): T;
 
   /**
-   * Set the year of the date time object based on a duration.
+   * Set the specified units on the date time object, leaving the rest
+   * unchanged. Here `month` is zero-based (0-11), matching `getMonth` so
+   * `set(date, { month: getMonth(other) })` round-trips. Note this differs from
+   * `create`, which takes a one-based month (1-12).
    */
   set(date: T, values: NgpDateUnits): T;
 

--- a/packages/ng-primitives/date-time/src/native-date-adapter/native-date-adapter.ts
+++ b/packages/ng-primitives/date-time/src/native-date-adapter/native-date-adapter.ts
@@ -44,30 +44,45 @@ export class NgpNativeDateAdapter implements NgpDateAdapter<Date> {
    * Add a duration to the date time object.
    */
   add(date: Date, duration: NgpDuration): Date {
-    return new Date(
-      date.getFullYear() + (duration.years ?? 0),
-      date.getMonth() + (duration.months ?? 0),
-      date.getDate() + (duration.days ?? 0),
-      date.getHours() + (duration.hours ?? 0),
-      date.getMinutes() + (duration.minutes ?? 0),
-      date.getSeconds() + (duration.seconds ?? 0),
-      date.getMilliseconds() + (duration.milliseconds ?? 0),
-    );
+    return this.shift(date, duration, 1);
   }
 
   /**
    * Subtract a duration from the date time object
    */
   subtract(date: Date, duration: NgpDuration): Date {
-    return new Date(
-      date.getFullYear() - (duration.years ?? 0),
-      date.getMonth() - (duration.months ?? 0),
-      date.getDate() - (duration.days ?? 0),
-      date.getHours() - (duration.hours ?? 0),
-      date.getMinutes() - (duration.minutes ?? 0),
-      date.getSeconds() - (duration.seconds ?? 0),
-      date.getMilliseconds() - (duration.milliseconds ?? 0),
+    return this.shift(date, duration, -1);
+  }
+
+  /**
+   * Apply a duration in `sign` direction. Year/month are applied first with the
+   * day clamped to the target month's length (so 31 Jan + 1 month is 28 Feb, not
+   * 3 Mar), matching the Luxon and date-fns adapters; day/time deltas follow.
+   */
+  private shift(date: Date, duration: NgpDuration, sign: 1 | -1): Date {
+    const year = date.getFullYear() + sign * (duration.years ?? 0);
+    const month = date.getMonth() + sign * (duration.months ?? 0);
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const day = Math.min(date.getDate(), daysInMonth);
+
+    const result = new Date(
+      year,
+      month,
+      day,
+      date.getHours(),
+      date.getMinutes(),
+      date.getSeconds(),
+      date.getMilliseconds(),
     );
+
+    result.setDate(result.getDate() + sign * (duration.days ?? 0));
+    result.setHours(
+      result.getHours() + sign * (duration.hours ?? 0),
+      result.getMinutes() + sign * (duration.minutes ?? 0),
+      result.getSeconds() + sign * (duration.seconds ?? 0),
+      result.getMilliseconds() + sign * (duration.milliseconds ?? 0),
+    );
+    return result;
   }
 
   /**
@@ -194,7 +209,7 @@ export class NgpNativeDateAdapter implements NgpDateAdapter<Date> {
    * Get the last day of the month.
    */
   endOfMonth(date: Date): Date {
-    return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+    return new Date(date.getFullYear(), date.getMonth() + 1, 0, 23, 59, 59, 999);
   }
 
   /**

--- a/packages/ng-primitives/date-time/testing/date-adapter-tests.ts
+++ b/packages/ng-primitives/date-time/testing/date-adapter-tests.ts
@@ -4,6 +4,102 @@ export function dateAdapterTests<T>(adapterClass: new () => NgpDateAdapter<T>) {
   describe('NgpDateAdapter via ' + adapterClass.name, () => {
     const adapter = new adapterClass();
 
+    // A fixed reference date used across the getters. All time components are
+    // provided explicitly so the assertions do not depend on the current time
+    // (some adapters default missing units to `now`, others to zero).
+    // Aug 15th, 2025 is a Friday.
+    const reference = () =>
+      adapter.create({
+        year: 2025,
+        month: 8,
+        day: 15,
+        hour: 12,
+        minute: 30,
+        second: 45,
+        millisecond: 500,
+      });
+
+    it('should read back the units it was created with', () => {
+      const date = reference();
+      expect(adapter.getYear(date)).toBe(2025);
+      expect(adapter.getDate(date)).toBe(15);
+      expect(adapter.getHours(date)).toBe(12);
+      expect(adapter.getMinutes(date)).toBe(30);
+      expect(adapter.getSeconds(date)).toBe(45);
+      expect(adapter.getMilliseconds(date)).toBe(500);
+    });
+
+    it('should create the current date and time via now()', () => {
+      const now = adapter.now();
+      expect(adapter.getYear(now)).toBeGreaterThanOrEqual(2025);
+      // now() is later than a fixed date well in the past.
+      expect(adapter.compare(now, adapter.create({ year: 2000, month: 1, day: 1 }))).toBe(1);
+    });
+
+    it('should set only the specified units, preserving the rest', () => {
+      const date = reference(); // 2025-08-15 12:30:45.500
+      const updated = adapter.set(date, { year: 2030, day: 3 });
+      expect(adapter.getYear(updated)).toBe(2030);
+      expect(adapter.getDate(updated)).toBe(3);
+      // untouched units are preserved
+      expect(adapter.getMonth(updated)).toBe(7); // still August
+      expect(adapter.getHours(updated)).toBe(12);
+      expect(adapter.getMinutes(updated)).toBe(30);
+      expect(adapter.getSeconds(updated)).toBe(45);
+      expect(adapter.getMilliseconds(updated)).toBe(500);
+    });
+
+    it('should overflow (not clamp) when set() is given a day past the month length', () => {
+      // Unlike add/subtract, set does not clamp: 31st of February rolls into March.
+      const result = adapter.set(adapter.create({ year: 2025, month: 2, day: 10 }), { day: 31 });
+      expect(adapter.getMonth(result)).toBe(2); // March
+      expect(adapter.getDate(result)).toBe(3);
+    });
+
+    it('should not mutate the input date when setting', () => {
+      const date = reference();
+      adapter.set(date, { year: 1999, day: 1 });
+      expect(adapter.getYear(date)).toBe(2025);
+      expect(adapter.getDate(date)).toBe(15);
+    });
+
+    it('should get the month as a zero-based number (0-11)', () => {
+      expect(adapter.getMonth(adapter.create({ year: 2025, month: 1, day: 1 }))).toBe(0);
+      expect(adapter.getMonth(reference())).toBe(7); // August
+      expect(adapter.getMonth(adapter.create({ year: 2025, month: 12, day: 1 }))).toBe(11);
+    });
+
+    it('should round-trip getMonth through set (as the date picker does)', () => {
+      const august = reference();
+      const target = adapter.create({ year: 2020, month: 1, day: 10 }); // January
+      const moved = adapter.set(target, { month: adapter.getMonth(august) });
+      expect(adapter.getMonth(moved)).toBe(adapter.getMonth(august));
+    });
+
+    it('should normalize an out-of-range month by rolling into the next year', () => {
+      // month 13 has no equivalent, so it rolls into January of the next year.
+      const rolled = adapter.create({ year: 2025, month: 13, day: 10 });
+      expect(adapter.getYear(rolled)).toBe(2026);
+      expect(adapter.getMonth(rolled)).toBe(0); // January
+      expect(adapter.getDate(rolled)).toBe(10);
+    });
+
+    it('should normalize a zero day into the last day of the previous month', () => {
+      const rolled = adapter.create({ year: 2025, month: 1, day: 0 });
+      expect(adapter.getYear(rolled)).toBe(2024);
+      expect(adapter.getMonth(rolled)).toBe(11); // December
+      expect(adapter.getDate(rolled)).toBe(31);
+    });
+
+    it('should normalize an out-of-range month passed to set()', () => {
+      // set uses a 0-11 month, so month index 12 rolls into January of the next year.
+      const rolled = adapter.set(reference(), { month: 12 });
+      expect(adapter.getYear(rolled)).toBe(2026);
+      expect(adapter.getMonth(rolled)).toBe(0); // January
+      expect(adapter.getDate(rolled)).toBe(15);
+      expect(adapter.getHours(rolled)).toBe(12); // other units preserved
+    });
+
     it('should get the day of the week (1-7)', () => {
       const lastOfAugust2025 = adapter.create({ year: 2025, month: 8, day: 31 }); // Aug 31st, 2025 is a Sunday
       expect(adapter.getDay(lastOfAugust2025)).toBe(7);
@@ -14,6 +110,157 @@ export function dateAdapterTests<T>(adapterClass: new () => NgpDateAdapter<T>) {
       expect(adapter.getDay(adapter.add(lastOfAugust2025, { days: 5 }))).toBe(5);
       expect(adapter.getDay(adapter.add(lastOfAugust2025, { days: 6 }))).toBe(6);
       expect(adapter.getDay(adapter.add(lastOfAugust2025, { days: 7 }))).toBe(7);
+    });
+
+    it('should add each duration unit', () => {
+      const date = reference();
+      expect(adapter.getYear(adapter.add(date, { years: 1 }))).toBe(2026);
+      expect(adapter.getDate(adapter.add(date, { days: 1 }))).toBe(16);
+      expect(adapter.getHours(adapter.add(date, { hours: 1 }))).toBe(13);
+      expect(adapter.getMinutes(adapter.add(date, { minutes: 1 }))).toBe(31);
+      expect(adapter.getSeconds(adapter.add(date, { seconds: 1 }))).toBe(46);
+      expect(adapter.getMilliseconds(adapter.add(date, { milliseconds: 1 }))).toBe(501);
+    });
+
+    it('should subtract each duration unit', () => {
+      const date = reference();
+      expect(adapter.getYear(adapter.subtract(date, { years: 1 }))).toBe(2024);
+      expect(adapter.getDate(adapter.subtract(date, { days: 1 }))).toBe(14);
+      expect(adapter.getHours(adapter.subtract(date, { hours: 1 }))).toBe(11);
+      expect(adapter.getMinutes(adapter.subtract(date, { minutes: 1 }))).toBe(29);
+      expect(adapter.getSeconds(adapter.subtract(date, { seconds: 1 }))).toBe(44);
+      expect(adapter.getMilliseconds(adapter.subtract(date, { milliseconds: 1 }))).toBe(499);
+    });
+
+    it('should clamp the day when month/year arithmetic lands on a shorter month', () => {
+      // 31 Jan + 1 month has no 31st in February, so clamp to the last day.
+      const fromJan31 = adapter.add(adapter.create({ year: 2025, month: 1, day: 31 }), {
+        months: 1,
+      });
+      expect(adapter.getMonth(fromJan31)).toBe(1); // February
+      expect(adapter.getDate(fromJan31)).toBe(28);
+
+      // 31 Mar - 1 month likewise clamps into February.
+      const fromMar31 = adapter.subtract(adapter.create({ year: 2025, month: 3, day: 31 }), {
+        months: 1,
+      });
+      expect(adapter.getMonth(fromMar31)).toBe(1); // February
+      expect(adapter.getDate(fromMar31)).toBe(28);
+
+      // 29 Feb (leap) + 1 year clamps to 28 Feb in a non-leap year.
+      const fromLeap = adapter.add(adapter.create({ year: 2024, month: 2, day: 29 }), { years: 1 });
+      expect(adapter.getYear(fromLeap)).toBe(2025);
+      expect(adapter.getMonth(fromLeap)).toBe(1); // February
+      expect(adapter.getDate(fromLeap)).toBe(28);
+    });
+
+    it('should apply month/year clamping before day and time deltas', () => {
+      // Clamp 31 Jan + 1 month to 28 Feb, then add the 2 days -> 2 Mar, time preserved.
+      const result = adapter.add(
+        adapter.create({
+          year: 2025,
+          month: 1,
+          day: 31,
+          hour: 12,
+          minute: 30,
+          second: 0,
+          millisecond: 0,
+        }),
+        { months: 1, days: 2 },
+      );
+      expect(adapter.getMonth(result)).toBe(2); // March
+      expect(adapter.getDate(result)).toBe(2);
+      expect(adapter.getHours(result)).toBe(12);
+      expect(adapter.getMinutes(result)).toBe(30);
+    });
+
+    it('should not mutate the input date when adding or subtracting', () => {
+      const date = reference();
+      adapter.add(date, { days: 5 });
+      adapter.subtract(date, { days: 5 });
+      expect(adapter.getDate(date)).toBe(15);
+    });
+
+    it('should compare two dates', () => {
+      const date = reference();
+      const later = adapter.add(date, { days: 1 });
+      expect(adapter.compare(date, later)).toBe(-1);
+      expect(adapter.compare(later, date)).toBe(1);
+      expect(adapter.compare(date, reference())).toBe(0);
+    });
+
+    it('should determine equality and ordering', () => {
+      const date = reference();
+      const later = adapter.add(date, { days: 1 });
+      expect(adapter.isEqual(date, reference())).toBe(true);
+      expect(adapter.isEqual(date, later)).toBe(false);
+      expect(adapter.isBefore(date, later)).toBe(true);
+      expect(adapter.isBefore(later, date)).toBe(false);
+      expect(adapter.isAfter(later, date)).toBe(true);
+      expect(adapter.isAfter(date, later)).toBe(false);
+    });
+
+    it('should determine same day, month and year', () => {
+      const date = reference();
+      const laterSameDay = adapter.add(date, { hours: 1 });
+      const nextDay = adapter.add(date, { days: 1 });
+      const nextMonth = adapter.add(date, { months: 1 });
+      const nextYear = adapter.add(date, { years: 1 });
+
+      expect(adapter.isSameDay(date, laterSameDay)).toBe(true);
+      expect(adapter.isSameDay(date, nextDay)).toBe(false);
+
+      expect(adapter.isSameMonth(date, laterSameDay)).toBe(true);
+      expect(adapter.isSameMonth(date, nextMonth)).toBe(false);
+
+      expect(adapter.isSameYear(date, nextMonth)).toBe(true);
+      expect(adapter.isSameYear(date, nextYear)).toBe(false);
+    });
+
+    it('should not treat matching day/month numbers in a different period as the same', () => {
+      const date = reference(); // 2025-08-15
+      const sameDayNextMonth = adapter.create({ year: 2025, month: 9, day: 15 });
+      const sameDateNextYear = adapter.create({ year: 2026, month: 8, day: 15 });
+
+      // same day-of-month number, different month
+      expect(adapter.isSameDay(date, sameDayNextMonth)).toBe(false);
+      // same day and month, different year
+      expect(adapter.isSameDay(date, sameDateNextYear)).toBe(false);
+      expect(adapter.isSameMonth(date, sameDateNextYear)).toBe(false);
+    });
+
+    it('should get the start of the day', () => {
+      const start = adapter.startOfDay(reference());
+      expect(adapter.getDate(start)).toBe(15);
+      expect(adapter.getHours(start)).toBe(0);
+      expect(adapter.getMinutes(start)).toBe(0);
+      expect(adapter.getSeconds(start)).toBe(0);
+      expect(adapter.getMilliseconds(start)).toBe(0);
+    });
+
+    it('should get the end of the day', () => {
+      const end = adapter.endOfDay(reference());
+      expect(adapter.getDate(end)).toBe(15);
+      expect(adapter.getHours(end)).toBe(23);
+      expect(adapter.getMinutes(end)).toBe(59);
+      expect(adapter.getSeconds(end)).toBe(59);
+      expect(adapter.getMilliseconds(end)).toBe(999);
+    });
+
+    it('should get the start of the month', () => {
+      const start = adapter.startOfMonth(reference());
+      expect(adapter.getDate(start)).toBe(1);
+      expect(adapter.getHours(start)).toBe(0);
+      expect(adapter.getMinutes(start)).toBe(0);
+    });
+
+    it('should get the last day of the month at the end of the day', () => {
+      const end = adapter.endOfMonth(reference());
+      expect(adapter.getDate(end)).toBe(31);
+      expect(adapter.getHours(end)).toBe(23);
+      expect(adapter.getMinutes(end)).toBe(59);
+      expect(adapter.getSeconds(end)).toBe(59);
+      expect(adapter.getMilliseconds(end)).toBe(999);
     });
   });
 }

--- a/packages/tools/src/executors/mcp-data-extraction/mcp-data-extraction.ts
+++ b/packages/tools/src/executors/mcp-data-extraction/mcp-data-extraction.ts
@@ -212,7 +212,7 @@ function inferCategory(primitiveName: string): string {
     layout: ['accordion', 'separator', 'portal'],
     data: ['avatar'],
     utility: ['focus-trap', 'roving-focus', 'resize', 'autofill', 'interactions', 'a11y'],
-    'date-time': ['date-picker', 'date-time', 'date-time-luxon'],
+    'date-time': ['date-picker', 'date-time', 'date-time-luxon', 'date-time-date-fns'],
   };
 
   for (const [category, primitives] of Object.entries(categories)) {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

Follow-up to #816 (date-fns adapter).

## What does this PR implement/fix?

Makes the native, Luxon and date-fns adapters behave identically across the whole `NgpDateAdapter` contract, and fixes a month off-by-one in the newly added date-fns adapter.

- **date-fns**: `set` no longer subtracts 1 from the month, so it matches the 0-11 range returned by `getMonth`. The date picker round-trips `set(date, { month: getMonth(other) })`, which previously produced the wrong month with the date-fns adapter.
- **Luxon**: `getMonth`/`set` now use the 0-11 month convention; `create` defaults unspecified time units to `now` and normalises out-of-range units by rolling over, matching the native adapter.
- **native**: `endOfMonth` now returns the last day at `23:59:59.999` instead of midnight, and `add`/`subtract` clamp the day when month/year arithmetic lands on a shorter month (31 Jan + 1 month is 28 Feb, not 3 Mar) instead of overflowing.
- Documented the zero-based `getMonth` range on the interface.
- Grew the shared `dateAdapterTests` contract from **1 to 24 cases** so all three adapters are verified as interchangeable, including overflow clamping, out-of-range normalisation, `set` preserve/immutability and the start/end helpers. A cross-adapter sweep confirms byte-for-byte agreement across valid and invalid input.
- Registered the `date-time-date-fns` entry point under the `date-time` category for MCP data extraction.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

The date-fns adapter is new (unreleased), so its change has no impact. Two released adapters change public behaviour:

- **native `endOfMonth`** now returns the last day at `23:59:59.999` rather than `00:00`. Code reading the returned time (not just the day) is affected.
- **native `add`/`subtract`** now clamp month/year arithmetic instead of rolling over (`31 Jan + 1 month` is now `28 Feb`, previously `3 Mar`).
- **Luxon `getMonth`** now returns a zero-based month (`0-11`) to match the native adapter, instead of Luxon's native `1-12`.

Migration: consumers reading `getMonth()` from the Luxon adapter directly should adjust by one; consumers depending on the old native `endOfMonth` time-of-day or overflow arithmetic should update accordingly. The built-in date picker is unaffected (all date-picker tests pass).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the native, Luxon, and `date-fns` date adapters to the same contract, fixes a `date-fns` month off-by-one, and clarifies month indexing in the adapter interface.

- **Bug Fixes**
  - Adapters: `getMonth`/`set` use zero-based months; `date-fns` `set` no longer subtracts; Luxon maps month and its `create` defaults unspecified units to now and rolls over out-of-range; native `endOfMonth` returns 23:59:59.999; `add`/`subtract` clamp when crossing shorter months.
  - Tests: expanded shared adapter contract from 1 to 24 cases covering normalization, clamping, immutability, and start/end helpers.
  - Docs/Tools: clarified one-based `create` vs zero-based `set`/`getMonth` on `NgpDateAdapter`; registered `date-time-date-fns` under `date-time` for MCP extraction.

- **Migration**
  - Native: `endOfMonth` now returns end of day; `add`/`subtract` clamp month/year arithmetic (e.g., 31 Jan + 1 month -> 28 Feb).
  - Luxon: `getMonth()` now returns 0–11; adjust any direct month usage by −1.
  - `date-fns`: change is unreleased; no migration needed.
  - The built-in date picker is unaffected.

<sup>Written for commit ee82bc6c491e263cb5f2d607f3a8cc961a6c187c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved month/day handling to align month indexing consistently across date adapters, preventing off-by-one issues.
  * Refined date creation and adjustment logic to better preserve native roll-over behaviour.
  * Updated duration subtraction and `endOfMonth` so month-end calculations resolve to the final moment of the day (not midnight).
* **Documentation**
  * Clarified month indexing expectations in the public adapter documentation.
* **Tests**
  * Expanded coverage for unit reads, creation/setting behaviour, comparisons, shifting, and `startOf*/endOf*` boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->