### PR TITLE
feat(color): add color primitives

### DIFF
--- a/apps/documentation/src/app/examples/color/color-field.example.ts
+++ b/apps/documentation/src/app/examples/color/color-field.example.ts
@@ -1,0 +1,77 @@
+import { Component } from '@angular/core';
+import { Color, NgpColorField, NgpColorPicker } from 'ng-primitives/color';
+
+@Component({
+  selector: 'app-color-field',
+  imports: [NgpColorPicker, NgpColorField],
+  styles: `
+    [ngpColorPicker] {
+      display: flex;
+      align-items: flex-end;
+      gap: 8px;
+    }
+
+    .swatch {
+      width: 34px;
+      height: 34px;
+      flex-shrink: 0;
+      border-radius: 0.5rem;
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .field label {
+      font-size: 0.75rem;
+      font-weight: 510;
+      letter-spacing: -0.011em;
+      color: var(--ngp-text-tertiary);
+    }
+
+    [ngpColorField] {
+      width: 3.5rem;
+      height: 34px;
+      padding: 0 0.5rem;
+      font-size: 0.875rem;
+      font-weight: 510;
+      font-variant-numeric: tabular-nums;
+      letter-spacing: -0.006em;
+      color: var(--ngp-text-primary);
+      background-color: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      border-radius: 0.5rem;
+      outline: none;
+    }
+
+    [ngpColorField][data-focus] {
+      border-color: var(--ngp-focus-ring);
+      box-shadow: 0 0 0 1px var(--ngp-focus-ring);
+    }
+  `,
+  template: `
+    <!-- channel-mode fields, coordinated by the picker so they update together -->
+    <div [(ngpColorPickerValue)]="color" ngpColorPicker>
+      <div class="swatch" [style.background]="color.toHex()"></div>
+
+      <div class="field">
+        <label for="r">R</label>
+        <input id="r" ngpColorField ngpColorFieldChannel="red" />
+      </div>
+      <div class="field">
+        <label for="g">G</label>
+        <input id="g" ngpColorField ngpColorFieldChannel="green" />
+      </div>
+      <div class="field">
+        <label for="b">B</label>
+        <input id="b" ngpColorField ngpColorFieldChannel="blue" />
+      </div>
+    </div>
+  `,
+})
+export default class ColorFieldExample {
+  color: Color = Color.parse('#3366cc');
+}

--- a/apps/documentation/src/app/examples/color/color-picker-popover.example.ts
+++ b/apps/documentation/src/app/examples/color/color-picker-popover.example.ts
@@ -1,0 +1,214 @@
+import { Component } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import {
+  Color,
+  NgpColorArea,
+  NgpColorAreaThumb,
+  NgpColorField,
+  NgpColorPicker,
+  NgpColorSlider,
+  NgpColorSliderThumb,
+  NgpColorSliderTrack,
+} from 'ng-primitives/color';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+
+@Component({
+  selector: 'app-color-picker-popover',
+  imports: [
+    NgpButton,
+    NgpPopoverTrigger,
+    NgpPopover,
+    NgpColorPicker,
+    NgpColorArea,
+    NgpColorAreaThumb,
+    NgpColorSlider,
+    NgpColorSliderTrack,
+    NgpColorSliderThumb,
+    NgpColorField,
+  ],
+  styles: `
+    .trigger {
+      width: 34px;
+      height: 34px;
+      padding: 0;
+      border: none;
+      border-radius: 0.5rem;
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.15);
+      cursor: pointer;
+      outline: none;
+    }
+
+    .trigger[data-focus-visible] {
+      box-shadow:
+        inset 0 0 0 1px rgb(0 0 0 / 0.15),
+        0 0 0 2px var(--ngp-focus-ring);
+    }
+
+    [ngpPopover] {
+      position: absolute;
+      width: 240px;
+      padding: 12px;
+      border-radius: 0.75rem;
+      background: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      box-shadow: var(--ngp-shadow);
+      outline: none;
+      animation: color-popover-show 0.1s ease-out;
+      transform-origin: var(--ngp-popover-transform-origin);
+    }
+
+    [ngpPopover][data-exit] {
+      animation: color-popover-show 0.1s ease-out reverse;
+    }
+
+    @keyframes color-popover-show {
+      from {
+        opacity: 0;
+        transform: scale(0.97);
+      }
+      to {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    [ngpColorPicker] {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    [ngpColorArea] {
+      position: relative;
+      width: 100%;
+      height: 160px;
+      border-radius: 0.625rem;
+      background: var(--ngp-color-area-background);
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+      touch-action: none;
+      user-select: none;
+    }
+
+    [ngpColorAreaThumb],
+    [ngpColorSliderThumb] {
+      position: absolute;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      border: 2px solid #fff;
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 1px 2px rgb(0 0 0 / 0.3);
+      transform: translate(-50%, -50%);
+      outline: none;
+    }
+
+    /* invisible 44px touch targets */
+    [ngpColorAreaThumb]::before,
+    [ngpColorSliderThumb]::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 44px;
+      height: 44px;
+      transform: translate(-50%, -50%);
+    }
+
+    [ngpColorAreaThumb][data-focus-visible],
+    [ngpColorSliderThumb][data-focus-visible] {
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 0 0 3px var(--ngp-focus-ring);
+    }
+
+    [ngpColorSlider] {
+      position: relative;
+      width: 100%;
+      height: 14px;
+      touch-action: none;
+      user-select: none;
+    }
+
+    [ngpColorSliderThumb] {
+      top: 50%;
+    }
+
+    [ngpColorSliderTrack] {
+      position: absolute;
+      inset: 0;
+      border-radius: 999px;
+      background: var(--ngp-color-slider-background);
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+    }
+
+    .row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .preview {
+      width: 34px;
+      height: 34px;
+      flex-shrink: 0;
+      border-radius: 0.5rem;
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+    }
+
+    [ngpColorField] {
+      flex: 1;
+      min-width: 0;
+      height: 34px;
+      padding: 0 0.625rem;
+      font-size: 0.875rem;
+      font-weight: 510;
+      letter-spacing: -0.006em;
+      color: var(--ngp-text-primary);
+      background-color: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      border-radius: 0.5rem;
+      outline: none;
+      text-transform: lowercase;
+    }
+
+    [ngpColorField][data-focus] {
+      border-color: var(--ngp-focus-ring);
+      box-shadow: 0 0 0 1px var(--ngp-focus-ring);
+    }
+  `,
+  template: `
+    <!-- the trigger swatch shows the current color; clicking opens the picker -->
+    <button
+      class="trigger"
+      [ngpPopoverTrigger]="picker"
+      [style.background]="color.toHex()"
+      ngpButton
+      type="button"
+      aria-label="Choose color"
+    ></button>
+
+    <ng-template #picker>
+      <div ngpPopover>
+        <div [(ngpColorPickerValue)]="color" ngpColorPicker>
+          <div ngpColorArea ngpColorAreaXChannel="saturation" ngpColorAreaYChannel="brightness">
+            <div ngpColorAreaThumb></div>
+          </div>
+
+          <div ngpColorSlider ngpColorSliderChannel="hue">
+            <div ngpColorSliderTrack></div>
+            <div ngpColorSliderThumb></div>
+          </div>
+
+          <div class="row">
+            <div class="preview" [style.background]="color.toHex()"></div>
+            <input ngpColorField aria-label="Hex" />
+          </div>
+        </div>
+      </div>
+    </ng-template>
+  `,
+})
+export default class ColorPickerPopoverExample {
+  color: Color = Color.parse('#f01e2b');
+}

--- a/apps/documentation/src/app/examples/color/color-picker.example.ts
+++ b/apps/documentation/src/app/examples/color/color-picker.example.ts
@@ -1,0 +1,185 @@
+import { Component } from '@angular/core';
+import {
+  Color,
+  NgpColorArea,
+  NgpColorAreaThumb,
+  NgpColorField,
+  NgpColorPicker,
+  NgpColorSlider,
+  NgpColorSliderThumb,
+  NgpColorSliderTrack,
+} from 'ng-primitives/color';
+
+@Component({
+  selector: 'app-color-picker',
+  imports: [
+    NgpColorPicker,
+    NgpColorArea,
+    NgpColorAreaThumb,
+    NgpColorSlider,
+    NgpColorSliderTrack,
+    NgpColorSliderThumb,
+    NgpColorField,
+  ],
+  styles: `
+    [ngpColorPicker] {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      width: 100%;
+      max-width: 240px;
+      padding: 12px;
+      border-radius: 0.75rem;
+      background-color: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      box-shadow: var(--ngp-shadow);
+    }
+
+    [ngpColorArea] {
+      position: relative;
+      width: 100%;
+      height: 160px;
+      border-radius: 0.625rem;
+      /* the functional 2D gradient computed by the primitive */
+      background: var(--ngp-color-area-background);
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+      touch-action: none;
+      user-select: none;
+    }
+
+    [ngpColorAreaThumb] {
+      position: absolute;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: transparent;
+      border: 2px solid #fff;
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 1px 2px rgb(0 0 0 / 0.3);
+      transform: translate(-50%, -50%);
+      outline: none;
+    }
+
+    /* invisible 44px touch target */
+    [ngpColorAreaThumb]::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 44px;
+      height: 44px;
+      transform: translate(-50%, -50%);
+    }
+
+    [ngpColorAreaThumb][data-focus-visible] {
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 0 0 3px var(--ngp-focus-ring);
+    }
+
+    [ngpColorSlider] {
+      position: relative;
+      width: 100%;
+      height: 14px;
+      touch-action: none;
+      user-select: none;
+    }
+
+    [ngpColorSliderTrack] {
+      position: absolute;
+      inset: 0;
+      border-radius: 999px;
+      /* the functional channel gradient computed by the primitive */
+      background: var(--ngp-color-slider-background);
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+    }
+
+    [ngpColorSliderThumb] {
+      position: absolute;
+      top: 50%;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: transparent;
+      border: 2px solid #fff;
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 1px 2px rgb(0 0 0 / 0.3);
+      transform: translate(-50%, -50%);
+      outline: none;
+    }
+
+    /* invisible 44px touch target */
+    [ngpColorSliderThumb]::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 44px;
+      height: 44px;
+      transform: translate(-50%, -50%);
+    }
+
+    [ngpColorSliderThumb][data-focus-visible] {
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 0 0 3px var(--ngp-focus-ring);
+    }
+
+    .color-picker-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .color-picker-preview {
+      width: 34px;
+      height: 34px;
+      flex-shrink: 0;
+      border-radius: 0.5rem;
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+    }
+
+    [ngpColorField] {
+      flex: 1;
+      min-width: 0;
+      height: 34px;
+      padding: 0 0.625rem;
+      font-size: 0.875rem;
+      font-weight: 510;
+      letter-spacing: -0.006em;
+      color: var(--ngp-text-primary);
+      background-color: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      border-radius: 0.5rem;
+      outline: none;
+      text-transform: lowercase;
+    }
+
+    [ngpColorField][data-focus] {
+      border-color: var(--ngp-focus-ring);
+      box-shadow: 0 0 0 1px var(--ngp-focus-ring);
+    }
+  `,
+  template: `
+    <div [(ngpColorPickerValue)]="color" ngpColorPicker>
+      <div ngpColorArea ngpColorAreaXChannel="saturation" ngpColorAreaYChannel="brightness">
+        <div ngpColorAreaThumb></div>
+      </div>
+
+      <div ngpColorSlider ngpColorSliderChannel="hue">
+        <div ngpColorSliderTrack></div>
+        <div ngpColorSliderThumb></div>
+      </div>
+
+      <div class="color-picker-row">
+        <div class="color-picker-preview" [style.background]="color.toHex()"></div>
+        <input ngpColorField aria-label="Hex" />
+      </div>
+    </div>
+  `,
+})
+export default class ColorPickerExample {
+  color: Color = Color.parse('#f01e2b');
+}

--- a/apps/documentation/src/app/examples/color/color-picker.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/color/color-picker.tailwind.example.ts
@@ -1,0 +1,76 @@
+import { Component } from '@angular/core';
+import {
+  Color,
+  NgpColorArea,
+  NgpColorAreaThumb,
+  NgpColorField,
+  NgpColorPicker,
+  NgpColorSlider,
+  NgpColorSliderThumb,
+  NgpColorSliderTrack,
+} from 'ng-primitives/color';
+
+@Component({
+  selector: 'app-color-picker',
+  imports: [
+    NgpColorPicker,
+    NgpColorArea,
+    NgpColorAreaThumb,
+    NgpColorSlider,
+    NgpColorSliderTrack,
+    NgpColorSliderThumb,
+    NgpColorField,
+  ],
+  host: {
+    class: 'contents',
+  },
+  template: `
+    <div
+      class="flex w-full max-w-60 flex-col gap-3 rounded-xl border border-gray-200 bg-white p-3 shadow-sm dark:border-zinc-800 dark:bg-zinc-950"
+      [(ngpColorPickerValue)]="color"
+      ngpColorPicker
+    >
+      <div
+        class="relative h-40 w-full touch-none rounded-[0.625rem] shadow-[inset_0_0_0_1px_rgb(0_0_0/0.1)] select-none [background:var(--ngp-color-area-background)]"
+        ngpColorArea
+        ngpColorAreaXChannel="saturation"
+        ngpColorAreaYChannel="brightness"
+      >
+        <div
+          class="absolute size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow-[0_0_0_1px_rgb(0_0_0/0.3),0_1px_2px_rgb(0_0_0/0.3)] outline-none before:absolute before:top-1/2 before:left-1/2 before:size-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] data-[focus-visible]:shadow-[0_0_0_1px_rgb(0_0_0/0.3),0_0_0_3px_theme(colors.blue.500)] dark:data-[focus-visible]:shadow-[0_0_0_1px_rgb(0_0_0/0.3),0_0_0_3px_theme(colors.blue.400)]"
+          ngpColorAreaThumb
+        ></div>
+      </div>
+
+      <div
+        class="relative h-3.5 w-full touch-none select-none"
+        ngpColorSlider
+        ngpColorSliderChannel="hue"
+      >
+        <div
+          class="absolute inset-0 rounded-full shadow-[inset_0_0_0_1px_rgb(0_0_0/0.1)] [background:var(--ngp-color-slider-background)]"
+          ngpColorSliderTrack
+        ></div>
+        <div
+          class="absolute top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow-[0_0_0_1px_rgb(0_0_0/0.3),0_1px_2px_rgb(0_0_0/0.3)] outline-none before:absolute before:top-1/2 before:left-1/2 before:size-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-[''] data-[focus-visible]:shadow-[0_0_0_1px_rgb(0_0_0/0.3),0_0_0_3px_theme(colors.blue.500)] dark:data-[focus-visible]:shadow-[0_0_0_1px_rgb(0_0_0/0.3),0_0_0_3px_theme(colors.blue.400)]"
+          ngpColorSliderThumb
+        ></div>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <div
+          class="size-[34px] shrink-0 rounded-lg shadow-[inset_0_0_0_1px_rgb(0_0_0/0.1)]"
+          [style.background]="color.toHex()"
+        ></div>
+        <input
+          class="h-[34px] min-w-0 flex-1 rounded-lg border border-gray-200 bg-white px-2.5 text-sm font-[510] tracking-[-0.006em] text-gray-950 lowercase outline-none data-[focus]:border-blue-500 data-[focus]:ring-1 data-[focus]:ring-blue-500 dark:border-zinc-800 dark:bg-zinc-950 dark:text-white dark:data-[focus]:border-blue-400 dark:data-[focus]:ring-blue-400"
+          ngpColorField
+          aria-label="Hex"
+        />
+      </div>
+    </div>
+  `,
+})
+export default class ColorPickerExample {
+  color: Color = Color.parse('#f01e2b');
+}

--- a/apps/documentation/src/app/examples/color/color-slider-alpha.example.ts
+++ b/apps/documentation/src/app/examples/color/color-slider-alpha.example.ts
@@ -1,0 +1,91 @@
+import { Component } from '@angular/core';
+import {
+  Color,
+  NgpColorSlider,
+  NgpColorSliderThumb,
+  NgpColorSliderTrack,
+} from 'ng-primitives/color';
+
+@Component({
+  selector: 'app-color-slider-alpha',
+  imports: [NgpColorSlider, NgpColorSliderTrack, NgpColorSliderThumb],
+  styles: `
+    :host {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 8px;
+    }
+
+    .value {
+      font-size: 0.875rem;
+      font-variant-numeric: tabular-nums;
+      color: var(--ngp-text-secondary);
+      letter-spacing: -0.006em;
+    }
+
+    [ngpColorSlider] {
+      position: relative;
+      width: 200px;
+      height: 14px;
+      touch-action: none;
+      user-select: none;
+    }
+
+    [ngpColorSliderTrack] {
+      position: absolute;
+      inset: 0;
+      border-radius: 999px;
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+      /* the channel gradient (transparent -> opaque) sits over a checkerboard */
+      background:
+        var(--ngp-color-slider-background),
+        conic-gradient(#c8c8c8 25%, #fff 0 50%, #c8c8c8 0 75%, #fff 0);
+      background-size:
+        auto,
+        12px 12px;
+    }
+
+    [ngpColorSliderThumb] {
+      position: absolute;
+      top: 50%;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      border: 2px solid #fff;
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 1px 2px rgb(0 0 0 / 0.3);
+      transform: translate(-50%, -50%);
+      outline: none;
+    }
+
+    /* invisible 44px touch target */
+    [ngpColorSliderThumb]::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 44px;
+      height: 44px;
+      transform: translate(-50%, -50%);
+    }
+
+    [ngpColorSliderThumb][data-focus-visible] {
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 0 0 3px var(--ngp-focus-ring);
+    }
+  `,
+  template: `
+    <div [(ngpColorSliderValue)]="color" ngpColorSlider ngpColorSliderChannel="alpha">
+      <div ngpColorSliderTrack></div>
+      <div ngpColorSliderThumb></div>
+    </div>
+
+    <span class="value">{{ color.toRgba() }}</span>
+  `,
+})
+export default class ColorSliderAlphaExample {
+  color: Color = Color.parse('rgba(240, 30, 43, 1)');
+}

--- a/apps/documentation/src/app/examples/color/color-slider.example.ts
+++ b/apps/documentation/src/app/examples/color/color-slider.example.ts
@@ -1,0 +1,86 @@
+import { Component } from '@angular/core';
+import {
+  Color,
+  NgpColorSlider,
+  NgpColorSliderThumb,
+  NgpColorSliderTrack,
+} from 'ng-primitives/color';
+
+@Component({
+  selector: 'app-color-slider',
+  imports: [NgpColorSlider, NgpColorSliderTrack, NgpColorSliderThumb],
+  styles: `
+    :host {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .swatch {
+      width: 34px;
+      height: 34px;
+      flex-shrink: 0;
+      border-radius: 0.5rem;
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+    }
+
+    [ngpColorSlider] {
+      position: relative;
+      width: 200px;
+      height: 14px;
+      touch-action: none;
+      user-select: none;
+    }
+
+    [ngpColorSliderTrack] {
+      position: absolute;
+      inset: 0;
+      border-radius: 999px;
+      background: var(--ngp-color-slider-background);
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+    }
+
+    [ngpColorSliderThumb] {
+      position: absolute;
+      top: 50%;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      border: 2px solid #fff;
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 1px 2px rgb(0 0 0 / 0.3);
+      transform: translate(-50%, -50%);
+      outline: none;
+    }
+
+    /* invisible 44px touch target */
+    [ngpColorSliderThumb]::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 44px;
+      height: 44px;
+      transform: translate(-50%, -50%);
+    }
+
+    [ngpColorSliderThumb][data-focus-visible] {
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 0 0 3px var(--ngp-focus-ring);
+    }
+  `,
+  template: `
+    <!-- a color slider works standalone, without a color picker -->
+    <div class="swatch" [style.background]="color.toHex()"></div>
+
+    <div [(ngpColorSliderValue)]="color" ngpColorSlider ngpColorSliderChannel="hue">
+      <div ngpColorSliderTrack></div>
+      <div ngpColorSliderThumb></div>
+    </div>
+  `,
+})
+export default class ColorSliderExample {
+  color: Color = Color.parse('hsl(200, 90%, 50%)');
+}

--- a/apps/documentation/src/app/examples/color/color-swatch-picker.example.ts
+++ b/apps/documentation/src/app/examples/color/color-swatch-picker.example.ts
@@ -1,0 +1,72 @@
+import { Component } from '@angular/core';
+import { Color, NgpColorSwatchPicker, NgpColorSwatchPickerItem } from 'ng-primitives/color';
+
+@Component({
+  selector: 'app-color-swatch-picker',
+  imports: [NgpColorSwatchPicker, NgpColorSwatchPickerItem],
+  styles: `
+    [ngpColorSwatchPicker] {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      max-width: 200px;
+      outline: none;
+    }
+
+    .swatch {
+      width: 28px;
+      height: 28px;
+      padding: 0;
+      border: none;
+      border-radius: 0.5rem;
+      background: var(--ngp-color-swatch-color);
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+      cursor: pointer;
+      outline: none;
+      transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .swatch[data-hover] {
+      transform: scale(1.08);
+    }
+
+    .swatch[data-focus-visible] {
+      box-shadow:
+        inset 0 0 0 1px rgb(0 0 0 / 0.1),
+        0 0 0 2px var(--ngp-focus-ring);
+    }
+
+    /* the selected swatch gets a neutral ring so it doesn't clash with the swatch colors */
+    .swatch[data-selected] {
+      box-shadow:
+        inset 0 0 0 1px rgb(0 0 0 / 0.1),
+        0 0 0 2px var(--ngp-background),
+        0 0 0 3.5px var(--ngp-text-primary);
+    }
+  `,
+  template: `
+    <div [(ngpColorSwatchPickerValue)]="color" ngpColorSwatchPicker aria-label="Color swatches">
+      @for (swatch of swatches; track swatch) {
+        <button
+          class="swatch"
+          [ngpColorSwatchPickerItem]="swatch"
+          [attr.aria-label]="swatch.toHex()"
+        ></button>
+      }
+    </div>
+  `,
+})
+export default class ColorSwatchPickerExample {
+  readonly swatches: Color[] = [
+    '#f01e2b',
+    '#f97316',
+    '#eab308',
+    '#22c55e',
+    '#06b6d4',
+    '#3b82f6',
+    '#8b5cf6',
+    '#ec4899',
+    '#111827',
+  ].map(hex => Color.parse(hex));
+  color: Color = Color.parse('#3b82f6');
+}

--- a/apps/documentation/src/app/examples/color/color-wheel.example.ts
+++ b/apps/documentation/src/app/examples/color/color-wheel.example.ts
@@ -1,0 +1,77 @@
+import { Component } from '@angular/core';
+import { Color, NgpColorWheel, NgpColorWheelThumb } from 'ng-primitives/color';
+
+@Component({
+  selector: 'app-color-wheel',
+  imports: [NgpColorWheel, NgpColorWheelThumb],
+  styles: `
+    :host {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .swatch {
+      width: 40px;
+      height: 40px;
+      border-radius: 0.625rem;
+      box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1);
+    }
+
+    [ngpColorWheel] {
+      position: relative;
+      width: 180px;
+      height: 180px;
+      border-radius: 50%;
+      background: var(--ngp-color-wheel-background);
+      /* carve out the centre to leave a colour ring */
+      mask: radial-gradient(farthest-side, transparent calc(100% - 26px), #000 calc(100% - 26px));
+      touch-action: none;
+      user-select: none;
+    }
+
+    [ngpColorWheelThumb] {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 18px;
+      height: 18px;
+      margin: -9px;
+      border-radius: 50%;
+      border: 2px solid #fff;
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 1px 2px rgb(0 0 0 / 0.3);
+      /* position on the ring using the hue angle exposed by the primitive */
+      transform: rotate(var(--ngp-color-wheel-hue)) translateY(-77px);
+      outline: none;
+    }
+
+    /* invisible 44px touch target */
+    [ngpColorWheelThumb]::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 44px;
+      height: 44px;
+      transform: translate(-50%, -50%);
+    }
+
+    [ngpColorWheelThumb][data-focus-visible] {
+      box-shadow:
+        0 0 0 1px rgb(0 0 0 / 0.3),
+        0 0 0 3px var(--ngp-focus-ring);
+    }
+  `,
+  template: `
+    <div [(ngpColorWheelValue)]="color" ngpColorWheel>
+      <div ngpColorWheelThumb></div>
+    </div>
+
+    <div class="swatch" [style.background]="color.toHex()"></div>
+  `,
+})
+export default class ColorWheelExample {
+  color: Color = Color.parse('hsl(140, 90%, 50%)');
+}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/color-picker.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/color-picker.md
@@ -1,0 +1,296 @@
+---
+name: 'Color Picker'
+sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/color'
+---
+
+# Color Picker
+
+A composable, accessible color picker: a 2D area, channel sliders and hex/channel fields that share one color value.
+
+**Note:** The color primitives are currently experimental. The API may change in future releases.
+
+<docs-example name="color-picker"></docs-example>
+
+## Import
+
+Import the color primitives from `ng-primitives/color`.
+
+```ts
+import {
+  Color,
+  NgpColorPicker,
+  NgpColorArea,
+  NgpColorAreaThumb,
+  NgpColorSlider,
+  NgpColorSliderTrack,
+  NgpColorSliderThumb,
+  NgpColorField,
+} from 'ng-primitives/color';
+```
+
+## Usage
+
+`NgpColorPicker` is an optional coordinator: it holds a single color value and shares it with any color
+components nested inside it. Each color component also works standalone with its own `value`/`valueChange`.
+
+```html
+<div [(ngpColorPickerValue)]="color" ngpColorPicker>
+  <!-- adjust two channels on a 2D surface -->
+  <div ngpColorArea ngpColorAreaXChannel="saturation" ngpColorAreaYChannel="brightness">
+    <div ngpColorAreaThumb></div>
+  </div>
+
+  <!-- adjust the hue -->
+  <div ngpColorSlider ngpColorSliderChannel="hue">
+    <div ngpColorSliderTrack></div>
+    <div ngpColorSliderThumb></div>
+  </div>
+
+  <!-- edit the hex value -->
+  <input ngpColorField />
+</div>
+```
+
+## Color values
+
+Color values are represented by an immutable `Color` object. Parse one from any CSS color string with
+`Color.parse`, and read it back in any format with the `to*` methods.
+
+```ts
+import { Color } from 'ng-primitives/color';
+
+const color = Color.parse('#f01e2b'); // hex, rgb(a), hsl(a) and hsb(a) are all supported
+color.toHex(); // '#f01e2b'
+color.toRgb(); // 'rgb(240, 30, 43)'
+color.toHsl(); // 'hsl(356, 88%, 53%)'
+color.getRed(); // 240  (or color.getChannelValue('red'))
+color.withRed(0); // a new Color, original unchanged
+color.withAlpha(0.5).toRgba(); // 'rgba(240, 30, 43, 0.5)'
+```
+
+Reads and derivations auto-convert across spaces, so `color.getHue()` and `color.withHue(200)`
+(or the generic `getChannelValue`/`withChannelValue`) work regardless of the color's current space
+(ambiguous channels resolve to hsb).
+
+The `value` inputs and `valueChange` outputs are always a `Color`, so bind `[(ngpColorPickerValue)]` to a
+`Color` (use `Color.parse('#f01e2b')` to create one from a string).
+
+## Gradients
+
+The area and sliders compute their functional gradient and expose it as a CSS custom property, which you opt
+into as a background:
+
+- `NgpColorArea` sets `--ngp-color-area-background`.
+- `NgpColorSlider` sets `--ngp-color-slider-background` (it inherits down to the track).
+
+```css
+[ngpColorArea] {
+  background: var(--ngp-color-area-background);
+}
+[ngpColorSliderTrack] {
+  background: var(--ngp-color-slider-background);
+}
+```
+
+The area background is tuned for the default `saturation` × `brightness` pairing. If you set different
+`xChannel`/`yChannel` values, provide your own `background` for the area rather than relying on the var.
+
+## Examples
+
+Here are some additional examples of how to use the color primitives.
+
+### Standalone Slider
+
+A color slider works on its own, without a color picker, adjusting a single channel of its own value.
+
+<docs-example name="color-slider"></docs-example>
+
+### Alpha Slider
+
+Set the channel to `alpha` and layer the gradient over a checkerboard to edit transparency.
+
+<docs-example name="color-slider-alpha"></docs-example>
+
+### Channel Fields
+
+Give `NgpColorField` a channel to edit that channel as a number. Nested in a picker, the fields stay in sync.
+
+<docs-example name="color-field"></docs-example>
+
+### Color Wheel
+
+`NgpColorWheel` is a circular alternative to a hue slider. Position the thumb with the `--ngp-color-wheel-hue` angle.
+
+<docs-example name="color-wheel"></docs-example>
+
+### Swatch Picker
+
+`NgpColorSwatchPicker` presents a set of predefined colors as a keyboard-navigable, single-select list.
+
+<docs-example name="color-swatch-picker"></docs-example>
+
+### Popover
+
+Pair the picker with a [popover](/primitives/popover) so a swatch button opens the full picker on demand.
+
+<docs-example name="color-picker-popover"></docs-example>
+
+## API Reference
+
+The following directives are available to import from the `ng-primitives/color` package:
+
+### NgpColorPicker
+
+<api-docs name="NgpColorPicker"></api-docs>
+
+<api-reference-props name="NgpColorPicker"></api-reference-props>
+
+### NgpColorArea
+
+<api-docs name="NgpColorArea"></api-docs>
+
+<api-reference-props name="NgpColorArea"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-disabled" description="Applied when the area is disabled." />
+</api-reference-attributes>
+
+### NgpColorAreaThumb
+
+<api-docs name="NgpColorAreaThumb"></api-docs>
+
+<api-reference-props name="NgpColorAreaThumb"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-disabled" description="Applied when the area is disabled." />
+  <api-attribute name="data-hover" description="Applied when the thumb is hovered." />
+  <api-attribute name="data-focus-visible" description="Applied when the thumb is focused via the keyboard." />
+  <api-attribute name="data-press" description="Applied when the thumb is pressed." />
+</api-reference-attributes>
+
+### NgpColorSlider
+
+<api-docs name="NgpColorSlider"></api-docs>
+
+<api-reference-props name="NgpColorSlider"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-disabled" description="Applied when the slider is disabled." />
+  <api-attribute name="data-orientation" description="The orientation of the slider." value="horizontal | vertical" />
+</api-reference-attributes>
+
+### NgpColorSliderTrack
+
+<api-docs name="NgpColorSliderTrack"></api-docs>
+
+<api-reference-props name="NgpColorSliderTrack"></api-reference-props>
+
+### NgpColorSliderThumb
+
+<api-docs name="NgpColorSliderThumb"></api-docs>
+
+<api-reference-props name="NgpColorSliderThumb"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-disabled" description="Applied when the slider is disabled." />
+  <api-attribute name="data-orientation" description="The orientation of the slider." value="horizontal | vertical" />
+  <api-attribute name="data-hover" description="Applied when the thumb is hovered." />
+  <api-attribute name="data-focus-visible" description="Applied when the thumb is focused via the keyboard." />
+  <api-attribute name="data-press" description="Applied when the thumb is pressed." />
+</api-reference-attributes>
+
+### NgpColorField
+
+<api-docs name="NgpColorField"></api-docs>
+
+<api-reference-props name="NgpColorField"></api-reference-props>
+
+### NgpColorWheel
+
+A circular control adjusting the hue channel. Set its background to `var(--ngp-color-wheel-background)`.
+
+<api-docs name="NgpColorWheel"></api-docs>
+
+<api-reference-props name="NgpColorWheel"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-disabled" description="Applied when the wheel is disabled." />
+</api-reference-attributes>
+
+### NgpColorWheelThumb
+
+The draggable thumb within a color wheel. Position it with the `--ngp-color-wheel-hue` custom property.
+
+<api-docs name="NgpColorWheelThumb"></api-docs>
+
+<api-reference-props name="NgpColorWheelThumb"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-disabled" description="Applied when the wheel is disabled." />
+  <api-attribute name="data-hover" description="Applied when the thumb is hovered." />
+  <api-attribute name="data-focus-visible" description="Applied when the thumb is focused via the keyboard." />
+  <api-attribute name="data-press" description="Applied when the thumb is pressed." />
+</api-reference-attributes>
+
+### NgpColorSwatch
+
+A non-interactive preview of a color. Set its background to `var(--ngp-color-swatch-color)`.
+
+<api-docs name="NgpColorSwatch"></api-docs>
+
+<api-reference-props name="NgpColorSwatch"></api-reference-props>
+
+### NgpColorSwatchPicker
+
+A single-select list of color swatches with roving-focus keyboard navigation.
+
+<api-docs name="NgpColorSwatchPicker"></api-docs>
+
+<api-reference-props name="NgpColorSwatchPicker"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-orientation" description="The orientation of the swatch list." value="horizontal | vertical" />
+  <api-attribute name="data-disabled" description="Applied when the swatch picker is disabled." />
+</api-reference-attributes>
+
+### NgpColorSwatchPickerItem
+
+A selectable swatch within a swatch picker. Set its background to `var(--ngp-color-swatch-color)`.
+
+<api-docs name="NgpColorSwatchPickerItem"></api-docs>
+
+<api-reference-props name="NgpColorSwatchPickerItem"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-selected" description="Applied when the swatch is the selected color." />
+  <api-attribute name="data-disabled" description="Applied when the swatch is disabled." />
+  <api-attribute name="data-hover" description="Applied when the swatch is hovered." />
+  <api-attribute name="data-focus-visible" description="Applied when the swatch is focused via the keyboard." />
+  <api-attribute name="data-press" description="Applied when the swatch is pressed." />
+</api-reference-attributes>
+
+## Accessibility
+
+Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider/).
+
+The area, sliders and wheel each expose a `slider` role. The color area is a two-dimensional control, so
+its thumb additionally exposes an `aria-valuetext` describing both channels (for example
+`saturation 50, brightness 70`). The swatch picker uses a `listbox` role with selectable `option` swatches.
+
+### Keyboard Interactions
+
+On a slider or the wheel, all four arrows adjust its single channel:
+
+- <kbd>Left Arrow</kbd> / <kbd>Down Arrow</kbd>: Decrease the channel by the step.
+- <kbd>Right Arrow</kbd> / <kbd>Up Arrow</kbd>: Increase the channel by the step.
+- <kbd>Home</kbd> / <kbd>End</kbd>: Set the channel to its minimum / maximum.
+
+On the color area, the horizontal and vertical arrows adjust separate channels:
+
+- <kbd>Left Arrow</kbd> / <kbd>Right Arrow</kbd>: Decrease / increase the x channel.
+- <kbd>Down Arrow</kbd> / <kbd>Up Arrow</kbd>: Decrease / increase the y channel.
+
+For all of the above:
+
+- <kbd>Shift</kbd> + arrow: Adjust by a larger amount.
+- <kbd>Enter</kbd> / <kbd>Space</kbd>: Select the focused swatch (swatch picker).

--- a/packages/ng-primitives/color/README.md
+++ b/packages/ng-primitives/color/README.md
@@ -1,0 +1,3 @@
+# ng-primitives/color
+
+Secondary entry point of `ng-primitives`. It can be used by importing from `ng-primitives/color`.

--- a/packages/ng-primitives/color/ng-package.json
+++ b/packages/ng-primitives/color/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/ng-primitives/color/src/color-area-thumb/color-area-thumb-state.ts
+++ b/packages/ng-primitives/color/src/color-area-thumb/color-area-thumb-state.ts
@@ -1,0 +1,112 @@
+import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
+import { computed, inject } from '@angular/core';
+import { ngpInteractions } from 'ng-primitives/interactions';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  createPrimitive,
+  dataBinding,
+  listener,
+  onDestroy,
+  styleBinding,
+} from 'ng-primitives/state';
+import { injectColorAreaState } from '../color-area/color-area-state';
+
+type AreaKey = 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown';
+
+/**
+ * Public state surface for the Color Area Thumb primitive.
+ */
+export interface NgpColorAreaThumbState {
+  /** Focus the thumb element. */
+  focus(origin?: FocusOrigin): void;
+}
+
+/**
+ * Inputs for configuring the Color Area Thumb primitive.
+ */
+export interface NgpColorAreaThumbProps {}
+
+export const [
+  NgpColorAreaThumbStateToken,
+  ngpColorAreaThumb,
+  injectColorAreaThumbState,
+  provideColorAreaThumbState,
+] = createPrimitive('NgpColorAreaThumb', ({}: NgpColorAreaThumbProps): NgpColorAreaThumbState => {
+  const element = injectElementRef<HTMLElement>();
+  const area = injectColorAreaState();
+  const focusMonitor = inject(FocusMonitor);
+
+  const tabindex = computed(() => (area().disabled() ? -1 : 0));
+
+  // Host bindings. A color area is a 2D control with no single ARIA role, so we expose a
+  // slider whose aria-valuetext describes both channels (aria-valuenow tracks the x channel).
+  attrBinding(element, 'role', 'slider');
+  attrBinding(element, 'aria-label', () => `${area().xChannel()} and ${area().yChannel()}`);
+  attrBinding(element, 'aria-valuemin', () => area().xRange().min.toString());
+  attrBinding(element, 'aria-valuemax', () => area().xRange().max.toString());
+  attrBinding(element, 'aria-valuenow', () => Math.round(area().xValue()).toString());
+  attrBinding(
+    element,
+    'aria-valuetext',
+    () =>
+      `${area().xChannel()} ${Math.round(area().xValue())}, ${area().yChannel()} ${Math.round(
+        area().yValue(),
+      )}`,
+  );
+  attrBinding(element, 'tabindex', () => tabindex().toString());
+  dataBinding(element, 'data-disabled', () => area().disabled());
+  styleBinding(element, 'inset-inline-start.%', () => area().xPercentage());
+  styleBinding(element, 'inset-block-start.%', () => 100 - area().yPercentage());
+
+  ngpInteractions({
+    hover: true,
+    focusVisible: true,
+    press: true,
+    disabled: area().disabled,
+  });
+
+  area().setThumb(element);
+  onDestroy(() => area().setThumb(undefined));
+
+  // Keyboard: arrows move in 2D (x = left/right, y = up/down), shift for a x10 step.
+  listener(element, 'keydown', (event: KeyboardEvent) => {
+    if (area().disabled()) {
+      return;
+    }
+
+    const isRTL = getComputedStyle(element.nativeElement).direction === 'rtl';
+    const multiplier = event.shiftKey ? 10 : 1;
+
+    switch (event.key as AreaKey) {
+      case 'ArrowLeft':
+        area().adjustChannel(
+          area().xChannel(),
+          (isRTL ? 1 : -1) * area().xRange().step * multiplier,
+        );
+        break;
+      case 'ArrowRight':
+        area().adjustChannel(
+          area().xChannel(),
+          (isRTL ? -1 : 1) * area().xRange().step * multiplier,
+        );
+        break;
+      case 'ArrowUp':
+        area().adjustChannel(area().yChannel(), area().yRange().step * multiplier);
+        break;
+      case 'ArrowDown':
+        area().adjustChannel(area().yChannel(), -area().yRange().step * multiplier);
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+  });
+
+  function focus(origin: FocusOrigin = 'program'): void {
+    focusMonitor.focusVia(element, origin, { preventScroll: true });
+  }
+
+  return { focus } satisfies NgpColorAreaThumbState;
+});

--- a/packages/ng-primitives/color/src/color-area-thumb/color-area-thumb.ts
+++ b/packages/ng-primitives/color/src/color-area-thumb/color-area-thumb.ts
@@ -1,0 +1,16 @@
+import { Directive } from '@angular/core';
+import { ngpColorAreaThumb, provideColorAreaThumbState } from './color-area-thumb-state';
+
+/**
+ * Apply the `ngpColorAreaThumb` directive to the element that represents the color area thumb.
+ */
+@Directive({
+  selector: '[ngpColorAreaThumb]',
+  exportAs: 'ngpColorAreaThumb',
+  providers: [provideColorAreaThumbState()],
+})
+export class NgpColorAreaThumb {
+  constructor() {
+    ngpColorAreaThumb({});
+  }
+}

--- a/packages/ng-primitives/color/src/color-area/color-area-state.ts
+++ b/packages/ng-primitives/color/src/color-area/color-area-state.ts
@@ -1,0 +1,304 @@
+import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
+import { DOCUMENT } from '@angular/common';
+import {
+  computed,
+  ElementRef,
+  inject,
+  Injector,
+  Signal,
+  signal,
+  WritableSignal,
+} from '@angular/core';
+import { ngpFormControl } from 'ng-primitives/form-field';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  controlled,
+  createPrimitive,
+  dataBinding,
+  emitter,
+  listener,
+  SetterOptions,
+  styleBinding,
+} from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Observable } from 'rxjs';
+import { injectColorPickerState } from '../color-picker/color-picker-state';
+import { Color, ColorChannel, ColorChannelRange, ColorSpace } from '../color/color';
+
+/**
+ * Public state surface for the Color Area primitive - a 2D surface adjusting two channels
+ * of a color value against a gradient background.
+ */
+export interface NgpColorAreaState {
+  /** The id of the area. */
+  readonly id: Signal<string>;
+  /** The current color value (the parent picker's value when inside one). */
+  readonly value: Signal<Color>;
+  /** The channel mapped to the horizontal axis. */
+  readonly xChannel: Signal<ColorChannel>;
+  /** The channel mapped to the vertical axis. */
+  readonly yChannel: Signal<ColorChannel>;
+  /** The color space the area operates in. */
+  readonly colorSpace: Signal<ColorSpace>;
+  /** The current value of the x channel. */
+  readonly xValue: Signal<number>;
+  /** The current value of the y channel. */
+  readonly yValue: Signal<number>;
+  /** The range of the x channel. */
+  readonly xRange: Signal<ColorChannelRange>;
+  /** The range of the y channel. */
+  readonly yRange: Signal<ColorChannelRange>;
+  /** The thumb horizontal position as a percentage (0-100). */
+  readonly xPercentage: Signal<number>;
+  /** The thumb vertical position as a percentage (0-100, 0 = top). */
+  readonly yPercentage: Signal<number>;
+  /** A CSS background representing the 2D gradient. */
+  readonly gradient: Signal<string>;
+  /** Whether the area is disabled (includes form control state). */
+  readonly disabled: WritableSignal<boolean>;
+  /** @internal The thumb element reference. */
+  readonly thumb: Signal<ElementRef<HTMLElement> | undefined>;
+  /** Emits when the value changes. */
+  readonly valueChange: Observable<Color>;
+  /** Set the full color value. */
+  setValue(value: Color, options?: SetterOptions): void;
+  /** Set both channels to values (clamped + stepped). */
+  setChannels(xValue: number, yValue: number, options?: SetterOptions): void;
+  /** Adjust a single channel by a delta (clamped + stepped). */
+  adjustChannel(channel: ColorChannel, delta: number, options?: SetterOptions): void;
+  /** @internal Register the thumb element. */
+  setThumb(thumb: ElementRef<HTMLElement> | undefined): void;
+  /** Focus the thumb element. */
+  focusThumb(origin: FocusOrigin): void;
+  /** Set the disabled state. */
+  setDisabled(disabled: boolean): void;
+}
+
+/**
+ * Inputs for configuring the Color Area primitive.
+ */
+export interface NgpColorAreaProps {
+  readonly id?: Signal<string>;
+  readonly value?: Signal<Color>;
+  readonly xChannel?: Signal<ColorChannel>;
+  readonly yChannel?: Signal<ColorChannel>;
+  readonly colorSpace?: Signal<ColorSpace | undefined>;
+  readonly disabled?: Signal<boolean>;
+  readonly onValueChange?: (value: Color) => void;
+}
+
+const spaceOfChannel: Record<ColorChannel, ColorSpace | undefined> = {
+  red: 'rgb',
+  green: 'rgb',
+  blue: 'rgb',
+  lightness: 'hsl',
+  brightness: 'hsb',
+  hue: undefined,
+  saturation: undefined,
+  alpha: undefined,
+};
+
+/** Resolve the working space from the two channels, an explicit override, and the value's space. */
+function resolveColorSpace(
+  xChannel: ColorChannel,
+  yChannel: ColorChannel,
+  explicit: ColorSpace | undefined,
+  valueSpace: ColorSpace,
+): ColorSpace {
+  return explicit ?? spaceOfChannel[xChannel] ?? spaceOfChannel[yChannel] ?? valueSpace;
+}
+
+function clampStep(value: number, { min, max, step }: ColorChannelRange): number {
+  const clamped = Math.min(max, Math.max(min, value));
+  const stepped = Math.round((clamped - min) / step) * step + min;
+  return Math.min(max, Math.max(min, stepped));
+}
+
+function percentage(value: number, { min, max }: ColorChannelRange): number {
+  const range = max - min;
+  return range <= 0 ? 0 : Math.min(100, Math.max(0, ((value - min) / range) * 100));
+}
+
+export const [NgpColorAreaStateToken, ngpColorArea, injectColorAreaState, provideColorAreaState] =
+  createPrimitive(
+    'NgpColorArea',
+    ({
+      id = signal(uniqueId('ngp-color-area')),
+      value: _value = signal(Color.parse('hsb(0, 100%, 100%)')),
+      xChannel = signal<ColorChannel>('saturation'),
+      yChannel = signal<ColorChannel>('brightness'),
+      colorSpace: _colorSpace = signal<ColorSpace | undefined>(undefined),
+      disabled: _disabled = signal(false),
+      onValueChange,
+    }: NgpColorAreaProps): NgpColorAreaState => {
+      const element = injectElementRef<HTMLElement>();
+      const focusMonitor = inject(FocusMonitor);
+      const injector = inject(Injector);
+      const document = inject(DOCUMENT);
+      // Bind to a parent color picker when present, otherwise own the value locally.
+      const picker = injectColorPickerState({ optional: true });
+      const local = controlled(_value);
+      const value = computed(() => picker()?.value() ?? local());
+      const disabled = controlled(_disabled);
+      const valueChange = emitter<Color>();
+      const thumb = signal<ElementRef<HTMLElement> | undefined>(undefined);
+
+      const status = ngpFormControl({ id, disabled });
+
+      const colorSpace = computed(() =>
+        resolveColorSpace(xChannel(), yChannel(), _colorSpace(), value().getColorSpace()),
+      );
+      const converted = computed(() => value().toFormat(colorSpace()));
+      const xRange = computed(() => converted().getChannelRange(xChannel()));
+      const yRange = computed(() => converted().getChannelRange(yChannel()));
+      const xValue = computed(() => converted().getChannelValue(xChannel()));
+      const yValue = computed(() => converted().getChannelValue(yChannel()));
+      const xPercentage = computed(() => percentage(xValue(), xRange()));
+      const yPercentage = computed(() => percentage(yValue(), yRange()));
+
+      const gradient = computed(() =>
+        areaGradient(converted(), xChannel(), yChannel(), xRange(), yRange()),
+      );
+
+      // Host bindings
+      attrBinding(element, 'id', id);
+      dataBinding(element, 'data-disabled', () => status().disabled);
+      styleBinding(element, '--ngp-color-area-background', gradient);
+
+      let dragging = false;
+      let activePointerId: number | null = null;
+      let cleanup: (() => void)[] = [];
+
+      // Pointer down anywhere on the surface positions the thumb and begins a drag.
+      listener(element, 'pointerdown', (event: PointerEvent) => {
+        if (status().disabled) {
+          return;
+        }
+        event.preventDefault();
+        dragging = true;
+        activePointerId = event.pointerId;
+        setFromPointer(event);
+        focusThumb(event.pointerType === 'touch' ? 'touch' : 'mouse');
+
+        cleanup.forEach(fn => fn());
+        cleanup = [
+          listener(document, 'pointermove', onPointerMove, { config: false, injector }),
+          listener(document, 'pointerup', onPointerEnd, { config: false, injector }),
+          listener(document, 'pointercancel', onPointerEnd, { config: false, injector }),
+        ];
+      });
+
+      function onPointerMove(event: PointerEvent): void {
+        if (status().disabled || !dragging || event.pointerId !== activePointerId) {
+          return;
+        }
+        setFromPointer(event);
+      }
+
+      function onPointerEnd(event: PointerEvent): void {
+        if (event.pointerId !== activePointerId) {
+          return;
+        }
+        dragging = false;
+        activePointerId = null;
+        cleanup.forEach(fn => fn());
+        cleanup = [];
+      }
+
+      function setFromPointer(event: PointerEvent): void {
+        const rect = element.nativeElement.getBoundingClientRect();
+        const xPct = rect.width === 0 ? 0 : (event.clientX - rect.left) / rect.width;
+        // invert y so the top of the surface is the channel maximum
+        const yPct = rect.height === 0 ? 0 : 1 - (event.clientY - rect.top) / rect.height;
+        const x = xRange().min + (xRange().max - xRange().min) * Math.max(0, Math.min(1, xPct));
+        const y = yRange().min + (yRange().max - yRange().min) * Math.max(0, Math.min(1, yPct));
+        setChannels(x, y);
+      }
+
+      function setValue(newValue: Color, options?: SetterOptions): void {
+        const parent = picker();
+        if (parent) {
+          parent.setValue(newValue, options);
+        } else {
+          local.set(newValue);
+        }
+        if (options?.emit !== false) {
+          onValueChange?.(newValue);
+          valueChange.emit(newValue);
+        }
+      }
+
+      function setChannels(x: number, y: number, options?: SetterOptions): void {
+        const newColor = converted()
+          .withChannelValue(xChannel(), clampStep(x, xRange()))
+          .withChannelValue(yChannel(), clampStep(y, yRange()));
+        setValue(newColor, options);
+      }
+
+      function adjustChannel(channel: ColorChannel, delta: number, options?: SetterOptions): void {
+        const range = channel === xChannel() ? xRange() : yRange();
+        const current = channel === xChannel() ? xValue() : yValue();
+        setValue(converted().withChannelValue(channel, clampStep(current + delta, range)), options);
+      }
+
+      function setThumb(newThumb: ElementRef<HTMLElement> | undefined): void {
+        thumb.set(newThumb);
+      }
+
+      function focusThumb(origin: FocusOrigin): void {
+        const el = thumb();
+        if (el) {
+          focusMonitor.focusVia(el, origin, { preventScroll: true });
+        }
+      }
+
+      function setDisabled(isDisabled: boolean): void {
+        disabled.set(isDisabled);
+      }
+
+      return {
+        id,
+        value,
+        xChannel,
+        yChannel,
+        colorSpace,
+        xValue,
+        yValue,
+        xRange,
+        yRange,
+        xPercentage,
+        yPercentage,
+        gradient,
+        disabled,
+        thumb,
+        valueChange: valueChange.asObservable(),
+        setValue,
+        setChannels,
+        adjustChannel,
+        setThumb,
+        focusThumb,
+        setDisabled,
+      } satisfies NgpColorAreaState;
+    },
+  );
+
+/**
+ * Build a CSS background for the 2D area.
+ * ponytail: tuned for the default saturation(x)×brightness(y) square (the overwhelmingly common
+ * pairing) — a white→transparent horizontal layer and a transparent→black vertical layer over the
+ * full-strength base color. Consumers can override `--ngp-color-area-background` for other pairings.
+ */
+function areaGradient(
+  color: Color,
+  xChannel: ColorChannel,
+  yChannel: ColorChannel,
+  xRange: ColorChannelRange,
+  yRange: ColorChannelRange,
+): string {
+  const base = color
+    .withChannelValue(xChannel, xRange.max)
+    .withChannelValue(yChannel, yRange.max)
+    .toRgb();
+  return `linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, transparent), ${base}`;
+}

--- a/packages/ng-primitives/color/src/color-area/color-area.ts
+++ b/packages/ng-primitives/color/src/color-area/color-area.ts
@@ -1,0 +1,71 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input, output } from '@angular/core';
+import { SetterOptions } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Color, ColorChannel, ColorSpace } from '../color/color';
+import { ngpColorArea, provideColorAreaState } from './color-area-state';
+
+/**
+ * Apply the `ngpColorArea` directive to a 2D surface that adjusts two channels of a color value.
+ * The surface should set its background to `var(--ngp-color-area-background)` and contain a thumb.
+ */
+@Directive({
+  selector: '[ngpColorArea]',
+  exportAs: 'ngpColorArea',
+  providers: [provideColorAreaState()],
+})
+export class NgpColorArea {
+  /** The id of the area. */
+  readonly id = input<string>(uniqueId('ngp-color-area'));
+
+  /** The color value. */
+  readonly value = input<Color>(Color.parse('hsb(0, 100%, 100%)'), {
+    alias: 'ngpColorAreaValue',
+  });
+
+  /** Emits when the value changes. */
+  readonly valueChange = output<Color>({
+    alias: 'ngpColorAreaValueChange',
+  });
+
+  /** The channel mapped to the horizontal axis. */
+  readonly xChannel = input<ColorChannel>('saturation', {
+    alias: 'ngpColorAreaXChannel',
+  });
+
+  /** The channel mapped to the vertical axis. */
+  readonly yChannel = input<ColorChannel>('brightness', {
+    alias: 'ngpColorAreaYChannel',
+  });
+
+  /** The color space to operate in. Resolved from the channels/value when not set. */
+  readonly colorSpace = input<ColorSpace | undefined>(undefined, {
+    alias: 'ngpColorAreaColorSpace',
+  });
+
+  /** The disabled state of the area. */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpColorAreaDisabled',
+    transform: booleanAttribute,
+  });
+
+  protected readonly state = ngpColorArea({
+    id: this.id,
+    value: this.value,
+    xChannel: this.xChannel,
+    yChannel: this.yChannel,
+    colorSpace: this.colorSpace,
+    disabled: this.disabled,
+    onValueChange: value => this.valueChange.emit(value),
+  });
+
+  /** Set the value of the area. */
+  setValue(value: Color, options?: SetterOptions): void {
+    this.state.setValue(value, options);
+  }
+
+  /** Set the disabled state. */
+  setDisabled(disabled: boolean): void {
+    this.state.setDisabled(disabled);
+  }
+}

--- a/packages/ng-primitives/color/src/color-area/tests/color-area.test.ts
+++ b/packages/ng-primitives/color/src/color-area/tests/color-area.test.ts
@@ -1,0 +1,113 @@
+import { fireEvent, render } from '@testing-library/angular';
+import { Color, NgpColorArea, NgpColorAreaThumb } from 'ng-primitives/color';
+import { describe, expect, it, vi } from 'vitest';
+
+const imports = [NgpColorArea, NgpColorAreaThumb];
+
+function template(extra = ''): string {
+  return `
+    <div
+      ngpColorArea
+      data-testid="area"
+      [ngpColorAreaValue]="value"
+      ${extra}
+      (ngpColorAreaValueChange)="onChange($event)">
+      <div ngpColorAreaThumb data-testid="thumb"></div>
+    </div>
+  `;
+}
+
+async function setup(props: { value?: Color; extra?: string } = {}) {
+  const onChange = vi.fn<(c: Color) => void>();
+  const view = await render(template(props.extra), {
+    imports,
+    componentProperties: {
+      value: props.value ?? Color.parse('hsb(0, 100%, 100%)'),
+      onChange,
+    },
+  });
+  return { ...view, onChange, last: () => onChange.mock.lastCall?.[0] as Color };
+}
+
+describe('NgpColorArea', () => {
+  it('exposes a slider thumb describing both channels', async () => {
+    const { getByTestId } = await setup({ value: Color.parse('hsb(0, 50%, 50%)') });
+    const thumb = getByTestId('thumb');
+    expect(thumb).toHaveAttribute('role', 'slider');
+    expect(thumb).toHaveAttribute('aria-label', 'saturation and brightness');
+    expect(thumb).toHaveAttribute('aria-valuemin', '0');
+    expect(thumb).toHaveAttribute('aria-valuemax', '100');
+    expect(thumb).toHaveAttribute('aria-valuenow', '50'); // x = saturation
+    expect(thumb).toHaveAttribute('aria-valuetext', 'saturation 50, brightness 50');
+  });
+
+  it('positions the thumb from both channel percentages (y inverted)', async () => {
+    const { getByTestId } = await setup({ value: Color.parse('hsb(0, 25%, 75%)') });
+    const thumb = getByTestId('thumb');
+    expect(thumb.style.getPropertyValue('inset-inline-start')).toBe('25%');
+    // brightness 75 -> 75% up -> 25% from the top
+    expect(thumb.style.getPropertyValue('inset-block-start')).toBe('25%');
+  });
+
+  it('moves the x channel with left/right arrows', async () => {
+    const { getByTestId, last } = await setup({ value: Color.parse('hsb(0, 50%, 50%)') });
+    const thumb = getByTestId('thumb');
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    expect(last().getChannelValue('saturation')).toBe(51);
+    fireEvent.keyDown(thumb, { key: 'ArrowLeft' });
+    expect(last().getChannelValue('saturation')).toBe(50);
+  });
+
+  it('moves the y channel with up/down arrows', async () => {
+    const { getByTestId, last } = await setup({ value: Color.parse('hsb(0, 50%, 50%)') });
+    const thumb = getByTestId('thumb');
+    fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+    expect(last().getChannelValue('brightness')).toBe(51);
+    fireEvent.keyDown(thumb, { key: 'ArrowDown' });
+    expect(last().getChannelValue('brightness')).toBe(50);
+  });
+
+  it('uses a x10 step with shift', async () => {
+    const { getByTestId, last } = await setup({ value: Color.parse('hsb(0, 50%, 50%)') });
+    fireEvent.keyDown(getByTestId('thumb'), { key: 'ArrowUp', shiftKey: true });
+    expect(last().getChannelValue('brightness')).toBe(60);
+  });
+
+  it('sets both channels from a pointer position on the surface', async () => {
+    const { getByTestId, last } = await setup();
+    const area = getByTestId('area');
+    vi.spyOn(area, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.pointerDown(area, { clientX: 25, clientY: 75 });
+    // x = 25% -> saturation 25; y inverted (75px down of 100) -> brightness 25
+    expect(last().getChannelValue('saturation')).toBe(25);
+    expect(last().getChannelValue('brightness')).toBe(25);
+  });
+
+  it('exposes a 2D gradient background as a CSS custom property', async () => {
+    const { getByTestId } = await setup();
+    const bg = getByTestId('area').style.getPropertyValue('--ngp-color-area-background');
+    expect(bg).toContain('linear-gradient(to top, #000');
+    expect(bg).toContain('linear-gradient(to right, #fff');
+  });
+
+  it('does not respond when disabled', async () => {
+    const { getByTestId, onChange } = await setup({ extra: '[ngpColorAreaDisabled]="true"' });
+    const thumb = getByTestId('thumb');
+    expect(thumb).toHaveAttribute('tabindex', '-1');
+    expect(thumb).toHaveAttribute('data-disabled', '');
+    fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+    fireEvent.pointerDown(getByTestId('area'), { clientX: 10, clientY: 10 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ng-primitives/color/src/color-field/color-field-state.ts
+++ b/packages/ng-primitives/color/src/color-field/color-field-state.ts
@@ -1,0 +1,238 @@
+import { computed, effect, Signal, signal, WritableSignal } from '@angular/core';
+import { ngpInput } from 'ng-primitives/input';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  controlled,
+  createPrimitive,
+  emitter,
+  listener,
+  SetterOptions,
+} from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Observable } from 'rxjs';
+import { injectColorPickerState } from '../color-picker/color-picker-state';
+import { Color, ColorChannel, ColorChannelRange, ColorSpace } from '../color/color';
+
+export type NgpColorFieldMode = 'hex' | 'channel';
+
+/**
+ * Public state surface for the Color Field primitive - a text input that edits a color as a hex
+ * string, or a single channel as a number.
+ */
+export interface NgpColorFieldState {
+  /** The id of the field. */
+  readonly id: Signal<string>;
+  /** The current color value (the parent picker's value when inside one). */
+  readonly value: Signal<Color>;
+  /** The editing mode - `hex` (whole color) or `channel` (single channel number). */
+  readonly mode: Signal<NgpColorFieldMode>;
+  /** The channel being edited, when in channel mode. */
+  readonly channel: Signal<ColorChannel | undefined>;
+  /** Whether the field is disabled. */
+  readonly disabled: WritableSignal<boolean>;
+  /** Emits when the value changes. */
+  readonly valueChange: Observable<Color>;
+  /** Set the full color value. */
+  setValue(value: Color, options?: SetterOptions): void;
+  /** Set the disabled state. */
+  setDisabled(disabled: boolean): void;
+}
+
+/**
+ * Inputs for configuring the Color Field primitive.
+ */
+export interface NgpColorFieldProps {
+  readonly id?: Signal<string>;
+  readonly value?: Signal<Color>;
+  readonly channel?: Signal<ColorChannel | undefined>;
+  readonly colorSpace?: Signal<ColorSpace | undefined>;
+  readonly disabled?: Signal<boolean>;
+  readonly onValueChange?: (value: Color) => void;
+}
+
+function spaceForChannel(channel: ColorChannel, valueSpace: ColorSpace): ColorSpace {
+  switch (channel) {
+    case 'red':
+    case 'green':
+    case 'blue':
+      return 'rgb';
+    case 'lightness':
+      return 'hsl';
+    case 'brightness':
+      return 'hsb';
+    case 'hue':
+    case 'saturation':
+      return valueSpace === 'hsl' ? 'hsl' : 'hsb';
+    case 'alpha':
+      return valueSpace;
+  }
+}
+
+function clampStep(value: number, { min, max, step }: ColorChannelRange): number {
+  const clamped = Math.min(max, Math.max(min, value));
+  const stepped = Math.round((clamped - min) / step) * step + min;
+  return Math.min(max, Math.max(min, stepped));
+}
+
+export const [
+  NgpColorFieldStateToken,
+  ngpColorField,
+  injectColorFieldState,
+  provideColorFieldState,
+] = createPrimitive(
+  'NgpColorField',
+  ({
+    id = signal(uniqueId('ngp-color-field')),
+    value: _value = signal(Color.parse('#ff0000')),
+    channel = signal<ColorChannel | undefined>(undefined),
+    colorSpace: _colorSpace = signal<ColorSpace | undefined>(undefined),
+    disabled = signal(false),
+    onValueChange,
+  }: NgpColorFieldProps): NgpColorFieldState => {
+    const element = injectElementRef<HTMLInputElement>();
+    // Bind to a parent color picker when present, otherwise own the value locally.
+    const picker = injectColorPickerState({ optional: true });
+    const local = controlled(_value);
+    const value = computed(() => picker()?.value() ?? local());
+    const valueChange = emitter<Color>();
+
+    // Compose the base input primitive (form control, interactions, disabled binding).
+    const input = ngpInput({ id, disabled });
+
+    const mode = computed<NgpColorFieldMode>(() => (channel() ? 'channel' : 'hex'));
+
+    // channel-mode derivations (only read while in channel mode)
+    const colorSpace = computed(
+      () => _colorSpace() ?? spaceForChannel(channel()!, value().getColorSpace()),
+    );
+    const converted = computed(() => value().toFormat(colorSpace()));
+    const channelRange = computed(() => converted().getChannelRange(channel()!));
+    const channelValue = computed(() => converted().getChannelValue(channel()!));
+
+    const displayValue = computed(() => {
+      if (mode() === 'hex') {
+        const color = value();
+        return color.getChannelValue('alpha') < 1 ? color.toHexa() : color.toHex();
+      }
+      // integer channels round to whole numbers; the fractional alpha channel (step 0.01) keeps 2dp
+      return Number.isInteger(channelRange().step)
+        ? String(Math.round(channelValue()))
+        : String(Math.round(channelValue() * 100) / 100);
+    });
+
+    // Native input has no ARIA role of its own to add; hint the keyboard/autocomplete.
+    attrBinding(element, 'inputmode', () => (mode() === 'channel' ? 'numeric' : 'text'));
+    attrBinding(element, 'autocomplete', 'off');
+    attrBinding(element, 'spellcheck', 'false');
+
+    let focused = false;
+
+    function render(): void {
+      element.nativeElement.value = displayValue();
+    }
+
+    // Reflect external value changes into the input while the user is not editing.
+    effect(() => {
+      displayValue();
+      if (!focused) {
+        render();
+      }
+    });
+
+    function setValue(newValue: Color, options?: SetterOptions): void {
+      const parent = picker();
+      if (parent) {
+        parent.setValue(newValue, options);
+      } else {
+        local.set(newValue);
+      }
+      if (options?.emit !== false) {
+        onValueChange?.(newValue);
+        valueChange.emit(newValue);
+      }
+    }
+
+    function parseInput(raw: string): Color | null {
+      const text = raw.trim();
+      if (mode() === 'hex') {
+        try {
+          return Color.parse(text.startsWith('#') ? text : `#${text}`);
+        } catch {
+          return null;
+        }
+      }
+      if (text === '' || Number.isNaN(Number(text))) {
+        return null;
+      }
+      return converted().withChannelValue(channel()!, clampStep(Number(text), channelRange()));
+    }
+
+    function commit(): void {
+      const parsed = parseInput(element.nativeElement.value);
+      if (parsed) {
+        setValue(parsed);
+      }
+      // reformat to the canonical representation (also reverts invalid input)
+      render();
+    }
+
+    // Restrict typed characters to the current mode.
+    listener(element, 'input', () => {
+      const current = element.nativeElement.value;
+      const cleaned =
+        mode() === 'hex' ? current.replace(/[^#0-9a-fA-F]/g, '') : current.replace(/[^0-9.]/g, '');
+      // ponytail: naive sanitize resets the caret to the end — fine for these short fields.
+      if (cleaned !== current) {
+        element.nativeElement.value = cleaned;
+      }
+    });
+
+    listener(element, 'keydown', (event: KeyboardEvent) => {
+      if (input.disabled()) {
+        return;
+      }
+      if (mode() === 'channel' && (event.key === 'ArrowUp' || event.key === 'ArrowDown')) {
+        event.preventDefault();
+        const delta =
+          (event.key === 'ArrowUp' ? 1 : -1) * channelRange().step * (event.shiftKey ? 10 : 1);
+        setValue(
+          converted().withChannelValue(
+            channel()!,
+            clampStep(channelValue() + delta, channelRange()),
+          ),
+        );
+        render();
+        return;
+      }
+      if (event.key === 'Enter') {
+        commit();
+      }
+    });
+
+    listener(element, 'focus', () => {
+      focused = true;
+      element.nativeElement.select();
+    });
+
+    listener(element, 'blur', () => {
+      focused = false;
+      commit();
+    });
+
+    function setDisabled(isDisabled: boolean): void {
+      input.setDisabled(isDisabled);
+    }
+
+    return {
+      id,
+      value,
+      mode,
+      channel,
+      disabled: input.disabled,
+      valueChange: valueChange.asObservable(),
+      setValue,
+      setDisabled,
+    } satisfies NgpColorFieldState;
+  },
+);

--- a/packages/ng-primitives/color/src/color-field/color-field.ts
+++ b/packages/ng-primitives/color/src/color-field/color-field.ts
@@ -1,0 +1,67 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input, output } from '@angular/core';
+import { provideInputState } from 'ng-primitives/input';
+import { SetterOptions } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Color, ColorChannel, ColorSpace } from '../color/color';
+import { ngpColorField, provideColorFieldState } from './color-field-state';
+
+/**
+ * Apply the `ngpColorField` directive to an `input` element to edit a color. Without a channel it
+ * edits the whole color as a hex string; with a channel it edits that single channel as a number.
+ * It composes the input primitive, so it provides the input state.
+ */
+@Directive({
+  selector: 'input[ngpColorField]',
+  exportAs: 'ngpColorField',
+  providers: [provideColorFieldState(), provideInputState({ inherit: false })],
+})
+export class NgpColorField {
+  /** The id of the field. */
+  readonly id = input<string>(uniqueId('ngp-color-field'));
+
+  /** The color value. */
+  readonly value = input<Color>(Color.parse('#ff0000'), {
+    alias: 'ngpColorFieldValue',
+  });
+
+  /** Emits when the value changes. */
+  readonly valueChange = output<Color>({
+    alias: 'ngpColorFieldValueChange',
+  });
+
+  /** The channel to edit. When omitted, the field edits the whole color as hex. */
+  readonly channel = input<ColorChannel | undefined>(undefined, {
+    alias: 'ngpColorFieldChannel',
+  });
+
+  /** The color space for channel mode. Resolved from the channel/value when not set. */
+  readonly colorSpace = input<ColorSpace | undefined>(undefined, {
+    alias: 'ngpColorFieldColorSpace',
+  });
+
+  /** The disabled state of the field. */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpColorFieldDisabled',
+    transform: booleanAttribute,
+  });
+
+  protected readonly state = ngpColorField({
+    id: this.id,
+    value: this.value,
+    channel: this.channel,
+    colorSpace: this.colorSpace,
+    disabled: this.disabled,
+    onValueChange: value => this.valueChange.emit(value),
+  });
+
+  /** Set the value of the field. */
+  setValue(value: Color, options?: SetterOptions): void {
+    this.state.setValue(value, options);
+  }
+
+  /** Set the disabled state. */
+  setDisabled(disabled: boolean): void {
+    this.state.setDisabled(disabled);
+  }
+}

--- a/packages/ng-primitives/color/src/color-field/tests/color-field.test.ts
+++ b/packages/ng-primitives/color/src/color-field/tests/color-field.test.ts
@@ -1,0 +1,106 @@
+import { fireEvent, render } from '@testing-library/angular';
+import { Color, NgpColorField } from 'ng-primitives/color';
+import { describe, expect, it, vi } from 'vitest';
+
+async function setup(props: { value?: Color; channel?: string; extra?: string } = {}) {
+  const onChange = vi.fn<(c: Color) => void>();
+  const view = await render(
+    `<input
+        ngpColorField
+        data-testid="field"
+        [ngpColorFieldValue]="value"
+        ${props.channel ? `ngpColorFieldChannel="${props.channel}"` : ''}
+        ${props.extra ?? ''}
+        (ngpColorFieldValueChange)="onChange($event)" />`,
+    {
+      imports: [NgpColorField],
+      componentProperties: {
+        value: props.value ?? Color.parse('#ff0000'),
+        onChange,
+      },
+    },
+  );
+  const input = view.getByTestId('field') as HTMLInputElement;
+  return { ...view, input, onChange, last: () => onChange.mock.lastCall?.[0] as Color };
+}
+
+describe('NgpColorField', () => {
+  describe('hex mode', () => {
+    it('renders the color as a hex string', async () => {
+      const { input } = await setup({ value: Color.parse('#3366cc') });
+      expect(input.value).toBe('#3366cc');
+      expect(input).toHaveAttribute('inputmode', 'text');
+    });
+
+    it('renders alpha as an 8-digit hex', async () => {
+      const { input } = await setup({ value: Color.parse('rgba(255,0,0,0.5)') });
+      expect(input.value).toBe('#ff000080');
+    });
+
+    it('commits a valid hex on blur and emits a Color', async () => {
+      const { input, last } = await setup();
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: '#00ff00' } });
+      fireEvent.blur(input);
+      expect(last().toHex()).toBe('#00ff00');
+      expect(input.value).toBe('#00ff00');
+    });
+
+    it('reverts invalid input on blur', async () => {
+      const { input, onChange } = await setup({ value: Color.parse('#ff0000') });
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: '#12' } }); // too short
+      fireEvent.blur(input);
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input.value).toBe('#ff0000');
+    });
+
+    it('strips non-hex characters as you type', async () => {
+      const { input } = await setup();
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: '#00zzff' } });
+      expect(input.value).toBe('#00ff');
+    });
+  });
+
+  describe('channel mode', () => {
+    it('renders a single channel as a number', async () => {
+      const { input } = await setup({ value: Color.parse('#3366cc'), channel: 'red' });
+      expect(input.value).toBe('51');
+      expect(input).toHaveAttribute('inputmode', 'numeric');
+    });
+
+    it('renders the fractional alpha channel without rounding to an integer', async () => {
+      const { input } = await setup({ value: Color.parse('rgba(255,0,0,0.5)'), channel: 'alpha' });
+      expect(input.value).toBe('0.5');
+    });
+
+    it('steps the channel with ArrowUp/ArrowDown', async () => {
+      const { input, last } = await setup({ value: Color.parse('#3366cc'), channel: 'red' });
+      fireEvent.keyDown(input, { key: 'ArrowUp' });
+      expect(last().getChannelValue('red')).toBe(52);
+      expect(input.value).toBe('52');
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      expect(last().getChannelValue('red')).toBe(51);
+    });
+
+    it('commits a typed number clamped to the channel range', async () => {
+      const { input, last } = await setup({ value: Color.parse('#3366cc'), channel: 'red' });
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: '999' } });
+      fireEvent.blur(input);
+      expect(last().getChannelValue('red')).toBe(255);
+      expect(input.value).toBe('255');
+    });
+  });
+
+  it('does not commit or step when disabled', async () => {
+    const { input, onChange } = await setup({
+      channel: 'red',
+      extra: '[ngpColorFieldDisabled]="true"',
+    });
+    expect(input).toHaveAttribute('disabled');
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ng-primitives/color/src/color-picker/color-picker-state.ts
+++ b/packages/ng-primitives/color/src/color-picker/color-picker-state.ts
@@ -1,0 +1,71 @@
+import { Signal, signal, WritableSignal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  controlled,
+  createPrimitive,
+  emitter,
+  SetterOptions,
+} from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Observable } from 'rxjs';
+import { Color } from '../color/color';
+
+/**
+ * Public state surface for the Color Picker primitive - a coordinator that holds a single
+ * color value shared across child color components (area, sliders, fields).
+ */
+export interface NgpColorPickerState {
+  /** The id of the picker. */
+  readonly id: Signal<string>;
+  /** The shared color value. */
+  readonly value: WritableSignal<Color>;
+  /** Emits when the value changes. */
+  readonly valueChange: Observable<Color>;
+  /** Set the shared color value. */
+  setValue(value: Color, options?: SetterOptions): void;
+}
+
+/**
+ * Inputs for configuring the Color Picker primitive.
+ */
+export interface NgpColorPickerProps {
+  readonly id?: Signal<string>;
+  readonly value?: Signal<Color>;
+  readonly onValueChange?: (value: Color) => void;
+}
+
+export const [
+  NgpColorPickerStateToken,
+  ngpColorPicker,
+  injectColorPickerState,
+  provideColorPickerState,
+] = createPrimitive(
+  'NgpColorPicker',
+  ({
+    id = signal(uniqueId('ngp-color-picker')),
+    value: _value = signal(Color.parse('#ff0000')),
+    onValueChange,
+  }: NgpColorPickerProps): NgpColorPickerState => {
+    const element = injectElementRef();
+    const value = controlled(_value);
+    const valueChange = emitter<Color>();
+
+    attrBinding(element, 'id', id);
+
+    function setValue(newValue: Color, options?: SetterOptions): void {
+      value.set(newValue);
+      if (options?.emit !== false) {
+        onValueChange?.(newValue);
+        valueChange.emit(newValue);
+      }
+    }
+
+    return {
+      id,
+      value,
+      valueChange: valueChange.asObservable(),
+      setValue,
+    } satisfies NgpColorPickerState;
+  },
+);

--- a/packages/ng-primitives/color/src/color-picker/color-picker.ts
+++ b/packages/ng-primitives/color/src/color-picker/color-picker.ts
@@ -1,0 +1,40 @@
+import { Directive, input, output } from '@angular/core';
+import { SetterOptions } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Color } from '../color/color';
+import { ngpColorPicker, provideColorPickerState } from './color-picker-state';
+
+/**
+ * Apply the `ngpColorPicker` directive to a container that coordinates a single color value across
+ * child color components. Child areas, sliders and fields bind to the picker's value automatically.
+ */
+@Directive({
+  selector: '[ngpColorPicker]',
+  exportAs: 'ngpColorPicker',
+  providers: [provideColorPickerState()],
+})
+export class NgpColorPicker {
+  /** The id of the picker. */
+  readonly id = input<string>(uniqueId('ngp-color-picker'));
+
+  /** The color value. */
+  readonly value = input<Color>(Color.parse('#ff0000'), {
+    alias: 'ngpColorPickerValue',
+  });
+
+  /** Emits when the value changes. */
+  readonly valueChange = output<Color>({
+    alias: 'ngpColorPickerValueChange',
+  });
+
+  protected readonly state = ngpColorPicker({
+    id: this.id,
+    value: this.value,
+    onValueChange: value => this.valueChange.emit(value),
+  });
+
+  /** Set the value of the picker. */
+  setValue(value: Color, options?: SetterOptions): void {
+    this.state.setValue(value, options);
+  }
+}

--- a/packages/ng-primitives/color/src/color-picker/tests/color-picker.test.ts
+++ b/packages/ng-primitives/color/src/color-picker/tests/color-picker.test.ts
@@ -1,0 +1,71 @@
+import { fireEvent, render } from '@testing-library/angular';
+import {
+  Color,
+  NgpColorField,
+  NgpColorPicker,
+  NgpColorSlider,
+  NgpColorSliderThumb,
+  NgpColorSliderTrack,
+} from 'ng-primitives/color';
+import { describe, expect, it, vi } from 'vitest';
+
+const imports = [
+  NgpColorPicker,
+  NgpColorSlider,
+  NgpColorSliderTrack,
+  NgpColorSliderThumb,
+  NgpColorField,
+];
+
+async function setup(value: Color = Color.parse('#ff0000')) {
+  const onChange = vi.fn<(c: Color) => void>();
+  const view = await render(
+    `<div ngpColorPicker [ngpColorPickerValue]="value" (ngpColorPickerValueChange)="onChange($event)">
+       <div ngpColorSlider ngpColorSliderChannel="hue">
+         <div ngpColorSliderTrack></div>
+         <div ngpColorSliderThumb data-testid="thumb"></div>
+       </div>
+       <input ngpColorField data-testid="field" />
+     </div>`,
+    { imports, componentProperties: { value, onChange } },
+  );
+  return {
+    ...view,
+    onChange,
+    thumb: view.getByTestId('thumb'),
+    field: view.getByTestId('field') as HTMLInputElement,
+    last: () => onChange.mock.lastCall?.[0] as Color,
+  };
+}
+
+describe('NgpColorPicker coordination', () => {
+  it('shares the picker value with all children', async () => {
+    const { thumb, field } = await setup(Color.parse('#ff0000'));
+    // hue slider: red -> hue 0
+    expect(thumb).toHaveAttribute('aria-valuenow', '0');
+    // hex field mirrors the same color
+    expect(field.value).toBe('#ff0000');
+  });
+
+  it('propagates a child slider change to the picker and siblings', async () => {
+    const { thumb, field, onChange, last } = await setup(Color.parse('#ff0000'));
+    fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+
+    // picker emitted the new color
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(last().getChannelValue('hue')).toBe(1);
+    // the sibling field re-rendered from the shared value
+    expect(field.value).not.toBe('#ff0000');
+  });
+
+  it('propagates a child field change to the picker and siblings', async () => {
+    const { thumb, field, onChange } = await setup(Color.parse('#ff0000'));
+    fireEvent.focus(field);
+    fireEvent.input(field, { target: { value: '#00ff00' } });
+    fireEvent.blur(field);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    // green -> hue 120, so the sibling slider thumb moved
+    expect(thumb).toHaveAttribute('aria-valuenow', '120');
+  });
+});

--- a/packages/ng-primitives/color/src/color-slider-thumb/color-slider-thumb-state.ts
+++ b/packages/ng-primitives/color/src/color-slider-thumb/color-slider-thumb-state.ts
@@ -1,0 +1,52 @@
+import { FocusOrigin } from '@angular/cdk/a11y';
+import { Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { ngpSliderThumb } from 'ng-primitives/slider';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+import { injectColorSliderState } from '../color-slider/color-slider-state';
+
+/**
+ * Public state surface for the Color Slider Thumb primitive.
+ */
+export interface NgpColorSliderThumbState {
+  /** Whether the thumb is currently dragging. */
+  readonly dragging: Signal<boolean>;
+  /** Focus the thumb element. */
+  focus(origin?: FocusOrigin): void;
+}
+
+/**
+ * Inputs for configuring the Color Slider Thumb primitive.
+ */
+export interface NgpColorSliderThumbProps {
+  /** Callback fired when dragging starts. */
+  readonly onDragStart?: () => void;
+  /** Callback fired when dragging ends. */
+  readonly onDragEnd?: () => void;
+}
+
+export const [
+  NgpColorSliderThumbStateToken,
+  ngpColorSliderThumb,
+  injectColorSliderThumbState,
+  provideColorSliderThumbState,
+] = createPrimitive(
+  'NgpColorSliderThumb',
+  ({ onDragStart, onDragEnd }: NgpColorSliderThumbProps): NgpColorSliderThumbState => {
+    const element = injectElementRef<HTMLElement>();
+    const color = injectColorSliderState();
+
+    // Compose the slider thumb: it owns role=slider, aria-value*, keyboard, drag and focus.
+    const thumb = ngpSliderThumb({ onDragStart, onDragEnd });
+
+    // Name and describe the slider in terms of the color channel for screen readers.
+    attrBinding(element, 'aria-label', () => color().channel());
+    attrBinding(
+      element,
+      'aria-valuetext',
+      () => `${color().channel()} ${Math.round(color().channelValue())}`,
+    );
+
+    return thumb;
+  },
+);

--- a/packages/ng-primitives/color/src/color-slider-thumb/color-slider-thumb.ts
+++ b/packages/ng-primitives/color/src/color-slider-thumb/color-slider-thumb.ts
@@ -1,0 +1,30 @@
+import { Directive, output } from '@angular/core';
+import { provideSliderThumbState } from 'ng-primitives/slider';
+import { ngpColorSliderThumb, provideColorSliderThumbState } from './color-slider-thumb-state';
+
+/**
+ * Apply the `ngpColorSliderThumb` directive to the element that represents the color slider thumb.
+ */
+@Directive({
+  selector: '[ngpColorSliderThumb]',
+  exportAs: 'ngpColorSliderThumb',
+  providers: [provideColorSliderThumbState(), provideSliderThumbState()],
+})
+export class NgpColorSliderThumb {
+  /** Emits when the thumb drag starts. */
+  readonly dragStart = output<void>({
+    alias: 'ngpColorSliderThumbDragStart',
+  });
+
+  /** Emits when the thumb drag ends. */
+  readonly dragEnd = output<void>({
+    alias: 'ngpColorSliderThumbDragEnd',
+  });
+
+  constructor() {
+    ngpColorSliderThumb({
+      onDragStart: () => this.dragStart.emit(),
+      onDragEnd: () => this.dragEnd.emit(),
+    });
+  }
+}

--- a/packages/ng-primitives/color/src/color-slider-track/color-slider-track-state.ts
+++ b/packages/ng-primitives/color/src/color-slider-track/color-slider-track-state.ts
@@ -1,0 +1,27 @@
+import { ngpSliderTrack } from 'ng-primitives/slider';
+import { createPrimitive } from 'ng-primitives/state';
+
+/**
+ * Public state surface for the Color Slider Track primitive.
+ */
+export interface NgpColorSliderTrackState {}
+
+/**
+ * Inputs for configuring the Color Slider Track primitive.
+ */
+export interface NgpColorSliderTrackProps {}
+
+export const [
+  NgpColorSliderTrackStateToken,
+  ngpColorSliderTrack,
+  injectColorSliderTrackState,
+  provideColorSliderTrackState,
+] = createPrimitive(
+  'NgpColorSliderTrack',
+  ({}: NgpColorSliderTrackProps): NgpColorSliderTrackState => {
+    // Compose the slider track: it registers the track element and handles pointer
+    // interactions that set the value from the click position.
+    ngpSliderTrack({});
+    return {} satisfies NgpColorSliderTrackState;
+  },
+);

--- a/packages/ng-primitives/color/src/color-slider-track/color-slider-track.ts
+++ b/packages/ng-primitives/color/src/color-slider-track/color-slider-track.ts
@@ -1,0 +1,18 @@
+import { Directive } from '@angular/core';
+import { provideSliderTrackState } from 'ng-primitives/slider';
+import { ngpColorSliderTrack, provideColorSliderTrackState } from './color-slider-track-state';
+
+/**
+ * Apply the `ngpColorSliderTrack` directive to the element that represents the color slider track.
+ * Set its background to `var(--ngp-color-slider-background)` to render the channel gradient.
+ */
+@Directive({
+  selector: '[ngpColorSliderTrack]',
+  exportAs: 'ngpColorSliderTrack',
+  providers: [provideColorSliderTrackState(), provideSliderTrackState()],
+})
+export class NgpColorSliderTrack {
+  constructor() {
+    ngpColorSliderTrack({});
+  }
+}

--- a/packages/ng-primitives/color/src/color-slider/color-slider-state.ts
+++ b/packages/ng-primitives/color/src/color-slider/color-slider-state.ts
@@ -1,0 +1,200 @@
+import { FocusOrigin } from '@angular/cdk/a11y';
+import { computed, Signal, signal, WritableSignal } from '@angular/core';
+import { NgpOrientation } from 'ng-primitives/common';
+import { injectElementRef } from 'ng-primitives/internal';
+import { ngpSlider } from 'ng-primitives/slider';
+import {
+  controlled,
+  createPrimitive,
+  emitter,
+  SetterOptions,
+  styleBinding,
+} from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Observable } from 'rxjs';
+import { injectColorPickerState } from '../color-picker/color-picker-state';
+import { Color, ColorChannel, ColorChannelRange, ColorSpace } from '../color/color';
+
+/**
+ * Public state surface for the Color Slider primitive.
+ *
+ * A color slider composes the underlying {@link ngpSlider} primitive, mapping a single
+ * color channel to a numeric slider value. The slider parts (track, thumb) are the
+ * standard slider parts and read the composed slider state directly.
+ */
+export interface NgpColorSliderState {
+  /** The id of the slider. */
+  readonly id: Signal<string>;
+  /** The current color value (the parent picker's value when inside one). */
+  readonly value: Signal<Color>;
+  /** The channel this slider adjusts. */
+  readonly channel: Signal<ColorChannel>;
+  /** The color space the slider operates in (resolved from the channel/value if not set). */
+  readonly colorSpace: Signal<ColorSpace>;
+  /** The current value of the adjusted channel. */
+  readonly channelValue: Signal<number>;
+  /** The range (min/max/step) of the adjusted channel. */
+  readonly channelRange: Signal<ColorChannelRange>;
+  /** The thumb position as a percentage (0-100). */
+  readonly percentage: Signal<number>;
+  /** A CSS gradient representing the channel across its range. */
+  readonly gradient: Signal<string>;
+  /** The slider orientation. */
+  readonly orientation: WritableSignal<NgpOrientation>;
+  /** Whether the slider is disabled (includes form control state). */
+  readonly disabled: WritableSignal<boolean>;
+  /** Emits when the value changes. */
+  readonly valueChange: Observable<Color>;
+  /** Set the full color value. */
+  setValue(value: Color, options?: SetterOptions): void;
+  /** Focus the thumb element. */
+  focusThumb(origin: FocusOrigin): void;
+  /** Set the disabled state. */
+  setDisabled(disabled: boolean): void;
+  /** Set the orientation. */
+  setOrientation(orientation: NgpOrientation): void;
+}
+
+/**
+ * Inputs for configuring the Color Slider primitive.
+ */
+export interface NgpColorSliderProps {
+  readonly id?: Signal<string>;
+  readonly value?: Signal<Color>;
+  readonly channel?: Signal<ColorChannel>;
+  readonly colorSpace?: Signal<ColorSpace | undefined>;
+  readonly orientation?: Signal<NgpOrientation>;
+  readonly disabled?: Signal<boolean>;
+  readonly onValueChange?: (value: Color) => void;
+}
+
+/** Resolve the color space to operate in from the channel, an explicit override, and the value's own space. */
+function resolveColorSpace(
+  channel: ColorChannel,
+  explicit: ColorSpace | undefined,
+  valueSpace: ColorSpace,
+): ColorSpace {
+  if (explicit) {
+    return explicit;
+  }
+  switch (channel) {
+    case 'red':
+    case 'green':
+    case 'blue':
+      return 'rgb';
+    case 'lightness':
+      return 'hsl';
+    case 'brightness':
+      return 'hsb';
+    case 'hue':
+    case 'saturation':
+      return valueSpace === 'hsl' ? 'hsl' : 'hsb';
+    case 'alpha':
+      return valueSpace;
+  }
+}
+
+export const [
+  NgpColorSliderStateToken,
+  ngpColorSlider,
+  injectColorSliderState,
+  provideColorSliderState,
+] = createPrimitive(
+  'NgpColorSlider',
+  ({
+    id = signal(uniqueId('ngp-color-slider')),
+    value: _value = signal(Color.parse('#ff0000')),
+    channel = signal<ColorChannel>('hue'),
+    colorSpace: _colorSpace = signal<ColorSpace | undefined>(undefined),
+    orientation = signal<NgpOrientation>('horizontal'),
+    disabled = signal(false),
+    onValueChange,
+  }: NgpColorSliderProps): NgpColorSliderState => {
+    const element = injectElementRef();
+    // Bind to a parent color picker when present, otherwise own the value locally.
+    const picker = injectColorPickerState({ optional: true });
+    const local = controlled(_value);
+    const value = computed(() => picker()?.value() ?? local());
+    const valueChange = emitter<Color>();
+
+    const colorSpace = computed(() =>
+      resolveColorSpace(channel(), _colorSpace(), value().getColorSpace()),
+    );
+    // the value converted into the space we operate in, so the channel is readable/writable
+    const converted = computed(() => value().toFormat(colorSpace()));
+    const channelRange = computed(() => converted().getChannelRange(channel()));
+    const channelValue = computed(() => converted().getChannelValue(channel()));
+
+    // Compose the numeric slider: it owns percentage, clamping/stepping, track/thumb
+    // registration, keyboard, drag, focus, orientation and form-control state. We only
+    // translate the adjusted channel to and from a Color value.
+    const slider = ngpSlider({
+      id,
+      value: channelValue,
+      min: computed(() => channelRange().min),
+      max: computed(() => channelRange().max),
+      step: computed(() => channelRange().step),
+      orientation,
+      disabled,
+      onValueChange: channelNumber =>
+        setValue(converted().withChannelValue(channel(), channelNumber)),
+    });
+
+    const gradient = computed(() =>
+      channelGradient(converted(), channel(), channelRange(), slider.orientation()),
+    );
+
+    // Expose the channel gradient as a custom property; it inherits down to the track.
+    styleBinding(element, '--ngp-color-slider-background', gradient);
+
+    function setValue(newValue: Color, options?: SetterOptions): void {
+      const parent = picker();
+      if (parent) {
+        parent.setValue(newValue, options);
+      } else {
+        local.set(newValue);
+      }
+      if (options?.emit !== false) {
+        onValueChange?.(newValue);
+        valueChange.emit(newValue);
+      }
+    }
+
+    return {
+      id,
+      value,
+      channel,
+      colorSpace,
+      channelValue,
+      channelRange,
+      percentage: slider.percentage,
+      gradient,
+      orientation: slider.orientation,
+      disabled: slider.disabled,
+      valueChange: valueChange.asObservable(),
+      setValue,
+      focusThumb: slider.focusThumb,
+      setDisabled: slider.setDisabled,
+      setOrientation: slider.setOrientation,
+    } satisfies NgpColorSliderState;
+  },
+);
+
+/** Build a CSS `linear-gradient` sampling `channel` across its range, holding the other channels. */
+function channelGradient(
+  color: Color,
+  channel: ColorChannel,
+  range: ColorChannelRange,
+  orientation: NgpOrientation,
+): string {
+  // ponytail: fixed stop counts — hue needs many samples to render the spectrum,
+  // lightness needs a midpoint (black→color→white), the rest read fine as endpoints.
+  const stops = channel === 'hue' ? 12 : channel === 'lightness' ? 2 : 1;
+  const direction = orientation === 'horizontal' ? 'to right' : 'to top';
+  const parts: string[] = [];
+  for (let i = 0; i <= stops; i++) {
+    const channelValue = range.min + ((range.max - range.min) * i) / stops;
+    parts.push(color.withChannelValue(channel, channelValue).toRgba());
+  }
+  return `linear-gradient(${direction}, ${parts.join(', ')})`;
+}

--- a/packages/ng-primitives/color/src/color-slider/color-slider.ts
+++ b/packages/ng-primitives/color/src/color-slider/color-slider.ts
@@ -1,0 +1,79 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input, output } from '@angular/core';
+import { NgpOrientation } from 'ng-primitives/common';
+import { provideSliderState } from 'ng-primitives/slider';
+import { SetterOptions } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Color, ColorChannel, ColorSpace } from '../color/color';
+import { ngpColorSlider, provideColorSliderState } from './color-slider-state';
+
+/**
+ * Apply the `ngpColorSlider` directive to an element that contains a color slider track and thumb.
+ * A color slider adjusts a single channel (e.g. hue, saturation, alpha) of a color value. It composes
+ * the underlying slider primitive, so it provides the slider state its track and thumb parts read.
+ */
+@Directive({
+  selector: '[ngpColorSlider]',
+  exportAs: 'ngpColorSlider',
+  providers: [provideColorSliderState(), provideSliderState({ inherit: false })],
+})
+export class NgpColorSlider {
+  /** The id of the slider. */
+  readonly id = input<string>(uniqueId('ngp-color-slider'));
+
+  /** The color value. */
+  readonly value = input<Color>(Color.parse('#ff0000'), {
+    alias: 'ngpColorSliderValue',
+  });
+
+  /** Emits when the value changes. */
+  readonly valueChange = output<Color>({
+    alias: 'ngpColorSliderValueChange',
+  });
+
+  /** The channel this slider adjusts. */
+  readonly channel = input<ColorChannel>('hue', {
+    alias: 'ngpColorSliderChannel',
+  });
+
+  /** The color space to operate in. Resolved from the channel/value when not set. */
+  readonly colorSpace = input<ColorSpace | undefined>(undefined, {
+    alias: 'ngpColorSliderColorSpace',
+  });
+
+  /** The orientation of the slider. */
+  readonly orientation = input<NgpOrientation>('horizontal', {
+    alias: 'ngpColorSliderOrientation',
+  });
+
+  /** The disabled state of the slider. */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpColorSliderDisabled',
+    transform: booleanAttribute,
+  });
+
+  protected readonly state = ngpColorSlider({
+    id: this.id,
+    value: this.value,
+    channel: this.channel,
+    colorSpace: this.colorSpace,
+    orientation: this.orientation,
+    disabled: this.disabled,
+    onValueChange: value => this.valueChange.emit(value),
+  });
+
+  /** Set the value of the slider. */
+  setValue(value: Color, options?: SetterOptions): void {
+    this.state.setValue(value, options);
+  }
+
+  /** Set the disabled state. */
+  setDisabled(disabled: boolean): void {
+    this.state.setDisabled(disabled);
+  }
+
+  /** Set the orientation. */
+  setOrientation(orientation: NgpOrientation): void {
+    this.state.setOrientation(orientation);
+  }
+}

--- a/packages/ng-primitives/color/src/color-slider/tests/color-slider.test.ts
+++ b/packages/ng-primitives/color/src/color-slider/tests/color-slider.test.ts
@@ -1,0 +1,122 @@
+import { fireEvent, render } from '@testing-library/angular';
+import { Color } from 'ng-primitives/color';
+import { NgpColorSlider, NgpColorSliderThumb, NgpColorSliderTrack } from 'ng-primitives/color';
+import { describe, expect, it, vi } from 'vitest';
+
+const imports = [NgpColorSlider, NgpColorSliderTrack, NgpColorSliderThumb];
+
+function template(extra = ''): string {
+  return `
+    <div
+      ngpColorSlider
+      data-testid="slider"
+      [ngpColorSliderValue]="value"
+      [ngpColorSliderChannel]="channel"
+      ${extra}
+      (ngpColorSliderValueChange)="onChange($event)">
+      <div ngpColorSliderTrack data-testid="track"></div>
+      <div ngpColorSliderThumb data-testid="thumb"></div>
+    </div>
+  `;
+}
+
+async function setup(props: { value?: Color; channel?: string; extra?: string } = {}) {
+  const onChange = vi.fn<(c: Color) => void>();
+  const view = await render(template(props.extra), {
+    imports,
+    componentProperties: {
+      value: props.value ?? Color.parse('#ff0000'),
+      channel: props.channel ?? 'hue',
+      onChange,
+    },
+  });
+  return { ...view, onChange, last: () => onChange.mock.lastCall?.[0] as Color };
+}
+
+describe('NgpColorSlider', () => {
+  it('exposes the channel as an ARIA slider', async () => {
+    const { getByTestId } = await setup(); // red, hue channel -> hsb hue = 0
+    const thumb = getByTestId('thumb');
+    expect(thumb).toHaveAttribute('role', 'slider');
+    expect(thumb).toHaveAttribute('aria-label', 'hue');
+    expect(thumb).toHaveAttribute('aria-valuemin', '0');
+    expect(thumb).toHaveAttribute('aria-valuemax', '360');
+    expect(thumb).toHaveAttribute('aria-valuenow', '0');
+    expect(thumb).toHaveAttribute('aria-orientation', 'horizontal');
+    expect(thumb).toHaveAttribute('aria-valuetext', 'hue 0');
+  });
+
+  it('positions the thumb by channel percentage', async () => {
+    const { getByTestId } = await setup({ value: Color.parse('hsb(180, 100%, 100%)') });
+    // hue 180 of 360 -> 50%
+    expect(getByTestId('thumb').style.getPropertyValue('inset-inline-start')).toBe('50%');
+  });
+
+  it('increments the channel on ArrowUp and emits a Color', async () => {
+    const { getByTestId, last } = await setup();
+    fireEvent.keyDown(getByTestId('thumb'), { key: 'ArrowUp' });
+    expect(last().getChannelValue('hue')).toBe(1);
+  });
+
+  it('uses a x10 step with shift', async () => {
+    const { getByTestId, last } = await setup();
+    fireEvent.keyDown(getByTestId('thumb'), { key: 'ArrowUp', shiftKey: true });
+    expect(last().getChannelValue('hue')).toBe(10);
+  });
+
+  it('Home/End jump to channel min/max', async () => {
+    const { getByTestId, last } = await setup({ value: Color.parse('hsb(200,100%,100%)') });
+    fireEvent.keyDown(getByTestId('thumb'), { key: 'Home' });
+    expect(last().getChannelValue('hue')).toBe(0);
+    fireEvent.keyDown(getByTestId('thumb'), { key: 'End' });
+    expect(last().getChannelValue('hue')).toBe(360);
+  });
+
+  it('operates on an rgb channel with the right range', async () => {
+    const { getByTestId, last } = await setup({
+      value: Color.parse('#3366cc'),
+      channel: 'red',
+    });
+    const thumb = getByTestId('thumb');
+    expect(thumb).toHaveAttribute('aria-valuemin', '0');
+    expect(thumb).toHaveAttribute('aria-valuemax', '255');
+    expect(thumb).toHaveAttribute('aria-valuenow', '51');
+    fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+    expect(last().getChannelValue('red')).toBe(52);
+  });
+
+  it('sets the channel from a track click position', async () => {
+    const { getByTestId, last } = await setup();
+    const track = getByTestId('track');
+    vi.spyOn(track, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 10,
+      width: 100,
+      height: 10,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.pointerDown(track, { clientX: 50, clientY: 5 });
+    expect(last().getChannelValue('hue')).toBe(180);
+  });
+
+  it('exposes a channel gradient as a CSS custom property', async () => {
+    const { getByTestId } = await setup();
+    const bg = getByTestId('slider').style.getPropertyValue('--ngp-color-slider-background');
+    expect(bg).toContain('linear-gradient(to right');
+    expect(bg).toContain('rgba(');
+  });
+
+  it('does not respond to keyboard when disabled', async () => {
+    const { getByTestId, onChange } = await setup({ extra: '[ngpColorSliderDisabled]="true"' });
+    const thumb = getByTestId('thumb');
+    expect(thumb).toHaveAttribute('tabindex', '-1');
+    expect(thumb).toHaveAttribute('data-disabled', '');
+    fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ng-primitives/color/src/color-swatch-picker-item/color-swatch-picker-item-state.ts
+++ b/packages/ng-primitives/color/src/color-swatch-picker-item/color-swatch-picker-item-state.ts
@@ -1,0 +1,80 @@
+import { computed, Signal, signal } from '@angular/core';
+import { ngpInteractions } from 'ng-primitives/interactions';
+import { injectElementRef } from 'ng-primitives/internal';
+import { ngpRovingFocusItem } from 'ng-primitives/roving-focus';
+import {
+  attrBinding,
+  createPrimitive,
+  dataBinding,
+  listener,
+  styleBinding,
+} from 'ng-primitives/state';
+import { injectColorSwatchPickerState } from '../color-swatch-picker/color-swatch-picker-state';
+import { Color } from '../color/color';
+
+/**
+ * Public state surface for a Color Swatch Picker Item primitive.
+ */
+export interface NgpColorSwatchPickerItemState {
+  /** Whether this swatch is the selected color. */
+  readonly selected: Signal<boolean>;
+}
+
+/**
+ * Inputs for configuring the Color Swatch Picker Item primitive.
+ */
+export interface NgpColorSwatchPickerItemProps {
+  /** The color this swatch represents. */
+  readonly color: Signal<Color>;
+  /** Whether the swatch is disabled. */
+  readonly disabled?: Signal<boolean>;
+}
+
+export const [
+  NgpColorSwatchPickerItemStateToken,
+  ngpColorSwatchPickerItem,
+  injectColorSwatchPickerItemState,
+  provideColorSwatchPickerItemState,
+] = createPrimitive(
+  'NgpColorSwatchPickerItem',
+  ({
+    color,
+    disabled = signal(false),
+  }: NgpColorSwatchPickerItemProps): NgpColorSwatchPickerItemState => {
+    const element = injectElementRef<HTMLElement>();
+    const picker = injectColorSwatchPickerState();
+
+    // Compose roving focus so this swatch participates in single-tab-stop keyboard navigation.
+    ngpRovingFocusItem({ disabled });
+
+    const selected = computed(() => picker().isSelected(color()));
+
+    // Host bindings — an option in the listbox.
+    attrBinding(element, 'role', 'option');
+    attrBinding(element, 'aria-selected', () => (selected() ? 'true' : 'false'));
+    attrBinding(element, 'aria-label', () => color().toHex());
+    dataBinding(element, 'data-selected', selected);
+    dataBinding(element, 'data-disabled', disabled);
+    styleBinding(element, '--ngp-color-swatch-color', () => color().toRgba());
+
+    ngpInteractions({ hover: true, focusVisible: true, press: true, disabled });
+
+    listener(element, 'click', () => {
+      if (!disabled()) {
+        picker().select(color());
+      }
+    });
+
+    listener(element, 'keydown', (event: KeyboardEvent) => {
+      if (disabled()) {
+        return;
+      }
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        picker().select(color());
+      }
+    });
+
+    return { selected } satisfies NgpColorSwatchPickerItemState;
+  },
+);

--- a/packages/ng-primitives/color/src/color-swatch-picker-item/color-swatch-picker-item.ts
+++ b/packages/ng-primitives/color/src/color-swatch-picker-item/color-swatch-picker-item.ts
@@ -1,0 +1,35 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import { provideRovingFocusItemState } from 'ng-primitives/roving-focus';
+import { Color } from '../color/color';
+import {
+  ngpColorSwatchPickerItem,
+  provideColorSwatchPickerItemState,
+} from './color-swatch-picker-item-state';
+
+/**
+ * Apply the `ngpColorSwatchPickerItem` directive to a selectable swatch within a swatch picker. Set its
+ * background to `var(--ngp-color-swatch-color)`. It composes a roving focus item.
+ */
+@Directive({
+  selector: '[ngpColorSwatchPickerItem]',
+  exportAs: 'ngpColorSwatchPickerItem',
+  providers: [provideColorSwatchPickerItemState(), provideRovingFocusItemState()],
+})
+export class NgpColorSwatchPickerItem {
+  /** The color this swatch represents. */
+  readonly color = input<Color>(Color.parse('#000000'), {
+    alias: 'ngpColorSwatchPickerItem',
+  });
+
+  /** Whether the swatch is disabled. */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpColorSwatchPickerItemDisabled',
+    transform: booleanAttribute,
+  });
+
+  protected readonly state = ngpColorSwatchPickerItem({
+    color: this.color,
+    disabled: this.disabled,
+  });
+}

--- a/packages/ng-primitives/color/src/color-swatch-picker/color-swatch-picker-state.ts
+++ b/packages/ng-primitives/color/src/color-swatch-picker/color-swatch-picker-state.ts
@@ -1,0 +1,114 @@
+import { computed, Signal, signal } from '@angular/core';
+import { NgpOrientation } from 'ng-primitives/common';
+import { injectElementRef } from 'ng-primitives/internal';
+import { ngpRovingFocusGroup } from 'ng-primitives/roving-focus';
+import {
+  attrBinding,
+  controlled,
+  createPrimitive,
+  dataBinding,
+  emitter,
+  SetterOptions,
+} from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Observable } from 'rxjs';
+import { injectColorPickerState } from '../color-picker/color-picker-state';
+import { Color } from '../color/color';
+
+/**
+ * Public state surface for the Color Swatch Picker primitive - a list of selectable color swatches.
+ */
+export interface NgpColorSwatchPickerState {
+  /** The id of the swatch picker. */
+  readonly id: Signal<string>;
+  /** The currently selected color (the parent picker's value when inside one). */
+  readonly value: Signal<Color>;
+  /** Whether the swatch picker is disabled. */
+  readonly disabled: Signal<boolean>;
+  /** Emits when the selected color changes. */
+  readonly valueChange: Observable<Color>;
+  /** Whether a color matches the current selection. */
+  isSelected(color: Color): boolean;
+  /** Select a color. */
+  select(color: Color, options?: SetterOptions): void;
+}
+
+/**
+ * Inputs for configuring the Color Swatch Picker primitive.
+ */
+export interface NgpColorSwatchPickerProps {
+  readonly id?: Signal<string>;
+  readonly value?: Signal<Color | undefined>;
+  readonly orientation?: Signal<NgpOrientation>;
+  readonly disabled?: Signal<boolean>;
+  readonly onValueChange?: (value: Color) => void;
+}
+
+/** Two colors are equal if they serialize identically (including alpha). */
+function colorsEqual(a: Color, b: Color): boolean {
+  return a.toRgba() === b.toRgba();
+}
+
+export const [
+  NgpColorSwatchPickerStateToken,
+  ngpColorSwatchPicker,
+  injectColorSwatchPickerState,
+  provideColorSwatchPickerState,
+] = createPrimitive(
+  'NgpColorSwatchPicker',
+  ({
+    id = signal(uniqueId('ngp-color-swatch-picker')),
+    value: _value = signal<Color | undefined>(undefined),
+    orientation = signal<NgpOrientation>('horizontal'),
+    disabled = signal(false),
+    onValueChange,
+  }: NgpColorSwatchPickerProps): NgpColorSwatchPickerState => {
+    const element = injectElementRef<HTMLElement>();
+    const picker = injectColorPickerState({ optional: true });
+    const local = controlled(_value);
+    const value = computed(() => picker()?.value() ?? local() ?? Color.parse('#000000'));
+    const hasSelection = computed(() => !!(picker() || local()));
+    const valueChange = emitter<Color>();
+
+    // Compose roving focus so arrow keys move between swatches with a single tab stop.
+    ngpRovingFocusGroup({
+      orientation,
+      wrap: signal(true),
+      homeEnd: signal(true),
+      disabled,
+      inherit: false,
+    });
+
+    // Host bindings — a single-select list of colors.
+    attrBinding(element, 'id', id);
+    attrBinding(element, 'role', 'listbox');
+    dataBinding(element, 'data-orientation', orientation);
+    dataBinding(element, 'data-disabled', disabled);
+
+    function isSelected(color: Color): boolean {
+      return hasSelection() && colorsEqual(color, value());
+    }
+
+    function select(color: Color, options?: SetterOptions): void {
+      const parent = picker();
+      if (parent) {
+        parent.setValue(color, options);
+      } else {
+        local.set(color);
+      }
+      if (options?.emit !== false) {
+        onValueChange?.(color);
+        valueChange.emit(color);
+      }
+    }
+
+    return {
+      id,
+      value,
+      disabled,
+      valueChange: valueChange.asObservable(),
+      isSelected,
+      select,
+    } satisfies NgpColorSwatchPickerState;
+  },
+);

--- a/packages/ng-primitives/color/src/color-swatch-picker/color-swatch-picker.ts
+++ b/packages/ng-primitives/color/src/color-swatch-picker/color-swatch-picker.ts
@@ -1,0 +1,56 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input, output } from '@angular/core';
+import { NgpOrientation } from 'ng-primitives/common';
+import { provideRovingFocusGroupState } from 'ng-primitives/roving-focus';
+import { SetterOptions } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Color } from '../color/color';
+import { ngpColorSwatchPicker, provideColorSwatchPickerState } from './color-swatch-picker-state';
+
+/**
+ * Apply the `ngpColorSwatchPicker` directive to a container of selectable color swatches. It composes
+ * roving focus for keyboard navigation, so it provides the roving focus group state.
+ */
+@Directive({
+  selector: '[ngpColorSwatchPicker]',
+  exportAs: 'ngpColorSwatchPicker',
+  providers: [provideColorSwatchPickerState(), provideRovingFocusGroupState({ inherit: false })],
+})
+export class NgpColorSwatchPicker {
+  /** The id of the swatch picker. */
+  readonly id = input<string>(uniqueId('ngp-color-swatch-picker'));
+
+  /** The selected color. */
+  readonly value = input<Color | undefined>(undefined, {
+    alias: 'ngpColorSwatchPickerValue',
+  });
+
+  /** Emits when the selected color changes. */
+  readonly valueChange = output<Color>({
+    alias: 'ngpColorSwatchPickerValueChange',
+  });
+
+  /** The orientation of the swatch list. */
+  readonly orientation = input<NgpOrientation>('horizontal', {
+    alias: 'ngpColorSwatchPickerOrientation',
+  });
+
+  /** The disabled state of the swatch picker. */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpColorSwatchPickerDisabled',
+    transform: booleanAttribute,
+  });
+
+  protected readonly state = ngpColorSwatchPicker({
+    id: this.id,
+    value: this.value,
+    orientation: this.orientation,
+    disabled: this.disabled,
+    onValueChange: value => this.valueChange.emit(value),
+  });
+
+  /** Select a color. */
+  select(color: Color, options?: SetterOptions): void {
+    this.state.select(color, options);
+  }
+}

--- a/packages/ng-primitives/color/src/color-swatch-picker/tests/color-swatch-picker.test.ts
+++ b/packages/ng-primitives/color/src/color-swatch-picker/tests/color-swatch-picker.test.ts
@@ -1,0 +1,78 @@
+import { fireEvent, render } from '@testing-library/angular';
+import { Color, NgpColorSwatchPicker, NgpColorSwatchPickerItem } from 'ng-primitives/color';
+import { describe, expect, it, vi } from 'vitest';
+
+const imports = [NgpColorSwatchPicker, NgpColorSwatchPickerItem];
+
+async function setup(selected = '#ff0000') {
+  const onChange = vi.fn<(c: Color) => void>();
+  const view = await render(
+    `<div
+        ngpColorSwatchPicker
+        data-testid="picker"
+        [ngpColorSwatchPickerValue]="value"
+        (ngpColorSwatchPickerValueChange)="onChange($event)">
+       <button [ngpColorSwatchPickerItem]="red" data-testid="red"></button>
+       <button [ngpColorSwatchPickerItem]="green" data-testid="green"></button>
+       <button [ngpColorSwatchPickerItem]="blue" data-testid="blue"></button>
+     </div>`,
+    {
+      imports,
+      componentProperties: {
+        value: Color.parse(selected),
+        red: Color.parse('#ff0000'),
+        green: Color.parse('#00ff00'),
+        blue: Color.parse('#0000ff'),
+        onChange,
+      },
+    },
+  );
+  return {
+    ...view,
+    onChange,
+    picker: view.getByTestId('picker'),
+    red: view.getByTestId('red'),
+    green: view.getByTestId('green'),
+    blue: view.getByTestId('blue'),
+    last: () => onChange.mock.lastCall?.[0] as Color,
+  };
+}
+
+describe('NgpColorSwatchPicker', () => {
+  it('renders a listbox of option swatches with the selected one marked', async () => {
+    const { picker, red, green } = await setup('#ff0000');
+    expect(picker).toHaveAttribute('role', 'listbox');
+    expect(red).toHaveAttribute('role', 'option');
+    expect(red).toHaveAttribute('aria-selected', 'true');
+    expect(red).toHaveAttribute('data-selected', '');
+    expect(green).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('exposes each swatch color as a CSS var', async () => {
+    const { green } = await setup();
+    expect(green.style.getPropertyValue('--ngp-color-swatch-color')).toBe('rgba(0, 255, 0, 1)');
+  });
+
+  it('selects a swatch on click', async () => {
+    const { green, red, last } = await setup('#ff0000');
+    fireEvent.click(green);
+    expect(last().toHex()).toBe('#00ff00');
+    expect(green).toHaveAttribute('aria-selected', 'true');
+    expect(red).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('selects a swatch with Enter and Space', async () => {
+    const { blue, green, onChange } = await setup('#ff0000');
+    fireEvent.keyDown(blue, { key: 'Enter' });
+    expect(onChange).toHaveBeenLastCalledWith(expect.anything());
+    expect(blue).toHaveAttribute('aria-selected', 'true');
+    fireEvent.keyDown(green, { key: ' ' });
+    expect(green).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('uses a single tab stop across the swatches (roving focus)', async () => {
+    const { red, green, blue } = await setup();
+    const stops = [red, green, blue].filter(el => el.getAttribute('tabindex') === '0');
+    expect(stops).toHaveLength(1);
+  });
+});

--- a/packages/ng-primitives/color/src/color-swatch/color-swatch-state.ts
+++ b/packages/ng-primitives/color/src/color-swatch/color-swatch-state.ts
@@ -1,0 +1,46 @@
+import { computed, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, styleBinding } from 'ng-primitives/state';
+import { injectColorPickerState } from '../color-picker/color-picker-state';
+import { Color } from '../color/color';
+
+/**
+ * Public state surface for the Color Swatch primitive - a non-interactive preview of a color.
+ */
+export interface NgpColorSwatchState {
+  /** The color being displayed. */
+  readonly color: Signal<Color>;
+}
+
+/**
+ * Inputs for configuring the Color Swatch primitive.
+ */
+export interface NgpColorSwatchProps {
+  /** The color to display. Falls back to the parent picker's value when omitted. */
+  readonly color?: Signal<Color | undefined>;
+  /** An accessible label. Defaults to the color's hex string. */
+  readonly label?: Signal<string | undefined>;
+}
+
+export const [
+  NgpColorSwatchStateToken,
+  ngpColorSwatch,
+  injectColorSwatchState,
+  provideColorSwatchState,
+] = createPrimitive(
+  'NgpColorSwatch',
+  ({ color: _color, label }: NgpColorSwatchProps): NgpColorSwatchState => {
+    const element = injectElementRef<HTMLElement>();
+    const picker = injectColorPickerState({ optional: true });
+
+    const color = computed(() => _color?.() ?? picker()?.value() ?? Color.parse('#000000'));
+
+    // A swatch is a picture of a color for assistive tech.
+    attrBinding(element, 'role', 'img');
+    attrBinding(element, 'aria-label', () => label?.() ?? color().toHex());
+    // Expose the color (with alpha) as a custom property to opt into as a background.
+    styleBinding(element, '--ngp-color-swatch-color', () => color().toRgba());
+
+    return { color } satisfies NgpColorSwatchState;
+  },
+);

--- a/packages/ng-primitives/color/src/color-swatch/color-swatch.ts
+++ b/packages/ng-primitives/color/src/color-swatch/color-swatch.ts
@@ -1,0 +1,31 @@
+import { Directive, input } from '@angular/core';
+import { Color } from '../color/color';
+import { ngpColorSwatch, provideColorSwatchState } from './color-swatch-state';
+
+/**
+ * Apply the `ngpColorSwatch` directive to an element to display a color preview. Set its background to
+ * `var(--ngp-color-swatch-color)`. Inside a color picker it shows the picker's value by default.
+ */
+@Directive({
+  selector: '[ngpColorSwatch]',
+  exportAs: 'ngpColorSwatch',
+  providers: [provideColorSwatchState()],
+})
+export class NgpColorSwatch {
+  /** The color to display. Falls back to the parent picker's value when omitted. */
+  readonly color = input<Color | undefined, Color | '' | undefined>(undefined, {
+    alias: 'ngpColorSwatch',
+    // an empty/bare attribute means "no explicit color" — fall back to the parent picker
+    transform: value => value || undefined,
+  });
+
+  /** An accessible label. Defaults to the color's hex string. */
+  readonly label = input<string | undefined>(undefined, {
+    alias: 'ngpColorSwatchLabel',
+  });
+
+  protected readonly state = ngpColorSwatch({
+    color: this.color,
+    label: this.label,
+  });
+}

--- a/packages/ng-primitives/color/src/color-swatch/tests/color-swatch.test.ts
+++ b/packages/ng-primitives/color/src/color-swatch/tests/color-swatch.test.ts
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/angular';
+import { Color, NgpColorPicker, NgpColorSwatch } from 'ng-primitives/color';
+import { describe, expect, it } from 'vitest';
+
+describe('NgpColorSwatch', () => {
+  it('renders as an image with a hex label and exposes the color as a CSS var', async () => {
+    const { getByTestId } = await render(
+      `<div [ngpColorSwatch]="color" data-testid="swatch"></div>`,
+      {
+        imports: [NgpColorSwatch],
+        componentProperties: { color: Color.parse('#00ff00') },
+      },
+    );
+    const el = getByTestId('swatch');
+    expect(el).toHaveAttribute('role', 'img');
+    expect(el).toHaveAttribute('aria-label', '#00ff00');
+    expect(el.style.getPropertyValue('--ngp-color-swatch-color')).toBe('rgba(0, 255, 0, 1)');
+  });
+
+  it('renders a translucent color', async () => {
+    const { getByTestId } = await render(
+      `<div [ngpColorSwatch]="color" data-testid="swatch"></div>`,
+      {
+        imports: [NgpColorSwatch],
+        componentProperties: { color: Color.parse('rgba(255,0,0,0.5)') },
+      },
+    );
+    expect(getByTestId('swatch').style.getPropertyValue('--ngp-color-swatch-color')).toBe(
+      'rgba(255, 0, 0, 0.5)',
+    );
+  });
+
+  it('uses a custom label when provided', async () => {
+    const { getByTestId } = await render(
+      `<div [ngpColorSwatch]="color" ngpColorSwatchLabel="Black" data-testid="swatch"></div>`,
+      { imports: [NgpColorSwatch], componentProperties: { color: Color.parse('#000000') } },
+    );
+    expect(getByTestId('swatch')).toHaveAttribute('aria-label', 'Black');
+  });
+
+  it('falls back to the parent picker value', async () => {
+    const { getByTestId } = await render(
+      `<div ngpColorPicker [ngpColorPickerValue]="color">
+         <div ngpColorSwatch data-testid="swatch"></div>
+       </div>`,
+      {
+        imports: [NgpColorPicker, NgpColorSwatch],
+        componentProperties: { color: Color.parse('#3366cc') },
+      },
+    );
+    expect(getByTestId('swatch')).toHaveAttribute('aria-label', '#3366cc');
+  });
+});

--- a/packages/ng-primitives/color/src/color-wheel-thumb/color-wheel-thumb-state.ts
+++ b/packages/ng-primitives/color/src/color-wheel-thumb/color-wheel-thumb-state.ts
@@ -1,0 +1,98 @@
+import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
+import { computed, inject } from '@angular/core';
+import { ngpInteractions } from 'ng-primitives/interactions';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  createPrimitive,
+  dataBinding,
+  listener,
+  onDestroy,
+} from 'ng-primitives/state';
+import { injectColorWheelState } from '../color-wheel/color-wheel-state';
+
+type WheelKey = 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown' | 'Home' | 'End';
+
+/**
+ * Public state surface for the Color Wheel Thumb primitive.
+ */
+export interface NgpColorWheelThumbState {
+  /** Focus the thumb element. */
+  focus(origin?: FocusOrigin): void;
+}
+
+/**
+ * Inputs for configuring the Color Wheel Thumb primitive.
+ */
+export interface NgpColorWheelThumbProps {}
+
+export const [
+  NgpColorWheelThumbStateToken,
+  ngpColorWheelThumb,
+  injectColorWheelThumbState,
+  provideColorWheelThumbState,
+] = createPrimitive(
+  'NgpColorWheelThumb',
+  ({}: NgpColorWheelThumbProps): NgpColorWheelThumbState => {
+    const element = injectElementRef<HTMLElement>();
+    const wheel = injectColorWheelState();
+    const focusMonitor = inject(FocusMonitor);
+
+    const tabindex = computed(() => (wheel().disabled() ? -1 : 0));
+
+    // Host bindings — the wheel adjusts a single hue value, so it is an ARIA slider.
+    attrBinding(element, 'role', 'slider');
+    attrBinding(element, 'aria-label', 'Hue');
+    attrBinding(element, 'aria-valuemin', '0');
+    attrBinding(element, 'aria-valuemax', '360');
+    attrBinding(element, 'aria-valuenow', () => Math.round(wheel().hue()).toString());
+    attrBinding(element, 'aria-valuetext', () => `${Math.round(wheel().hue())}°`);
+    attrBinding(element, 'tabindex', () => tabindex().toString());
+    dataBinding(element, 'data-disabled', () => wheel().disabled());
+
+    ngpInteractions({
+      hover: true,
+      focusVisible: true,
+      press: true,
+      disabled: wheel().disabled,
+    });
+
+    wheel().setThumb(element);
+    onDestroy(() => wheel().setThumb(undefined));
+
+    listener(element, 'keydown', (event: KeyboardEvent) => {
+      if (wheel().disabled()) {
+        return;
+      }
+      const step = event.shiftKey ? 10 : 1;
+      const hue = wheel().hue();
+
+      switch (event.key as WheelKey) {
+        case 'ArrowRight':
+        case 'ArrowUp':
+          wheel().setHue(hue + step);
+          break;
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          wheel().setHue(hue - step);
+          break;
+        case 'Home':
+          wheel().setHue(0);
+          break;
+        case 'End':
+          wheel().setHue(360);
+          break;
+        default:
+          return;
+      }
+
+      event.preventDefault();
+    });
+
+    function focus(origin: FocusOrigin = 'program'): void {
+      focusMonitor.focusVia(element, origin, { preventScroll: true });
+    }
+
+    return { focus } satisfies NgpColorWheelThumbState;
+  },
+);

--- a/packages/ng-primitives/color/src/color-wheel-thumb/color-wheel-thumb.ts
+++ b/packages/ng-primitives/color/src/color-wheel-thumb/color-wheel-thumb.ts
@@ -1,0 +1,18 @@
+import { Directive } from '@angular/core';
+import { ngpColorWheelThumb, provideColorWheelThumbState } from './color-wheel-thumb-state';
+
+/**
+ * Apply the `ngpColorWheelThumb` directive to the element that represents the color wheel thumb.
+ * Position it with the `--ngp-color-wheel-hue` custom property, e.g.
+ * `transform: translate(-50%, -50%) rotate(var(--ngp-color-wheel-hue)) translateY(calc(-1 * <radius>))`.
+ */
+@Directive({
+  selector: '[ngpColorWheelThumb]',
+  exportAs: 'ngpColorWheelThumb',
+  providers: [provideColorWheelThumbState()],
+})
+export class NgpColorWheelThumb {
+  constructor() {
+    ngpColorWheelThumb({});
+  }
+}

--- a/packages/ng-primitives/color/src/color-wheel/color-wheel-state.ts
+++ b/packages/ng-primitives/color/src/color-wheel/color-wheel-state.ts
@@ -1,0 +1,221 @@
+import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
+import { DOCUMENT } from '@angular/common';
+import {
+  computed,
+  ElementRef,
+  inject,
+  Injector,
+  Signal,
+  signal,
+  WritableSignal,
+} from '@angular/core';
+import { ngpFormControl } from 'ng-primitives/form-field';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  controlled,
+  createPrimitive,
+  dataBinding,
+  emitter,
+  listener,
+  SetterOptions,
+  styleBinding,
+} from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Observable } from 'rxjs';
+import { injectColorPickerState } from '../color-picker/color-picker-state';
+import { Color, ColorSpace } from '../color/color';
+
+/**
+ * Public state surface for the Color Wheel primitive - a circular control adjusting the hue channel.
+ */
+export interface NgpColorWheelState {
+  /** The id of the wheel. */
+  readonly id: Signal<string>;
+  /** The current color value (the parent picker's value when inside one). */
+  readonly value: Signal<Color>;
+  /** The color space the wheel operates in. */
+  readonly colorSpace: Signal<ColorSpace>;
+  /** The current hue in degrees (0-360). */
+  readonly hue: Signal<number>;
+  /** A conic-gradient of the full hue spectrum. */
+  readonly gradient: Signal<string>;
+  /** Whether the wheel is disabled (includes form control state). */
+  readonly disabled: WritableSignal<boolean>;
+  /** @internal The thumb element reference. */
+  readonly thumb: Signal<ElementRef<HTMLElement> | undefined>;
+  /** Emits when the value changes. */
+  readonly valueChange: Observable<Color>;
+  /** Set the full color value. */
+  setValue(value: Color, options?: SetterOptions): void;
+  /** Set the hue to a value in degrees (clamped 0-360). */
+  setHue(hue: number, options?: SetterOptions): void;
+  /** @internal Register the thumb element. */
+  setThumb(thumb: ElementRef<HTMLElement> | undefined): void;
+  /** Focus the thumb element. */
+  focusThumb(origin: FocusOrigin): void;
+  /** Set the disabled state. */
+  setDisabled(disabled: boolean): void;
+}
+
+/**
+ * Inputs for configuring the Color Wheel primitive.
+ */
+export interface NgpColorWheelProps {
+  readonly id?: Signal<string>;
+  readonly value?: Signal<Color>;
+  readonly colorSpace?: Signal<ColorSpace>;
+  readonly disabled?: Signal<boolean>;
+  readonly onValueChange?: (value: Color) => void;
+}
+
+/** Angle from the top of the circle, measured clockwise, in degrees (0-360). Matches CSS conic-gradient. */
+function angleFromCenter(dx: number, dy: number): number {
+  const deg = (Math.atan2(dx, -dy) * 180) / Math.PI;
+  return (deg + 360) % 360;
+}
+
+export const [
+  NgpColorWheelStateToken,
+  ngpColorWheel,
+  injectColorWheelState,
+  provideColorWheelState,
+] = createPrimitive(
+  'NgpColorWheel',
+  ({
+    id = signal(uniqueId('ngp-color-wheel')),
+    value: _value = signal(Color.parse('hsl(0, 100%, 50%)')),
+    colorSpace = signal<ColorSpace>('hsl'),
+    disabled: _disabled = signal(false),
+    onValueChange,
+  }: NgpColorWheelProps): NgpColorWheelState => {
+    const element = injectElementRef<HTMLElement>();
+    const focusMonitor = inject(FocusMonitor);
+    const injector = inject(Injector);
+    const document = inject(DOCUMENT);
+    const picker = injectColorPickerState({ optional: true });
+    const local = controlled(_value);
+    const value = computed(() => picker()?.value() ?? local());
+    const disabled = controlled(_disabled);
+    const valueChange = emitter<Color>();
+    const thumb = signal<ElementRef<HTMLElement> | undefined>(undefined);
+
+    const status = ngpFormControl({ id, disabled });
+
+    const converted = computed(() => value().toFormat(colorSpace()));
+    const hue = computed(() => converted().getChannelValue('hue'));
+
+    const gradient = computed(() => hueGradient(converted()));
+
+    // Host bindings
+    attrBinding(element, 'id', id);
+    dataBinding(element, 'data-disabled', () => status().disabled);
+    styleBinding(element, '--ngp-color-wheel-background', gradient);
+    // the hue angle, for positioning the thumb: transform: rotate(var(--ngp-color-wheel-hue)) ...
+    styleBinding(element, '--ngp-color-wheel-hue', () => `${hue()}deg`);
+
+    let dragging = false;
+    let activePointerId: number | null = null;
+    let cleanup: (() => void)[] = [];
+
+    listener(element, 'pointerdown', (event: PointerEvent) => {
+      if (status().disabled) {
+        return;
+      }
+      event.preventDefault();
+      dragging = true;
+      activePointerId = event.pointerId;
+      setFromPointer(event);
+      focusThumb(event.pointerType === 'touch' ? 'touch' : 'mouse');
+
+      cleanup.forEach(fn => fn());
+      cleanup = [
+        listener(document, 'pointermove', onPointerMove, { config: false, injector }),
+        listener(document, 'pointerup', onPointerEnd, { config: false, injector }),
+        listener(document, 'pointercancel', onPointerEnd, { config: false, injector }),
+      ];
+    });
+
+    function onPointerMove(event: PointerEvent): void {
+      if (status().disabled || !dragging || event.pointerId !== activePointerId) {
+        return;
+      }
+      setFromPointer(event);
+    }
+
+    function onPointerEnd(event: PointerEvent): void {
+      if (event.pointerId !== activePointerId) {
+        return;
+      }
+      dragging = false;
+      activePointerId = null;
+      cleanup.forEach(fn => fn());
+      cleanup = [];
+    }
+
+    function setFromPointer(event: PointerEvent): void {
+      const rect = element.nativeElement.getBoundingClientRect();
+      const dx = event.clientX - (rect.left + rect.width / 2);
+      const dy = event.clientY - (rect.top + rect.height / 2);
+      setHue(angleFromCenter(dx, dy));
+    }
+
+    function setValue(newValue: Color, options?: SetterOptions): void {
+      const parent = picker();
+      if (parent) {
+        parent.setValue(newValue, options);
+      } else {
+        local.set(newValue);
+      }
+      if (options?.emit !== false) {
+        onValueChange?.(newValue);
+        valueChange.emit(newValue);
+      }
+    }
+
+    function setHue(newHue: number, options?: SetterOptions): void {
+      const clamped = Math.min(360, Math.max(0, Math.round(newHue)));
+      setValue(converted().withChannelValue('hue', clamped), options);
+    }
+
+    function setThumb(newThumb: ElementRef<HTMLElement> | undefined): void {
+      thumb.set(newThumb);
+    }
+
+    function focusThumb(origin: FocusOrigin): void {
+      const el = thumb();
+      if (el) {
+        focusMonitor.focusVia(el, origin, { preventScroll: true });
+      }
+    }
+
+    function setDisabled(isDisabled: boolean): void {
+      disabled.set(isDisabled);
+    }
+
+    return {
+      id,
+      value,
+      colorSpace,
+      hue,
+      gradient,
+      disabled,
+      thumb,
+      valueChange: valueChange.asObservable(),
+      setValue,
+      setHue,
+      setThumb,
+      focusThumb,
+      setDisabled,
+    } satisfies NgpColorWheelState;
+  },
+);
+
+/** A conic-gradient of the full hue spectrum (red at top, clockwise), matching the thumb angle. */
+function hueGradient(color: Color): string {
+  const stops: string[] = [];
+  for (let hue = 0; hue <= 360; hue += 60) {
+    stops.push(color.withChannelValue('hue', hue).toRgb());
+  }
+  return `conic-gradient(${stops.join(', ')})`;
+}

--- a/packages/ng-primitives/color/src/color-wheel/color-wheel.ts
+++ b/packages/ng-primitives/color/src/color-wheel/color-wheel.ts
@@ -1,0 +1,59 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input, output } from '@angular/core';
+import { SetterOptions } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Color, ColorSpace } from '../color/color';
+import { ngpColorWheel, provideColorWheelState } from './color-wheel-state';
+
+/**
+ * Apply the `ngpColorWheel` directive to a circular element that adjusts the hue channel of a color.
+ * Set its background to `var(--ngp-color-wheel-background)` and contain a thumb.
+ */
+@Directive({
+  selector: '[ngpColorWheel]',
+  exportAs: 'ngpColorWheel',
+  providers: [provideColorWheelState()],
+})
+export class NgpColorWheel {
+  /** The id of the wheel. */
+  readonly id = input<string>(uniqueId('ngp-color-wheel'));
+
+  /** The color value. */
+  readonly value = input<Color>(Color.parse('hsl(0, 100%, 50%)'), {
+    alias: 'ngpColorWheelValue',
+  });
+
+  /** Emits when the value changes. */
+  readonly valueChange = output<Color>({
+    alias: 'ngpColorWheelValueChange',
+  });
+
+  /** The color space to operate in. */
+  readonly colorSpace = input<ColorSpace>('hsl', {
+    alias: 'ngpColorWheelColorSpace',
+  });
+
+  /** The disabled state of the wheel. */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpColorWheelDisabled',
+    transform: booleanAttribute,
+  });
+
+  protected readonly state = ngpColorWheel({
+    id: this.id,
+    value: this.value,
+    colorSpace: this.colorSpace,
+    disabled: this.disabled,
+    onValueChange: value => this.valueChange.emit(value),
+  });
+
+  /** Set the value of the wheel. */
+  setValue(value: Color, options?: SetterOptions): void {
+    this.state.setValue(value, options);
+  }
+
+  /** Set the disabled state. */
+  setDisabled(disabled: boolean): void {
+    this.state.setDisabled(disabled);
+  }
+}

--- a/packages/ng-primitives/color/src/color-wheel/tests/color-wheel.test.ts
+++ b/packages/ng-primitives/color/src/color-wheel/tests/color-wheel.test.ts
@@ -1,0 +1,89 @@
+import { fireEvent, render } from '@testing-library/angular';
+import { Color, NgpColorWheel, NgpColorWheelThumb } from 'ng-primitives/color';
+import { describe, expect, it, vi } from 'vitest';
+
+async function setup(props: { value?: Color; extra?: string } = {}) {
+  const onChange = vi.fn<(c: Color) => void>();
+  const view = await render(
+    `<div
+        ngpColorWheel
+        data-testid="wheel"
+        [ngpColorWheelValue]="value"
+        ${props.extra ?? ''}
+        (ngpColorWheelValueChange)="onChange($event)">
+       <div ngpColorWheelThumb data-testid="thumb"></div>
+     </div>`,
+    {
+      imports: [NgpColorWheel, NgpColorWheelThumb],
+      componentProperties: { value: props.value ?? Color.parse('hsl(0, 100%, 50%)'), onChange },
+    },
+  );
+  return {
+    ...view,
+    onChange,
+    wheel: view.getByTestId('wheel'),
+    thumb: view.getByTestId('thumb'),
+    last: () => onChange.mock.lastCall?.[0] as Color,
+  };
+}
+
+describe('NgpColorWheel', () => {
+  it('exposes the hue as an ARIA slider', async () => {
+    const { thumb } = await setup({ value: Color.parse('hsl(120, 100%, 50%)') });
+    expect(thumb).toHaveAttribute('role', 'slider');
+    expect(thumb).toHaveAttribute('aria-label', 'Hue');
+    expect(thumb).toHaveAttribute('aria-valuemin', '0');
+    expect(thumb).toHaveAttribute('aria-valuemax', '360');
+    expect(thumb).toHaveAttribute('aria-valuenow', '120');
+  });
+
+  it('exposes the hue angle and a conic gradient as CSS custom properties', async () => {
+    const { wheel } = await setup({ value: Color.parse('hsl(90, 100%, 50%)') });
+    expect(wheel.style.getPropertyValue('--ngp-color-wheel-hue')).toBe('90deg');
+    expect(wheel.style.getPropertyValue('--ngp-color-wheel-background')).toContain(
+      'conic-gradient(',
+    );
+  });
+
+  it('adjusts hue with arrow keys, shift and Home/End', async () => {
+    const { thumb, last } = await setup({ value: Color.parse('hsl(100, 100%, 50%)') });
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    expect(last().getChannelValue('hue')).toBe(101);
+    fireEvent.keyDown(thumb, { key: 'ArrowLeft', shiftKey: true });
+    expect(last().getChannelValue('hue')).toBe(91);
+    fireEvent.keyDown(thumb, { key: 'Home' });
+    expect(last().getChannelValue('hue')).toBe(0);
+    fireEvent.keyDown(thumb, { key: 'End' });
+    expect(last().getChannelValue('hue')).toBe(360);
+  });
+
+  it('sets hue from the pointer angle around the center', async () => {
+    const { wheel, last } = await setup();
+    vi.spyOn(wheel, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    // click at the right edge -> 90° clockwise from top -> hue 90
+    fireEvent.pointerDown(wheel, { clientX: 200, clientY: 100 });
+    expect(last().getChannelValue('hue')).toBe(90);
+    // click at the bottom -> 180°
+    fireEvent.pointerDown(wheel, { clientX: 100, clientY: 200 });
+    expect(last().getChannelValue('hue')).toBe(180);
+  });
+
+  it('does not respond when disabled', async () => {
+    const { thumb, wheel, onChange } = await setup({ extra: '[ngpColorWheelDisabled]="true"' });
+    expect(thumb).toHaveAttribute('tabindex', '-1');
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    fireEvent.pointerDown(wheel, { clientX: 200, clientY: 100 });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ng-primitives/color/src/color/color.test.ts
+++ b/packages/ng-primitives/color/src/color/color.test.ts
@@ -1,0 +1,293 @@
+import { Color } from './color';
+
+describe('Color.parse', () => {
+  it('parses 6-digit hex', () => {
+    const c = Color.parse('#3366cc');
+    expect(c.getColorSpace()).toBe('rgb');
+    expect(c.getChannelValue('red')).toBe(51);
+    expect(c.getChannelValue('green')).toBe(102);
+    expect(c.getChannelValue('blue')).toBe(204);
+    expect(c.getChannelValue('alpha')).toBe(1);
+  });
+
+  it('parses 3-digit shorthand hex', () => {
+    const c = Color.parse('#f00');
+    expect(c.getChannelValue('red')).toBe(255);
+    expect(c.getChannelValue('green')).toBe(0);
+    expect(c.getChannelValue('blue')).toBe(0);
+  });
+
+  it('parses 8-digit hex with alpha', () => {
+    const c = Color.parse('#3366cc80');
+    expect(c.getChannelValue('red')).toBe(51);
+    expect(c.getChannelValue('alpha')).toBeCloseTo(0.502, 2);
+  });
+
+  it('parses rgb() and rgba()', () => {
+    expect(Color.parse('rgb(51, 102, 204)').getChannelValue('blue')).toBe(204);
+    expect(Color.parse('rgba(51, 102, 204, 0.5)').getChannelValue('alpha')).toBe(0.5);
+  });
+
+  it('parses hsl() and hsla()', () => {
+    const c = Color.parse('hsl(220, 60%, 50%)');
+    expect(c.getColorSpace()).toBe('hsl');
+    expect(c.getChannelValue('hue')).toBe(220);
+    expect(c.getChannelValue('saturation')).toBe(60);
+    expect(c.getChannelValue('lightness')).toBe(50);
+  });
+
+  it('parses hsb()/hsba()', () => {
+    const c = Color.parse('hsb(220, 75%, 80%)');
+    expect(c.getColorSpace()).toBe('hsb');
+    expect(c.getChannelValue('brightness')).toBe(80);
+  });
+
+  it('is case and whitespace insensitive', () => {
+    expect(Color.parse('  #FFF  ').getChannelValue('red')).toBe(255);
+    expect(Color.parse('RGB(1,2,3)').getChannelValue('red')).toBe(1);
+  });
+
+  it('parses modern space-separated syntax with alpha', () => {
+    const c = Color.parse('rgb(51 102 204 / 0.5)');
+    expect(c.getChannelValue('red')).toBe(51);
+    expect(c.getChannelValue('alpha')).toBe(0.5);
+  });
+
+  it('clamps out-of-range channel values and wraps hue', () => {
+    expect(Color.parse('rgb(999, 0, 300)').getChannelValue('red')).toBe(255);
+    expect(Color.parse('rgb(999, 0, 300)').getChannelValue('blue')).toBe(255);
+    // hue wraps modulo 360 to match CSS (hsl(400) -> 40), the rest clamp
+    expect(Color.parse('hsl(400, 150%, 50%)').getChannelValue('hue')).toBe(40);
+    expect(Color.parse('hsl(400, 150%, 50%)').getChannelValue('saturation')).toBe(100);
+    expect(Color.parse('rgba(0,0,0,2)').getChannelValue('alpha')).toBe(1);
+  });
+
+  it('throws on invalid input', () => {
+    expect(() => Color.parse('not a color')).toThrow();
+    expect(() => Color.parse('#gg0000')).toThrow();
+    expect(() => Color.parse('#12345')).toThrow();
+  });
+});
+
+describe('getChannelValue (auto-converting reads)', () => {
+  // #3366cc = rgb(51,102,204) = hsl(220,60,50) = hsb(220,75,80)
+  const rgb = Color.parse('#3366cc');
+
+  it('reads in-space channels directly', () => {
+    expect(rgb.getChannelValue('red')).toBe(51);
+  });
+
+  it('reads a foreign channel by converting (hue -> hsb/hsl are equal)', () => {
+    expect(rgb.getChannelValue('hue')).toBeCloseTo(220, 0);
+  });
+
+  it('reads lightness by converting to hsl', () => {
+    expect(rgb.getChannelValue('lightness')).toBeCloseTo(50, 0);
+  });
+
+  it('reads brightness by converting to hsb', () => {
+    expect(rgb.getChannelValue('brightness')).toBeCloseTo(80, 0);
+  });
+
+  it('resolves the ambiguous saturation channel to hsb', () => {
+    // hsb saturation = 75, hsl saturation = 60 — must pick hsb
+    expect(rgb.getChannelValue('saturation')).toBeCloseTo(75, 0);
+  });
+
+  it('reads saturation in-space when the color is already hsl', () => {
+    expect(Color.parse('hsl(220, 60%, 50%)').getChannelValue('saturation')).toBe(60);
+  });
+});
+
+describe('getChannelRange', () => {
+  it('reports space-independent ranges per channel', () => {
+    const c = Color.parse('#3366cc');
+    expect(c.getChannelRange('red')).toEqual({ min: 0, max: 255, step: 1 });
+    expect(c.getChannelRange('hue')).toEqual({ min: 0, max: 360, step: 1 });
+    expect(c.getChannelRange('saturation')).toEqual({ min: 0, max: 100, step: 1 });
+    expect(c.getChannelRange('alpha')).toEqual({ min: 0, max: 1, step: 0.01 });
+  });
+});
+
+describe('getColorChannels', () => {
+  it('lists the three non-alpha channels of the space', () => {
+    expect(Color.parse('#3366cc').getColorChannels()).toEqual(['red', 'green', 'blue']);
+    expect(Color.parse('hsl(0,0%,0%)').getColorChannels()).toEqual([
+      'hue',
+      'saturation',
+      'lightness',
+    ]);
+    expect(Color.parse('hsb(0,0%,0%)').getColorChannels()).toEqual([
+      'hue',
+      'saturation',
+      'brightness',
+    ]);
+  });
+});
+
+describe('toFormat', () => {
+  const rgb = Color.parse('#3366cc');
+
+  it('rgb -> hsl', () => {
+    const hsl = rgb.toFormat('hsl');
+    expect(hsl.getColorSpace()).toBe('hsl');
+    expect(hsl.getChannelValue('hue')).toBeCloseTo(220, 0);
+    expect(hsl.getChannelValue('saturation')).toBeCloseTo(60, 0);
+    expect(hsl.getChannelValue('lightness')).toBeCloseTo(50, 0);
+  });
+
+  it('rgb -> hsb', () => {
+    const hsb = rgb.toFormat('hsb');
+    expect(hsb.getChannelValue('saturation')).toBeCloseTo(75, 0);
+    expect(hsb.getChannelValue('brightness')).toBeCloseTo(80, 0);
+  });
+
+  it('round-trips primaries without drift', () => {
+    const red = Color.parse('#ff0000');
+    expect(red.toFormat('hsb').toFormat('rgb').toHex()).toBe('#ff0000');
+    expect(red.toFormat('hsl').toFormat('rgb').toHex()).toBe('#ff0000');
+  });
+
+  it('handles achromatic colors', () => {
+    expect(Color.parse('#ffffff').toFormat('hsb').getChannelValue('saturation')).toBe(0);
+    expect(Color.parse('#000000').toFormat('hsl').getChannelValue('lightness')).toBe(0);
+  });
+
+  it('preserves alpha across conversion', () => {
+    expect(Color.parse('rgba(255,0,0,0.5)').toFormat('hsb').getChannelValue('alpha')).toBe(0.5);
+  });
+});
+
+describe('string outputs', () => {
+  const c = Color.parse('#3366cc');
+  const translucent = Color.parse('rgba(51, 102, 204, 0.5)');
+
+  it('toHex / toHexa', () => {
+    expect(c.toHex()).toBe('#3366cc');
+    expect(translucent.toHexa()).toBe('#3366cc80');
+  });
+
+  it('toRgb / toRgba (comma form)', () => {
+    expect(c.toRgb()).toBe('rgb(51, 102, 204)');
+    expect(translucent.toRgba()).toBe('rgba(51, 102, 204, 0.5)');
+  });
+
+  it('toHsl / toHsla', () => {
+    expect(c.toHsl()).toBe('hsl(220, 60%, 50%)');
+    expect(translucent.toHsla()).toBe('hsla(220, 60%, 50%, 0.5)');
+  });
+
+  it('toHsb / toHsba', () => {
+    expect(c.toHsb()).toBe('hsb(220, 75%, 80%)');
+    expect(translucent.toHsba()).toBe('hsba(220, 75%, 80%, 0.5)');
+  });
+
+  it('toCss picks hex when opaque, rgba when translucent', () => {
+    expect(c.toCss()).toBe('#3366cc');
+    expect(translucent.toCss()).toBe('rgba(51, 102, 204, 0.5)');
+  });
+
+  it('toString delegates to toCss', () => {
+    expect(c.toString()).toBe(c.toCss());
+    expect(`${translucent}`).toBe('rgba(51, 102, 204, 0.5)');
+  });
+});
+
+describe('withChannelValue (immutable, auto-converting)', () => {
+  it('returns a new color, leaving the original unchanged', () => {
+    const a = Color.parse('#3366cc');
+    const b = a.withChannelValue('red', 0);
+    expect(a.getChannelValue('red')).toBe(51);
+    expect(b.getChannelValue('red')).toBe(0);
+    expect(b).not.toBe(a);
+  });
+
+  it('clamps to the channel range', () => {
+    const hsb = Color.parse('hsb(220,75%,80%)');
+    expect(hsb.withChannelValue('saturation', 500).getChannelValue('saturation')).toBe(100);
+    expect(hsb.withChannelValue('brightness', -20).getChannelValue('brightness')).toBe(0);
+    expect(Color.parse('#3366cc').withChannelValue('alpha', 5).getChannelValue('alpha')).toBe(1);
+  });
+
+  it('auto-converts when the channel is not in the color own space', () => {
+    const green = Color.parse('#ff0000').withChannelValue('hue', 120);
+    expect(green.getColorSpace()).toBe('hsb');
+    expect(green.toHex()).toBe('#00ff00');
+  });
+
+  it('stays in space when the channel belongs to it', () => {
+    const c = Color.parse('hsl(220,60%,50%)').withChannelValue('saturation', 30);
+    expect(c.getColorSpace()).toBe('hsl');
+    expect(c.getChannelValue('saturation')).toBe(30);
+  });
+});
+
+describe('fluent getters', () => {
+  const rgb = Color.parse('#3366cc');
+
+  it('getRed/getGreen/getBlue read the rgb channels', () => {
+    expect(rgb.getRed()).toBe(51);
+    expect(rgb.getGreen()).toBe(102);
+    expect(rgb.getBlue()).toBe(204);
+  });
+
+  it('getAlpha reads alpha', () => {
+    expect(Color.parse('rgba(0,0,0,0.5)').getAlpha()).toBe(0.5);
+    expect(rgb.getAlpha()).toBe(1);
+  });
+
+  it('getHue/getSaturation/getLightness/getBrightness auto-convert', () => {
+    expect(rgb.getHue()).toBeCloseTo(220, 0);
+    expect(rgb.getSaturation()).toBeCloseTo(75, 0); // ambiguous -> hsb
+    expect(rgb.getLightness()).toBeCloseTo(50, 0);
+    expect(rgb.getBrightness()).toBeCloseTo(80, 0);
+  });
+
+  it('getSaturation stays hsl when the color is hsl', () => {
+    expect(Color.parse('hsl(220,60%,50%)').getSaturation()).toBe(60);
+  });
+});
+
+describe('fluent withers', () => {
+  it('withAlpha', () => {
+    const c = Color.parse('#ff0000').withAlpha(0.5);
+    expect(c.getChannelValue('alpha')).toBe(0.5);
+    expect(c.toRgba()).toBe('rgba(255, 0, 0, 0.5)');
+  });
+
+  it('withRed/withGreen/withBlue operate in rgb', () => {
+    expect(Color.parse('#000000').withRed(255).toHex()).toBe('#ff0000');
+    expect(Color.parse('#000000').withGreen(255).toHex()).toBe('#00ff00');
+    expect(Color.parse('#000000').withBlue(255).toHex()).toBe('#0000ff');
+  });
+
+  it('withHue auto-converts to hsb', () => {
+    const c = Color.parse('#ff0000').withHue(240);
+    expect(c.getColorSpace()).toBe('hsb');
+    expect(c.toHex()).toBe('#0000ff');
+  });
+
+  it('withSaturation resolves to hsb by default', () => {
+    const c = Color.parse('#ff0000').withSaturation(50);
+    expect(c.getColorSpace()).toBe('hsb');
+    expect(c.getChannelValue('saturation')).toBe(50);
+  });
+
+  it('withSaturation stays hsl when the color is hsl', () => {
+    const c = Color.parse('hsl(0,100%,50%)').withSaturation(40);
+    expect(c.getColorSpace()).toBe('hsl');
+    expect(c.getChannelValue('saturation')).toBe(40);
+  });
+
+  it('withLightness -> hsl, withBrightness -> hsb', () => {
+    expect(Color.parse('#ff0000').withLightness(100).getColorSpace()).toBe('hsl');
+    expect(Color.parse('#ff0000').withBrightness(50).getColorSpace()).toBe('hsb');
+  });
+
+  it('withers clamp and are immutable', () => {
+    const red = Color.parse('#ff0000');
+    expect(red.withAlpha(9).getChannelValue('alpha')).toBe(1);
+    expect(red.getChannelValue('alpha')).toBe(1); // original unchanged
+    expect(red.withHue(400).getChannelValue('hue')).toBe(360);
+  });
+});

--- a/packages/ng-primitives/color/src/color/color.ts
+++ b/packages/ng-primitives/color/src/color/color.ts
@@ -1,0 +1,415 @@
+/**
+ * A minimal immutable color model supporting the rgb, hsl and hsb color spaces (each with alpha).
+ * Construct with {@link Color.parse}; derive new colors with the immutable `with*` methods. Reads and
+ * withers auto-convert across spaces, so any channel is accessible regardless of the color's own space.
+ */
+export type ColorSpace = 'rgb' | 'hsl' | 'hsb';
+
+export type ColorChannel =
+  | 'red'
+  | 'green'
+  | 'blue'
+  | 'hue'
+  | 'saturation'
+  | 'lightness'
+  | 'brightness'
+  | 'alpha';
+
+export interface ColorChannelRange {
+  min: number;
+  max: number;
+  step: number;
+}
+
+const SPACE_CHANNELS: Record<ColorSpace, [ColorChannel, ColorChannel, ColorChannel]> = {
+  rgb: ['red', 'green', 'blue'],
+  hsl: ['hue', 'saturation', 'lightness'],
+  hsb: ['hue', 'saturation', 'brightness'],
+};
+
+const RANGES: Record<ColorChannel, ColorChannelRange> = {
+  red: { min: 0, max: 255, step: 1 },
+  green: { min: 0, max: 255, step: 1 },
+  blue: { min: 0, max: 255, step: 1 },
+  hue: { min: 0, max: 360, step: 1 },
+  saturation: { min: 0, max: 100, step: 1 },
+  lightness: { min: 0, max: 100, step: 1 },
+  brightness: { min: 0, max: 100, step: 1 },
+  alpha: { min: 0, max: 1, step: 0.01 },
+};
+
+/** The space a channel resolves to when it is not present in a color's own space (ambiguous → hsb). */
+const CHANNEL_SPACE: Record<Exclude<ColorChannel, 'alpha'>, ColorSpace> = {
+  red: 'rgb',
+  green: 'rgb',
+  blue: 'rgb',
+  lightness: 'hsl',
+  brightness: 'hsb',
+  hue: 'hsb',
+  saturation: 'hsb',
+};
+
+function clamp(value: number, { min, max }: ColorChannelRange): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function isChannelInSpace(space: ColorSpace, channel: ColorChannel): boolean {
+  return channel === 'alpha' || SPACE_CHANNELS[space].includes(channel);
+}
+
+const ZERO: Record<ColorChannel, number> = {
+  red: 0,
+  green: 0,
+  blue: 0,
+  hue: 0,
+  saturation: 0,
+  lightness: 0,
+  brightness: 0,
+  alpha: 1,
+};
+
+export class Color {
+  private constructor(
+    private readonly space: ColorSpace,
+    private readonly values: Record<ColorChannel, number>,
+    private readonly alpha: number,
+  ) {}
+
+  /** Parse a CSS color string (hex, rgb(a), hsl(a) or hsb(a)) into a `Color`. Throws on invalid input. */
+  static parse(value: string): Color {
+    const input = value.trim();
+
+    const hex = HEX_RE.exec(input);
+    if (hex) {
+      return Color.fromHex(hex[1]);
+    }
+
+    // normalise out-of-range channel values to match CSS semantics: hue wraps (hsl(400) -> 40),
+    // the rest clamp to their range (rgb(999,...) -> 255)
+    const ch = (v: string, channel: ColorChannel) =>
+      channel === 'hue' ? ((+v % 360) + 360) % 360 : clamp(+v, RANGES[channel]);
+    const alpha = (v: string | undefined) => (v === undefined ? 1 : clamp(+v, RANGES.alpha));
+
+    const rgb = RGB_RE.exec(input);
+    if (rgb) {
+      return new Color(
+        'rgb',
+        { ...ZERO, red: ch(rgb[1], 'red'), green: ch(rgb[2], 'green'), blue: ch(rgb[3], 'blue') },
+        alpha(rgb[4]),
+      );
+    }
+
+    const hsl = HSL_RE.exec(input);
+    if (hsl) {
+      return new Color(
+        'hsl',
+        {
+          ...ZERO,
+          hue: ch(hsl[1], 'hue'),
+          saturation: ch(hsl[2], 'saturation'),
+          lightness: ch(hsl[3], 'lightness'),
+        },
+        alpha(hsl[4]),
+      );
+    }
+
+    const hsb = HSB_RE.exec(input);
+    if (hsb) {
+      return new Color(
+        'hsb',
+        {
+          ...ZERO,
+          hue: ch(hsb[1], 'hue'),
+          saturation: ch(hsb[2], 'saturation'),
+          brightness: ch(hsb[3], 'brightness'),
+        },
+        alpha(hsb[4]),
+      );
+    }
+
+    throw new Error(`Invalid color value: "${value}"`);
+  }
+
+  /** The color space this color is defined in. */
+  getColorSpace(): ColorSpace {
+    return this.space;
+  }
+
+  /** The three non-alpha channels of this color's space, in order. */
+  getColorChannels(): ColorChannel[] {
+    return [...SPACE_CHANNELS[this.space]];
+  }
+
+  /** The value of a channel. Channels outside this color's space are read by converting. */
+  getChannelValue(channel: ColorChannel): number {
+    if (channel === 'alpha') {
+      return this.alpha;
+    }
+    if (isChannelInSpace(this.space, channel)) {
+      return this.values[channel];
+    }
+    return this.toFormat(CHANNEL_SPACE[channel]).getChannelValue(channel);
+  }
+
+  /** The valid range and step for a channel. */
+  getChannelRange(channel: ColorChannel): ColorChannelRange {
+    return RANGES[channel];
+  }
+
+  /** The red channel (0-255), converting to rgb if needed. */
+  getRed(): number {
+    return this.getChannelValue('red');
+  }
+  /** The green channel (0-255), converting to rgb if needed. */
+  getGreen(): number {
+    return this.getChannelValue('green');
+  }
+  /** The blue channel (0-255), converting to rgb if needed. */
+  getBlue(): number {
+    return this.getChannelValue('blue');
+  }
+  /** The hue (0-360), converting if needed. */
+  getHue(): number {
+    return this.getChannelValue('hue');
+  }
+  /** The saturation (0-100), resolving to hsb when the color is not already hsl/hsb. */
+  getSaturation(): number {
+    return this.getChannelValue('saturation');
+  }
+  /** The lightness (0-100), converting to hsl if needed. */
+  getLightness(): number {
+    return this.getChannelValue('lightness');
+  }
+  /** The brightness (0-100), converting to hsb if needed. */
+  getBrightness(): number {
+    return this.getChannelValue('brightness');
+  }
+  /** The alpha (0-1). */
+  getAlpha(): number {
+    return this.alpha;
+  }
+
+  /** A new color with `channel` set to `value` (clamped). Converts space if the channel is foreign. */
+  withChannelValue(channel: ColorChannel, value: number): Color {
+    if (channel === 'alpha') {
+      return new Color(this.space, { ...this.values }, clamp(value, RANGES.alpha));
+    }
+    const targetSpace = isChannelInSpace(this.space, channel) ? this.space : CHANNEL_SPACE[channel];
+    const base = this.toFormat(targetSpace);
+    return new Color(
+      targetSpace,
+      { ...base.values, [channel]: clamp(value, RANGES[channel]) },
+      base.alpha,
+    );
+  }
+
+  /** @returns a new color with the red channel set (in rgb). */
+  withRed(value: number): Color {
+    return this.withChannelValue('red', value);
+  }
+  /** @returns a new color with the green channel set (in rgb). */
+  withGreen(value: number): Color {
+    return this.withChannelValue('green', value);
+  }
+  /** @returns a new color with the blue channel set (in rgb). */
+  withBlue(value: number): Color {
+    return this.withChannelValue('blue', value);
+  }
+  /** @returns a new color with the hue set (in hsb, unless already hsl). */
+  withHue(value: number): Color {
+    return this.withChannelValue('hue', value);
+  }
+  /** @returns a new color with the saturation set (in hsb, unless already hsl). */
+  withSaturation(value: number): Color {
+    return this.withChannelValue('saturation', value);
+  }
+  /** @returns a new color with the lightness set (in hsl). */
+  withLightness(value: number): Color {
+    return this.withChannelValue('lightness', value);
+  }
+  /** @returns a new color with the brightness set (in hsb). */
+  withBrightness(value: number): Color {
+    return this.withChannelValue('brightness', value);
+  }
+  /** @returns a new color with the alpha set (0-1). */
+  withAlpha(value: number): Color {
+    return this.withChannelValue('alpha', value);
+  }
+
+  /** This color converted to another color space (alpha preserved). */
+  toFormat(space: ColorSpace): Color {
+    if (space === this.space) {
+      return this;
+    }
+    const { r, g, b } = this.toRgbChannels();
+    return Color.fromRgb(space, r, g, b, this.alpha);
+  }
+
+  /** '#rrggbb' */
+  toHex(): string {
+    const { r, g, b } = this.toRgbChannels();
+    return `#${hex2(r)}${hex2(g)}${hex2(b)}`;
+  }
+  /** '#rrggbbaa' */
+  toHexa(): string {
+    return `${this.toHex()}${hex2(this.alpha * 255)}`;
+  }
+  /** 'rgb(r, g, b)' */
+  toRgb(): string {
+    const { r, g, b } = this.toRgbChannels();
+    return `rgb(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)})`;
+  }
+  /** 'rgba(r, g, b, a)' */
+  toRgba(): string {
+    const { r, g, b } = this.toRgbChannels();
+    return `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${round2(this.alpha)})`;
+  }
+  /** 'hsl(h, s%, l%)' */
+  toHsl(): string {
+    const c = this.toFormat('hsl');
+    return `hsl(${Math.round(c.values.hue)}, ${Math.round(c.values.saturation)}%, ${Math.round(c.values.lightness)}%)`;
+  }
+  /** 'hsla(h, s%, l%, a)' */
+  toHsla(): string {
+    const c = this.toFormat('hsl');
+    return `hsla(${Math.round(c.values.hue)}, ${Math.round(c.values.saturation)}%, ${Math.round(c.values.lightness)}%, ${round2(this.alpha)})`;
+  }
+  /** 'hsb(h, s%, b%)' */
+  toHsb(): string {
+    const c = this.toFormat('hsb');
+    return `hsb(${Math.round(c.values.hue)}, ${Math.round(c.values.saturation)}%, ${Math.round(c.values.brightness)}%)`;
+  }
+  /** 'hsba(h, s%, b%, a)' */
+  toHsba(): string {
+    const c = this.toFormat('hsb');
+    return `hsba(${Math.round(c.values.hue)}, ${Math.round(c.values.saturation)}%, ${Math.round(c.values.brightness)}%, ${round2(this.alpha)})`;
+  }
+  /** The shortest sensible CSS: hex when opaque, rgba when translucent. */
+  toCss(): string {
+    return this.alpha < 1 ? this.toRgba() : this.toHex();
+  }
+  /** Delegates to {@link toCss}, so `${color}` yields a valid CSS string. */
+  toString(): string {
+    return this.toCss();
+  }
+
+  /** Convert this color to rgb channels in the 0-255 range (unrounded). */
+  private toRgbChannels(): { r: number; g: number; b: number } {
+    if (this.space === 'rgb') {
+      return { r: this.values.red, g: this.values.green, b: this.values.blue };
+    }
+    const h = this.values.hue;
+    const s = this.values.saturation / 100;
+    if (this.space === 'hsl') {
+      return hslToRgb(h, s, this.values.lightness / 100);
+    }
+    return hsbToRgb(h, s, this.values.brightness / 100);
+  }
+
+  private static fromHex(hex: string): Color {
+    const full =
+      hex.length <= 4
+        ? hex
+            .split('')
+            .map(c => c + c)
+            .join('')
+        : hex;
+    return new Color(
+      'rgb',
+      {
+        ...ZERO,
+        red: parseInt(full.slice(0, 2), 16),
+        green: parseInt(full.slice(2, 4), 16),
+        blue: parseInt(full.slice(4, 6), 16),
+      },
+      full.length === 8 ? parseInt(full.slice(6, 8), 16) / 255 : 1,
+    );
+  }
+
+  private static fromRgb(space: ColorSpace, r: number, g: number, b: number, alpha: number): Color {
+    if (space === 'rgb') {
+      return new Color('rgb', { ...ZERO, red: r, green: g, blue: b }, alpha);
+    }
+    const { h, s, x } = space === 'hsl' ? rgbToHsl(r, g, b) : rgbToHsb(r, g, b);
+    const third = space === 'hsl' ? 'lightness' : 'brightness';
+    return new Color(space, { ...ZERO, hue: h, saturation: s, [third]: x }, alpha);
+  }
+}
+
+function hex2(value: number): string {
+  return Math.round(clamp(value, RANGES.red)).toString(16).padStart(2, '0');
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function rgbHue(r: number, g: number, b: number, max: number, delta: number): number {
+  if (delta === 0) {
+    return 0;
+  }
+  let h: number;
+  if (max === r) {
+    h = ((g - b) / delta) % 6;
+  } else if (max === g) {
+    h = (b - r) / delta + 2;
+  } else {
+    h = (r - g) / delta + 4;
+  }
+  h *= 60;
+  return h < 0 ? h + 360 : h;
+}
+
+function rgbToHsl(r: number, g: number, b: number): { h: number; s: number; x: number } {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+  return { h: rgbHue(r, g, b, max, delta), s: s * 100, x: l * 100 };
+}
+
+function rgbToHsb(r: number, g: number, b: number): { h: number; s: number; x: number } {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+  const s = max === 0 ? 0 : delta / max;
+  return { h: rgbHue(r, g, b, max, delta), s: s * 100, x: max * 100 };
+}
+
+function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const [r, g, b] = hueChroma(h, c, l - c / 2);
+  return { r: r * 255, g: g * 255, b: b * 255 };
+}
+
+function hsbToRgb(h: number, s: number, v: number): { r: number; g: number; b: number } {
+  const c = v * s;
+  const [r, g, b] = hueChroma(h, c, v - c);
+  return { r: r * 255, g: g * 255, b: b * 255 };
+}
+
+function hueChroma(h: number, c: number, m: number): [number, number, number] {
+  const hp = (((h % 360) + 360) % 360) / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let rgb: [number, number, number];
+  if (hp < 1) rgb = [c, x, 0];
+  else if (hp < 2) rgb = [x, c, 0];
+  else if (hp < 3) rgb = [0, c, x];
+  else if (hp < 4) rgb = [0, x, c];
+  else if (hp < 5) rgb = [x, 0, c];
+  else rgb = [c, 0, x];
+  return [rgb[0] + m, rgb[1] + m, rgb[2] + m];
+}
+
+const HEX_RE = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+// accept comma- or space-separated channels, and a comma or slash before alpha (modern CSS)
+const RGB_RE = /^rgba?\(\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)\s*(?:[,/]\s*([\d.]+)\s*)?\)$/i;
+const HSL_RE = /^hsla?\(\s*([\d.]+)[\s,]+([\d.]+)%[\s,]+([\d.]+)%\s*(?:[,/]\s*([\d.]+)\s*)?\)$/i;
+const HSB_RE = /^hsba?\(\s*([\d.]+)[\s,]+([\d.]+)%[\s,]+([\d.]+)%\s*(?:[,/]\s*([\d.]+)\s*)?\)$/i;

--- a/packages/ng-primitives/color/src/index.ts
+++ b/packages/ng-primitives/color/src/index.ts
@@ -1,0 +1,109 @@
+export { Color, ColorSpace, ColorChannel, ColorChannelRange } from './color/color';
+export { NgpColorSlider } from './color-slider/color-slider';
+export {
+  NgpColorSliderStateToken,
+  ngpColorSlider,
+  injectColorSliderState,
+  provideColorSliderState,
+  type NgpColorSliderState,
+  type NgpColorSliderProps,
+} from './color-slider/color-slider-state';
+export { NgpColorSliderTrack } from './color-slider-track/color-slider-track';
+export {
+  NgpColorSliderTrackStateToken,
+  ngpColorSliderTrack,
+  injectColorSliderTrackState,
+  provideColorSliderTrackState,
+  type NgpColorSliderTrackState,
+  type NgpColorSliderTrackProps,
+} from './color-slider-track/color-slider-track-state';
+export { NgpColorSliderThumb } from './color-slider-thumb/color-slider-thumb';
+export {
+  NgpColorSliderThumbStateToken,
+  ngpColorSliderThumb,
+  injectColorSliderThumbState,
+  provideColorSliderThumbState,
+  type NgpColorSliderThumbState,
+  type NgpColorSliderThumbProps,
+} from './color-slider-thumb/color-slider-thumb-state';
+export { NgpColorArea } from './color-area/color-area';
+export {
+  NgpColorAreaStateToken,
+  ngpColorArea,
+  injectColorAreaState,
+  provideColorAreaState,
+  type NgpColorAreaState,
+  type NgpColorAreaProps,
+} from './color-area/color-area-state';
+export { NgpColorAreaThumb } from './color-area-thumb/color-area-thumb';
+export {
+  NgpColorAreaThumbStateToken,
+  ngpColorAreaThumb,
+  injectColorAreaThumbState,
+  provideColorAreaThumbState,
+  type NgpColorAreaThumbState,
+  type NgpColorAreaThumbProps,
+} from './color-area-thumb/color-area-thumb-state';
+export { NgpColorField } from './color-field/color-field';
+export {
+  NgpColorFieldStateToken,
+  ngpColorField,
+  injectColorFieldState,
+  provideColorFieldState,
+  type NgpColorFieldState,
+  type NgpColorFieldProps,
+} from './color-field/color-field-state';
+export { NgpColorPicker } from './color-picker/color-picker';
+export {
+  NgpColorPickerStateToken,
+  ngpColorPicker,
+  injectColorPickerState,
+  provideColorPickerState,
+  type NgpColorPickerState,
+  type NgpColorPickerProps,
+} from './color-picker/color-picker-state';
+export { NgpColorSwatch } from './color-swatch/color-swatch';
+export {
+  NgpColorSwatchStateToken,
+  ngpColorSwatch,
+  injectColorSwatchState,
+  provideColorSwatchState,
+  type NgpColorSwatchState,
+  type NgpColorSwatchProps,
+} from './color-swatch/color-swatch-state';
+export { NgpColorWheel } from './color-wheel/color-wheel';
+export {
+  NgpColorWheelStateToken,
+  ngpColorWheel,
+  injectColorWheelState,
+  provideColorWheelState,
+  type NgpColorWheelState,
+  type NgpColorWheelProps,
+} from './color-wheel/color-wheel-state';
+export { NgpColorWheelThumb } from './color-wheel-thumb/color-wheel-thumb';
+export {
+  NgpColorWheelThumbStateToken,
+  ngpColorWheelThumb,
+  injectColorWheelThumbState,
+  provideColorWheelThumbState,
+  type NgpColorWheelThumbState,
+  type NgpColorWheelThumbProps,
+} from './color-wheel-thumb/color-wheel-thumb-state';
+export { NgpColorSwatchPicker } from './color-swatch-picker/color-swatch-picker';
+export {
+  NgpColorSwatchPickerStateToken,
+  ngpColorSwatchPicker,
+  injectColorSwatchPickerState,
+  provideColorSwatchPickerState,
+  type NgpColorSwatchPickerState,
+  type NgpColorSwatchPickerProps,
+} from './color-swatch-picker/color-swatch-picker-state';
+export { NgpColorSwatchPickerItem } from './color-swatch-picker-item/color-swatch-picker-item';
+export {
+  NgpColorSwatchPickerItemStateToken,
+  ngpColorSwatchPickerItem,
+  injectColorSwatchPickerItemState,
+  provideColorSwatchPickerItemState,
+  type NgpColorSwatchPickerItemState,
+  type NgpColorSwatchPickerItemProps,
+} from './color-swatch-picker-item/color-swatch-picker-item-state';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -72,7 +72,8 @@
       "ng-primitives/navigation-menu": ["packages/ng-primitives/navigation-menu/src/index.ts"],
       "ng-primitives/number-field": ["packages/ng-primitives/number-field/src/index.ts"],
       "ng-primitives/context-menu": ["packages/ng-primitives/context-menu/src/index.ts"],
-      "ng-primitives/password": ["./packages/ng-primitives/password/src/index.ts"]
+      "ng-primitives/password": ["./packages/ng-primitives/password/src/index.ts"],
+      "ng-primitives/color": ["./packages/ng-primitives/color/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Feature

## Issue

Closes #

## What does this PR implement/fix?

Adds a headless color primitive family:

- An immutable `Color` model — `Color.parse` plus hsb/hsl/rgb/hex (with alpha), auto-converting getters/withers, and `to*` string methods.
- A `ColorPicker` coordinator with `ColorArea`, `ColorSlider`, `ColorField`, `ColorWheel`, `ColorSwatch` and `ColorSwatchPicker` parts. Each part works standalone or binds to the picker's value automatically.

Includes unit tests, a documentation page, and CSS/Tailwind examples.

## Does this PR introduce a breaking change?

- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ng-primitives/color`: an immutable `Color` model and a headless, composable color picker set (area + thumb, sliders + track/thumb, field, wheel + thumb, swatch, swatch picker + item) that share one value and expose CSS vars.

- **New Features**
  - `Color` model: parse hex/rgb/hsl/hsb (with alpha), auto-converting getters/withers, and `to*` string methods.
  - Coordinator and parts: `NgpColorPicker`, `NgpColorArea` + thumb, `NgpColorSlider` + track/thumb, `NgpColorField`, `NgpColorWheel` + thumb, `NgpColorSwatch`, `NgpColorSwatchPicker` + item; standalone or bound to the picker.
  - Accessible keyboard/pointer interactions and disabled states via `ng-primitives/slider`, `ng-primitives/input`, and `ng-primitives/roving-focus`.
  - Exposes CSS vars: `--ngp-color-area-background`, `--ngp-color-slider-background`, `--ngp-color-wheel-background`, `--ngp-color-wheel-hue`, `--ngp-color-swatch-color`.
  - Added `ng-primitives/color` entry point and TS path mapping.

- **Documentation**
  - New docs page and examples (basic, Tailwind, popover) showcasing all parts, plus unit tests across the color model and primitives.

<sup>Written for commit 20ea2bb3173a8dc6fd9d1b10853be28300e00cab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Angular colour primitives: picker coordination, 2D colour area, sliders (including hue/alpha), colour wheel, colour field, swatches, and swatch picker selection.
  * Introduced an immutable `Color` model with parsing, RGB/HSL/HSB conversion, alpha support, and CSS/hex output.
  * Added accessibility-aligned keyboard/pointer interactions and disabled-state handling across controls.
* **Documentation**
  * Added a new “Color Picker” documentation page and multiple interactive examples (including popover/Tailwind styles).
  * Added a package entry README for `ng-primitives/color`.
* **Tests**
  * Added comprehensive coverage for `Color` parsing/conversion plus interaction, accessibility, selection, gradients/CSS variables, and disabled behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->