### PR TITLE
feat(password): add password primitive with show/hide toggle

### DIFF
--- a/.claude/rules/state-management.md
+++ b/.claude/rules/state-management.md
@@ -1,0 +1,97 @@
+# State Management Pattern
+
+> **Scaffold first.** Do not hand-write `-state.ts` files. Generate the directive
+> and its state with `nx g @ng-primitives/tools:directive <name> <primitive>`
+> (`addState` defaults true), or add state to an existing directive with
+> `nx g @ng-primitives/tools:state <directive> <primitive>`. See the Nx
+> Generators section in `CLAUDE.md`. The rules below describe what the generated
+> code should look like when you fill it in.
+
+Every primitive and every **part** of a primitive (container, input, toggle,
+item, option, trigger, etc.) follows the same `createPrimitive` state pattern.
+This is the current pattern - do **not** use the older
+`createStateToken`/`createStateProvider`/`createStateInjector`/`createState`
+quadruple (only legacy primitives like `search` still use it).
+
+## Each part gets a `<name>-state.ts`
+
+The state file owns the logic. It calls `createPrimitive` and returns the
+4-tuple `[Token, factory, injectFn, provideFn]`:
+
+```ts
+export const [NgpToggleStateToken, ngpToggle, injectToggleState, provideToggleState] =
+  createPrimitive('NgpToggle', (props: NgpToggleProps): NgpToggleState => {
+    const element = injectElementRef<HTMLElement>();
+    // ...all host bindings and listeners live HERE, inside the factory...
+    return {
+      /* NgpToggleState */
+    } satisfies NgpToggleState;
+  });
+```
+
+Export from the barrel: the directive **and** `injectXState`, `ngpX`,
+`NgpXProps`, `NgpXState`, `provideXState`.
+
+## All host bindings live in the factory, not the directive
+
+Use `attrBinding`, `dataBinding`, `styleBinding`, and `listener` from
+`ng-primitives/state` **inside the factory**. Directives must not carry `host: {}`
+bindings or wire listeners themselves - the factory runs in the correct
+injection/render context and keeps every part consistent.
+
+```ts
+attrBinding(element, 'aria-pressed', selected);
+dataBinding(element, 'data-selected', selected);
+listener(element, 'click', () => toggle());
+```
+
+## The directive is a thin shell
+
+It declares the inputs (with `ngp` aliases + coercion), lists `provideXState()`
+in `providers`, registers the state at the **end** of the property block, and
+exposes public methods that delegate to the state:
+
+```ts
+@Directive({
+  selector: '[ngpToggle]',
+  exportAs: 'ngpToggle',
+  providers: [provideToggleState()],
+})
+export class NgpToggle {
+  readonly selected = input(/* ... */);
+
+  // registered last, after all inputs (avoid-early-state lint rule)
+  protected readonly state = ngpToggle({ selected: this.selected /* ... */ });
+
+  toggle(): void {
+    this.state.toggle();
+  }
+}
+```
+
+Pass input **signals** to the factory (`selected: this.selected`) - never call
+them (`this.selected()`), which the `prefer-state` lint rule forbids.
+
+## Controlled vs uncontrolled state
+
+- `controlledState({ value, defaultValue, onChange })` for two-way bindable
+  state - returns `[signal, setter, changeObservable]`. Emit the local value
+  through the output so parent bindings round-trip (`avoid-state-emit`).
+- `controlled(inputSignal, defaultValue)` wraps an input in a writable
+  `linkedSignal` for internal mutation that still tracks the input.
+
+## Compose state functions to reuse behaviour
+
+State factories call other state factories - this is how parts inherit
+behaviour rather than reimplementing it. `ngpInput` composes `ngpFormControl`,
+`ngpInteractions`, and `ngpAutofill`; `ngpToggleGroupItem` composes
+`ngpRovingFocusItem`; `ngpPasswordInput` composes `ngpInput`. If a new part
+needs the behaviour of an existing primitive, call its `ngpX({...})` factory and
+return/extend its state instead of duplicating bindings.
+
+## `@internal`
+
+Mark `injectX`/`registerX`-style members that are public on the state interface
+but not for consumers with `@internal`. Do **not** put `@internal` on the
+`protected readonly state` field or any private/protected member - they are
+already excluded from the public API (see `angular-patterns.md`).

--- a/.claude/skills/ngp-code-review/SKILL.md
+++ b/.claude/skills/ngp-code-review/SKILL.md
@@ -46,14 +46,27 @@ Read `.claude/rules/naming-conventions.md` and flag any violation. Common ones: 
 
 ### 3. State pattern
 
-Every primitive uses the same four exports from `packages/ng-primitives/state/src/`:
+Read `.claude/rules/state-management.md`. Every primitive **and every part** (container, input, toggle, item, option, trigger, …) uses the `createPrimitive` pattern — a `<name>-state.ts` that returns the 4-tuple and holds all host bindings inside the factory, with a thin directive that provides the state and delegates to it:
 
-- `NgpXStateToken = createStateToken<NgpX>('X')`
-- `provideXState = createStateProvider(NgpXStateToken)`
-- `injectXState = createStateInjector<NgpX>(NgpXStateToken)`
-- `xState = createState(NgpXStateToken)`
+```ts
+export const [NgpXStateToken, ngpX, injectXState, provideXState] = createPrimitive(
+  'NgpX',
+  (props: NgpXProps): NgpXState => {
+    const element = injectElementRef();
+    // attrBinding / dataBinding / listener all live HERE
+    return {
+      /* ... */
+    } satisfies NgpXState;
+  },
+);
+```
 
-Flag new primitives that don't follow this quadruple. Specific rule violations (early state, missing generic, emitting state, reading raw input) are owned by §4.
+Flag as HIGH:
+
+- **New use of the legacy state pattern.** Any added file — or any changed line in the diff — that calls `createStateToken`, `createStateProvider`, `createStateInjector`, or `createState` (from `ng-primitives/state`). These are the pre-`createPrimitive` primitives (`search`-era) and are deprecated for new code. Grep the diff: `git diff next...HEAD | grep -nE '^\+.*\bcreateState(Token|Provider|Injector)?\b'`. A hit on an added (`+`) line is a finding — the part must be rewritten with `createPrimitive`. Editing an existing legacy primitive in place does **not** require migrating it (don't force-migrate untouched primitives), but a **new** primitive or part using the quadruple is a HIGH finding.
+- **A part directive that inlines host bindings / listeners** in the directive constructor instead of a `-state.ts` factory, or that omits `provideXState()` from its `providers`.
+
+Specific rule violations (early state, missing generic, emitting state, reading raw input) are owned by §4.
 
 ### 4. Custom workspace lint rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,13 +41,47 @@ This is an Nx monorepo for Angular Primitives, a headless UI library focused on 
 
 ## Nx Generators
 
-Use these generators to scaffold new code:
+**Always scaffold with the generators below before writing code by hand.** They
+are deterministic and produce the correct file layout, the `createPrimitive`
+state pattern, barrel exports, entry-point wiring, and naming. Hand-writing a
+directive or a `-state.ts` from scratch is how conventions drift (e.g. inlining
+host bindings in the directive instead of the state factory). Generate first,
+then fill in the behaviour.
 
-- `nx g @ng-primitives/tools:primitive <name>` - New primitive secondary entry point
-- `nx g @ng-primitives/tools:reusable-component <name>` - New reusable component
-- `nx g @ng-primitives/tools:example <name> --primitive <primitive>` - New example
+Collection: `@ng-primitives/tools`. Run with `nx g @ng-primitives/tools:<gen>`
+(or the Nx Console UI). Pass `--dry-run` first to preview the file list.
 
-Prefer using Nx Console UI in your IDE for running generators.
+| Generator            | Command                                                                  | Produces                                                                                  |
+| -------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `primitive`          | `nx g ...:primitive <name>`                                              | New secondary entry point (`packages/ng-primitives/<name>/`), `index.ts`, tsconfig wiring |
+| `directive`          | `nx g ...:directive <name> <primitive>`                                  | A directive **and its `-state.ts`** (`addState` defaults **true**); flags below           |
+| `state`              | `nx g ...:state <directive> <primitive>`                                 | A `-state.ts` (`createPrimitive` factory) for an existing directive                       |
+| `config`             | `nx g ...:config <primitive>`                                            | A global config provider (`provideXConfig`/`injectXConfig`)                               |
+| `token`              | `nx g ...:token <directive> <primitive>`                                 | An injection token for a directive                                                        |
+| `example`            | `nx g ...:example <directive> <primitive>`                               | A docs example (`.example.ts` + `.tailwind.example.ts`)                                   |
+| `documentation`      | `nx g ...:documentation <name> --primitive <p> --section Primitives ...` | A docs page under `apps/documentation`                                                    |
+| `reusable-component` | `nx g ...:reusable-component <name>`                                     | A reusable component under `apps/components` (drives the `docs-snippet`)                  |
+
+`directive` is the workhorse - it composes the others via flags:
+`--addState` (default true), `--addToken`, `--addConfig`, `--addExample`,
+`--reusableComponent`, `--documentation <section>`.
+
+**Workflow for a new primitive** with a root directive and extra parts (the
+second arg to `directive` is the entry point / `--primitive`):
+
+```bash
+# 1. create the secondary entry point
+nx g @ng-primitives/tools:primitive <name>
+# 2. scaffold each part directive — each gets its -state.ts automatically
+nx g @ng-primitives/tools:directive <name> <name> --addConfig --addExample --documentation Primitives
+nx g @ng-primitives/tools:directive <name>-trigger <name>
+# 3. optional reusable component (drives the docs snippet)
+nx g @ng-primitives/tools:reusable-component <name>
+```
+
+Each part directive gets its `-state.ts` automatically - never scaffold those by
+hand. See `.claude/rules/state-management.md` for what the generated state should
+contain.
 
 ## Coding Conventions
 
@@ -55,6 +89,7 @@ See `.claude/rules/` for detailed coding standards:
 
 - `angular-patterns.md` - Signal-based APIs, readonly signals, computed/effects
 - `naming-conventions.md` - Selector prefixes, class names, file names
+- `state-management.md` - The `createPrimitive` state pattern: one `-state.ts` per part, host bindings inside the factory, thin directives, controlled state, state composition
 - `docs-example-styling.md` - Styling the documentation examples: brand red reserved for state, blue for focus, typography/radii scale, CSS + Tailwind parity
 
 For code review, use the `ngp-code-review` skill — it consolidates these rules with the custom workspace lint rules, test conventions, and PR checklist.

--- a/apps/components/src/app/pages/reusable-components/password/index.page.ts
+++ b/apps/components/src/app/pages/reusable-components/password/index.page.ts
@@ -1,0 +1,14 @@
+import { Component, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Password } from './password';
+
+@Component({
+  selector: 'app-password-example',
+  imports: [Password, FormsModule],
+  template: `
+    <app-password [(ngModel)]="value" placeholder="Enter your password" />
+  `,
+})
+export default class App {
+  readonly value = signal<string>('');
+}

--- a/apps/components/src/app/pages/reusable-components/password/password.ts
+++ b/apps/components/src/app/pages/reusable-components/password/password.ts
@@ -1,9 +1,14 @@
-import { Component, inject, input, signal } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideEye, lucideEyeOff } from '@ng-icons/lucide';
 import { NgpButton } from 'ng-primitives/button';
-import { NgpPassword, NgpPasswordInput, NgpPasswordToggle } from 'ng-primitives/password';
+import {
+  injectPasswordState,
+  NgpPassword,
+  NgpPasswordInput,
+  NgpPasswordToggle,
+} from 'ng-primitives/password';
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
@@ -21,7 +26,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
       autocomplete="current-password"
     />
     <button ngpButton ngpPasswordToggle>
-      <ng-icon [name]="password.isVisible() ? 'lucideEyeOff' : 'lucideEye'" />
+      <ng-icon [name]="state().visible() ? 'lucideEyeOff' : 'lucideEye'" />
     </button>
   `,
   styles: `
@@ -86,12 +91,12 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
     }
   `,
   host: {
-    '(focusout)': 'onTouched?.()',
+    '(focusout)': 'onFocusOut($event)',
   },
 })
 export class Password implements ControlValueAccessor {
-  /** Access the password directive to read the visibility state. */
-  protected readonly password = inject(NgpPassword);
+  /** Access the password state to read the visibility. */
+  protected readonly state = injectPasswordState();
 
   /** The placeholder text */
   readonly placeholder = input<string>('');
@@ -121,5 +126,14 @@ export class Password implements ControlValueAccessor {
     const input = event.target as HTMLInputElement;
     this.value.set(input.value);
     this.onChange?.(input.value);
+  }
+
+  protected onFocusOut(event: FocusEvent): void {
+    // only mark as touched when focus leaves the component, not when moving
+    // between the input and the toggle button
+    const host = event.currentTarget as HTMLElement;
+    if (!host.contains(event.relatedTarget as Node | null)) {
+      this.onTouched?.();
+    }
   }
 }

--- a/apps/components/src/app/pages/reusable-components/password/password.ts
+++ b/apps/components/src/app/pages/reusable-components/password/password.ts
@@ -1,0 +1,125 @@
+import { Component, inject, input, signal } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideEye, lucideEyeOff } from '@ng-icons/lucide';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpPassword, NgpPasswordInput, NgpPasswordToggle } from 'ng-primitives/password';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: 'app-password',
+  hostDirectives: [NgpPassword],
+  imports: [NgIcon, NgpPasswordInput, NgpPasswordToggle, NgpButton],
+  providers: [provideValueAccessor(Password), provideIcons({ lucideEye, lucideEyeOff })],
+  template: `
+    <input
+      [value]="value()"
+      [placeholder]="placeholder()"
+      (input)="onValueChange($event)"
+      ngpPasswordInput
+      type="password"
+      autocomplete="current-password"
+    />
+    <button ngpButton ngpPasswordToggle>
+      <ng-icon [name]="password.isVisible() ? 'lucideEyeOff' : 'lucideEye'" />
+    </button>
+  `,
+  styles: `
+    :host {
+      display: block;
+      position: relative;
+    }
+
+    [ngpPasswordInput] {
+      height: 2.125rem;
+      width: 100%;
+      border-radius: 0.5rem;
+      padding: 0 40px 0 12px;
+      border: none;
+      background: var(--ngp-background);
+      color: var(--ngp-text-primary);
+      font-size: 0.875rem;
+      letter-spacing: -0.006em;
+      box-shadow: var(--ngp-input-shadow);
+      outline: none;
+    }
+
+    [ngpPasswordInput][data-focus] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    [ngpPasswordInput]::placeholder {
+      color: var(--ngp-text-placeholder);
+    }
+
+    [ngpPasswordToggle] {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 2.125rem;
+      width: 2.125rem;
+      border: none;
+      border-radius: 0.5rem;
+      background-color: transparent;
+      color: var(--ngp-text-tertiary);
+      font-size: 1.125rem;
+      cursor: pointer;
+      outline: none;
+      transition: color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpPasswordToggle][data-hover] {
+      color: var(--ngp-text-secondary);
+    }
+
+    [ngpPasswordToggle][data-visible] {
+      color: var(--ngp-primary);
+    }
+
+    [ngpPasswordToggle][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: -2px;
+    }
+  `,
+  host: {
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Password implements ControlValueAccessor {
+  /** Access the password directive to read the visibility state. */
+  protected readonly password = inject(NgpPassword);
+
+  /** The placeholder text */
+  readonly placeholder = input<string>('');
+
+  /** The current value */
+  protected value = signal<string>('');
+
+  /** The function to call when the value changes */
+  private onChange?: ChangeFn<string>;
+
+  /** The function to call when the control is touched */
+  protected onTouched?: TouchedFn;
+
+  writeValue(value: string): void {
+    this.value.set(value);
+  }
+
+  registerOnChange(fn: ChangeFn<string>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  protected onValueChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.value.set(input.value);
+    this.onChange?.(input.value);
+  }
+}

--- a/apps/documentation/src/app/examples/password/password.example.ts
+++ b/apps/documentation/src/app/examples/password/password.example.ts
@@ -1,0 +1,118 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideEye, lucideEyeOff } from '@ng-icons/lucide';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpFormField, NgpLabel } from 'ng-primitives/form-field';
+import { NgpPassword, NgpPasswordInput, NgpPasswordToggle } from 'ng-primitives/password';
+
+@Component({
+  selector: 'app-password',
+  imports: [
+    NgpFormField,
+    NgpLabel,
+    NgpPassword,
+    NgpPasswordInput,
+    NgpPasswordToggle,
+    NgpButton,
+    NgIcon,
+  ],
+  providers: [provideIcons({ lucideEye, lucideEyeOff })],
+  template: `
+    <div ngpFormField>
+      <label ngpLabel>Password</label>
+      <div #password="ngpPassword" ngpPassword>
+        <input
+          ngpPasswordInput
+          type="password"
+          placeholder="Enter your password"
+          autocomplete="current-password"
+        />
+        <button ngpButton ngpPasswordToggle>
+          <ng-icon [name]="password.isVisible() ? 'lucideEyeOff' : 'lucideEye'" />
+        </button>
+      </div>
+    </div>
+  `,
+  styles: `
+    :host {
+      display: contents;
+    }
+
+    [ngpFormField] {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      width: 300px;
+    }
+
+    [ngpLabel] {
+      color: var(--ngp-text-primary);
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      font-weight: 510;
+      letter-spacing: -0.014em;
+      margin: 0;
+    }
+
+    [ngpPassword] {
+      position: relative;
+    }
+
+    [ngpPasswordInput] {
+      height: 2.125rem;
+      width: 100%;
+      border-radius: 0.5rem;
+      padding: 0 40px 0 12px;
+      border: none;
+      background: var(--ngp-background);
+      color: var(--ngp-text-primary);
+      font-size: 0.875rem;
+      letter-spacing: -0.006em;
+      box-shadow: var(--ngp-input-shadow);
+      outline: none;
+    }
+
+    [ngpPasswordInput][data-focus] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    [ngpPasswordInput]::placeholder {
+      color: var(--ngp-text-placeholder);
+    }
+
+    [ngpPasswordToggle] {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 2.125rem;
+      width: 2.125rem;
+      border: none;
+      border-radius: 0.5rem;
+      background-color: transparent;
+      color: var(--ngp-text-tertiary);
+      font-size: 1.125rem;
+      cursor: pointer;
+      outline: none;
+      transition: color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpPasswordToggle][data-hover] {
+      color: var(--ngp-text-secondary);
+    }
+
+    /* red = active state: the password is currently visible */
+    [ngpPasswordToggle][data-visible] {
+      color: var(--ngp-primary);
+    }
+
+    [ngpPasswordToggle][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: -2px;
+    }
+  `,
+})
+export default class PasswordExample {}

--- a/apps/documentation/src/app/examples/password/password.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/password/password.tailwind.example.ts
@@ -1,0 +1,47 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideEye, lucideEyeOff } from '@ng-icons/lucide';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpFormField, NgpLabel } from 'ng-primitives/form-field';
+import { NgpPassword, NgpPasswordInput, NgpPasswordToggle } from 'ng-primitives/password';
+
+@Component({
+  selector: 'app-password',
+  imports: [
+    NgpFormField,
+    NgpLabel,
+    NgpPassword,
+    NgpPasswordInput,
+    NgpPasswordToggle,
+    NgpButton,
+    NgIcon,
+  ],
+  providers: [provideIcons({ lucideEye, lucideEyeOff })],
+  template: `
+    <div class="flex w-[300px] flex-col gap-1.5" ngpFormField>
+      <label
+        class="m-0 text-sm font-[510] tracking-[-0.014em] text-zinc-950 dark:text-white"
+        ngpLabel
+      >
+        Password
+      </label>
+      <div class="relative" #password="ngpPassword" ngpPassword>
+        <input
+          class="h-[2.125rem] w-full rounded-lg border-none bg-white px-3 pr-10 text-sm tracking-[-0.006em] text-zinc-950 shadow-[0_1px_2px_rgba(0,0,0,0.05),0_0_0_1px_rgba(0,0,0,0.1)] outline-none placeholder:text-zinc-400 focus:outline-2 focus:outline-offset-2 focus:outline-blue-500 data-[focus]:outline-2 data-[focus]:outline-offset-2 data-[focus]:outline-blue-500 dark:bg-zinc-950 dark:text-white dark:shadow-[0_1px_2px_rgba(0,0,0,0.3),0_0_0_1px_rgba(255,255,255,0.1)] dark:data-[focus]:outline-blue-400"
+          ngpPasswordInput
+          type="password"
+          placeholder="Enter your password"
+          autocomplete="current-password"
+        />
+        <button
+          class="absolute top-0 right-0 flex h-[2.125rem] w-[2.125rem] cursor-pointer items-center justify-center rounded-lg border-none bg-transparent text-lg text-zinc-500 transition-colors duration-150 outline-none data-[focus-visible]:outline-2 data-[focus-visible]:-outline-offset-2 data-[focus-visible]:outline-blue-500 data-[hover]:text-zinc-700 data-[visible]:text-[#f01e2b] dark:data-[focus-visible]:outline-blue-400 dark:data-[hover]:text-zinc-300 dark:data-[visible]:text-[#ff4651]"
+          ngpButton
+          ngpPasswordToggle
+        >
+          <ng-icon [name]="password.isVisible() ? 'lucideEyeOff' : 'lucideEye'" />
+        </button>
+      </div>
+    </div>
+  `,
+})
+export default class PasswordExample {}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/password.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/password.md
@@ -19,7 +19,7 @@ import { NgpPassword, NgpPasswordInput, NgpPasswordToggle } from 'ng-primitives/
 
 ## Usage
 
-Assemble the password directives in your template. `ngpPasswordInput` is a complete input (it composes `ngpInput` internally), so you do not add `ngpInput` separately. Keep `type="password"` on the field so it stays masked when JavaScript is unavailable.
+Assemble the password directives in your template. `ngpPasswordInput` is a complete input (it composes `ngpInput` internally), so you do not add `ngpInput` separately. Keep `type="password"` on the field so it renders masked from the start; the toggle switches it to `text` and back.
 
 ```html
 <div ngpFormField>
@@ -111,6 +111,6 @@ The following directives are available to import from the `ng-primitives/passwor
 
 ## Accessibility
 
-The toggle button is a real `<button type="button">` with `aria-controls` pointing at the input. Its accessible label swaps between "Show password" and "Hide password", and visibility changes are announced to screen readers via a live region rather than exposing the password itself.
+The toggle button is a real `button` element with `type="button"` and `aria-controls` pointing at the input. Its accessible label swaps between "Show password" and "Hide password", and visibility changes are announced to screen readers via a live region rather than exposing the password itself.
 
 For security, the input reverts to `type="password"` when its form is submitted, so browsers never cache a revealed password as an autocomplete suggestion.

--- a/apps/documentation/src/app/pages/(documentation)/primitives/password.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/password.md
@@ -111,6 +111,6 @@ The following directives are available to import from the `ng-primitives/passwor
 
 ## Accessibility
 
-The toggle button is a real `button` element with `type="button"` and `aria-controls` pointing at the input. Its accessible label swaps between "Show password" and "Hide password", and visibility changes are announced to screen readers via a live region rather than exposing the password itself.
+The toggle button is a real `<button>` element with `type="button"` and `aria-controls` pointing at the input. Its accessible label swaps between "Show password" and "Hide password", and visibility changes are announced to screen readers via a live region rather than exposing the password itself.
 
 For security, the input reverts to `type="password"` when its form is submitted, so browsers never cache a revealed password as an autocomplete suggestion.

--- a/apps/documentation/src/app/pages/(documentation)/primitives/password.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/password.md
@@ -1,0 +1,116 @@
+---
+name: 'Password'
+sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/password'
+---
+
+# Password
+
+The password primitive is a form control that lets users reveal and hide the contents of a password field with an accessible toggle button.
+
+<docs-example name="password"></docs-example>
+
+## Import
+
+Import the Password primitives from `ng-primitives/password`.
+
+```ts
+import { NgpPassword, NgpPasswordInput, NgpPasswordToggle } from 'ng-primitives/password';
+```
+
+## Usage
+
+Assemble the password directives in your template. `ngpPasswordInput` is a complete input (it composes `ngpInput` internally), so you do not add `ngpInput` separately. Keep `type="password"` on the field so it stays masked when JavaScript is unavailable.
+
+```html
+<div ngpFormField>
+  <label ngpLabel>Password</label>
+  <div ngpPassword #password="ngpPassword">
+    <input ngpPasswordInput type="password" autocomplete="current-password" />
+    <button ngpButton ngpPasswordToggle>
+      <ng-icon [name]="password.isVisible() ? 'lucideEyeOff' : 'lucideEye'" />
+    </button>
+  </div>
+</div>
+```
+
+## Reusable Component
+
+Create a password component that uses the `NgpPassword` directive.
+
+<docs-snippet name="password"></docs-snippet>
+
+## Schematics
+
+Generate a reusable password component using the Angular CLI.
+
+```bash npm
+ng g ng-primitives:primitive password
+```
+
+### Options
+
+- `path`: The path at which to create the component file.
+- `prefix`: The prefix to apply to the generated component selector.
+- `component-suffix`: The suffix to apply to the generated component class name.
+- `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
+- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+
+## Global Configuration
+
+You can configure the default labels and announcements for all password primitives in your application by using the `providePasswordConfig` function in a providers array.
+
+```ts
+import { providePasswordConfig } from 'ng-primitives/password';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    providePasswordConfig({
+      showLabel: 'Show password',
+      hideLabel: 'Hide password',
+      shownAnnouncement: 'Your password is shown',
+      hiddenAnnouncement: 'Your password is hidden',
+      ignorePasswordManagers: false,
+    }),
+  ],
+});
+```
+
+## API Reference
+
+The following directives are available to import from the `ng-primitives/password` package:
+
+### NgpPassword
+
+<api-docs name="NgpPassword"></api-docs>
+
+<api-reference-props name="NgpPassword"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-visible" description="Applied when the password is visible." />
+</api-reference-attributes>
+
+### NgpPasswordInput
+
+<api-docs name="NgpPasswordInput"></api-docs>
+
+<api-reference-props name="NgpPasswordInput"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-visible" description="Applied when the password is visible." />
+</api-reference-attributes>
+
+### NgpPasswordToggle
+
+<api-docs name="NgpPasswordToggle"></api-docs>
+
+<api-reference-props name="NgpPasswordToggle"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-visible" description="Applied when the password is visible." />
+</api-reference-attributes>
+
+## Accessibility
+
+The toggle button is a real `<button type="button">` with `aria-controls` pointing at the input. Its accessible label swaps between "Show password" and "Hide password", and visibility changes are announced to screen readers via a live region rather than exposing the password itself.
+
+For security, the input reverts to `type="password"` when its form is submitted, so browsers never cache a revealed password as an autocomplete suggestion.

--- a/apps/documentation/vite.config.ts
+++ b/apps/documentation/vite.config.ts
@@ -88,6 +88,26 @@ export default defineConfig(({ mode }) => {
               themes: ['github-light', 'github-dark'],
             },
           },
+          markedOptions: {
+            extensions: [
+              {
+                // AnalogJS's build-time codespan renderer inserts the raw token
+                // text, so inline code such as `<button>` leaks into the page as
+                // a real element. Escape it so tag names in backticks render
+                // literally. Registered after the default renderer, so it wins.
+                renderer: {
+                  codespan(token: { text: string }) {
+                    const escaped = token.text
+                      .replace(/&/g, '&amp;')
+                      .replace(/</g, '&lt;')
+                      .replace(/>/g, '&gt;')
+                      .replace(/"/g, '&quot;');
+                    return `<code>${escaped}</code>`;
+                  },
+                },
+              },
+            ],
+          },
         },
       }),
       nxViteTsPaths(),

--- a/packages/ng-primitives/password/README.md
+++ b/packages/ng-primitives/password/README.md
@@ -1,0 +1,3 @@
+# ng-primitives/password
+
+Secondary entry point of `ng-primitives`. It can be used by importing from `ng-primitives/password`.

--- a/packages/ng-primitives/password/ng-package.json
+++ b/packages/ng-primitives/password/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/ng-primitives/password/src/config/password-config.ts
+++ b/packages/ng-primitives/password/src/config/password-config.ts
@@ -1,0 +1,67 @@
+import { inject, InjectionToken, Provider } from '@angular/core';
+
+export interface NgpPasswordConfig {
+  /**
+   * The accessible label for the toggle button when the password is hidden.
+   * @default 'Show password'
+   */
+  showLabel: string;
+
+  /**
+   * The accessible label for the toggle button when the password is visible.
+   * @default 'Hide password'
+   */
+  hideLabel: string;
+
+  /**
+   * The message announced to screen readers when the password becomes visible.
+   * @default 'Your password is shown'
+   */
+  shownAnnouncement: string;
+
+  /**
+   * The message announced to screen readers when the password becomes hidden.
+   * @default 'Your password is hidden'
+   */
+  hiddenAnnouncement: string;
+
+  /**
+   * Whether to opt the input out of password manager injection by default.
+   * @default false
+   */
+  ignorePasswordManagers: boolean;
+}
+
+export const defaultPasswordConfig: NgpPasswordConfig = {
+  showLabel: 'Show password',
+  hideLabel: 'Hide password',
+  shownAnnouncement: 'Your password is shown',
+  hiddenAnnouncement: 'Your password is hidden',
+  ignorePasswordManagers: false,
+};
+
+export const NgpPasswordConfigToken = new InjectionToken<NgpPasswordConfig>(
+  'NgpPasswordConfigToken',
+);
+
+/**
+ * Provide the default Password configuration
+ * @param config The Password configuration
+ * @returns The provider
+ */
+export function providePasswordConfig(config: Partial<NgpPasswordConfig>): Provider[] {
+  return [
+    {
+      provide: NgpPasswordConfigToken,
+      useValue: { ...defaultPasswordConfig, ...config },
+    },
+  ];
+}
+
+/**
+ * Inject the Password configuration
+ * @returns The global Password configuration
+ */
+export function injectPasswordConfig(): NgpPasswordConfig {
+  return inject(NgpPasswordConfigToken, { optional: true }) ?? defaultPasswordConfig;
+}

--- a/packages/ng-primitives/password/src/index.ts
+++ b/packages/ng-primitives/password/src/index.ts
@@ -1,0 +1,31 @@
+export {
+  defaultPasswordConfig,
+  injectPasswordConfig,
+  NgpPasswordConfig,
+  NgpPasswordConfigToken,
+  providePasswordConfig,
+} from './config/password-config';
+export { NgpPasswordInput } from './password-input/password-input';
+export {
+  injectPasswordInputState,
+  ngpPasswordInput,
+  NgpPasswordInputProps,
+  NgpPasswordInputState,
+  providePasswordInputState,
+} from './password-input/password-input-state';
+export { NgpPasswordToggle } from './password-toggle/password-toggle';
+export {
+  injectPasswordToggleState,
+  ngpPasswordToggle,
+  NgpPasswordToggleProps,
+  NgpPasswordToggleState,
+  providePasswordToggleState,
+} from './password-toggle/password-toggle-state';
+export { NgpPassword } from './password/password';
+export {
+  injectPasswordState,
+  ngpPassword,
+  NgpPasswordProps,
+  NgpPasswordState,
+  providePasswordState,
+} from './password/password-state';

--- a/packages/ng-primitives/password/src/password-input/password-input-state.ts
+++ b/packages/ng-primitives/password/src/password-input/password-input-state.ts
@@ -1,0 +1,72 @@
+import { Signal, signal } from '@angular/core';
+import { ngpInput, NgpInputState } from 'ng-primitives/input';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, dataBinding, listener, onMount } from 'ng-primitives/state';
+import { injectPasswordState } from '../password/password-state';
+
+/**
+ * The state for the PasswordInput pattern, extending the Input state.
+ */
+export type NgpPasswordInputState = NgpInputState;
+
+/**
+ * The props interface for the PasswordInput pattern.
+ */
+export interface NgpPasswordInputProps {
+  /**
+   * The id of the input.
+   */
+  readonly id?: Signal<string>;
+  /**
+   * Whether the input is disabled.
+   */
+  readonly disabled?: Signal<boolean>;
+  /**
+   * Whether to opt the input out of password manager injection.
+   */
+  readonly ignorePasswordManagers?: Signal<boolean>;
+}
+
+export const [
+  NgpPasswordInputStateToken,
+  ngpPasswordInput,
+  injectPasswordInputState,
+  providePasswordInputState,
+] = createPrimitive(
+  'NgpPasswordInput',
+  ({
+    id,
+    disabled,
+    ignorePasswordManagers = signal(false),
+  }: NgpPasswordInputProps): NgpPasswordInputState => {
+    const element = injectElementRef<HTMLInputElement>();
+    const password = injectPasswordState();
+
+    // Compose ngpInput for form control, interactions, autofill and the id.
+    const input = ngpInput({ id, disabled });
+
+    // Mask synchronously so the field is never briefly plaintext before the binding runs.
+    element.nativeElement.type = password().visible() ? 'text' : 'password';
+
+    // Register with the container for aria-controls.
+    password().registerInput(element.nativeElement, input.id);
+
+    attrBinding(element, 'type', () => (password().visible() ? 'text' : 'password'));
+    dataBinding(element, 'data-visible', () => password().visible());
+
+    // Opt out of password manager injection when requested.
+    attrBinding(element, 'data-1p-ignore', () => (ignorePasswordManagers() ? '' : null));
+    attrBinding(element, 'data-lpignore', () => (ignorePasswordManagers() ? 'true' : null));
+    attrBinding(element, 'data-bwignore', () => (ignorePasswordManagers() ? '' : null));
+
+    // Reset to hidden on submit so browsers don't cache a plaintext field.
+    onMount(() => {
+      const form = element.nativeElement.form;
+      if (form) {
+        listener(form, 'submit', () => password().setVisible(false));
+      }
+    });
+
+    return input;
+  },
+);

--- a/packages/ng-primitives/password/src/password-input/password-input-state.ts
+++ b/packages/ng-primitives/password/src/password-input/password-input-state.ts
@@ -45,12 +45,11 @@ export const [
     // Compose ngpInput for form control, interactions, autofill and the id.
     const input = ngpInput({ id, disabled });
 
-    // Mask synchronously so the field is never briefly plaintext before the binding runs.
-    element.nativeElement.type = password().visible() ? 'text' : 'password';
-
     // Register with the container for aria-controls.
     password().registerInput(element.nativeElement, input.id);
 
+    // Consumers keep type="password" in the markup so the field is masked without
+    // JS; this drives the toggle to text and back.
     attrBinding(element, 'type', () => (password().visible() ? 'text' : 'password'));
     dataBinding(element, 'data-visible', () => password().visible());
 

--- a/packages/ng-primitives/password/src/password-input/password-input-state.ts
+++ b/packages/ng-primitives/password/src/password-input/password-input-state.ts
@@ -48,8 +48,8 @@ export const [
     // Register with the container for aria-controls.
     password().registerInput(element.nativeElement, input.id);
 
-    // Consumers keep type="password" in the markup so the field is masked without
-    // JS; this drives the toggle to text and back.
+    // Consumers keep type="password" in the markup so the field renders masked
+    // from the start; this drives the toggle to text and back.
     attrBinding(element, 'type', () => (password().visible() ? 'text' : 'password'));
     dataBinding(element, 'data-visible', () => password().visible());
 

--- a/packages/ng-primitives/password/src/password-input/password-input.ts
+++ b/packages/ng-primitives/password/src/password-input/password-input.ts
@@ -1,0 +1,55 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import { uniqueId } from 'ng-primitives/utils';
+import { injectPasswordConfig } from '../config/password-config';
+import { ngpPasswordInput, providePasswordInputState } from './password-input-state';
+
+/**
+ * Apply the `ngpPasswordInput` directive to an `input` element within an `ngpPassword` container.
+ * It is a complete input (form control, interactions, autofill) with password visibility toggling
+ * layered on top, so it does not need to be combined with `ngpInput`.
+ */
+@Directive({
+  selector: 'input[ngpPasswordInput]',
+  exportAs: 'ngpPasswordInput',
+  providers: [providePasswordInputState()],
+})
+export class NgpPasswordInput {
+  /**
+   * Access the global password configuration.
+   */
+  private readonly config = injectPasswordConfig();
+
+  /**
+   * The id of the input.
+   */
+  readonly id = input<string>(uniqueId('ngp-password-input'));
+
+  /**
+   * Whether the input is disabled.
+   */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    transform: booleanAttribute,
+  });
+
+  /**
+   * Whether to opt the input out of password manager injection
+   * (1Password, LastPass, Bitwarden, etc.).
+   */
+  readonly ignorePasswordManagers = input<boolean, BooleanInput>(
+    this.config.ignorePasswordManagers,
+    {
+      alias: 'ngpPasswordInputIgnorePasswordManagers',
+      transform: booleanAttribute,
+    },
+  );
+
+  /**
+   * The state for the password input primitive.
+   */
+  protected readonly state = ngpPasswordInput({
+    id: this.id,
+    disabled: this.disabled,
+    ignorePasswordManagers: this.ignorePasswordManagers,
+  });
+}

--- a/packages/ng-primitives/password/src/password-toggle/password-toggle-state.ts
+++ b/packages/ng-primitives/password/src/password-toggle/password-toggle-state.ts
@@ -72,10 +72,12 @@ export const [
 
     function toggle(): void {
       const state = password();
+      // Announce the intended state: in controlled mode state.visible() may not
+      // reflect the new value until the parent propagates it back.
+      const willBeVisible = !state.visible();
       state.toggle();
 
-      const visible = state.visible();
-      announcer.announce(visible ? shownAnnouncement() : hiddenAnnouncement());
+      announcer.announce(willBeVisible ? shownAnnouncement() : hiddenAnnouncement());
 
       if (pointerActivated()) {
         state.focusInput();

--- a/packages/ng-primitives/password/src/password-toggle/password-toggle-state.ts
+++ b/packages/ng-primitives/password/src/password-toggle/password-toggle-state.ts
@@ -1,0 +1,88 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { inject, Signal, signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
+import { injectPasswordState } from '../password/password-state';
+
+/**
+ * The state interface for the PasswordToggle pattern.
+ */
+export interface NgpPasswordToggleState {
+  /**
+   * Toggle the visibility of the password.
+   */
+  toggle(): void;
+}
+
+/**
+ * The props interface for the PasswordToggle pattern.
+ */
+export interface NgpPasswordToggleProps {
+  /**
+   * The accessible label shown when the password is hidden.
+   */
+  readonly showLabel: Signal<string>;
+  /**
+   * The accessible label shown when the password is visible.
+   */
+  readonly hideLabel: Signal<string>;
+  /**
+   * The message announced when the password becomes visible.
+   */
+  readonly shownAnnouncement: Signal<string>;
+  /**
+   * The message announced when the password becomes hidden.
+   */
+  readonly hiddenAnnouncement: Signal<string>;
+}
+
+export const [
+  NgpPasswordToggleStateToken,
+  ngpPasswordToggle,
+  injectPasswordToggleState,
+  providePasswordToggleState,
+] = createPrimitive(
+  'NgpPasswordToggle',
+  ({
+    showLabel,
+    hideLabel,
+    shownAnnouncement,
+    hiddenAnnouncement,
+  }: NgpPasswordToggleProps): NgpPasswordToggleState => {
+    const element = injectElementRef<HTMLButtonElement>();
+    const password = injectPasswordState();
+    const announcer = inject(LiveAnnouncer);
+
+    // Pointer activation returns focus to the input; keyboard keeps it on the button.
+    const pointerActivated = signal(false);
+
+    attrBinding(element, 'type', 'button');
+    attrBinding(element, 'aria-controls', () => password().inputId());
+    attrBinding(element, 'aria-label', () => {
+      // Defer to the button's own text if it has any.
+      if ((element.nativeElement.textContent ?? '').trim().length > 0) {
+        return null;
+      }
+      return password().visible() ? hideLabel() : showLabel();
+    });
+    dataBinding(element, 'data-visible', () => password().visible());
+
+    listener(element, 'pointerdown', () => pointerActivated.set(true));
+    listener(element, 'click', () => toggle());
+
+    function toggle(): void {
+      const state = password();
+      state.toggle();
+
+      const visible = state.visible();
+      announcer.announce(visible ? shownAnnouncement() : hiddenAnnouncement());
+
+      if (pointerActivated()) {
+        state.focusInput();
+      }
+      pointerActivated.set(false);
+    }
+
+    return { toggle } satisfies NgpPasswordToggleState;
+  },
+);

--- a/packages/ng-primitives/password/src/password-toggle/password-toggle.ts
+++ b/packages/ng-primitives/password/src/password-toggle/password-toggle.ts
@@ -1,0 +1,60 @@
+import { Directive, input } from '@angular/core';
+import { injectPasswordConfig } from '../config/password-config';
+import { ngpPasswordToggle, providePasswordToggleState } from './password-toggle-state';
+
+/**
+ * Apply the `ngpPasswordToggle` directive to a `button` element to toggle the visibility of the
+ * password within an `ngpPassword` container.
+ */
+@Directive({
+  selector: 'button[ngpPasswordToggle]',
+  exportAs: 'ngpPasswordToggle',
+  providers: [providePasswordToggleState()],
+})
+export class NgpPasswordToggle {
+  /**
+   * Access the global password configuration.
+   */
+  private readonly config = injectPasswordConfig();
+
+  /**
+   * The accessible label shown when the password is hidden.
+   */
+  readonly showLabel = input(this.config.showLabel, { alias: 'ngpPasswordToggleShowLabel' });
+
+  /**
+   * The accessible label shown when the password is visible.
+   */
+  readonly hideLabel = input(this.config.hideLabel, { alias: 'ngpPasswordToggleHideLabel' });
+
+  /**
+   * The message announced when the password becomes visible.
+   */
+  readonly shownAnnouncement = input(this.config.shownAnnouncement, {
+    alias: 'ngpPasswordToggleShownAnnouncement',
+  });
+
+  /**
+   * The message announced when the password becomes hidden.
+   */
+  readonly hiddenAnnouncement = input(this.config.hiddenAnnouncement, {
+    alias: 'ngpPasswordToggleHiddenAnnouncement',
+  });
+
+  /**
+   * The state for the password toggle primitive.
+   */
+  protected readonly state = ngpPasswordToggle({
+    showLabel: this.showLabel,
+    hideLabel: this.hideLabel,
+    shownAnnouncement: this.shownAnnouncement,
+    hiddenAnnouncement: this.hiddenAnnouncement,
+  });
+
+  /**
+   * Toggle the visibility of the password.
+   */
+  toggle(): void {
+    this.state.toggle();
+  }
+}

--- a/packages/ng-primitives/password/src/password/password-state.ts
+++ b/packages/ng-primitives/password/src/password/password-state.ts
@@ -1,0 +1,118 @@
+import { computed, Signal, signal, WritableSignal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  controlled,
+  controlledState,
+  createPrimitive,
+  dataBinding,
+  deprecatedSetter,
+  SetterOptions,
+} from 'ng-primitives/state';
+import { Observable } from 'rxjs';
+
+/**
+ * Public state surface for the Password primitive.
+ */
+export interface NgpPasswordState {
+  /**
+   * Whether the password is currently visible.
+   */
+  readonly visible: WritableSignal<boolean>;
+  /**
+   * Emits when the visibility state changes.
+   */
+  readonly visibleChange: Observable<boolean>;
+  /**
+   * The id of the registered input, used to wire up `aria-controls`.
+   * @internal
+   */
+  readonly inputId: Signal<string | null>;
+  /**
+   * Toggle the visibility state.
+   */
+  toggle(): void;
+  /**
+   * Set the visibility state.
+   */
+  setVisible(value: boolean, options?: SetterOptions): void;
+  /**
+   * Set the default visibility state.
+   */
+  setDefaultVisible(value: boolean): void;
+  /**
+   * Register the password input with the container.
+   * @internal
+   */
+  registerInput(input: HTMLInputElement, id: Signal<string>): void;
+  /**
+   * Focus the registered input.
+   * @internal
+   */
+  focusInput(): void;
+}
+
+/**
+ * Inputs for configuring the Password primitive.
+ */
+export interface NgpPasswordProps {
+  /**
+   * Whether the password is visible.
+   */
+  readonly visible: Signal<boolean | undefined>;
+  /**
+   * The default visibility state for uncontrolled usage.
+   */
+  readonly defaultVisible?: Signal<boolean>;
+  /**
+   * Callback fired when the visibility state changes.
+   */
+  readonly onVisibleChange?: (visible: boolean) => void;
+}
+
+export const [NgpPasswordStateToken, ngpPassword, injectPasswordState, providePasswordState] =
+  createPrimitive(
+    'NgpPassword',
+    ({
+      visible: _visible,
+      defaultVisible: _defaultVisible,
+      onVisibleChange,
+    }: NgpPasswordProps): NgpPasswordState => {
+      const element = injectElementRef<HTMLElement>();
+      const defaultVisible = controlled(_defaultVisible, false);
+
+      const input = signal<HTMLInputElement | null>(null);
+      const inputId = signal<Signal<string> | null>(null);
+
+      const [visible, setVisible, visibleChange] = controlledState({
+        value: _visible,
+        defaultValue: defaultVisible,
+        onChange: onVisibleChange,
+      });
+
+      dataBinding(element, 'data-visible', visible);
+
+      function toggle(): void {
+        setVisible(!visible());
+      }
+
+      function registerInput(el: HTMLInputElement, id: Signal<string>): void {
+        input.set(el);
+        inputId.set(id);
+      }
+
+      function focusInput(): void {
+        input()?.focus();
+      }
+
+      return {
+        visible: deprecatedSetter(visible, 'setVisible', setVisible),
+        visibleChange,
+        inputId: computed(() => inputId()?.() ?? null),
+        toggle,
+        setVisible,
+        setDefaultVisible: defaultVisible.set,
+        registerInput,
+        focusInput,
+      } satisfies NgpPasswordState;
+    },
+  );

--- a/packages/ng-primitives/password/src/password/password.ts
+++ b/packages/ng-primitives/password/src/password/password.ts
@@ -1,0 +1,66 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, computed, Directive, input, output, Signal } from '@angular/core';
+import { SetterOptions } from 'ng-primitives/state';
+import { ngpPassword, providePasswordState } from './password-state';
+
+/**
+ * The `NgpPassword` directive is a container for a password field and its visibility toggle.
+ */
+@Directive({
+  selector: '[ngpPassword]',
+  exportAs: 'ngpPassword',
+  providers: [providePasswordState()],
+})
+export class NgpPassword {
+  /**
+   * Whether the password is visible.
+   */
+  readonly visible = input<boolean | undefined, BooleanInput>(undefined, {
+    alias: 'ngpPasswordVisible',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * The default visibility state for uncontrolled usage.
+   * @default false
+   */
+  readonly defaultVisible = input<boolean, BooleanInput>(false, {
+    alias: 'ngpPasswordDefaultVisible',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * Emits when the visibility state changes.
+   */
+  readonly visibleChange = output<boolean>({
+    alias: 'ngpPasswordVisibleChange',
+  });
+
+  /**
+   * The state for the password primitive.
+   */
+  protected readonly state = ngpPassword({
+    visible: this.visible,
+    defaultVisible: this.defaultVisible,
+    onVisibleChange: value => this.visibleChange.emit(value),
+  });
+
+  /**
+   * Whether the password is currently visible.
+   */
+  readonly isVisible: Signal<boolean> = computed(() => this.state.visible());
+
+  /**
+   * Toggle the visibility of the password.
+   */
+  toggle(): void {
+    this.state.toggle();
+  }
+
+  /**
+   * Set the visibility of the password.
+   */
+  setVisible(value: boolean, options?: SetterOptions): void {
+    this.state.setVisible(value, options);
+  }
+}

--- a/packages/ng-primitives/password/src/password/tests/password-primitive.test.ts
+++ b/packages/ng-primitives/password/src/password/tests/password-primitive.test.ts
@@ -149,7 +149,7 @@ describe('NgpPassword', () => {
     });
 
     it('should allow overriding the labels', async () => {
-      const { getByTestId } = await render(
+      const { getByTestId, fixture } = await render(
         `
         <div ngpPassword>
           <input ngpPasswordInput />
@@ -164,7 +164,13 @@ describe('NgpPassword', () => {
         { imports },
       );
 
-      expect(getByTestId('toggle')).toHaveAttribute('aria-label', 'Reveal');
+      const toggle = getByTestId('toggle');
+      expect(toggle).toHaveAttribute('aria-label', 'Reveal');
+
+      fireEvent.click(toggle);
+      await fixture.whenStable();
+
+      expect(toggle).toHaveAttribute('aria-label', 'Conceal');
     });
   });
 
@@ -226,6 +232,26 @@ describe('NgpPassword', () => {
       await fixture.whenStable();
 
       expect(getByTestId('input')).toHaveAttribute('type', 'password');
+    });
+
+    it('should reflect a parent-controlled visible change on the input', async () => {
+      const { getByTestId, fixture } = await render(
+        `
+        <div ngpPassword [ngpPasswordVisible]="visible">
+          <input data-testid="input" ngpPasswordInput />
+        </div>
+        `,
+        { imports, componentProperties: { visible: false } },
+      );
+
+      expect(getByTestId('input')).toHaveAttribute('type', 'password');
+
+      // flipping the parent-controlled value should drive the input
+      (fixture.componentInstance as unknown as { visible: boolean }).visible = true;
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(getByTestId('input')).toHaveAttribute('type', 'text');
     });
   });
 

--- a/packages/ng-primitives/password/src/password/tests/password-primitive.test.ts
+++ b/packages/ng-primitives/password/src/password/tests/password-primitive.test.ts
@@ -1,0 +1,390 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
+import { By } from '@angular/platform-browser';
+import { fireEvent, render } from '@testing-library/angular';
+import { NgpFormField, NgpLabel } from 'ng-primitives/form-field';
+import { NgpPassword, NgpPasswordInput, NgpPasswordToggle } from 'ng-primitives/password';
+import { describe, expect, it, vi } from 'vitest';
+
+const imports = [NgpPassword, NgpPasswordInput, NgpPasswordToggle];
+
+describe('NgpPassword', () => {
+  describe('input type toggling', () => {
+    it('should render the input as a password field by default', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpPassword>
+          <input data-testid="input" ngpPasswordInput />
+        </div>
+        `,
+        { imports },
+      );
+
+      expect(getByTestId('input')).toHaveAttribute('type', 'password');
+    });
+
+    it('should switch the input to a text field when visible', async () => {
+      const { getByTestId, fixture } = await render(
+        `
+        <div ngpPassword>
+          <input data-testid="input" ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports },
+      );
+
+      fireEvent.click(getByTestId('toggle'));
+      await fixture.whenStable();
+
+      expect(getByTestId('input')).toHaveAttribute('type', 'text');
+
+      fireEvent.click(getByTestId('toggle'));
+      await fixture.whenStable();
+
+      expect(getByTestId('input')).toHaveAttribute('type', 'password');
+    });
+
+    it('should honour ngpPasswordDefaultVisible for uncontrolled usage', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpPassword ngpPasswordDefaultVisible>
+          <input data-testid="input" ngpPasswordInput />
+        </div>
+        `,
+        { imports },
+      );
+
+      expect(getByTestId('input')).toHaveAttribute('type', 'text');
+    });
+  });
+
+  describe('data-visible attribute', () => {
+    it('should reflect visibility on the container, input and toggle', async () => {
+      const { getByTestId, fixture } = await render(
+        `
+        <div data-testid="container" ngpPassword>
+          <input data-testid="input" ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports },
+      );
+
+      for (const id of ['container', 'input', 'toggle']) {
+        expect(getByTestId(id)).not.toHaveAttribute('data-visible');
+      }
+
+      fireEvent.click(getByTestId('toggle'));
+      await fixture.whenStable();
+
+      for (const id of ['container', 'input', 'toggle']) {
+        expect(getByTestId(id)).toHaveAttribute('data-visible', '');
+      }
+    });
+  });
+
+  describe('toggle button accessibility', () => {
+    it('should force type="button" so it never submits a form', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpPassword>
+          <input ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports },
+      );
+
+      expect(getByTestId('toggle')).toHaveAttribute('type', 'button');
+    });
+
+    it('should point aria-controls at the input id', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpPassword>
+          <input data-testid="input" ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports },
+      );
+
+      const inputId = getByTestId('input').getAttribute('id');
+      expect(inputId).toBeTruthy();
+      expect(getByTestId('toggle')).toHaveAttribute('aria-controls', inputId!);
+    });
+
+    it('should swap the aria-label between show and hide', async () => {
+      const { getByTestId, fixture } = await render(
+        `
+        <div ngpPassword>
+          <input ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports },
+      );
+
+      const toggle = getByTestId('toggle');
+      expect(toggle).toHaveAttribute('aria-label', 'Show password');
+
+      fireEvent.click(toggle);
+      await fixture.whenStable();
+
+      expect(toggle).toHaveAttribute('aria-label', 'Hide password');
+    });
+
+    it('should not set an aria-label when the button has visible text', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpPassword>
+          <input ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle>Show</button>
+        </div>
+        `,
+        { imports },
+      );
+
+      expect(getByTestId('toggle')).not.toHaveAttribute('aria-label');
+    });
+
+    it('should allow overriding the labels', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpPassword>
+          <input ngpPasswordInput />
+          <button
+            data-testid="toggle"
+            ngpPasswordToggle
+            ngpPasswordToggleShowLabel="Reveal"
+            ngpPasswordToggleHideLabel="Conceal"
+          ></button>
+        </div>
+        `,
+        { imports },
+      );
+
+      expect(getByTestId('toggle')).toHaveAttribute('aria-label', 'Reveal');
+    });
+  });
+
+  describe('announcements', () => {
+    it('should announce the visibility change politely', async () => {
+      const announce = vi.fn();
+      const { getByTestId, fixture } = await render(
+        `
+        <div ngpPassword>
+          <input ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports, providers: [{ provide: LiveAnnouncer, useValue: { announce } }] },
+      );
+
+      fireEvent.click(getByTestId('toggle'));
+      await fixture.whenStable();
+      expect(announce).toHaveBeenLastCalledWith('Your password is shown');
+
+      fireEvent.click(getByTestId('toggle'));
+      await fixture.whenStable();
+      expect(announce).toHaveBeenLastCalledWith('Your password is hidden');
+    });
+  });
+
+  describe('two-way binding', () => {
+    it('should emit ngpPasswordVisibleChange when toggled', async () => {
+      const onChange = vi.fn();
+      const { getByTestId, fixture } = await render(
+        `
+        <div ngpPassword (ngpPasswordVisibleChange)="onChange($event)">
+          <input ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports, componentProperties: { onChange } },
+      );
+
+      fireEvent.click(getByTestId('toggle'));
+      await fixture.whenStable();
+
+      expect(onChange).toHaveBeenCalledWith(true);
+    });
+
+    it('should stay controlled when ngpPasswordVisible is bound', async () => {
+      const { getByTestId, fixture } = await render(
+        `
+        <div ngpPassword [ngpPasswordVisible]="visible">
+          <input data-testid="input" ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports, componentProperties: { visible: false } },
+      );
+
+      // clicking must not change the input type because the parent controls it
+      fireEvent.click(getByTestId('toggle'));
+      await fixture.whenStable();
+
+      expect(getByTestId('input')).toHaveAttribute('type', 'password');
+    });
+  });
+
+  describe('reset on form submit', () => {
+    it('should hide a revealed password when the form is submitted', async () => {
+      const { getByTestId, fixture } = await render(
+        `
+        <form>
+          <div ngpPassword ngpPasswordDefaultVisible>
+            <input data-testid="input" ngpPasswordInput />
+            <button data-testid="toggle" ngpPasswordToggle></button>
+          </div>
+        </form>
+        `,
+        { imports },
+      );
+
+      const input = getByTestId('input');
+      expect(input).toHaveAttribute('type', 'text');
+
+      fireEvent.submit(input.closest('form')!);
+      await fixture.whenStable();
+
+      expect(input).toHaveAttribute('type', 'password');
+    });
+  });
+
+  describe('ignore password managers', () => {
+    it('should not set the opt-out attributes by default', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpPassword>
+          <input data-testid="input" ngpPasswordInput />
+        </div>
+        `,
+        { imports },
+      );
+
+      const input = getByTestId('input');
+      expect(input).not.toHaveAttribute('data-1p-ignore');
+      expect(input).not.toHaveAttribute('data-lpignore');
+      expect(input).not.toHaveAttribute('data-bwignore');
+    });
+
+    it('should set the opt-out attributes when enabled', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpPassword>
+          <input data-testid="input" ngpPasswordInput ngpPasswordInputIgnorePasswordManagers />
+        </div>
+        `,
+        { imports },
+      );
+
+      const input = getByTestId('input');
+      expect(input).toHaveAttribute('data-1p-ignore');
+      expect(input).toHaveAttribute('data-lpignore', 'true');
+      expect(input).toHaveAttribute('data-bwignore');
+    });
+  });
+
+  describe('focus modality', () => {
+    it('should return focus to the input after a pointer toggle', async () => {
+      const { getByTestId, fixture } = await render(
+        `
+        <div ngpPassword>
+          <input data-testid="input" ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports },
+      );
+
+      const toggle = getByTestId('toggle');
+      fireEvent.pointerDown(toggle);
+      fireEvent.click(toggle);
+      await fixture.whenStable();
+
+      expect(document.activeElement).toBe(getByTestId('input'));
+    });
+
+    it('should keep focus on the button after a keyboard toggle', async () => {
+      const { getByTestId, fixture } = await render(
+        `
+        <div ngpPassword>
+          <input data-testid="input" ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports },
+      );
+
+      const toggle = getByTestId('toggle') as HTMLButtonElement;
+      toggle.focus();
+      // a keyboard activation dispatches click with no preceding pointerdown
+      fireEvent.click(toggle);
+      await fixture.whenStable();
+
+      expect(document.activeElement).toBe(toggle);
+    });
+  });
+
+  describe('input composition (inherits ngpInput features)', () => {
+    it('should reflect the disabled state on the input', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpPassword>
+          <input data-testid="input" ngpPasswordInput disabled />
+        </div>
+        `,
+        { imports },
+      );
+
+      expect(getByTestId('input')).toHaveAttribute('disabled');
+    });
+
+    it('should wire up form-field label association for free', async () => {
+      const { getByTestId } = await render(
+        `
+        <div ngpFormField>
+          <label data-testid="label" ngpLabel>Password</label>
+          <div ngpPassword>
+            <input data-testid="input" ngpPasswordInput />
+          </div>
+        </div>
+        `,
+        { imports: [...imports, NgpFormField, NgpLabel] },
+      );
+
+      const inputId = getByTestId('input').getAttribute('id');
+      expect(inputId).toBeTruthy();
+      expect(getByTestId('label')).toHaveAttribute('for', inputId!);
+    });
+  });
+
+  describe('directive API', () => {
+    it('should expose an imperative toggle()', async () => {
+      const { fixture, getByTestId } = await render(
+        `
+        <div ngpPassword>
+          <input data-testid="input" ngpPasswordInput />
+        </div>
+        `,
+        { imports },
+      );
+
+      const password = fixture.debugElement
+        .query(By.directive(NgpPassword))
+        .injector.get(NgpPassword);
+
+      expect(getByTestId('input')).toHaveAttribute('type', 'password');
+      expect(password.isVisible()).toBe(false);
+
+      password.toggle();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(getByTestId('input')).toHaveAttribute('type', 'text');
+      expect(password.isVisible()).toBe(true);
+    });
+  });
+});

--- a/packages/ng-primitives/schematics/ng-generate/templates/password/password.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/password/password.__fileSuffix@dasherize__.ts.template
@@ -1,9 +1,14 @@
-import { Component, inject, input, signal } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideEye, lucideEyeOff } from '@ng-icons/lucide';
 import { NgpButton } from 'ng-primitives/button';
-import { NgpPassword, NgpPasswordInput, NgpPasswordToggle } from 'ng-primitives/password';
+import {
+  injectPasswordState,
+  NgpPassword,
+  NgpPasswordInput,
+  NgpPasswordToggle,
+} from 'ng-primitives/password';
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
@@ -21,7 +26,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
       autocomplete="current-password"
     />
     <button ngpButton ngpPasswordToggle>
-      <ng-icon [name]="password.isVisible() ? 'lucideEyeOff' : 'lucideEye'" />
+      <ng-icon [name]="state().visible() ? 'lucideEyeOff' : 'lucideEye'" />
     </button>
   `,
   styles: `
@@ -88,12 +93,12 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
     }
   `,
   host: {
-    '(focusout)': 'onTouched?.()',
+    '(focusout)': 'onFocusOut($event)',
   },
 })
 export class Password<%= componentSuffix %> implements ControlValueAccessor {
-  /** Access the password directive to read the visibility state. */
-  protected readonly password = inject(NgpPassword);
+  /** Access the password state to read the visibility. */
+  protected readonly state = injectPasswordState();
 
   /** The placeholder text */
   readonly placeholder = input<string>('');
@@ -123,5 +128,14 @@ export class Password<%= componentSuffix %> implements ControlValueAccessor {
     const input = event.target as HTMLInputElement;
     this.value.set(input.value);
     this.onChange?.(input.value);
+  }
+
+  protected onFocusOut(event: FocusEvent): void {
+    // only mark as touched when focus leaves the component, not when moving
+    // between the input and the toggle button
+    const host = event.currentTarget as HTMLElement;
+    if (!host.contains(event.relatedTarget as Node | null)) {
+      this.onTouched?.();
+    }
   }
 }

--- a/packages/ng-primitives/schematics/ng-generate/templates/password/password.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/password/password.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,127 @@
+import { Component, inject, input, signal } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideEye, lucideEyeOff } from '@ng-icons/lucide';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpPassword, NgpPasswordInput, NgpPasswordToggle } from 'ng-primitives/password';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<%= prefix %>-password',
+  hostDirectives: [NgpPassword],
+  imports: [NgIcon, NgpPasswordInput, NgpPasswordToggle, NgpButton],
+  providers: [provideValueAccessor(Password<%= componentSuffix %>), provideIcons({ lucideEye, lucideEyeOff })],
+  template: `
+    <input
+      [value]="value()"
+      [placeholder]="placeholder()"
+      (input)="onValueChange($event)"
+      ngpPasswordInput
+      type="password"
+      autocomplete="current-password"
+    />
+    <button ngpButton ngpPasswordToggle>
+      <ng-icon [name]="password.isVisible() ? 'lucideEyeOff' : 'lucideEye'" />
+    </button>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host {
+      display: block;
+      position: relative;
+    }
+
+    [ngpPasswordInput] {
+      height: 2.125rem;
+      width: 100%;
+      border-radius: 0.5rem;
+      padding: 0 40px 0 12px;
+      border: none;
+      background: var(--ngp-background);
+      color: var(--ngp-text-primary);
+      font-size: 0.875rem;
+      letter-spacing: -0.006em;
+      box-shadow: var(--ngp-input-shadow);
+      outline: none;
+    }
+
+    [ngpPasswordInput][data-focus] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    [ngpPasswordInput]::placeholder {
+      color: var(--ngp-text-placeholder);
+    }
+
+    [ngpPasswordToggle] {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 2.125rem;
+      width: 2.125rem;
+      border: none;
+      border-radius: 0.5rem;
+      background-color: transparent;
+      color: var(--ngp-text-tertiary);
+      font-size: 1.125rem;
+      cursor: pointer;
+      outline: none;
+      transition: color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpPasswordToggle][data-hover] {
+      color: var(--ngp-text-secondary);
+    }
+
+    [ngpPasswordToggle][data-visible] {
+      color: var(--ngp-primary);
+    }
+
+    [ngpPasswordToggle][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: -2px;
+    }
+  `,
+  host: {
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Password<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the password directive to read the visibility state. */
+  protected readonly password = inject(NgpPassword);
+
+  /** The placeholder text */
+  readonly placeholder = input<string>('');
+
+  /** The current value */
+  protected value = signal<string>('');
+
+  /** The function to call when the value changes */
+  private onChange?: ChangeFn<string>;
+
+  /** The function to call when the control is touched */
+  protected onTouched?: TouchedFn;
+
+  writeValue(value: string): void {
+    this.value.set(value);
+  }
+
+  registerOnChange(fn: ChangeFn<string>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  protected onValueChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.value.set(input.value);
+    this.onChange?.(input.value);
+  }
+}

--- a/packages/ng-primitives/tsconfig.lib.json
+++ b/packages/ng-primitives/tsconfig.lib.json
@@ -16,7 +16,12 @@
     "vite.config.ts",
     "vitest.node.config.ts",
     "**/*.stories.ts",
-    "**/*.stories.js"
+    "**/*.stories.js",
+    "password/**/*.spec.ts",
+    "password/**/*.test.ts",
+    "password/**/*.fixture.ts",
+    "password/**/*.stories.ts",
+    "password/**/*.stories.js"
   ],
-  "include": ["**/*.ts"]
+  "include": ["**/*.ts", "password/**/*.ts"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -70,7 +70,8 @@
       "@ng-primitives/mcp": ["packages/mcp/src/index.ts"],
       "ng-primitives/navigation-menu": ["packages/ng-primitives/navigation-menu/src/index.ts"],
       "ng-primitives/number-field": ["packages/ng-primitives/number-field/src/index.ts"],
-      "ng-primitives/context-menu": ["packages/ng-primitives/context-menu/src/index.ts"]
+      "ng-primitives/context-menu": ["packages/ng-primitives/context-menu/src/index.ts"],
+      "ng-primitives/password": ["./packages/ng-primitives/password/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Feature

## Issue

Closes #642

## What does this PR implement/fix?

Adds a headless **password** primitive (`ng-primitives/password`) - a password field with an accessible show/hide toggle, in the spirit of the existing `search` primitive.

**Anatomy**

- `NgpPassword` (`[ngpPassword]`) - container that owns the visibility state (`ngpPasswordVisible` / `ngpPasswordDefaultVisible` / `ngpPasswordVisibleChange`) and exposes `toggle()` / `isVisible()`.
- `NgpPasswordInput` (`input[ngpPasswordInput]`) - composes `ngpInput` (so it inherits form-control, interactions, autofill and the id) and toggles the field between `password` and `text`. Reflects `data-visible`.
- `NgpPasswordToggle` (`button[ngpPasswordToggle]`) - the visibility toggle button.

**Accessibility & behaviour** (following the [GOV.UK show-password guidance](https://technology.blog.gov.uk/2021/04/19/simple-things-are-complicated-making-a-show-password-option/)):

- Real `button[type="button"]` with `aria-controls` pointing at the input; `aria-label` swaps between "Show password" / "Hide password" and is suppressed when the button has visible text.
- Visibility changes are announced via `LiveAnnouncer` rather than exposing the password.
- Field resets to hidden on form submit so browsers never cache a plaintext value.
- Focus returns to the input on pointer toggles and stays on the button for keyboard toggles.
- Opt-in `ignorePasswordManagers` sets the 1Password / LastPass / Bitwarden opt-out attributes.
- Strings are configurable app-wide via `providePasswordConfig`.

Includes vitest coverage, CSS + Tailwind examples, a reusable component, and a docs page.

**Note:** this branch also carries a small `chore(claude)` commit documenting the `createPrimitive` state pattern, expanding the Nx generator docs, and adding a review auto-invoke hook. Happy to split it into its own PR if preferred.

## Does this PR introduce a breaking change?

- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ng-primitives/password`: an accessible password field with a show/hide toggle, secure defaults, polite announcements, and app-wide config. Implements the primitive requested in #642 and documents the `createPrimitive` state pattern and Nx generator workflow.

- **New Features**
  - `NgpPassword` container, `NgpPasswordInput` (composes `ngpInput`), and `NgpPasswordToggle`; all reflect `data-visible`.
  - A11y/security: real `button[type="button"]` with `aria-controls`, dynamic `aria-label` unless the button has text, LiveAnnouncer messages, resets to hidden on submit, correct pointer/keyboard focus, optional opt-out for password managers.
  - Config via `providePasswordConfig` (labels, announcements, ignore managers), plus docs page, CSS/Tailwind examples, a reusable component, a schematic template, and a new secondary entry point. State pattern and generators documented; `ngp-code-review` now flags legacy state usage.

- **Bug Fixes**
  - Toggle announces the intended visibility so controlled mode speaks correctly; label overrides persist after toggling.
  - Reusable password component only marks as touched when focus leaves the whole control; removed redundant input type assignment.
  - Added tests for parent-controlled visibility propagation and label overrides; docs clarify the field is masked from first render and the toggle switches it.
  - Docs renderer now escapes inline code spans so tag names in backticks (e.g. `<button>`) render literally site-wide; restored explicit references in the password docs.

<sup>Written for commit e777d78f3a806d786f0bb86a50a67cd70884a6e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a password input with show/hide toggle and form support.
  * Added configurable labels and announcements for the password toggle.
  * Added a new password example and documentation page, including reusable usage guidance.

* **Bug Fixes**
  * Improved focus handling so toggling the password view behaves more naturally.
  * Prevented password fields from staying visible after form submission.

* **Documentation**
  * Updated contribution guidance for the preferred state-management and scaffolding workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->