### PR TITLE
feat(collapsible): add collapsible primitive and share its core with accordion

### DIFF
--- a/apps/documentation/src/app/examples/collapsible/collapsible.example.ts
+++ b/apps/documentation/src/app/examples/collapsible/collapsible.example.ts
@@ -1,0 +1,139 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDownMini } from '@ng-icons/heroicons/mini';
+import { NgpButton } from 'ng-primitives/button';
+import {
+  NgpCollapsible,
+  NgpCollapsibleContent,
+  NgpCollapsibleTrigger,
+} from 'ng-primitives/collapsible';
+
+@Component({
+  selector: 'app-collapsible',
+  imports: [NgpButton, NgIcon, NgpCollapsible, NgpCollapsibleTrigger, NgpCollapsibleContent],
+  providers: [provideIcons({ heroChevronDownMini })],
+  styles: `
+    :host {
+      display: flex;
+      justify-content: center;
+      width: 100%;
+    }
+
+    [ngpCollapsible] {
+      width: 100%;
+      max-width: 24rem;
+      border-radius: 0.75rem;
+      border: 1px solid var(--ngp-border);
+      background-color: var(--ngp-background);
+      box-shadow: var(--ngp-shadow);
+      overflow: hidden;
+    }
+
+    [ngpCollapsibleTrigger] {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: space-between;
+      align-items: center;
+      width: 100%;
+      height: 3rem;
+      padding: 0 1rem;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      font-weight: 510;
+      letter-spacing: -0.006em;
+      text-align: left;
+      color: var(--ngp-text-primary);
+      background-color: transparent;
+      border: none;
+      outline: none;
+      cursor: pointer;
+      transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpCollapsibleTrigger][data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpCollapsibleTrigger][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: -2px;
+    }
+
+    [ngpCollapsibleContent] {
+      font-size: 0.875rem;
+      line-height: 1.5;
+      color: var(--ngp-text-secondary);
+      overflow: hidden;
+      height: 0;
+    }
+
+    [ngpCollapsibleContent][data-open] {
+      height: var(--ngp-collapsible-content-height, 0px);
+    }
+
+    [ngpCollapsibleContent][data-enter] {
+      animation: slideDown 0.2s ease-in-out forwards;
+    }
+
+    [ngpCollapsibleContent][data-exit] {
+      height: var(--ngp-collapsible-content-height, 0px);
+      animation: slideUp 0.2s ease-in-out forwards;
+    }
+
+    .collapsible-content {
+      padding: 0 1rem 1rem;
+    }
+
+    ng-icon {
+      flex: none;
+      font-size: 1.125rem;
+      color: var(--ngp-text-tertiary);
+      transition:
+        transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
+        color 150ms ease;
+    }
+
+    [ngpCollapsibleTrigger][data-hover] ng-icon {
+      color: var(--ngp-text-secondary);
+    }
+
+    [ngpCollapsibleTrigger][data-open] ng-icon {
+      transform: rotate(180deg);
+      color: var(--ngp-text-secondary);
+    }
+
+    @keyframes slideDown {
+      from {
+        height: 0;
+      }
+      to {
+        height: var(--ngp-collapsible-content-height);
+      }
+    }
+
+    @keyframes slideUp {
+      from {
+        height: var(--ngp-collapsible-content-height);
+      }
+      to {
+        height: 0;
+      }
+    }
+  `,
+  template: `
+    <div ngpCollapsible>
+      <button ngpCollapsibleTrigger ngpButton>
+        What is a headless component library?
+
+        <ng-icon name="heroChevronDownMini" />
+      </button>
+      <div ngpCollapsibleContent>
+        <div class="collapsible-content">
+          A headless library provides the behaviour and accessibility of a component without any
+          styling, leaving you in full control of the markup and design.
+        </div>
+      </div>
+    </div>
+  `,
+})
+export default class CollapsibleExample {}

--- a/apps/documentation/src/app/examples/collapsible/collapsible.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/collapsible/collapsible.tailwind.example.ts
@@ -1,0 +1,80 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDownMini } from '@ng-icons/heroicons/mini';
+import { NgpButton } from 'ng-primitives/button';
+import {
+  NgpCollapsible,
+  NgpCollapsibleContent,
+  NgpCollapsibleTrigger,
+} from 'ng-primitives/collapsible';
+
+@Component({
+  selector: 'app-collapsible',
+  imports: [NgpButton, NgIcon, NgpCollapsible, NgpCollapsibleTrigger, NgpCollapsibleContent],
+  providers: [provideIcons({ heroChevronDownMini })],
+  styles: `
+    [ngpCollapsibleContent] {
+      overflow: hidden;
+      height: 0;
+    }
+
+    [ngpCollapsibleContent][data-open] {
+      height: var(--ngp-collapsible-content-height, 0px);
+    }
+
+    [ngpCollapsibleContent][data-enter] {
+      animation: slideDown 0.2s ease-in-out forwards;
+    }
+
+    [ngpCollapsibleContent][data-exit] {
+      height: var(--ngp-collapsible-content-height, 0px);
+      animation: slideUp 0.2s ease-in-out forwards;
+    }
+
+    @keyframes slideDown {
+      from {
+        height: 0;
+      }
+      to {
+        height: var(--ngp-collapsible-content-height);
+      }
+    }
+
+    @keyframes slideUp {
+      from {
+        height: var(--ngp-collapsible-content-height);
+      }
+      to {
+        height: 0;
+      }
+    }
+  `,
+  host: {
+    class: 'w-full flex justify-center',
+  },
+  template: `
+    <div
+      class="w-full max-w-sm overflow-hidden rounded-xl border border-gray-200 bg-white ring-1 ring-black/5 dark:border-zinc-800 dark:bg-zinc-950 dark:ring-white/10"
+      ngpCollapsible
+    >
+      <button
+        class="group flex h-12 w-full cursor-pointer items-center justify-between gap-3 bg-transparent px-4 text-left text-sm font-medium tracking-[-0.006em] text-gray-900 outline-hidden transition-colors data-focus-visible:ring-2 data-focus-visible:ring-blue-500 data-focus-visible:ring-inset data-hover:bg-gray-50 dark:text-gray-100 dark:data-focus-visible:ring-blue-400 dark:data-hover:bg-zinc-900"
+        ngpCollapsibleTrigger
+        ngpButton
+      >
+        What is a headless component library?
+        <ng-icon
+          class="shrink-0 text-lg text-gray-400 transition-transform duration-200 ease-in-out group-data-[open]:rotate-180 dark:text-gray-500"
+          name="heroChevronDownMini"
+        />
+      </button>
+      <div class="text-sm leading-relaxed text-gray-500 dark:text-gray-400" ngpCollapsibleContent>
+        <div class="px-4 pt-0 pb-4">
+          A headless library provides the behaviour and accessibility of a component without any
+          styling, leaving you in full control of the markup and design.
+        </div>
+      </div>
+    </div>
+  `,
+})
+export default class CollapsibleExample {}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/accordion.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/accordion.md
@@ -90,6 +90,7 @@ The following directives are available to import from the `ng-primitives/accordi
 <api-reference-attributes>
   <api-attribute name="data-orientation" description="The orientation of the accordion." value="horizontal | vertical" />
   <api-attribute name="data-open" description="Applied when the accordion item is open." />
+  <api-attribute name="data-closed" description="Applied when the accordion item is closed." />
   <api-attribute name="data-disabled" description="Applied when the accordion item is disabled." />
 </api-reference-attributes>
 
@@ -102,6 +103,7 @@ The following directives are available to import from the `ng-primitives/accordi
 <api-reference-attributes>
   <api-attribute name="data-orientation" description="The orientation of the accordion." value="horizontal | vertical" />
   <api-attribute name="data-open" description="Applied when the accordion item is open." />
+  <api-attribute name="data-closed" description="Applied when the accordion item is closed." />
   <api-attribute name="data-disabled" description="Applied when the accordion item is disabled." />
 </api-reference-attributes>
 
@@ -114,6 +116,8 @@ The following directives are available to import from the `ng-primitives/accordi
 <api-reference-attributes>
   <api-attribute name="data-orientation" description="The orientation of the accordion." value="horizontal | vertical" />
   <api-attribute name="data-open" description="Applied when the accordion item is open." />
+  <api-attribute name="data-closed" description="Applied when the accordion item is closed." />
+  <api-attribute name="data-disabled" description="Applied when the accordion item is disabled." />
   <api-attribute name="data-enter" description="Applied when the accordion item is opening (user interaction). Removed on the content element's animationend event." />
   <api-attribute name="data-exit" description="Applied when the accordion item is closing (user interaction). Removed on the content element's animationend event." />
 </api-reference-attributes>

--- a/apps/documentation/src/app/pages/(documentation)/primitives/collapsible.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/collapsible.md
@@ -1,0 +1,108 @@
+---
+name: 'Collapsible'
+sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/collapsible'
+---
+
+# Collapsible
+
+A collapsible shows and hides an associated section of content, following the WAI-ARIA disclosure pattern.
+
+<docs-example name="collapsible"></docs-example>
+
+## Import
+
+Import the Collapsible primitives from `ng-primitives/collapsible`.
+
+```ts
+import {
+  NgpCollapsible,
+  NgpCollapsibleTrigger,
+  NgpCollapsibleContent,
+} from 'ng-primitives/collapsible';
+```
+
+## Usage
+
+Assemble the collapsible directives in your template.
+
+```html
+<div ngpCollapsible>
+  <button ngpCollapsibleTrigger>Show details</button>
+  <div ngpCollapsibleContent>The content that is shown and hidden.</div>
+</div>
+```
+
+## Grouping Collapsibles
+
+For a single collapsible, use this primitive directly. If you need multiple sections with coordinated open state - where opening one may close another - reach for the [Accordion](/primitives/accordion) primitive instead. Each accordion item is built on this same collapsible core.
+
+## API Reference
+
+The following directives are available to import from the `ng-primitives/collapsible` package:
+
+### NgpCollapsible
+
+<api-docs name="NgpCollapsible"></api-docs>
+
+<api-reference-props name="NgpCollapsible"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-open" description="Applied when the collapsible is open." />
+  <api-attribute name="data-closed" description="Applied when the collapsible is closed." />
+  <api-attribute name="data-disabled" description="Applied when the collapsible is disabled." />
+  <api-attribute name="data-orientation" description="The orientation of the collapsible." value="horizontal | vertical" />
+</api-reference-attributes>
+
+### NgpCollapsibleTrigger
+
+<api-docs name="NgpCollapsibleTrigger"></api-docs>
+
+<api-reference-props name="NgpCollapsibleTrigger"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-open" description="Applied when the collapsible is open." />
+  <api-attribute name="data-closed" description="Applied when the collapsible is closed." />
+  <api-attribute name="data-disabled" description="Applied when the collapsible is disabled." />
+  <api-attribute name="data-orientation" description="The orientation of the collapsible." value="horizontal | vertical" />
+</api-reference-attributes>
+
+### NgpCollapsibleContent
+
+<api-docs name="NgpCollapsibleContent"></api-docs>
+
+<api-reference-props name="NgpCollapsibleContent"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-open" description="Applied when the collapsible is open." />
+  <api-attribute name="data-closed" description="Applied when the collapsible is closed." />
+  <api-attribute name="data-disabled" description="Applied when the collapsible is disabled." />
+  <api-attribute name="data-orientation" description="The orientation of the collapsible." value="horizontal | vertical" />
+  <api-attribute name="data-enter" description="Applied when the collapsible is opening (user interaction). Removed on the content element's animationend event." />
+  <api-attribute name="data-exit" description="Applied when the collapsible is closing (user interaction). Removed on the content element's animationend event." />
+</api-reference-attributes>
+
+<api-reference-css-vars>
+  <api-css-var name="--ngp-collapsible-content-width" description="The width of the collapsible content." />
+  <api-css-var name="--ngp-collapsible-content-height" description="The height of the collapsible content." />
+</api-reference-css-vars>
+
+## Animations
+
+The `ngpCollapsibleContent` primitive sets `--ngp-collapsible-content-width` and `--ngp-collapsible-content-height` CSS custom properties on the element. Use these with the `data-enter` and `data-exit` attributes to animate open and close. These attributes are only set on user interaction - not on initial render - so no animation plays on page load.
+
+## Accessibility
+
+Adheres to the [Disclosure WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure).
+
+The trigger exposes `aria-expanded` and `aria-controls`, pointing at the content region. When the trigger is a `<button>` element the correct `type="button"` is applied automatically.
+
+### Keyboard Interactions
+
+- <kbd>Space</kbd> - Toggle the collapsible when the trigger is focused.
+- <kbd>Enter</kbd> - Toggle the collapsible when the trigger is focused.
+
+### Hidden Until Found
+
+The `ngpCollapsibleContent` primitive uses the `until-found` attribute so the browser can search text within the collapsed region and reveal it if a match is found. If the browser does not support this functionality, the attribute is ignored.
+
+More information about the `until-found` attribute can be found on [Can I use](https://caniuse.com/?search=hidden%20until-found).

--- a/packages/ng-primitives/accordion/src/accordion-content/accordion-content-state.ts
+++ b/packages/ng-primitives/accordion/src/accordion-content/accordion-content-state.ts
@@ -1,15 +1,8 @@
-import { afterRenderEffect, computed, signal, Signal } from '@angular/core';
-import {
-  explicitEffect,
-  fromMutationObserver,
-  injectDimensions,
-  injectElementRef,
-} from 'ng-primitives/internal';
-import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
-import { safeTakeUntilDestroyed, uniqueId } from 'ng-primitives/utils';
-import { debounceTime } from 'rxjs/operators';
-import { injectAccordionItemState } from '../accordion-item/accordion-item-state';
-import { injectAccordionState } from '../accordion/accordion-state';
+import { signal, Signal } from '@angular/core';
+import { injectCollapsibleState, ngpCollapsibleContent } from 'ng-primitives/collapsible';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
 
 export interface NgpAccordionContentState {
   /**
@@ -32,121 +25,19 @@ export const [
   provideAccordionContentState,
 ] = createPrimitive(
   'NgpAccordionContent',
-  <T>({ id = signal(uniqueId('ngp-accordion-content')) }: NgpAccordionContentProps) => {
+  ({ id = signal(uniqueId('ngp-accordion-content')) }: NgpAccordionContentProps) => {
     const element = injectElementRef();
-    const accordion = injectAccordionState<T>();
-    const accordionItem = injectAccordionItemState<T>();
-    const dimensions = injectDimensions();
+    const collapsible = injectCollapsibleState();
 
-    const hidden = computed(() =>
-      !accordionItem().open() && dimensions().height === 0 ? 'until-found' : null,
-    );
+    // Compose the shared collapsible content engine (dimensions, hidden
+    // until-found + beforematch, enter/exit animation attrs), but emit the
+    // accordion-namespaced CSS variables so existing consumer styles keep working.
+    const content = ngpCollapsibleContent({ id, cssVarPrefix: 'ngp-accordion-content' });
 
-    // Host bindings
+    // Unlike a standalone collapsible, an accordion panel is a labelled region.
     attrBinding(element, 'role', 'region');
-    attrBinding(element, 'id', id);
-    attrBinding(element, 'aria-labelledby', accordionItem().triggerId);
-    attrBinding(element, 'hidden', hidden);
+    attrBinding(element, 'aria-labelledby', collapsible().triggerId);
 
-    dataBinding(element, 'data-orientation', accordion().orientation);
-    dataBinding(element, 'data-open', accordionItem().open);
-    dataBinding(element, 'data-closed', () => !accordionItem().open());
-
-    // data-enter is set when the item opens (user interaction), data-exit when it closes.
-    // Neither is set on initial render, preventing animation on page load.
-    const enter = signal(false);
-    const exit = signal(false);
-    dataBinding(element, 'data-enter', enter);
-    dataBinding(element, 'data-exit', exit);
-
-    listener(element, 'beforematch', onBeforeMatch);
-    const clearAnimation = (event: AnimationEvent) => {
-      if (event.target === element.nativeElement) {
-        enter.set(false);
-        exit.set(false);
-      }
-    };
-    listener(element, 'animationend', clearAnimation);
-    listener(element, 'animationcancel', clearAnimation);
-
-    // Register the content with the accordion item state
-    accordionItem().setContent(id());
-
-    /**
-     * Handle the beforematch event to automatically open the accordion item
-     * when the browser's find-in-page functionality tries to reveal hidden content.
-     */
-    function onBeforeMatch(): void {
-      const isDisabled = accordion().disabled() || accordionItem().disabled();
-      if (isDisabled) {
-        return;
-      }
-      accordion().toggle(accordionItem().value() as T);
-    }
-
-    function updateDimensions(): void {
-      if (accordionItem().open()) {
-        const scrollHeight = element.nativeElement.scrollHeight;
-
-        // Element is inside a hidden container (e.g. inactive tab with display:none).
-        // All three dimensions are 0 only when the element has no layout at all.
-        // Checking dimensions() (from ResizeObserver) prevents misidentifying
-        // legitimately empty content (e.g. all children removed) as a hidden container.
-        const { width, height } = dimensions();
-        if (scrollHeight === 0 && width === 0 && height === 0) {
-          return;
-        }
-
-        const scrollWidth = element.nativeElement.scrollWidth;
-
-        // remove the inline styles to reset them
-        element.nativeElement.style.removeProperty('--ngp-accordion-content-width');
-        element.nativeElement.style.removeProperty('--ngp-accordion-content-height');
-        // set the dimensions based on the content
-        element.nativeElement.style.setProperty(
-          '--ngp-accordion-content-width',
-          `${scrollWidth}px`,
-        );
-        element.nativeElement.style.setProperty(
-          '--ngp-accordion-content-height',
-          `${scrollHeight}px`,
-        );
-      }
-    }
-
-    // Track dimensions() so this effect re-runs when the element becomes visible.
-    // Handles the case where the accordion is initialized inside a hidden container.
-    afterRenderEffect(() => {
-      dimensions(); // reactive dep — re-runs when element resizes (e.g. container becomes visible)
-      updateDimensions();
-    });
-
-    // Drive enter/exit attributes based on open state changes.
-    // Skips the initial run so no animation plays on page load.
-    let initialized = false;
-    explicitEffect([accordionItem().open], ([isOpen]) => {
-      if (!initialized) {
-        initialized = true;
-        return;
-      }
-      if (isOpen) {
-        exit.set(false);
-        enter.set(true);
-      } else {
-        enter.set(false);
-        exit.set(true);
-      }
-    });
-
-    // update dimensions when the content changes
-    fromMutationObserver(element.nativeElement, {
-      childList: true,
-      subtree: true,
-      disabled: computed(() => !accordionItem().open()),
-    })
-      .pipe(debounceTime(0), safeTakeUntilDestroyed())
-      .subscribe(() => updateDimensions());
-
-    return { id } satisfies NgpAccordionContentState;
+    return { id: content.id } satisfies NgpAccordionContentState;
   },
 );

--- a/packages/ng-primitives/accordion/src/accordion-content/accordion-content.ts
+++ b/packages/ng-primitives/accordion/src/accordion-content/accordion-content.ts
@@ -9,13 +9,13 @@ import { ngpAccordionContent } from './accordion-content-state';
   selector: '[ngpAccordionContent]',
   exportAs: 'ngpAccordionContent',
 })
-export class NgpAccordionContent<T> {
+export class NgpAccordionContent {
   /**
    * The id of the content region
    */
   readonly id = input<string>(uniqueId('ngp-accordion-content'));
 
   constructor() {
-    ngpAccordionContent<T>({ id: this.id });
+    ngpAccordionContent({ id: this.id });
   }
 }

--- a/packages/ng-primitives/accordion/src/accordion-item/accordion-item-state.ts
+++ b/packages/ng-primitives/accordion/src/accordion-item/accordion-item-state.ts
@@ -1,9 +1,8 @@
 import { computed, Signal, signal } from '@angular/core';
-import { injectElementRef } from 'ng-primitives/internal';
+import { ngpCollapsible } from 'ng-primitives/collapsible';
 import {
   controlled,
   createPrimitive,
-  dataBinding,
   deprecatedSetter,
   StateInjectionOptions,
 } from 'ng-primitives/state';
@@ -64,20 +63,21 @@ export const [
   'NgpAccordionItem',
   <T>({ value, disabled: _disabled = signal(false) }: NgpAccordionItemProps<T>) => {
     const accordion = injectAccordionState<T>();
-    const element = injectElementRef();
 
+    // Item-level disabled (public); the effective disabled also factors in the group.
     const disabled = controlled(_disabled);
 
-    // Whether the accordion item is expanded.
-    const open = computed<boolean>(() => accordion().isOpen(value()));
-
-    const trigger = signal<string | undefined>(undefined);
-    const content = signal<string | undefined>(undefined);
-
-    // Setup host data bindings
-    dataBinding(element, 'data-orientation', accordion().orientation);
-    dataBinding(element, 'data-open', open);
-    dataBinding(element, 'data-disabled', () => disabled() || accordion().disabled());
+    // Compose the shared collapsible core. `open` is derived from the group, so it
+    // is controlled - toggles route through onOpenChange -> accordion.toggle and the
+    // group stays authoritative (it may reject a toggle in single, non-collapsible
+    // mode). The core owns the item's data-orientation/open/closed/disabled bindings
+    // and the trigger/content id registration.
+    const collapsible = ngpCollapsible({
+      open: computed(() => accordion().isOpen(value())),
+      disabled: computed(() => disabled() || accordion().disabled()),
+      orientation: accordion().orientation,
+      onOpenChange: () => accordion().toggle(value() as T),
+    });
 
     // Set the disabled state of the accordion item.
     function setDisabled(value: boolean) {
@@ -85,19 +85,19 @@ export const [
     }
 
     function setTrigger(id: string) {
-      trigger.set(id);
+      collapsible.setTrigger(id);
     }
 
     function setContent(id: string) {
-      content.set(id);
+      collapsible.setContent(id);
     }
 
     return {
       value,
-      open,
+      open: collapsible.open,
       disabled: deprecatedSetter(disabled, 'setDisabled'),
-      triggerId: deprecatedSetter(trigger, 'setTrigger'),
-      contentId: deprecatedSetter(content, 'setContent'),
+      triggerId: collapsible.triggerId,
+      contentId: collapsible.contentId,
       setDisabled,
       setTrigger,
       setContent,

--- a/packages/ng-primitives/accordion/src/accordion-item/accordion-item.ts
+++ b/packages/ng-primitives/accordion/src/accordion-item/accordion-item.ts
@@ -1,5 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import { Directive, booleanAttribute, input } from '@angular/core';
+import { provideCollapsibleState } from 'ng-primitives/collapsible';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectAccordionState } from '../accordion/accordion-state';
 import { ngpAccordionItem, provideAccordionItemState } from './accordion-item-state';
@@ -10,7 +11,8 @@ import { ngpAccordionItem, provideAccordionItemState } from './accordion-item-st
 @Directive({
   selector: '[ngpAccordionItem]',
   exportAs: 'ngpAccordionItem',
-  providers: [provideAccordionItemState()],
+  // The item owns the shared collapsible state that its trigger and content compose.
+  providers: [provideAccordionItemState(), provideCollapsibleState({ inherit: false })],
 })
 export class NgpAccordionItem<T> {
   /**

--- a/packages/ng-primitives/accordion/src/accordion-trigger/accordion-trigger-state.ts
+++ b/packages/ng-primitives/accordion/src/accordion-trigger/accordion-trigger-state.ts
@@ -1,9 +1,7 @@
-import { HOST_TAG_NAME, inject, signal, Signal } from '@angular/core';
-import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
+import { signal, Signal } from '@angular/core';
+import { ngpCollapsibleTrigger } from 'ng-primitives/collapsible';
+import { createPrimitive } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
-import { injectAccordionItemState } from '../accordion-item/accordion-item-state';
-import { injectAccordionState } from '../accordion/accordion-state';
 
 export interface NgpAccordionTriggerState {
   /**
@@ -30,40 +28,12 @@ export const [
   provideAccordionTriggerState,
 ] = createPrimitive(
   'NgpAccordionTrigger',
-  <T>({ id = signal(uniqueId('ngp-accordion-trigger')) }: NgpAccordionTriggerProps) => {
-    const element = injectElementRef();
-    const tagName = inject(HOST_TAG_NAME);
-    const accordion = injectAccordionState<T>();
-    const accordionItem = injectAccordionItemState<T>();
+  ({ id = signal(uniqueId('ngp-accordion-trigger')) }: NgpAccordionTriggerProps) => {
+    // The accordion trigger is the shared collapsible trigger - it wires the
+    // button semantics (type, aria-expanded, aria-controls), registers its id
+    // with the item's collapsible state, and toggles on click.
+    const trigger = ngpCollapsibleTrigger({ id });
 
-    // Host bindings
-    attrBinding(element, 'id', id);
-    attrBinding(element, 'type', tagName === 'button' ? 'button' : null);
-    attrBinding(element, 'aria-controls', accordionItem().contentId);
-    attrBinding(element, 'aria-expanded', accordionItem().open);
-    dataBinding(element, 'data-orientation', accordion().orientation);
-    dataBinding(element, 'data-open', accordionItem().open);
-    dataBinding(
-      element,
-      'data-disabled',
-      () => accordionItem().disabled() || accordion().disabled(),
-    );
-
-    // register the trigger with the accordion item
-    accordionItem().setTrigger(id());
-
-    // Methods
-    function toggle(): void {
-      if (accordionItem().disabled() || accordion().disabled()) {
-        return;
-      }
-
-      accordion().toggle(accordionItem().value()!);
-    }
-
-    // Event listeners
-    listener(element, 'click', toggle);
-
-    return { id, toggle } satisfies NgpAccordionTriggerState;
+    return { id: trigger.id, toggle: trigger.toggle } satisfies NgpAccordionTriggerState;
   },
 );

--- a/packages/ng-primitives/accordion/src/accordion-trigger/accordion-trigger.ts
+++ b/packages/ng-primitives/accordion/src/accordion-trigger/accordion-trigger.ts
@@ -9,13 +9,13 @@ import { ngpAccordionTrigger } from './accordion-trigger-state';
   selector: '[ngpAccordionTrigger]',
   exportAs: 'ngpAccordionTrigger',
 })
-export class NgpAccordionTrigger<T> {
+export class NgpAccordionTrigger {
   /**
    * The id of the trigger.
    */
   readonly id = input<string>(uniqueId('ngp-accordion-trigger'));
 
-  private readonly state = ngpAccordionTrigger<T>({ id: this.id });
+  private readonly state = ngpAccordionTrigger({ id: this.id });
 
   /**
    * Toggle the accordion item.

--- a/packages/ng-primitives/accordion/src/accordion/tests/accordion-primitive.test.ts
+++ b/packages/ng-primitives/accordion/src/accordion/tests/accordion-primitive.test.ts
@@ -1,4 +1,5 @@
 import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
 import {
   NgpAccordion,
   NgpAccordionContent,
@@ -338,6 +339,169 @@ describe('NgpAccordion', () => {
       const content = fixture.getAllByTestId('accordion-content');
 
       expect(content[0].style.getPropertyValue('--ngp-accordion-content-height')).toBe('');
+    });
+  });
+
+  describe('content width CSS variable', () => {
+    it('should set --ngp-accordion-content-width when item is open', async () => {
+      const fixture = await renderTemplate({ orientation: 'horizontal', value: 'item-1' });
+      const content = fixture.getAllByTestId('accordion-content');
+
+      await waitFor(() => {
+        expect(content[0].style.getPropertyValue('--ngp-accordion-content-width')).not.toBe('');
+        expect(content[0].style.getPropertyValue('--ngp-accordion-content-width')).not.toBe('0px');
+      });
+    });
+
+    it('should not set --ngp-accordion-content-width for closed items', async () => {
+      const fixture = await renderTemplate({ orientation: 'horizontal', value: 'item-1' });
+      const content = fixture.getAllByTestId('accordion-content');
+
+      expect(content[1].style.getPropertyValue('--ngp-accordion-content-width')).toBe('');
+    });
+  });
+
+  describe('keyboard interaction', () => {
+    it('should toggle the item when Enter is pressed on a focused trigger', async () => {
+      const valueChange = vi.fn();
+      const fixture = await renderTemplate({ valueChange });
+      const triggers = fixture.getAllByTestId('accordion-trigger');
+
+      triggers[0].focus();
+      await userEvent.keyboard('{Enter}');
+
+      expect(valueChange).toHaveBeenCalledWith('item-1');
+      expect(triggers[0]).toHaveAttribute('data-open');
+    });
+
+    it('should toggle the item when Space is pressed on a focused trigger', async () => {
+      const valueChange = vi.fn();
+      const fixture = await renderTemplate({ valueChange });
+      const triggers = fixture.getAllByTestId('accordion-trigger');
+
+      triggers[0].focus();
+      await userEvent.keyboard(' ');
+
+      expect(valueChange).toHaveBeenCalledWith('item-1');
+      expect(triggers[0]).toHaveAttribute('data-open');
+    });
+  });
+
+  describe('find-in-page (hidden until-found + beforematch)', () => {
+    it('should mark a collapsed panel as hidden="until-found"', async () => {
+      const fixture = await render(
+        `
+        <style>[ngpAccordionContent]:not([data-open]) { height: 0; padding: 0; border: 0; overflow: hidden; }</style>
+        <div ngpAccordion ngpAccordionType="single" ngpAccordionValue="item-1">
+          <div ngpAccordionItem ngpAccordionItemValue="item-1">
+            <button ngpAccordionTrigger>Header 1</button>
+            <div data-testid="content-1" ngpAccordionContent>Content 1</div>
+          </div>
+          <div ngpAccordionItem ngpAccordionItemValue="item-2">
+            <button ngpAccordionTrigger>Header 2</button>
+            <div data-testid="content-2" ngpAccordionContent>Content 2</div>
+          </div>
+        </div>
+        `,
+        { imports },
+      );
+
+      // The closed panel collapses to zero height and becomes discoverable by find-in-page.
+      await waitFor(() =>
+        expect(fixture.getByTestId('content-2')).toHaveAttribute('hidden', 'until-found'),
+      );
+      // The open panel is not hidden.
+      expect(fixture.getByTestId('content-1')).not.toHaveAttribute('hidden');
+    });
+
+    it('should open the item when the browser fires beforematch on its content', async () => {
+      const valueChange = vi.fn();
+      const fixture = await renderTemplate({ valueChange });
+      const content = fixture.getAllByTestId('accordion-content');
+      const triggers = fixture.getAllByTestId('accordion-trigger');
+
+      content[0].dispatchEvent(new Event('beforematch'));
+      fixture.detectChanges();
+
+      expect(valueChange).toHaveBeenCalledWith('item-1');
+      expect(triggers[0]).toHaveAttribute('data-open');
+    });
+
+    it('should not open a disabled item on beforematch', async () => {
+      const valueChange = vi.fn();
+      const fixture = await renderTemplate({ itemDisabled: true, valueChange });
+      const content = fixture.getAllByTestId('accordion-content');
+
+      content[0].dispatchEvent(new Event('beforematch'));
+      fixture.detectChanges();
+
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+
+    it('should not open an item on beforematch when the accordion is disabled', async () => {
+      const valueChange = vi.fn();
+      const fixture = await renderTemplate({ accordionDisabled: true, valueChange });
+      const content = fixture.getAllByTestId('accordion-content');
+
+      content[0].dispatchEvent(new Event('beforematch'));
+      fixture.detectChanges();
+
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('content role', () => {
+    it('should set role="region" on the content elements', async () => {
+      const fixture = await renderTemplate();
+      const content = fixture.getAllByTestId('accordion-content');
+
+      for (const c of content) {
+        expect(c).toHaveAttribute('role', 'region');
+      }
+    });
+  });
+
+  describe('controlled and uncontrolled value', () => {
+    it('should round-trip a two-way [(ngpAccordionValue)] binding on click', async () => {
+      const fixture = await render(
+        `<div ngpAccordion ngpAccordionType="single" ngpAccordionCollapsible [(ngpAccordionValue)]="value">
+          <div ngpAccordionItem ngpAccordionItemValue="item-1">
+            <button data-testid="trigger-1" ngpAccordionTrigger>Header 1</button>
+            <div ngpAccordionContent>Content 1</div>
+          </div>
+        </div>`,
+        { imports, componentProperties: { value: null } },
+      );
+
+      const trigger = fixture.getByTestId('trigger-1');
+
+      fireEvent.click(trigger);
+      fixture.detectChanges();
+      expect(fixture.fixture.componentInstance.value).toBe('item-1');
+
+      fireEvent.click(trigger);
+      fixture.detectChanges();
+      expect(fixture.fixture.componentInstance.value).toBeNull();
+    });
+
+    it('should open and close on click when value is uncontrolled', async () => {
+      const fixture = await render(
+        `<div ngpAccordion ngpAccordionType="single" ngpAccordionCollapsible>
+          <div ngpAccordionItem ngpAccordionItemValue="item-1">
+            <button data-testid="trigger-1" ngpAccordionTrigger>Header 1</button>
+            <div ngpAccordionContent>Content 1</div>
+          </div>
+        </div>`,
+        { imports },
+      );
+
+      const trigger = fixture.getByTestId('trigger-1');
+
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute('data-open');
+
+      fireEvent.click(trigger);
+      expect(trigger).not.toHaveAttribute('data-open');
     });
   });
 });

--- a/packages/ng-primitives/collapsible/README.md
+++ b/packages/ng-primitives/collapsible/README.md
@@ -1,0 +1,3 @@
+# ng-primitives/collapsible
+
+Secondary entry point of `ng-primitives`. It can be used by importing from `ng-primitives/collapsible`.

--- a/packages/ng-primitives/collapsible/ng-package.json
+++ b/packages/ng-primitives/collapsible/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/ng-primitives/collapsible/src/collapsible-content/collapsible-content-state.ts
+++ b/packages/ng-primitives/collapsible/src/collapsible-content/collapsible-content-state.ts
@@ -1,0 +1,155 @@
+import { afterRenderEffect, computed, signal, Signal } from '@angular/core';
+import {
+  explicitEffect,
+  fromMutationObserver,
+  injectDimensions,
+  injectElementRef,
+} from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
+import { safeTakeUntilDestroyed, uniqueId } from 'ng-primitives/utils';
+import { debounceTime } from 'rxjs/operators';
+import { injectCollapsibleState } from '../collapsible/collapsible-state';
+
+export interface NgpCollapsibleContentState {
+  /**
+   * The id of the content region.
+   */
+  readonly id: Signal<string>;
+}
+
+export interface NgpCollapsibleContentProps {
+  /**
+   * The id of the content region.
+   */
+  readonly id?: Signal<string>;
+  /**
+   * The CSS custom property prefix for the measured dimensions. The content's
+   * width and height are exposed as `--<prefix>-width` and `--<prefix>-height`.
+   * @default 'ngp-collapsible-content'
+   */
+  readonly cssVarPrefix?: string;
+}
+
+export const [
+  NgpCollapsibleContentStateToken,
+  ngpCollapsibleContent,
+  injectCollapsibleContentState,
+  provideCollapsibleContentState,
+] = createPrimitive(
+  'NgpCollapsibleContent',
+  ({
+    id = signal(uniqueId('ngp-collapsible-content')),
+    cssVarPrefix = 'ngp-collapsible-content',
+  }: NgpCollapsibleContentProps): NgpCollapsibleContentState => {
+    const element = injectElementRef<HTMLElement>();
+    const collapsible = injectCollapsibleState();
+    const dimensions = injectDimensions();
+
+    const widthVar = `--${cssVarPrefix}-width`;
+    const heightVar = `--${cssVarPrefix}-height`;
+
+    const hidden = computed(() =>
+      !collapsible().open() && dimensions().height === 0 ? 'until-found' : null,
+    );
+
+    // Host bindings
+    attrBinding(element, 'id', id);
+    attrBinding(element, 'hidden', hidden);
+
+    dataBinding(element, 'data-orientation', collapsible().orientation);
+    dataBinding(element, 'data-open', collapsible().open);
+    dataBinding(element, 'data-closed', () => !collapsible().open());
+    dataBinding(element, 'data-disabled', collapsible().disabled);
+
+    // data-enter is set when the collapsible opens (user interaction), data-exit when it closes.
+    // Neither is set on initial render, preventing animation on page load.
+    const enter = signal(false);
+    const exit = signal(false);
+    dataBinding(element, 'data-enter', enter);
+    dataBinding(element, 'data-exit', exit);
+
+    listener(element, 'beforematch', onBeforeMatch);
+    const clearAnimation = (event: AnimationEvent) => {
+      if (event.target === element.nativeElement) {
+        enter.set(false);
+        exit.set(false);
+      }
+    };
+    listener(element, 'animationend', clearAnimation);
+    listener(element, 'animationcancel', clearAnimation);
+
+    // Register the content with the collapsible state
+    collapsible().setContent(id());
+
+    /**
+     * Handle the beforematch event to automatically open the collapsible
+     * when the browser's find-in-page functionality tries to reveal hidden content.
+     * The disabled guard lives in the collapsible state's toggle().
+     */
+    function onBeforeMatch(): void {
+      if (collapsible().open()) {
+        return;
+      }
+      collapsible().toggle();
+    }
+
+    function updateDimensions(): void {
+      if (collapsible().open()) {
+        const scrollHeight = element.nativeElement.scrollHeight;
+
+        // Element is inside a hidden container (e.g. inactive tab with display:none).
+        // All three dimensions are 0 only when the element has no layout at all.
+        // Checking dimensions() (from ResizeObserver) prevents misidentifying
+        // legitimately empty content (e.g. all children removed) as a hidden container.
+        const { width, height } = dimensions();
+        if (scrollHeight === 0 && width === 0 && height === 0) {
+          return;
+        }
+
+        const scrollWidth = element.nativeElement.scrollWidth;
+
+        // remove the inline styles to reset them
+        element.nativeElement.style.removeProperty(widthVar);
+        element.nativeElement.style.removeProperty(heightVar);
+        // set the dimensions based on the content
+        element.nativeElement.style.setProperty(widthVar, `${scrollWidth}px`);
+        element.nativeElement.style.setProperty(heightVar, `${scrollHeight}px`);
+      }
+    }
+
+    // Track dimensions() so this effect re-runs when the element becomes visible.
+    // Handles the case where the collapsible is initialized inside a hidden container.
+    afterRenderEffect(() => {
+      dimensions(); // reactive dep — re-runs when element resizes (e.g. container becomes visible)
+      updateDimensions();
+    });
+
+    // Drive enter/exit attributes based on open state changes.
+    // Skips the initial run so no animation plays on page load.
+    let initialized = false;
+    explicitEffect([collapsible().open], ([isOpen]) => {
+      if (!initialized) {
+        initialized = true;
+        return;
+      }
+      if (isOpen) {
+        exit.set(false);
+        enter.set(true);
+      } else {
+        enter.set(false);
+        exit.set(true);
+      }
+    });
+
+    // update dimensions when the content changes
+    fromMutationObserver(element.nativeElement, {
+      childList: true,
+      subtree: true,
+      disabled: computed(() => !collapsible().open()),
+    })
+      .pipe(debounceTime(0), safeTakeUntilDestroyed())
+      .subscribe(() => updateDimensions());
+
+    return { id } satisfies NgpCollapsibleContentState;
+  },
+);

--- a/packages/ng-primitives/collapsible/src/collapsible-content/collapsible-content.ts
+++ b/packages/ng-primitives/collapsible/src/collapsible-content/collapsible-content.ts
@@ -1,0 +1,23 @@
+import { Directive, input } from '@angular/core';
+import { uniqueId } from 'ng-primitives/utils';
+import { ngpCollapsibleContent, provideCollapsibleContentState } from './collapsible-content-state';
+
+/**
+ * Apply the `ngpCollapsibleContent` directive to the element that contains the
+ * collapsible content that is shown and hidden by the trigger.
+ */
+@Directive({
+  selector: '[ngpCollapsibleContent]',
+  exportAs: 'ngpCollapsibleContent',
+  providers: [provideCollapsibleContentState()],
+})
+export class NgpCollapsibleContent {
+  /**
+   * The id of the content region.
+   */
+  readonly id = input<string>(uniqueId('ngp-collapsible-content'));
+
+  constructor() {
+    ngpCollapsibleContent({ id: this.id });
+  }
+}

--- a/packages/ng-primitives/collapsible/src/collapsible-trigger/collapsible-trigger-state.ts
+++ b/packages/ng-primitives/collapsible/src/collapsible-trigger/collapsible-trigger-state.ts
@@ -1,0 +1,61 @@
+import { HOST_TAG_NAME, inject, signal, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { injectCollapsibleState } from '../collapsible/collapsible-state';
+
+export interface NgpCollapsibleTriggerState {
+  /**
+   * The id of the trigger.
+   */
+  readonly id: Signal<string>;
+  /**
+   * Toggle the collapsible.
+   */
+  toggle(): void;
+}
+
+export interface NgpCollapsibleTriggerProps {
+  /**
+   * The id of the trigger.
+   */
+  readonly id?: Signal<string>;
+}
+
+export const [
+  NgpCollapsibleTriggerStateToken,
+  ngpCollapsibleTrigger,
+  injectCollapsibleTriggerState,
+  provideCollapsibleTriggerState,
+] = createPrimitive(
+  'NgpCollapsibleTrigger',
+  ({
+    id = signal(uniqueId('ngp-collapsible-trigger')),
+  }: NgpCollapsibleTriggerProps): NgpCollapsibleTriggerState => {
+    const element = injectElementRef<HTMLElement>();
+    const tagName = inject(HOST_TAG_NAME);
+    const collapsible = injectCollapsibleState();
+
+    // Host bindings
+    attrBinding(element, 'id', id);
+    attrBinding(element, 'type', tagName === 'button' ? 'button' : null);
+    attrBinding(element, 'aria-controls', collapsible().contentId);
+    attrBinding(element, 'aria-expanded', collapsible().open);
+    dataBinding(element, 'data-open', collapsible().open);
+    dataBinding(element, 'data-closed', () => !collapsible().open());
+    dataBinding(element, 'data-disabled', collapsible().disabled);
+    dataBinding(element, 'data-orientation', collapsible().orientation);
+
+    // Register the trigger with the collapsible state
+    collapsible().setTrigger(id());
+
+    // The disabled guard lives in the collapsible state's toggle().
+    function toggle(): void {
+      collapsible().toggle();
+    }
+
+    listener(element, 'click', toggle);
+
+    return { id, toggle } satisfies NgpCollapsibleTriggerState;
+  },
+);

--- a/packages/ng-primitives/collapsible/src/collapsible-trigger/collapsible-trigger.ts
+++ b/packages/ng-primitives/collapsible/src/collapsible-trigger/collapsible-trigger.ts
@@ -1,0 +1,28 @@
+import { Directive, input } from '@angular/core';
+import { uniqueId } from 'ng-primitives/utils';
+import { ngpCollapsibleTrigger, provideCollapsibleTriggerState } from './collapsible-trigger-state';
+
+/**
+ * Apply the `ngpCollapsibleTrigger` directive to an element - typically a
+ * `button` - that toggles the collapsible open and closed.
+ */
+@Directive({
+  selector: '[ngpCollapsibleTrigger]',
+  exportAs: 'ngpCollapsibleTrigger',
+  providers: [provideCollapsibleTriggerState()],
+})
+export class NgpCollapsibleTrigger {
+  /**
+   * The id of the trigger.
+   */
+  readonly id = input<string>(uniqueId('ngp-collapsible-trigger'));
+
+  private readonly state = ngpCollapsibleTrigger({ id: this.id });
+
+  /**
+   * Toggle the collapsible.
+   */
+  toggle(): void {
+    this.state.toggle();
+  }
+}

--- a/packages/ng-primitives/collapsible/src/collapsible/collapsible-state.ts
+++ b/packages/ng-primitives/collapsible/src/collapsible/collapsible-state.ts
@@ -1,0 +1,166 @@
+import { signal, Signal, WritableSignal } from '@angular/core';
+import { NgpOrientation } from 'ng-primitives/common';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  controlled,
+  controlledState,
+  createPrimitive,
+  dataBinding,
+  deprecatedSetter,
+  SetterOptions,
+} from 'ng-primitives/state';
+import { Observable } from 'rxjs';
+
+/**
+ * The shared state for the Collapsible primitive. This is the reusable core
+ * behind both the standalone collapsible and each accordion item - the trigger
+ * and content parts read their open/disabled/orientation state and their
+ * registered ids from here.
+ */
+export interface NgpCollapsibleState {
+  /**
+   * Whether the collapsible is open.
+   */
+  readonly open: WritableSignal<boolean>;
+  /**
+   * Whether the collapsible is disabled.
+   */
+  readonly disabled: WritableSignal<boolean>;
+  /**
+   * The orientation of the collapsible.
+   */
+  readonly orientation: Signal<NgpOrientation>;
+  /**
+   * Emits when the open state changes.
+   */
+  readonly openChange: Observable<boolean>;
+  /**
+   * The id of the trigger, registered by the trigger part.
+   */
+  readonly triggerId: Signal<string | undefined>;
+  /**
+   * The id of the content, registered by the content part.
+   */
+  readonly contentId: Signal<string | undefined>;
+  /**
+   * Toggle the open state.
+   */
+  toggle(): void;
+  /**
+   * Set the open state.
+   */
+  setOpen(value: boolean, options?: SetterOptions): void;
+  /**
+   * Set the disabled state.
+   */
+  setDisabled(value: boolean): void;
+  /**
+   * Register the trigger id.
+   * @internal
+   */
+  setTrigger(id: string): void;
+  /**
+   * Register the content id.
+   * @internal
+   */
+  setContent(id: string): void;
+}
+
+/**
+ * Inputs for configuring the Collapsible primitive.
+ */
+export interface NgpCollapsibleProps {
+  /**
+   * Whether the collapsible is open. Leave `undefined` for uncontrolled usage.
+   */
+  readonly open: Signal<boolean | undefined>;
+  /**
+   * The default open state for uncontrolled usage.
+   */
+  readonly defaultOpen?: Signal<boolean>;
+  /**
+   * Whether the collapsible is disabled.
+   */
+  readonly disabled?: Signal<boolean>;
+  /**
+   * The orientation of the collapsible.
+   */
+  readonly orientation?: Signal<NgpOrientation>;
+  /**
+   * Callback fired when the open state changes.
+   */
+  readonly onOpenChange?: (open: boolean) => void;
+}
+
+export const [
+  NgpCollapsibleStateToken,
+  ngpCollapsible,
+  injectCollapsibleState,
+  provideCollapsibleState,
+] = createPrimitive(
+  'NgpCollapsible',
+  ({
+    open: _open,
+    defaultOpen: _defaultOpen,
+    disabled: _disabled,
+    orientation: _orientation,
+    onOpenChange,
+  }: NgpCollapsibleProps): NgpCollapsibleState => {
+    const element = injectElementRef<HTMLElement>();
+
+    const defaultOpen = controlled(_defaultOpen, false);
+    const disabled = controlled(_disabled, false);
+    const orientation = controlled(_orientation, 'vertical');
+
+    // controlledState is used (rather than a plain `controlled`) so that when an
+    // owner controls `open` - e.g. an accordion group that may reject a toggle
+    // in single, non-collapsible mode - the local state never desyncs from it.
+    const [open, setOpen, openChange] = controlledState({
+      value: _open,
+      defaultValue: defaultOpen,
+      onChange: onOpenChange,
+    });
+
+    const trigger = signal<string | undefined>(undefined);
+    const content = signal<string | undefined>(undefined);
+
+    // Host bindings
+    dataBinding(element, 'data-open', open);
+    dataBinding(element, 'data-closed', () => !open());
+    dataBinding(element, 'data-disabled', disabled);
+    dataBinding(element, 'data-orientation', orientation);
+
+    function toggle(): void {
+      if (disabled()) {
+        return;
+      }
+      setOpen(!open());
+    }
+
+    function setDisabled(value: boolean): void {
+      disabled.set(value);
+    }
+
+    function setTrigger(id: string): void {
+      trigger.set(id);
+    }
+
+    function setContent(id: string): void {
+      content.set(id);
+    }
+
+    return {
+      open: deprecatedSetter(open, 'setOpen', setOpen),
+      disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
+      orientation,
+      openChange,
+      triggerId: trigger,
+      contentId: content,
+      toggle,
+      setOpen,
+      setDisabled,
+      setTrigger,
+      setContent,
+    } satisfies NgpCollapsibleState;
+  },
+);

--- a/packages/ng-primitives/collapsible/src/collapsible/collapsible.ts
+++ b/packages/ng-primitives/collapsible/src/collapsible/collapsible.ts
@@ -1,0 +1,90 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input, output } from '@angular/core';
+import { NgpOrientation } from 'ng-primitives/common';
+import { SetterOptions } from 'ng-primitives/state';
+import { ngpCollapsible, provideCollapsibleState } from './collapsible-state';
+
+/**
+ * Apply the `ngpCollapsible` directive to an element that contains a collapsible
+ * trigger and content. It manages the open state of a single disclosure.
+ */
+@Directive({
+  selector: '[ngpCollapsible]',
+  exportAs: 'ngpCollapsible',
+  // inherit: false so nested collapsibles own independent state.
+  providers: [provideCollapsibleState({ inherit: false })],
+})
+export class NgpCollapsible {
+  /**
+   * Whether the collapsible is open. Leave unset for uncontrolled usage.
+   */
+  readonly open = input<boolean | undefined, BooleanInput>(undefined, {
+    alias: 'ngpCollapsibleOpen',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * The default open state for uncontrolled usage.
+   * @default false
+   */
+  readonly defaultOpen = input<boolean, BooleanInput>(false, {
+    alias: 'ngpCollapsibleDefaultOpen',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * Emits when the open state changes.
+   */
+  readonly openChange = output<boolean>({
+    alias: 'ngpCollapsibleOpenChange',
+  });
+
+  /**
+   * Whether the collapsible is disabled.
+   * @default false
+   */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpCollapsibleDisabled',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * The orientation of the collapsible.
+   * @default 'vertical'
+   */
+  readonly orientation = input<NgpOrientation>('vertical', {
+    alias: 'ngpCollapsibleOrientation',
+  });
+
+  /**
+   * The state for the collapsible primitive.
+   */
+  protected readonly state = ngpCollapsible({
+    open: this.open,
+    defaultOpen: this.defaultOpen,
+    disabled: this.disabled,
+    orientation: this.orientation,
+    onOpenChange: value => this.openChange.emit(value),
+  });
+
+  /**
+   * Toggle the open state.
+   */
+  toggle(): void {
+    this.state.toggle();
+  }
+
+  /**
+   * Set the open state.
+   */
+  setOpen(value: boolean, options?: SetterOptions): void {
+    this.state.setOpen(value, options);
+  }
+
+  /**
+   * Set the disabled state.
+   */
+  setDisabled(value: boolean): void {
+    this.state.setDisabled(value);
+  }
+}

--- a/packages/ng-primitives/collapsible/src/collapsible/tests/collapsible-primitive.test.ts
+++ b/packages/ng-primitives/collapsible/src/collapsible/tests/collapsible-primitive.test.ts
@@ -1,0 +1,312 @@
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
+import {
+  NgpCollapsible,
+  NgpCollapsibleContent,
+  NgpCollapsibleTrigger,
+} from 'ng-primitives/collapsible';
+import { describe, expect, it, vi } from 'vitest';
+
+const imports = [NgpCollapsible, NgpCollapsibleTrigger, NgpCollapsibleContent];
+
+// Note: `ngpCollapsibleOpen` is intentionally NOT bound here. Binding it - even
+// to `undefined` - runs the `booleanAttribute` transform which coerces to
+// `false`, forcing controlled mode. Uncontrolled usage means omitting the
+// attribute; controlled tests bind it explicitly with their own template.
+function renderTemplate(componentProperties?: { [alias: string]: unknown }) {
+  return render(
+    `
+    <div data-testid="root"
+         ngpCollapsible
+         [ngpCollapsibleDefaultOpen]="defaultOpen"
+         [ngpCollapsibleDisabled]="disabled"
+         [ngpCollapsibleOrientation]="orientation"
+         (ngpCollapsibleOpenChange)="openChange($event)">
+      <button data-testid="trigger" ngpCollapsibleTrigger>Toggle</button>
+      <div data-testid="content" ngpCollapsibleContent>Content</div>
+    </div>
+    `,
+    {
+      imports,
+      componentProperties: {
+        defaultOpen: false,
+        disabled: false,
+        orientation: 'vertical',
+        openChange: vi.fn(),
+        ...componentProperties,
+      },
+    },
+  );
+}
+
+describe('NgpCollapsible', () => {
+  it('should be closed by default', async () => {
+    const fixture = await renderTemplate();
+    expect(fixture.getByTestId('root')).not.toHaveAttribute('data-open');
+    expect(fixture.getByTestId('root')).toHaveAttribute('data-closed');
+    expect(fixture.getByTestId('trigger')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('should be open when defaultOpen is set (uncontrolled)', async () => {
+    const fixture = await renderTemplate({ defaultOpen: true });
+    expect(fixture.getByTestId('root')).toHaveAttribute('data-open');
+    expect(fixture.getByTestId('trigger')).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  describe('trigger', () => {
+    it('should set type="button" on a button host', async () => {
+      const fixture = await renderTemplate();
+      expect(fixture.getByTestId('trigger')).toHaveAttribute('type', 'button');
+    });
+
+    it('should not set type on a non-button host', async () => {
+      const fixture = await render(
+        `<div ngpCollapsible>
+          <div data-testid="trigger" ngpCollapsibleTrigger>Toggle</div>
+          <div ngpCollapsibleContent>Content</div>
+        </div>`,
+        { imports },
+      );
+      expect(fixture.getByTestId('trigger')).not.toHaveAttribute('type');
+    });
+
+    it('should set aria-controls to the content id', async () => {
+      const fixture = await renderTemplate();
+      expect(fixture.getByTestId('trigger').getAttribute('aria-controls')).toBe(
+        fixture.getByTestId('content').getAttribute('id'),
+      );
+    });
+
+    it('should reflect open state via aria-expanded', async () => {
+      const fixture = await renderTemplate({ defaultOpen: true });
+      expect(fixture.getByTestId('trigger')).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  describe('toggling', () => {
+    it('should open and close on click (uncontrolled)', async () => {
+      const openChange = vi.fn();
+      const fixture = await renderTemplate({ openChange });
+      const trigger = fixture.getByTestId('trigger');
+
+      fireEvent.click(trigger);
+      expect(fixture.getByTestId('root')).toHaveAttribute('data-open');
+      expect(openChange).toHaveBeenCalledWith(true);
+
+      fireEvent.click(trigger);
+      expect(fixture.getByTestId('root')).not.toHaveAttribute('data-open');
+      expect(openChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it('should toggle when Enter is pressed on the focused trigger', async () => {
+      const openChange = vi.fn();
+      const fixture = await renderTemplate({ openChange });
+
+      fixture.getByTestId('trigger').focus();
+      await userEvent.keyboard('{Enter}');
+
+      expect(fixture.getByTestId('root')).toHaveAttribute('data-open');
+      expect(openChange).toHaveBeenCalledWith(true);
+    });
+
+    it('should toggle when Space is pressed on the focused trigger', async () => {
+      const openChange = vi.fn();
+      const fixture = await renderTemplate({ openChange });
+
+      fixture.getByTestId('trigger').focus();
+      await userEvent.keyboard(' ');
+
+      expect(fixture.getByTestId('root')).toHaveAttribute('data-open');
+      expect(openChange).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('disabled', () => {
+    it('should not toggle on click when disabled', async () => {
+      const openChange = vi.fn();
+      const fixture = await renderTemplate({ disabled: true, openChange });
+
+      fireEvent.click(fixture.getByTestId('trigger'));
+
+      expect(fixture.getByTestId('root')).not.toHaveAttribute('data-open');
+      expect(openChange).not.toHaveBeenCalled();
+    });
+
+    it('should set data-disabled on the root, trigger and content', async () => {
+      const fixture = await renderTemplate({ disabled: true });
+      expect(fixture.getByTestId('root')).toHaveAttribute('data-disabled');
+      expect(fixture.getByTestId('trigger')).toHaveAttribute('data-disabled');
+      expect(fixture.getByTestId('content')).toHaveAttribute('data-disabled');
+    });
+  });
+
+  describe('controlled', () => {
+    it('should not change on click when open is controlled', async () => {
+      const openChange = vi.fn();
+      const fixture = await render(
+        `<div data-testid="root" ngpCollapsible [ngpCollapsibleOpen]="open"
+              (ngpCollapsibleOpenChange)="openChange($event)">
+          <button data-testid="trigger" ngpCollapsibleTrigger>Toggle</button>
+          <div ngpCollapsibleContent>Content</div>
+        </div>`,
+        { imports, componentProperties: { open: false, openChange } },
+      );
+
+      fireEvent.click(fixture.getByTestId('trigger'));
+
+      // Controlled: the state does not change until the parent updates `open`,
+      // but the change is still reported.
+      expect(fixture.getByTestId('root')).not.toHaveAttribute('data-open');
+      expect(openChange).toHaveBeenCalledWith(true);
+    });
+
+    it('should round-trip a two-way [(ngpCollapsibleOpen)] binding', async () => {
+      const fixture = await render(
+        `<div data-testid="root" ngpCollapsible [(ngpCollapsibleOpen)]="open">
+          <button data-testid="trigger" ngpCollapsibleTrigger>Toggle</button>
+          <div ngpCollapsibleContent>Content</div>
+        </div>`,
+        { imports, componentProperties: { open: false } },
+      );
+      const trigger = fixture.getByTestId('trigger');
+
+      fireEvent.click(trigger);
+      fixture.detectChanges();
+      expect(fixture.fixture.componentInstance.open).toBe(true);
+      expect(fixture.getByTestId('root')).toHaveAttribute('data-open');
+
+      fireEvent.click(trigger);
+      fixture.detectChanges();
+      expect(fixture.fixture.componentInstance.open).toBe(false);
+      expect(fixture.getByTestId('root')).not.toHaveAttribute('data-open');
+    });
+  });
+
+  describe('data attributes', () => {
+    it('should set data-open / data-closed on all parts', async () => {
+      const fixture = await renderTemplate({ defaultOpen: true });
+      for (const id of ['root', 'trigger', 'content']) {
+        expect(fixture.getByTestId(id)).toHaveAttribute('data-open');
+        expect(fixture.getByTestId(id)).not.toHaveAttribute('data-closed');
+      }
+    });
+
+    it('should reflect orientation on all parts', async () => {
+      const fixture = await renderTemplate({ orientation: 'horizontal' });
+      for (const id of ['root', 'trigger', 'content']) {
+        expect(fixture.getByTestId(id)).toHaveAttribute('data-orientation', 'horizontal');
+      }
+    });
+  });
+
+  describe('content role', () => {
+    it('should not put a role on the content (standalone disclosure)', async () => {
+      const fixture = await renderTemplate();
+      expect(fixture.getByTestId('content')).not.toHaveAttribute('role');
+      expect(fixture.getByTestId('content')).not.toHaveAttribute('aria-labelledby');
+    });
+  });
+
+  describe('find-in-page (hidden until-found + beforematch)', () => {
+    it('should mark collapsed content as hidden="until-found"', async () => {
+      const fixture = await render(
+        `
+        <style>[ngpCollapsibleContent]:not([data-open]) { height: 0; padding: 0; border: 0; overflow: hidden; }</style>
+        <div ngpCollapsible>
+          <button ngpCollapsibleTrigger>Toggle</button>
+          <div data-testid="content" ngpCollapsibleContent>Content</div>
+        </div>
+        `,
+        { imports },
+      );
+
+      await waitFor(() =>
+        expect(fixture.getByTestId('content')).toHaveAttribute('hidden', 'until-found'),
+      );
+    });
+
+    it('should open on beforematch', async () => {
+      const openChange = vi.fn();
+      const fixture = await renderTemplate({ openChange });
+
+      fixture.getByTestId('content').dispatchEvent(new Event('beforematch'));
+      fixture.detectChanges();
+
+      expect(fixture.getByTestId('root')).toHaveAttribute('data-open');
+      expect(openChange).toHaveBeenCalledWith(true);
+    });
+
+    it('should not open on beforematch when disabled', async () => {
+      const openChange = vi.fn();
+      const fixture = await renderTemplate({ disabled: true, openChange });
+
+      fixture.getByTestId('content').dispatchEvent(new Event('beforematch'));
+      fixture.detectChanges();
+
+      expect(fixture.getByTestId('root')).not.toHaveAttribute('data-open');
+      expect(openChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('content dimension CSS variables', () => {
+    it('should set --ngp-collapsible-content-height when open', async () => {
+      const fixture = await renderTemplate({ defaultOpen: true });
+      const content = fixture.getByTestId('content');
+
+      await waitFor(() => {
+        expect(content.style.getPropertyValue('--ngp-collapsible-content-height')).not.toBe('');
+        expect(content.style.getPropertyValue('--ngp-collapsible-content-height')).not.toBe('0px');
+      });
+    });
+
+    it('should set --ngp-collapsible-content-width when open', async () => {
+      const fixture = await renderTemplate({ defaultOpen: true, orientation: 'horizontal' });
+      const content = fixture.getByTestId('content');
+
+      await waitFor(() => {
+        expect(content.style.getPropertyValue('--ngp-collapsible-content-width')).not.toBe('');
+        expect(content.style.getPropertyValue('--ngp-collapsible-content-width')).not.toBe('0px');
+      });
+    });
+
+    it('should not set the height variable when closed', async () => {
+      const fixture = await renderTemplate();
+      expect(
+        fixture.getByTestId('content').style.getPropertyValue('--ngp-collapsible-content-height'),
+      ).toBe('');
+    });
+  });
+
+  describe('data-enter and data-exit attributes', () => {
+    it('should not set data-enter or data-exit on initial render', async () => {
+      const fixture = await renderTemplate({ defaultOpen: true });
+      const content = fixture.getByTestId('content');
+      expect(content).not.toHaveAttribute('data-enter');
+      expect(content).not.toHaveAttribute('data-exit');
+    });
+
+    it('should set data-enter when it opens via user interaction', async () => {
+      const fixture = await renderTemplate();
+      const content = fixture.getByTestId('content');
+
+      fireEvent.click(fixture.getByTestId('trigger'));
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      await waitFor(() => expect(content).toHaveAttribute('data-enter'));
+      expect(content).not.toHaveAttribute('data-exit');
+    });
+
+    it('should set data-exit when it closes via user interaction', async () => {
+      const fixture = await renderTemplate({ defaultOpen: true });
+      const content = fixture.getByTestId('content');
+
+      fireEvent.click(fixture.getByTestId('trigger'));
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      await waitFor(() => expect(content).toHaveAttribute('data-exit'));
+      expect(content).not.toHaveAttribute('data-enter');
+    });
+  });
+});

--- a/packages/ng-primitives/collapsible/src/index.ts
+++ b/packages/ng-primitives/collapsible/src/index.ts
@@ -1,0 +1,27 @@
+export { NgpCollapsible } from './collapsible/collapsible';
+export {
+  NgpCollapsibleStateToken,
+  ngpCollapsible,
+  injectCollapsibleState,
+  provideCollapsibleState,
+  type NgpCollapsibleState,
+  type NgpCollapsibleProps,
+} from './collapsible/collapsible-state';
+export { NgpCollapsibleTrigger } from './collapsible-trigger/collapsible-trigger';
+export {
+  NgpCollapsibleTriggerStateToken,
+  ngpCollapsibleTrigger,
+  injectCollapsibleTriggerState,
+  provideCollapsibleTriggerState,
+  type NgpCollapsibleTriggerState,
+  type NgpCollapsibleTriggerProps,
+} from './collapsible-trigger/collapsible-trigger-state';
+export { NgpCollapsibleContent } from './collapsible-content/collapsible-content';
+export {
+  NgpCollapsibleContentStateToken,
+  ngpCollapsibleContent,
+  injectCollapsibleContentState,
+  provideCollapsibleContentState,
+  type NgpCollapsibleContentState,
+  type NgpCollapsibleContentProps,
+} from './collapsible-content/collapsible-content-state';

--- a/packages/ng-primitives/tsconfig.lib.json
+++ b/packages/ng-primitives/tsconfig.lib.json
@@ -16,12 +16,7 @@
     "vite.config.ts",
     "vitest.node.config.ts",
     "**/*.stories.ts",
-    "**/*.stories.js",
-    "password/**/*.spec.ts",
-    "password/**/*.test.ts",
-    "password/**/*.fixture.ts",
-    "password/**/*.stories.ts",
-    "password/**/*.stories.js"
+    "**/*.stories.js"
   ],
-  "include": ["**/*.ts", "password/**/*.ts"]
+  "include": ["**/*.ts"]
 }

--- a/packages/tools/src/generators/primitive/generator.ts
+++ b/packages/tools/src/generators/primitive/generator.ts
@@ -1,5 +1,5 @@
 import { librarySecondaryEntryPointGenerator } from '@nx/angular/generators';
-import { formatFiles, Tree } from '@nx/devkit';
+import { formatFiles, getWorkspaceLayout, Tree, updateJson } from '@nx/devkit';
 import { getPrimitiveIndex } from '../../utils';
 import { PrimitiveGeneratorSchema } from './schema';
 
@@ -13,7 +13,41 @@ export async function primitiveGenerator(tree: Tree, options: PrimitiveGenerator
 
   tree.write(getPrimitiveIndex(tree, options.name), '');
 
+  normalizeLibTsconfig(tree);
+
   await formatFiles(tree);
+}
+
+/**
+ * Nx's secondary entry point generator appends a per-entry-point block of
+ * include/exclude globs (e.g. `collapsible/**\/*.ts`) to the library tsconfig on
+ * every run. Those are already covered by the base `**\/*` globs, and because the
+ * generator re-prefixes existing entries it compounds them into nonsensical nested
+ * patterns (e.g. `collapsible/password/**\/*.ts`). Strip the nested patterns so the
+ * tsconfig stays at the canonical base globs.
+ */
+function normalizeLibTsconfig(tree: Tree): void {
+  const { libsDir } = getWorkspaceLayout(tree);
+  const tsconfigPath = `${libsDir}/ng-primitives/tsconfig.lib.json`;
+
+  if (!tree.exists(tsconfigPath)) {
+    return;
+  }
+
+  // A per-entry-point pattern is one scoped to a sub-directory (e.g. `foo/**/*.ts`)
+  // rather than a top-level `**/*` glob or a specific `src/`/config file.
+  const isNestedPattern = (pattern: string): boolean =>
+    !pattern.startsWith('**/') && pattern.includes('/**/');
+
+  updateJson(tree, tsconfigPath, json => {
+    if (Array.isArray(json.include)) {
+      json.include = [...new Set(json.include.filter((p: string) => !isNestedPattern(p)))];
+    }
+    if (Array.isArray(json.exclude)) {
+      json.exclude = [...new Set(json.exclude.filter((p: string) => !isNestedPattern(p)))];
+    }
+    return json;
+  });
 }
 
 export default primitiveGenerator;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,6 +26,7 @@
       "ng-primitives/breadcrumbs": ["packages/ng-primitives/breadcrumbs/src/index.ts"],
       "ng-primitives/button": ["packages/ng-primitives/button/src/index.ts"],
       "ng-primitives/checkbox": ["packages/ng-primitives/checkbox/src/index.ts"],
+      "ng-primitives/collapsible": ["packages/ng-primitives/collapsible/src/index.ts"],
       "ng-primitives/combobox": ["packages/ng-primitives/combobox/src/index.ts"],
       "ng-primitives/common": ["packages/ng-primitives/common/src/index.ts"],
       "ng-primitives/date-picker": ["packages/ng-primitives/date-picker/src/index.ts"],


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Feature

## Issue

Closes #

## What does this PR implement/fix?

Adds a headless `collapsible` primitive (a trigger and a content region for a single expandable section), and refactors the accordion to share this collapsible core so both primitives stay consistent.

Includes unit tests, a documentation page, and CSS/Tailwind examples.

## Does this PR introduce a breaking change?

- [x] No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a headless `collapsible` primitive and refactors the accordion to use its shared core so disclosure behavior, accessibility, and animations are consistent across both.

- New Features
  - Added `NgpCollapsible`, `NgpCollapsibleTrigger`, and `NgpCollapsibleContent` in `ng-primitives/collapsible`.
  - Supports controlled/uncontrolled open state, `vertical | horizontal` orientation, and `data-open/closed/disabled`.
  - Keyboard toggle with Enter/Space; find-in-page via `hidden="until-found"` and `beforematch`.
  - Content dimension CSS vars `--ngp-collapsible-content-width|height` plus `data-enter`/`data-exit` animation hooks.
  - Documentation page and CSS/Tailwind examples, with full unit tests.

- Refactors
  - `ng-primitives/accordion` items compose the collapsible core; the group remains the source of truth for open state.
  - Accordion content adds `role="region"` and `aria-labelledby`, and continues emitting `--ngp-accordion-content-*` vars via a prefix.
  - Backfilled tests and updated docs to include `data-closed`/`data-disabled`.
  - Fixed the primitive generator to stop appending redundant tsconfig globs.

<sup>Written for commit fb70052c16c180cd5592bd67f85f26549610064e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable Collapsible primitive with open, disabled, controlled, keyboard, and orientation support.
  * Added animated content regions with accessibility attributes and find-in-page support.
  * Added documentation examples for standard and Tailwind implementations.

* **Documentation**
  * Added comprehensive Collapsible guidance and API reference.
  * Documented Accordion closed-state attributes.

* **Bug Fixes**
  * Improved Accordion behaviour by sharing Collapsible interactions and content handling.
  * Added coverage for keyboard controls and content sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->