### PR TITLE
feat(rating): add rating primitive

### DIFF
--- a/apps/components/src/app/app.ts
+++ b/apps/components/src/app/app.ts
@@ -24,6 +24,7 @@ import { RouterLink, RouterOutlet } from '@angular/router';
       <a routerLink="/reusable-components/popover">Popover</a>
       <a routerLink="/reusable-components/progress">Progress</a>
       <a routerLink="/reusable-components/radio">Radio</a>
+      <a routerLink="/reusable-components/rating">Rating</a>
       <a routerLink="/reusable-components/search">Search</a>
       <a routerLink="/reusable-components/separator">Separator</a>
       <a routerLink="/reusable-components/range-slider">Range Slider</a>

--- a/apps/components/src/app/pages/reusable-components/rating/index.page.ts
+++ b/apps/components/src/app/pages/reusable-components/rating/index.page.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { Rating } from './rating';
+
+@Component({
+  selector: 'app-rating-example',
+  imports: [Rating],
+  template: `
+    <app-rating [count]="5" [value]="3" aria-label="Rating" />
+  `,
+})
+export default class App {}

--- a/apps/components/src/app/pages/reusable-components/rating/rating.ts
+++ b/apps/components/src/app/pages/reusable-components/rating/rating.ts
@@ -1,0 +1,114 @@
+import { Component } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { injectRatingState, NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: 'app-rating',
+  hostDirectives: [
+    {
+      directive: NgpRating,
+      inputs: [
+        'ngpRatingValue:value',
+        'ngpRatingCount:count',
+        'ngpRatingAllowHalf:allowHalf',
+        'ngpRatingDisabled:disabled',
+        'ngpRatingReadonly:readonly',
+        'ngpRatingClearable:clearable',
+      ],
+      outputs: ['ngpRatingValueChange:valueChange'],
+    },
+  ],
+  imports: [NgIcon, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid }), provideValueAccessor(Rating)],
+  template: `
+    <span class="star" *ngpRatingItem="let star">
+      <ng-icon class="star-background" name="heroStarSolid" />
+      <span class="star-fill" [style.width.%]="star.fraction * 100">
+        <ng-icon name="heroStarSolid" />
+      </span>
+    </span>
+  `,
+  styles: `
+    :host {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      outline: none;
+      border-radius: 0.5rem;
+      cursor: pointer;
+    }
+
+    :host[data-disabled] {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    :host[data-readonly] {
+      cursor: default;
+    }
+
+    :host[data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    .star {
+      position: relative;
+      display: inline-flex;
+      font-size: 1.5rem;
+      line-height: 1;
+      color: var(--ngp-background-secondary);
+      transition: color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .star-fill {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      display: inline-flex;
+      overflow: hidden;
+      color: var(--ngp-primary);
+    }
+  `,
+  host: {
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Rating implements ControlValueAccessor {
+  /** Access the rating state. */
+  private readonly state = injectRatingState();
+
+  /** The onChange callback function. */
+  private onChange?: ChangeFn<number>;
+
+  /** The onTouched callback function. */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    // Whenever the user interacts with the rating, call onChange with the new value.
+    this.state()
+      .valueChange.pipe(takeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value));
+  }
+
+  writeValue(value: number): void {
+    // writing a value from the model must not re-emit through onChange
+    this.state().setValue(value, { emit: false });
+  }
+
+  registerOnChange(fn: ChangeFn<number>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/apps/documentation/src/app/examples/rating/rating-clearable.example.ts
+++ b/apps/documentation/src/app/examples/rating/rating-clearable.example.ts
@@ -1,0 +1,77 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+
+@Component({
+  selector: 'app-rating-clearable',
+  imports: [NgIcon, NgpRating, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid })],
+  styles: `
+    .rating {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.5rem;
+    }
+
+    [ngpRating] {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      outline: none;
+      border-radius: 0.5rem;
+      cursor: pointer;
+    }
+
+    [ngpRating][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    .star {
+      position: relative;
+      display: inline-flex;
+      font-size: 1.75rem;
+      line-height: 1;
+      color: var(--ngp-background-secondary);
+    }
+
+    .star-fill {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      display: inline-flex;
+      overflow: hidden;
+      color: var(--ngp-primary);
+    }
+
+    .hint {
+      font-size: 0.75rem;
+      letter-spacing: -0.011em;
+      color: var(--ngp-text-tertiary);
+    }
+  `,
+  template: `
+    <div class="rating">
+      <div
+        [(ngpRatingValue)]="value"
+        [ngpRatingCount]="5"
+        [ngpRatingClearable]="true"
+        ngpRating
+        aria-label="Rate this product"
+      >
+        <span class="star" *ngpRatingItem="let star">
+          <ng-icon name="heroStarSolid" />
+          <span class="star-fill" [style.width.%]="star.fraction * 100">
+            <ng-icon name="heroStarSolid" />
+          </span>
+        </span>
+      </div>
+      <span class="hint">Click the selected rating again to clear it.</span>
+    </div>
+  `,
+})
+export default class RatingClearableExample {
+  readonly value = signal(3);
+}

--- a/apps/documentation/src/app/examples/rating/rating-clearable.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/rating/rating-clearable.tailwind.example.ts
@@ -1,0 +1,41 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+
+@Component({
+  selector: 'app-rating-clearable',
+  imports: [NgIcon, NgpRating, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid })],
+  template: `
+    <div class="inline-flex flex-col items-start gap-2">
+      <div
+        class="inline-flex cursor-pointer items-center gap-1 rounded-lg outline-none data-[focus-visible]:outline-2 data-[focus-visible]:outline-offset-2 data-[focus-visible]:outline-blue-500 dark:data-[focus-visible]:outline-blue-400"
+        [(ngpRatingValue)]="value"
+        [ngpRatingCount]="5"
+        [ngpRatingClearable]="true"
+        ngpRating
+        aria-label="Rate this product"
+      >
+        <span
+          class="relative inline-flex text-[1.75rem] leading-none text-zinc-200 dark:text-zinc-700"
+          *ngpRatingItem="let star"
+        >
+          <ng-icon name="heroStarSolid" />
+          <span
+            class="absolute inset-y-0 start-0 inline-flex overflow-hidden text-[#f01e2b] dark:text-[#ff4651]"
+            [style.width.%]="star.fraction * 100"
+          >
+            <ng-icon name="heroStarSolid" />
+          </span>
+        </span>
+      </div>
+      <span class="text-xs tracking-[-0.011em] text-zinc-500 dark:text-zinc-400">
+        Click the selected rating again to clear it.
+      </span>
+    </div>
+  `,
+})
+export default class RatingClearableExample {
+  readonly value = signal(3);
+}

--- a/apps/documentation/src/app/examples/rating/rating-disabled.example.ts
+++ b/apps/documentation/src/app/examples/rating/rating-disabled.example.ts
@@ -1,0 +1,61 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+
+@Component({
+  selector: 'app-rating-disabled',
+  imports: [NgIcon, NgpRating, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid })],
+  styles: `
+    [ngpRating] {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      outline: none;
+      border-radius: 0.5rem;
+      cursor: pointer;
+    }
+
+    [ngpRating][data-disabled] {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    .star {
+      position: relative;
+      display: inline-flex;
+      font-size: 1.5rem;
+      line-height: 1;
+      color: var(--ngp-background-secondary);
+    }
+
+    .star-fill {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      display: inline-flex;
+      overflow: hidden;
+      color: var(--ngp-primary);
+    }
+  `,
+  template: `
+    <div
+      [ngpRatingValue]="value()"
+      [ngpRatingCount]="5"
+      ngpRating
+      aria-label="Rating"
+      ngpRatingDisabled
+    >
+      <span class="star" *ngpRatingItem="let star">
+        <ng-icon name="heroStarSolid" />
+        <span class="star-fill" [style.width.%]="star.fraction * 100">
+          <ng-icon name="heroStarSolid" />
+        </span>
+      </span>
+    </div>
+  `,
+})
+export default class RatingDisabledExample {
+  readonly value = signal(2);
+}

--- a/apps/documentation/src/app/examples/rating/rating-disabled.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/rating/rating-disabled.tailwind.example.ts
@@ -1,0 +1,36 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+
+@Component({
+  selector: 'app-rating-disabled',
+  imports: [NgIcon, NgpRating, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid })],
+  template: `
+    <div
+      class="inline-flex cursor-pointer items-center gap-1 rounded-lg outline-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50"
+      [ngpRatingValue]="value()"
+      [ngpRatingCount]="5"
+      ngpRating
+      aria-label="Rating"
+      ngpRatingDisabled
+    >
+      <span
+        class="relative inline-flex text-2xl leading-none text-zinc-200 dark:text-zinc-700"
+        *ngpRatingItem="let star"
+      >
+        <ng-icon name="heroStarSolid" />
+        <span
+          class="absolute inset-y-0 start-0 inline-flex overflow-hidden text-[#f01e2b] dark:text-[#ff4651]"
+          [style.width.%]="star.fraction * 100"
+        >
+          <ng-icon name="heroStarSolid" />
+        </span>
+      </span>
+    </div>
+  `,
+})
+export default class RatingDisabledExample {
+  readonly value = signal(2);
+}

--- a/apps/documentation/src/app/examples/rating/rating-half.example.ts
+++ b/apps/documentation/src/app/examples/rating/rating-half.example.ts
@@ -1,0 +1,71 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+
+@Component({
+  selector: 'app-rating-half',
+  imports: [NgIcon, NgpRating, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid })],
+  styles: `
+    [ngpRating] {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      outline: none;
+      border-radius: 0.5rem;
+      cursor: pointer;
+    }
+
+    [ngpRating][data-disabled] {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    [ngpRating][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    .star {
+      position: relative;
+      display: inline-flex;
+      font-size: 1.75rem;
+      line-height: 1;
+      color: var(--ngp-background-secondary);
+      transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .star[data-highlighted] {
+      transform: scale(1.1);
+    }
+
+    .star-fill {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      display: inline-flex;
+      overflow: hidden;
+      color: var(--ngp-primary);
+    }
+  `,
+  template: `
+    <div
+      [(ngpRatingValue)]="value"
+      [ngpRatingCount]="5"
+      ngpRating
+      aria-label="Rate this product"
+      ngpRatingAllowHalf
+    >
+      <span class="star" *ngpRatingItem="let star">
+        <ng-icon name="heroStarSolid" />
+        <span class="star-fill" [style.width.%]="star.fraction * 100">
+          <ng-icon name="heroStarSolid" />
+        </span>
+      </span>
+    </div>
+  `,
+})
+export default class RatingHalfExample {
+  readonly value = signal(2.5);
+}

--- a/apps/documentation/src/app/examples/rating/rating-half.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/rating/rating-half.tailwind.example.ts
@@ -1,0 +1,36 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+
+@Component({
+  selector: 'app-rating-half',
+  imports: [NgIcon, NgpRating, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid })],
+  template: `
+    <div
+      class="inline-flex cursor-pointer items-center gap-1 rounded-lg outline-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[focus-visible]:outline-2 data-[focus-visible]:outline-offset-2 data-[focus-visible]:outline-blue-500 dark:data-[focus-visible]:outline-blue-400"
+      [(ngpRatingValue)]="value"
+      [ngpRatingCount]="5"
+      ngpRating
+      aria-label="Rate this product"
+      ngpRatingAllowHalf
+    >
+      <span
+        class="relative inline-flex text-[1.75rem] leading-none text-zinc-200 transition-transform data-[highlighted]:scale-110 dark:text-zinc-700"
+        *ngpRatingItem="let star"
+      >
+        <ng-icon name="heroStarSolid" />
+        <span
+          class="absolute inset-y-0 start-0 inline-flex overflow-hidden text-[#f01e2b] dark:text-[#ff4651]"
+          [style.width.%]="star.fraction * 100"
+        >
+          <ng-icon name="heroStarSolid" />
+        </span>
+      </span>
+    </div>
+  `,
+})
+export default class RatingHalfExample {
+  readonly value = signal(2.5);
+}

--- a/apps/documentation/src/app/examples/rating/rating-readonly.example.ts
+++ b/apps/documentation/src/app/examples/rating/rating-readonly.example.ts
@@ -1,0 +1,76 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+
+@Component({
+  selector: 'app-rating-readonly',
+  imports: [NgIcon, NgpRating, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid })],
+  styles: `
+    .rating {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    [ngpRating] {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      outline: none;
+      border-radius: 0.5rem;
+    }
+
+    [ngpRating][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    .star {
+      position: relative;
+      display: inline-flex;
+      font-size: 1.5rem;
+      line-height: 1;
+      color: var(--ngp-background-secondary);
+    }
+
+    .star-fill {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      display: inline-flex;
+      overflow: hidden;
+      color: var(--ngp-primary);
+    }
+
+    .rating-value {
+      font-size: 0.875rem;
+      font-weight: 510;
+      letter-spacing: -0.006em;
+      color: var(--ngp-text-secondary);
+    }
+  `,
+  template: `
+    <div class="rating">
+      <div
+        [attr.aria-label]="'Average rating ' + value()"
+        [ngpRatingValue]="value()"
+        [ngpRatingCount]="5"
+        ngpRating
+        ngpRatingReadonly
+      >
+        <span class="star" *ngpRatingItem="let star">
+          <ng-icon name="heroStarSolid" />
+          <span class="star-fill" [style.width.%]="star.fraction * 100">
+            <ng-icon name="heroStarSolid" />
+          </span>
+        </span>
+      </div>
+      <span class="rating-value">{{ value() }} out of 5</span>
+    </div>
+  `,
+})
+export default class RatingReadonlyExample {
+  readonly value = signal(3.7);
+}

--- a/apps/documentation/src/app/examples/rating/rating-readonly.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/rating/rating-readonly.tailwind.example.ts
@@ -1,0 +1,41 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+
+@Component({
+  selector: 'app-rating-readonly',
+  imports: [NgIcon, NgpRating, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid })],
+  template: `
+    <div class="inline-flex items-center gap-2">
+      <div
+        class="inline-flex items-center gap-1 rounded-lg outline-none data-[focus-visible]:outline-2 data-[focus-visible]:outline-offset-2 data-[focus-visible]:outline-blue-500 dark:data-[focus-visible]:outline-blue-400"
+        [attr.aria-label]="'Average rating ' + value()"
+        [ngpRatingValue]="value()"
+        [ngpRatingCount]="5"
+        ngpRating
+        ngpRatingReadonly
+      >
+        <span
+          class="relative inline-flex text-2xl leading-none text-zinc-200 dark:text-zinc-700"
+          *ngpRatingItem="let star"
+        >
+          <ng-icon name="heroStarSolid" />
+          <span
+            class="absolute inset-y-0 start-0 inline-flex overflow-hidden text-[#f01e2b] dark:text-[#ff4651]"
+            [style.width.%]="star.fraction * 100"
+          >
+            <ng-icon name="heroStarSolid" />
+          </span>
+        </span>
+      </div>
+      <span class="text-sm font-[510] tracking-[-0.006em] text-zinc-600 dark:text-zinc-400">
+        {{ value() }} out of 5
+      </span>
+    </div>
+  `,
+})
+export default class RatingReadonlyExample {
+  readonly value = signal(3.7);
+}

--- a/apps/documentation/src/app/examples/rating/rating.example.ts
+++ b/apps/documentation/src/app/examples/rating/rating.example.ts
@@ -1,0 +1,65 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+
+@Component({
+  selector: 'app-rating',
+  imports: [NgIcon, NgpRating, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid })],
+  styles: `
+    [ngpRating] {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      outline: none;
+      border-radius: 0.5rem;
+      cursor: pointer;
+    }
+
+    [ngpRating][data-disabled] {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    [ngpRating][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    .star {
+      position: relative;
+      display: inline-flex;
+      font-size: 1.75rem;
+      line-height: 1;
+      color: var(--ngp-background-secondary);
+      transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .star[data-highlighted] {
+      transform: scale(1.1);
+    }
+
+    .star-fill {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      display: inline-flex;
+      overflow: hidden;
+      color: var(--ngp-primary);
+    }
+  `,
+  template: `
+    <div [(ngpRatingValue)]="value" [ngpRatingCount]="5" ngpRating aria-label="Rate this product">
+      <span class="star" *ngpRatingItem="let star">
+        <ng-icon name="heroStarSolid" />
+        <span class="star-fill" [style.width.%]="star.fraction * 100">
+          <ng-icon name="heroStarSolid" />
+        </span>
+      </span>
+    </div>
+  `,
+})
+export default class RatingExample {
+  readonly value = signal(3);
+}

--- a/apps/documentation/src/app/examples/rating/rating.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/rating/rating.tailwind.example.ts
@@ -1,0 +1,35 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+
+@Component({
+  selector: 'app-rating',
+  imports: [NgIcon, NgpRating, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid })],
+  template: `
+    <div
+      class="inline-flex cursor-pointer items-center gap-1 rounded-lg outline-none data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 data-[focus-visible]:outline-2 data-[focus-visible]:outline-offset-2 data-[focus-visible]:outline-blue-500 dark:data-[focus-visible]:outline-blue-400"
+      [(ngpRatingValue)]="value"
+      [ngpRatingCount]="5"
+      ngpRating
+      aria-label="Rate this product"
+    >
+      <span
+        class="relative inline-flex text-[1.75rem] leading-none text-zinc-200 transition-transform data-[highlighted]:scale-110 dark:text-zinc-700"
+        *ngpRatingItem="let star"
+      >
+        <ng-icon name="heroStarSolid" />
+        <span
+          class="absolute inset-y-0 start-0 inline-flex overflow-hidden text-[#f01e2b] dark:text-[#ff4651]"
+          [style.width.%]="star.fraction * 100"
+        >
+          <ng-icon name="heroStarSolid" />
+        </span>
+      </span>
+    </div>
+  `,
+})
+export default class RatingExample {
+  readonly value = signal(3);
+}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/rating.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/rating.md
@@ -1,0 +1,164 @@
+---
+name: 'Rating'
+sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/rating'
+---
+
+# Rating
+
+Capture a star rating within a range.
+
+**Note:** The rating primitives are currently experimental. The API may change in future releases.
+
+<docs-example name="rating"></docs-example>
+
+## Import
+
+Import the Rating primitives from `ng-primitives/rating`.
+
+```ts
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+```
+
+## Usage
+
+Apply the `ngpRating` directive to the container and project the item template
+once with the `*ngpRatingItem` structural directive. The container renders one
+item per `ngpRatingCount`, exposing the derived state of each item as the
+template context.
+
+```html
+<div ngpRating [(ngpRatingValue)]="value" [ngpRatingCount]="5">
+  <span *ngpRatingItem="let star">{{ star.checked ? '★' : '☆' }}</span>
+</div>
+```
+
+The `star` context provides `index`, `checked`, `half`, `fraction` (a `0`-`1`
+fill amount) and `highlighted` (whether the item is part of the current hover
+preview).
+
+## Reusable Component
+
+Create a reusable component that uses the rating directives.
+
+<docs-snippet name="rating"></docs-snippet>
+
+## Schematics
+
+Generate a reusable rating component using the Angular CLI.
+
+```bash npm
+ng g ng-primitives:primitive rating
+```
+
+### Options
+
+- `path`: The path at which to create the component file.
+- `prefix`: The prefix to apply to the generated component selector.
+- `component-suffix`: The suffix to apply to the generated component class name.
+- `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
+- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+
+## Examples
+
+### Half Ratings
+
+Set `ngpRatingAllowHalf` to allow half-star increments. The pointer position
+within an item selects the left or right half, and the arrow keys step by `0.5`.
+Use the `fraction` context value to clip the fill for a partially selected item.
+
+<docs-example name="rating-half"></docs-example>
+
+### Read-only
+
+Set `ngpRatingReadonly` to display a value without allowing edits, for example
+when showing an average score. A read-only rating stays focusable so assistive
+technology can announce it. Fractional values such as `3.7` are exposed through
+the per-item `fraction`, so you can render a precise partial fill.
+
+<docs-example name="rating-readonly"></docs-example>
+
+### Disabled
+
+Set `ngpRatingDisabled` to make the rating non-interactive and remove it from the
+tab order.
+
+<docs-example name="rating-disabled"></docs-example>
+
+### Deselection
+
+By default a rating can't be cleared once set - re-selecting the current value is
+a no-op and the keyboard can't take an existing rating below `1`. Set
+`[ngpRatingClearable]="true"` to allow deselection: clicking the currently
+selected value clears the rating to `0`, and <kbd>Home</kbd> / arrow keys can
+reach `0`.
+
+<docs-example name="rating-clearable"></docs-example>
+
+## API Reference
+
+The following directives are available to import from the `ng-primitives/rating` package:
+
+### NgpRating
+
+<api-docs name="NgpRating"></api-docs>
+
+<api-reference-props name="NgpRating"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-disabled" description="Applied when the rating is disabled." />
+  <api-attribute name="data-readonly" description="Applied when the rating is read-only." />
+  <api-attribute name="data-hovered" description="Applied while the rating is being hovered." />
+</api-reference-attributes>
+
+### NgpRatingItem
+
+<api-docs name="NgpRatingItem"></api-docs>
+
+A structural directive that renders one item per `ngpRatingCount`. Each rendered
+element automatically receives `data-checked`, `data-half` and `data-highlighted`
+attributes reflecting its state, so you can style items entirely from CSS without
+binding them by hand.
+
+The template context (`let star`) exposes the same state for use in markup (for
+example choosing an icon or clipping the fill width):
+
+- `index`: the 1-based position of the item.
+- `checked`: whether the item is fully filled.
+- `half`: whether the item is half filled (only when `ngpRatingAllowHalf`).
+- `fraction`: the fill amount of the item, `0`-`1`.
+- `highlighted`: whether the item is part of the current hover preview.
+
+<api-reference-attributes>
+  <api-attribute name="data-checked" description="Applied when the item is fully filled." />
+  <api-attribute name="data-half" description="Applied when the item is half filled (allowHalf only)." />
+  <api-attribute name="data-highlighted" description="Applied when the item is part of the current hover preview." />
+</api-reference-attributes>
+
+## Global Configuration
+
+You can configure the default options for all ratings in your application by using the `provideRatingConfig` function in a providers array.
+
+```ts
+import { provideRatingConfig } from 'ng-primitives/rating';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideRatingConfig({
+      count: 5,
+      clearable: false,
+      valueText: (value, count) => `${value} out of ${count} stars`,
+    }),
+  ],
+});
+```
+
+## Accessibility
+
+Adheres to the [Slider WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider/). The rating exposes `role="slider"` with `aria-valuemin`, `aria-valuemax`, `aria-valuenow` and an `aria-valuetext` describing the current value.
+
+### Keyboard Interactions
+
+- <kbd>Left Arrow</kbd> or <kbd>Down Arrow</kbd>: Decrease the value by the step (`0.5` when half ratings are allowed, otherwise `1`).
+- <kbd>Right Arrow</kbd> or <kbd>Up Arrow</kbd>: Increase the value by the step.
+- <kbd>Home</kbd>: Clear the value to `0`.
+- <kbd>End</kbd>: Set the value to the maximum.

--- a/packages/ng-primitives/internal/src/index.ts
+++ b/packages/ng-primitives/internal/src/index.ts
@@ -30,5 +30,6 @@ export * from './utilities/dom-sort';
 export * from './utilities/element-ref';
 export { fromMutationObserver } from './utilities/mutation-observer';
 export { setupOverflowListener } from './utilities/overflow';
+export { renderList, type NgpRenderListOptions } from './utilities/render-list';
 export { Dimensions, fromResizeEvent, injectDimensions, observeResize } from './utilities/resize';
 export * from './utilities/scrolling';

--- a/packages/ng-primitives/internal/src/utilities/render-list.ts
+++ b/packages/ng-primitives/internal/src/utilities/render-list.ts
@@ -1,0 +1,124 @@
+import {
+  DestroyableInjector,
+  ElementRef,
+  EmbeddedViewRef,
+  Injector,
+  Provider,
+  TemplateRef,
+  ViewContainerRef,
+  inject,
+  runInInjectionContext,
+} from '@angular/core';
+import { explicitEffect } from '../signals/explicit-effect';
+
+/**
+ * Options for {@link renderList}.
+ */
+export interface NgpRenderListOptions<T> {
+  /** The view container the items are rendered into. */
+  readonly viewContainer: ViewContainerRef;
+  /** The template instantiated once per item. */
+  readonly template: TemplateRef<unknown>;
+  /**
+   * A reactive source of items. Read inside an effect, so the list re-renders
+   * whenever any signal it touches changes.
+   */
+  readonly items: () => readonly T[];
+  /**
+   * Build the template context for an item. Defaults to `{ $implicit: item }`.
+   */
+  readonly context?: (item: T, index: number) => object;
+  /**
+   * Providers made available to each rendered view's injector (e.g. per-item
+   * injection tokens).
+   */
+  readonly providers?: (item: T, index: number) => Provider[];
+  /**
+   * The per-item state function, invoked once per rendered element inside an
+   * injection context scoped to that item. The rendered element is provided as
+   * `ElementRef`, so the function can call `injectElementRef()` like any other
+   * `-state.ts` factory. Anything it registers (`dataBinding`, `listener`,
+   * effects, `inject(DestroyRef).onDestroy`, ...) is cleaned up automatically
+   * when the item is removed or the list is destroyed.
+   *
+   * If it returns a value (e.g. the state from a `createPrimitive` factory) that
+   * value becomes the template context's `$implicit`, so `let item` exposes it.
+   */
+  readonly setup?: (item: T, index: number) => unknown;
+  /** The injector to bind the render effect to. Defaults to the current one. */
+  readonly injector?: Injector;
+}
+
+/**
+ * Render a reactive list of items from a template into a view container,
+ * managing the embedded-view lifecycle and per-item state wiring.
+ *
+ * The list re-renders whenever the reactive `items` source changes. Each item
+ * runs its `setup` in its own injector, so effects registered there are torn
+ * down when the item is removed or the host is destroyed - callers never manage
+ * view refs or cleanup by hand.
+ *
+ * Must be called from an injection context (e.g. a directive constructor).
+ */
+export function renderList<T>(options: NgpRenderListOptions<T>): void {
+  const injector = options.injector ?? inject(Injector);
+
+  explicitEffect(
+    [options.items],
+    ([items], onCleanup) => {
+      const views: EmbeddedViewRef<unknown>[] = [];
+      const injectors: DestroyableInjector[] = [];
+
+      // Registered before rendering so partial state is torn down even if an
+      // item's `setup` throws mid-loop.
+      onCleanup(() => {
+        injectors.forEach(itemInjector => itemInjector.destroy());
+        views.forEach(view => view.destroy());
+      });
+
+      items.forEach((item, index) => {
+        const context = options.context?.(item, index) ?? { $implicit: item };
+        const viewInjector = options.providers
+          ? Injector.create({
+              parent: options.viewContainer.injector,
+              providers: options.providers(item, index),
+            })
+          : undefined;
+        if (viewInjector) {
+          injectors.push(viewInjector);
+        }
+
+        const view = options.viewContainer.createEmbeddedView(
+          options.template,
+          context,
+          viewInjector ? { injector: viewInjector } : undefined,
+        );
+        views.push(view);
+
+        const element = view.rootNodes[0];
+        if (options.setup && element instanceof HTMLElement) {
+          // A per-item injector exposes the rendered element via
+          // `injectElementRef()` and scopes the item's effects/listeners so they
+          // are torn down when the list re-renders or the host is destroyed. It
+          // is parented on the view's `providers` injector so a `createPrimitive`
+          // item factory can register its state (`provideXState()`) there and the
+          // rendered content can inject it.
+          const itemInjector = Injector.create({
+            parent: viewInjector ?? injector,
+            providers: [{ provide: ElementRef, useValue: new ElementRef(element) }],
+          });
+          injectors.push(itemInjector);
+          const state = runInInjectionContext(itemInjector, () => options.setup!(item, index));
+          // Expose the item factory's state as the template context.
+          if (state !== undefined) {
+            (context as { $implicit: unknown }).$implicit = state;
+          }
+        }
+
+        // Detect changes after `setup` so the view renders with the state above.
+        view.detectChanges();
+      });
+    },
+    { injector },
+  );
+}

--- a/packages/ng-primitives/rating/README.md
+++ b/packages/ng-primitives/rating/README.md
@@ -1,0 +1,3 @@
+# ng-primitives/rating
+
+Secondary entry point of `ng-primitives`. It can be used by importing from `ng-primitives/rating`.

--- a/packages/ng-primitives/rating/ng-package.json
+++ b/packages/ng-primitives/rating/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/ng-primitives/rating/src/config/rating-config.ts
+++ b/packages/ng-primitives/rating/src/config/rating-config.ts
@@ -1,0 +1,47 @@
+import { InjectionToken, Provider, inject } from '@angular/core';
+
+export interface NgpRatingConfig {
+  /**
+   * The default number of items in the rating.
+   */
+  count: number;
+  /**
+   * Whether re-selecting the current value clears the rating to 0 (deselection).
+   */
+  clearable: boolean;
+  /**
+   * Produce the `aria-valuetext` announced to assistive technology. Override
+   * for localisation.
+   */
+  valueText: (value: number, count: number) => string;
+}
+
+export const defaultRatingConfig: NgpRatingConfig = {
+  count: 5,
+  clearable: false,
+  valueText: (value, count) => `${value} out of ${count}`,
+};
+
+export const NgpRatingConfigToken = new InjectionToken<NgpRatingConfig>('NgpRatingConfigToken');
+
+/**
+ * Provide the default Rating configuration
+ * @param config The Rating configuration
+ * @returns The provider
+ */
+export function provideRatingConfig(config: Partial<NgpRatingConfig>): Provider[] {
+  return [
+    {
+      provide: NgpRatingConfigToken,
+      useValue: { ...defaultRatingConfig, ...config },
+    },
+  ];
+}
+
+/**
+ * Inject the Rating configuration
+ * @returns The global Rating configuration
+ */
+export function injectRatingConfig(): NgpRatingConfig {
+  return inject(NgpRatingConfigToken, { optional: true }) ?? defaultRatingConfig;
+}

--- a/packages/ng-primitives/rating/src/index.ts
+++ b/packages/ng-primitives/rating/src/index.ts
@@ -1,0 +1,19 @@
+export { NgpRating } from './rating/rating';
+export {
+  NgpRatingStateToken,
+  ngpRating,
+  injectRatingState,
+  provideRatingState,
+  type NgpRatingState,
+  type NgpRatingProps,
+  type NgpRatingItemState,
+} from './rating/rating-state';
+export { NgpRatingConfig, provideRatingConfig } from './config/rating-config';
+export { NgpRatingItem, type NgpRatingItemContext } from './rating-item/rating-item';
+export {
+  NgpRatingItemStateToken,
+  ngpRatingItem,
+  injectRatingItemState,
+  provideRatingItemState,
+  type NgpRatingItemProps,
+} from './rating-item/rating-item-state';

--- a/packages/ng-primitives/rating/src/rating-item/rating-item-state.ts
+++ b/packages/ng-primitives/rating/src/rating-item/rating-item-state.ts
@@ -1,0 +1,105 @@
+import { Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { createPrimitive, dataBinding, listener } from 'ng-primitives/state';
+import { NgpRatingItemState } from '../rating/rating-state';
+
+/**
+ * Inputs for the rating item state function. The parent passes exactly what the
+ * item needs - the item never reaches back into the rating state.
+ */
+export interface NgpRatingItemProps {
+  /** The 1-based position of the item. */
+  readonly index: number;
+  /** Whether the item is fully filled. */
+  readonly checked: Signal<boolean>;
+  /** Whether the item is half filled. */
+  readonly half: Signal<boolean>;
+  /** The fill amount of the item, 0-1. */
+  readonly fraction: Signal<number>;
+  /** Whether the item is part of the current hover preview. */
+  readonly highlighted: Signal<boolean>;
+  /** Whether half values are allowed (for pointer half-detection). */
+  readonly allowHalf: Signal<boolean>;
+  /** Preview the value the pointer is over. */
+  readonly preview: (value: number) => void;
+  /** Commit the value the pointer selects. */
+  readonly commit: (value: number) => void;
+}
+
+/**
+ * The state function for a single rendered rating item. Reflects the item's
+ * state onto the element as data attributes, wires the pointer interactions
+ * (hover preview + click, with half-value detection), and returns the item's
+ * render state - which `renderList` exposes as the `*ngpRatingItem` context.
+ *
+ * Runs inside the render-pass injection context provided by `renderList`, so its
+ * element is available via `injectElementRef()` and its `dataBinding` effects and
+ * listeners are cleaned up automatically.
+ */
+export const [
+  NgpRatingItemStateToken,
+  ngpRatingItem,
+  injectRatingItemState,
+  provideRatingItemState,
+] = createPrimitive(
+  'NgpRatingItem',
+  ({
+    index,
+    checked,
+    half,
+    fraction,
+    highlighted,
+    allowHalf,
+    preview,
+    commit,
+  }: NgpRatingItemProps): NgpRatingItemState => {
+    const element = injectElementRef<HTMLElement>();
+
+    dataBinding(element, 'data-checked', checked);
+    dataBinding(element, 'data-half', half);
+    dataBinding(element, 'data-highlighted', highlighted);
+
+    listener(element, 'pointermove', event =>
+      preview(valueAt(element.nativeElement, index, allowHalf(), event)),
+    );
+    listener(element, 'click', event =>
+      commit(valueAt(element.nativeElement, index, allowHalf(), event)),
+    );
+
+    // Getters so each template read re-derives from the live signals.
+    return {
+      index,
+      get checked() {
+        return checked();
+      },
+      get half() {
+        return half();
+      },
+      get fraction() {
+        return fraction();
+      },
+      get highlighted() {
+        return highlighted();
+      },
+    } satisfies NgpRatingItemState;
+  },
+);
+
+/** Resolve the value the pointer is currently over, honouring half steps. */
+function valueAt(
+  element: HTMLElement,
+  index: number,
+  allowHalf: boolean,
+  event: { clientX: number },
+): number {
+  if (!allowHalf) {
+    return index;
+  }
+
+  const rect = element.getBoundingClientRect();
+  const isRTL = getComputedStyle(element).direction === 'rtl';
+  const ratio = isRTL
+    ? (rect.right - event.clientX) / rect.width
+    : (event.clientX - rect.left) / rect.width;
+  return ratio <= 0.5 ? index - 0.5 : index;
+}

--- a/packages/ng-primitives/rating/src/rating-item/rating-item.ts
+++ b/packages/ng-primitives/rating/src/rating-item/rating-item.ts
@@ -1,0 +1,61 @@
+import { Directive, TemplateRef, ViewContainerRef, computed, inject } from '@angular/core';
+import { renderList } from 'ng-primitives/internal';
+import { NgpRatingItemState, injectRatingState } from '../rating/rating-state';
+import { ngpRatingItem, provideRatingItemState } from './rating-item-state';
+
+/**
+ * The render context exposed to the `*ngpRatingItem` template. Every field is
+ * derived reactively from the rating value / hover state, so the template
+ * updates automatically as the rating changes.
+ */
+export interface NgpRatingItemContext {
+  $implicit: NgpRatingItemState;
+}
+
+/**
+ * A structural directive that renders one item (star) per `count`, driven by the
+ * parent `ngpRating`. Each generated element automatically receives the
+ * `data-checked`, `data-half` and `data-highlighted` attributes and has its
+ * pointer interactions wired up via the `ngpRatingItem` state function.
+ */
+@Directive({
+  selector: '[ngpRatingItem]',
+  exportAs: 'ngpRatingItem',
+})
+export class NgpRatingItem {
+  private readonly template = inject<TemplateRef<NgpRatingItemContext>>(TemplateRef);
+  private readonly viewContainer = inject(ViewContainerRef);
+  private readonly state = injectRatingState();
+
+  // Make sure the template checker knows the type of the context.
+  static ngTemplateContextGuard(
+    _: NgpRatingItem,
+    context: unknown,
+  ): context is NgpRatingItemContext {
+    return true;
+  }
+
+  constructor() {
+    renderList<number>({
+      viewContainer: this.viewContainer,
+      template: this.template,
+      items: () => Array.from({ length: this.state().count() }, (_, i) => i + 1),
+      // Register each item's state so it can be injected within the item view.
+      providers: () => [provideRatingItemState()],
+      // The item factory's returned state becomes the `let star` context.
+      setup: index => {
+        const item = computed(() => this.state().itemState(index));
+        return ngpRatingItem({
+          index,
+          checked: computed(() => item().checked),
+          half: computed(() => item().half),
+          fraction: computed(() => item().fraction),
+          highlighted: computed(() => item().highlighted),
+          allowHalf: this.state().allowHalf,
+          preview: value => this.state().preview(value),
+          commit: value => this.state().commit(value),
+        });
+      },
+    });
+  }
+}

--- a/packages/ng-primitives/rating/src/rating/rating-state.ts
+++ b/packages/ng-primitives/rating/src/rating/rating-state.ts
@@ -1,0 +1,251 @@
+import { Signal, WritableSignal, computed, signal } from '@angular/core';
+import { ngpFormControl } from 'ng-primitives/form-field';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  SetterOptions,
+  attrBinding,
+  controlled,
+  createPrimitive,
+  dataBinding,
+  emitter,
+  listener,
+} from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Observable } from 'rxjs';
+
+/**
+ * The derived render state for a single rating item (star).
+ */
+export interface NgpRatingItemState {
+  /** The 1-based position of the item. */
+  readonly index: number;
+  /** Whether the item is fully filled. */
+  readonly checked: boolean;
+  /** Whether the item is half filled (only when `allowHalf`). */
+  readonly half: boolean;
+  /** The fill amount of the item, 0-1 (for fractional/readonly averages). */
+  readonly fraction: number;
+  /** Whether the item is part of the current hover preview. */
+  readonly highlighted: boolean;
+}
+
+/**
+ * Public state surface for the Rating primitive.
+ */
+export interface NgpRatingState {
+  /** The id of the rating. */
+  readonly id: Signal<string>;
+  /** The committed rating value. */
+  readonly value: WritableSignal<number>;
+  /** The number of items. */
+  readonly count: Signal<number>;
+  /** Whether half values are allowed. */
+  readonly allowHalf: Signal<boolean>;
+  /** Whether the rating is disabled (includes form control state). */
+  readonly disabled: Signal<boolean>;
+  /** Whether the rating is read-only. */
+  readonly readonly: Signal<boolean>;
+  /** Emits when the committed value changes. */
+  readonly valueChange: Observable<number>;
+  /** Set the committed value (clamped to `[0, count]`). */
+  setValue(value: number, options?: SetterOptions): void;
+  /** Set the disabled state (merged with any form control disabled state). */
+  setDisabled(disabled: boolean): void;
+  /**
+   * @internal Commit an interactive value, clearing to 0 when re-selecting the
+   * current value.
+   */
+  commit(value: number): void;
+  /**
+   * @internal Set the hover preview value.
+   */
+  preview(value: number): void;
+  /**
+   * @internal Derive the render state for the item at `index` (1-based).
+   */
+  itemState(index: number): NgpRatingItemState;
+}
+
+/**
+ * Inputs for configuring the Rating primitive.
+ */
+export interface NgpRatingProps {
+  /** The id of the rating. */
+  readonly id?: Signal<string>;
+  /** The committed rating value. */
+  readonly value?: Signal<number>;
+  /** The number of items. */
+  readonly count?: Signal<number>;
+  /** Whether half values are allowed. */
+  readonly allowHalf?: Signal<boolean>;
+  /** Whether the rating is disabled. */
+  readonly disabled?: Signal<boolean>;
+  /** Whether the rating is read-only. */
+  readonly readonly?: Signal<boolean>;
+  /** Whether re-selecting the current value clears the rating to 0. */
+  readonly clearable?: Signal<boolean>;
+  /** Produce the `aria-valuetext` string. */
+  readonly valueText?: Signal<(value: number, count: number) => string>;
+  /** Callback fired when the committed value changes. */
+  readonly onValueChange?: (value: number) => void;
+}
+
+export const [NgpRatingStateToken, ngpRating, injectRatingState, provideRatingState] =
+  createPrimitive(
+    'NgpRating',
+    ({
+      id = signal(uniqueId('ngp-rating')),
+      value: _value = signal(0),
+      count = signal(5),
+      allowHalf = signal(false),
+      disabled: _disabled = signal(false),
+      readonly = signal(false),
+      clearable = signal(false),
+      valueText = signal<(value: number, count: number) => string>(
+        (value, count) => `${value} out of ${count}`,
+      ),
+      onValueChange,
+    }: NgpRatingProps): NgpRatingState => {
+      const element = injectElementRef<HTMLElement>();
+      const value = controlled(_value);
+      const disabledInput = controlled(_disabled);
+      const hovered = signal<number | null>(null);
+      const valueChange = emitter<number>();
+
+      // Merge the input disabled state with the form control (NgControl) state.
+      const status = ngpFormControl({ id, disabled: disabledInput });
+      const disabled = computed(() => status().disabled ?? false);
+
+      const displayValue = computed(() => {
+        const preview = hovered();
+        return preview !== null ? preview : value();
+      });
+
+      function itemState(index: number): NgpRatingItemState {
+        const fraction = Math.min(1, Math.max(0, displayValue() - (index - 1)));
+        return {
+          index,
+          checked: fraction >= 1,
+          half: allowHalf() && fraction >= 0.5 && fraction < 1,
+          fraction,
+          highlighted: hovered() !== null && fraction > 0,
+        };
+      }
+
+      function setValue(newValue: number, options?: SetterOptions): void {
+        const clamped = Math.min(count(), Math.max(0, newValue));
+        value.set(clamped);
+        if (options?.emit !== false) {
+          onValueChange?.(clamped);
+          valueChange.emit(clamped);
+        }
+      }
+
+      function setDisabled(isDisabled: boolean): void {
+        disabledInput.set(isDisabled);
+      }
+
+      function isInteractive(): boolean {
+        return !disabled() && !readonly();
+      }
+
+      function commit(newValue: number): void {
+        if (!isInteractive()) {
+          return;
+        }
+        // Re-selecting the current value clears the rating, when clearable.
+        if (newValue === value()) {
+          if (clearable()) {
+            setValue(0);
+          }
+          return;
+        }
+        setValue(newValue);
+      }
+
+      function preview(newValue: number): void {
+        if (!isInteractive()) {
+          return;
+        }
+        hovered.set(newValue);
+      }
+
+      function clearPreview(): void {
+        hovered.set(null);
+      }
+
+      function onKeydown(event: KeyboardEvent): void {
+        if (!isInteractive()) {
+          return;
+        }
+
+        const step = allowHalf() ? 0.5 : 1;
+        const isRTL = getComputedStyle(element.nativeElement).direction === 'rtl';
+        const current = value();
+        let next = current;
+
+        switch (event.key) {
+          case 'ArrowUp':
+            next = current + step;
+            break;
+          case 'ArrowDown':
+            next = current - step;
+            break;
+          case 'ArrowRight':
+            next = isRTL ? current - step : current + step;
+            break;
+          case 'ArrowLeft':
+            next = isRTL ? current + step : current - step;
+            break;
+          case 'Home':
+            next = 0;
+            break;
+          case 'End':
+            next = count();
+            break;
+          default:
+            return;
+        }
+
+        event.preventDefault();
+        // When not clearable, an existing rating can't be decreased to 0.
+        const floor = !clearable() && current > 0 ? 1 : 0;
+        next = Math.min(count(), Math.max(floor, next));
+        if (next !== current) {
+          setValue(next);
+        }
+      }
+
+      // Host bindings
+      attrBinding(element, 'role', 'slider');
+      attrBinding(element, 'id', id);
+      attrBinding(element, 'tabindex', () => (disabled() ? '-1' : '0'));
+      attrBinding(element, 'aria-valuemin', '0');
+      attrBinding(element, 'aria-valuemax', () => String(count()));
+      attrBinding(element, 'aria-valuenow', () => String(value()));
+      attrBinding(element, 'aria-valuetext', () => valueText()(value(), count()));
+      attrBinding(element, 'aria-readonly', () => (readonly() ? 'true' : null));
+      attrBinding(element, 'aria-disabled', () => (disabled() ? 'true' : null));
+      dataBinding(element, 'data-readonly', readonly);
+      dataBinding(element, 'data-hovered', () => hovered() !== null);
+
+      // Listeners
+      listener(element, 'keydown', onKeydown);
+      listener(element, 'pointerleave', clearPreview);
+
+      return {
+        id,
+        value,
+        count,
+        allowHalf,
+        disabled,
+        readonly,
+        valueChange: valueChange.asObservable(),
+        setValue,
+        setDisabled,
+        commit,
+        preview,
+        itemState,
+      } satisfies NgpRatingState;
+    },
+  );

--- a/packages/ng-primitives/rating/src/rating/rating.ts
+++ b/packages/ng-primitives/rating/src/rating/rating.ts
@@ -1,0 +1,109 @@
+import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
+import { Directive, booleanAttribute, input, numberAttribute, output } from '@angular/core';
+import { SetterOptions } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { injectRatingConfig } from '../config/rating-config';
+import { ngpRating, provideRatingState } from './rating-state';
+
+/**
+ * Apply the `ngpRating` directive to an element that represents the rating. It
+ * exposes the slider role and owns the value, keyboard, and form integration.
+ * Project the star markup once via the `*ngpRatingItem` structural directive.
+ */
+@Directive({
+  selector: '[ngpRating]',
+  exportAs: 'ngpRating',
+  providers: [provideRatingState()],
+})
+export class NgpRating {
+  private readonly config = injectRatingConfig();
+
+  /**
+   * The id of the rating. If not provided, a unique id will be generated.
+   */
+  readonly id = input<string>(uniqueId('ngp-rating'));
+
+  /**
+   * The value of the rating.
+   */
+  readonly value = input<number, NumberInput>(0, {
+    alias: 'ngpRatingValue',
+    transform: numberAttribute,
+  });
+
+  /**
+   * Emits when the value changes.
+   */
+  readonly valueChange = output<number>({
+    alias: 'ngpRatingValueChange',
+  });
+
+  /**
+   * The number of items in the rating.
+   */
+  readonly count = input<number, NumberInput>(this.config.count, {
+    alias: 'ngpRatingCount',
+    transform: numberAttribute,
+  });
+
+  /**
+   * Whether half values are allowed.
+   */
+  readonly allowHalf = input<boolean, BooleanInput>(false, {
+    alias: 'ngpRatingAllowHalf',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * Whether the rating is disabled.
+   */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpRatingDisabled',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * Whether the rating is read-only.
+   */
+  readonly readonly = input<boolean, BooleanInput>(false, {
+    alias: 'ngpRatingReadonly',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * Whether re-selecting the current value clears the rating to 0 (deselection).
+   */
+  readonly clearable = input<boolean, BooleanInput>(this.config.clearable, {
+    alias: 'ngpRatingClearable',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * Produce the `aria-valuetext` announced to assistive technology.
+   */
+  readonly valueText = input<(value: number, count: number) => string>(this.config.valueText, {
+    alias: 'ngpRatingValueText',
+  });
+
+  /**
+   * The state of the rating.
+   */
+  protected readonly state = ngpRating({
+    id: this.id,
+    value: this.value,
+    count: this.count,
+    allowHalf: this.allowHalf,
+    disabled: this.disabled,
+    readonly: this.readonly,
+    clearable: this.clearable,
+    valueText: this.valueText,
+    onValueChange: value => this.valueChange.emit(value),
+  });
+
+  /**
+   * Set the value of the rating.
+   */
+  setValue(value: number, options?: SetterOptions): void {
+    this.state.setValue(value, options);
+  }
+}

--- a/packages/ng-primitives/rating/src/rating/tests/rating-forms.fixture.ts
+++ b/packages/ng-primitives/rating/src/rating/tests/rating-forms.fixture.ts
@@ -1,0 +1,67 @@
+import { Component } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+import {
+  ChangeFn,
+  provideValueAccessor,
+  safeTakeUntilDestroyed,
+  TouchedFn,
+} from 'ng-primitives/utils';
+import { injectRatingState } from '../rating-state';
+
+/**
+ * Inline fixture mirroring `apps/components/.../reusable-components/rating/rating.ts`.
+ * Used by the reusable-component form test suites.
+ */
+@Component({
+  selector: 'app-rating',
+  hostDirectives: [
+    {
+      directive: NgpRating,
+      inputs: [
+        'ngpRatingValue:value',
+        'ngpRatingCount:count',
+        'ngpRatingAllowHalf:allowHalf',
+        'ngpRatingDisabled:disabled',
+        'ngpRatingReadonly:readonly',
+      ],
+      outputs: ['ngpRatingValueChange:valueChange'],
+    },
+  ],
+  imports: [NgpRatingItem],
+  providers: [provideValueAccessor(Rating)],
+  template: `
+    <span class="star" *ngpRatingItem="let star"></span>
+  `,
+  host: {
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Rating implements ControlValueAccessor {
+  private readonly state = injectRatingState();
+  private onChange?: ChangeFn<number>;
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    this.state()
+      .valueChange.pipe(safeTakeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value));
+  }
+
+  writeValue(value: number): void {
+    // writing a value from the model must not re-emit through onChange
+    this.state().setValue(value, { emit: false });
+  }
+
+  registerOnChange(fn: ChangeFn<number>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/rating/src/rating/tests/rating-forms.test.ts
+++ b/packages/ng-primitives/rating/src/rating/tests/rating-forms.test.ts
@@ -1,0 +1,149 @@
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it, vi } from 'vitest';
+import { Rating } from './rating-forms.fixture';
+
+describe('Rating (reusable component) — template-driven forms', () => {
+  it('reflects the initial [(ngModel)] value', async () => {
+    const { getByRole, fixture } = await render(
+      `<app-rating [(ngModel)]="value" count="5"></app-rating>`,
+      {
+        imports: [Rating, FormsModule],
+        componentProperties: { value: 3 },
+      },
+    );
+
+    await fixture.whenStable();
+    expect(getByRole('slider')).toHaveAttribute('aria-valuenow', '3');
+  });
+
+  it('binds with [(ngModel)] two-way on keyboard interaction', async () => {
+    const ngModelChange = vi.fn();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      const { getByRole, fixture, rerender } = await render(
+        `<app-rating [(ngModel)]="value" (ngModelChange)="ngModelChange($event)" count="5"></app-rating>`,
+        {
+          imports: [Rating, FormsModule],
+          componentProperties: { value: 2, ngModelChange },
+        },
+      );
+
+      await fixture.whenStable();
+      const rating = getByRole('slider');
+      expect(rating).toHaveAttribute('aria-valuenow', '2');
+
+      fireEvent.keyDown(rating, { key: 'ArrowRight' });
+      await fixture.whenStable();
+      expect(rating).toHaveAttribute('aria-valuenow', '3');
+      expect(ngModelChange).toHaveBeenCalledTimes(1);
+      expect(ngModelChange).toHaveBeenLastCalledWith(3);
+
+      // writing a new value from the model must not re-emit through onChange
+      await rerender({ componentProperties: { value: 1, ngModelChange } });
+      await fixture.whenStable();
+      expect(rating).toHaveAttribute('aria-valuenow', '1');
+      expect(ngModelChange).toHaveBeenCalledTimes(1);
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});
+
+describe('Rating (reusable component) — reactive forms', () => {
+  it('reflects the initial form control value', async () => {
+    const formControl = new FormControl(3);
+    const { getByRole } = await render(
+      `<app-rating [formControl]="formControl" count="5"></app-rating>`,
+      {
+        imports: [Rating, ReactiveFormsModule],
+        componentProperties: { formControl },
+      },
+    );
+
+    expect(getByRole('slider')).toHaveAttribute('aria-valuenow', '3');
+    expect(formControl.value).toBe(3);
+  });
+
+  it('updates the form control on keyboard and the DOM on setValue', async () => {
+    const formControl = new FormControl(2);
+    const { getByRole, fixture } = await render(
+      `<app-rating [formControl]="formControl" count="5"></app-rating>`,
+      {
+        imports: [Rating, ReactiveFormsModule],
+        componentProperties: { formControl },
+      },
+    );
+
+    const rating = getByRole('slider');
+
+    fireEvent.keyDown(rating, { key: 'ArrowRight' });
+    expect(formControl.value).toBe(3);
+
+    formControl.setValue(1);
+    await fixture.whenStable();
+    expect(rating).toHaveAttribute('aria-valuenow', '1');
+  });
+
+  it('reflects the disabled state from the form control', async () => {
+    const formControl = new FormControl(0);
+    const { getByRole, fixture } = await render(
+      `<app-rating [formControl]="formControl" count="5"></app-rating>`,
+      {
+        imports: [Rating, ReactiveFormsModule],
+        componentProperties: { formControl },
+      },
+    );
+
+    expect(getByRole('slider')).not.toHaveAttribute('data-disabled');
+
+    formControl.disable();
+    await fixture.whenStable();
+    expect(getByRole('slider')).toHaveAttribute('data-disabled', '');
+    expect(getByRole('slider')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('does not change value with the keyboard while disabled', async () => {
+    const formControl = new FormControl({ value: 2, disabled: true });
+    const { getByRole, fixture } = await render(
+      `<app-rating [formControl]="formControl" count="5"></app-rating>`,
+      {
+        imports: [Rating, ReactiveFormsModule],
+        componentProperties: { formControl },
+      },
+    );
+
+    await fixture.whenStable();
+    const rating = getByRole('slider');
+
+    fireEvent.keyDown(rating, { key: 'ArrowRight' });
+    await fixture.whenStable();
+    expect(formControl.value).toBe(2);
+    expect(rating).toHaveAttribute('aria-valuenow', '2');
+
+    // re-enabling the control restores interaction
+    formControl.enable();
+    await fixture.whenStable();
+    fireEvent.keyDown(rating, { key: 'ArrowRight' });
+    expect(formControl.value).toBe(3);
+  });
+
+  it('marks the control as touched on focusout', async () => {
+    const formControl = new FormControl(0);
+    const { getByRole, fixture } = await render(
+      `<app-rating [formControl]="formControl" count="5"></app-rating>`,
+      {
+        imports: [Rating, ReactiveFormsModule],
+        componentProperties: { formControl },
+      },
+    );
+
+    await fixture.whenStable();
+    expect(formControl.touched).toBe(false);
+
+    fireEvent.focusOut(getByRole('slider'));
+    expect(formControl.touched).toBe(true);
+  });
+});

--- a/packages/ng-primitives/rating/src/rating/tests/rating-primitive.test.ts
+++ b/packages/ng-primitives/rating/src/rating/tests/rating-primitive.test.ts
@@ -1,0 +1,357 @@
+import { Directive } from '@angular/core';
+import { fireEvent, render } from '@testing-library/angular';
+import { injectRatingItemState, NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+import { describe, expect, it, vi } from 'vitest';
+
+/** Probe that injects the item state from within a rendered item view. */
+@Directive({ selector: '[probeItemState]', exportAs: 'probeItemState' })
+class ProbeItemState {
+  readonly state = injectRatingItemState();
+}
+
+/**
+ * The stars are rendered by the `*ngpRatingItem` structural directive. The test
+ * template binds the render context onto data attributes so we can assert the
+ * derived per-item state (checked / half / fraction / highlighted).
+ */
+function createTemplate(extraProps = ''): string {
+  return `
+    <div
+      ngpRating
+      data-testid="rating"
+      (ngpRatingValueChange)="valueChange($event)"
+      ${extraProps}>
+      <span
+        *ngpRatingItem="let star"
+        class="star"
+        [attr.data-index]="star.index"
+        [attr.data-fraction]="star.fraction">
+      </span>
+    </div>
+  `;
+}
+
+const imports = [NgpRating, NgpRatingItem];
+
+async function renderRating(extraProps = '', props: Record<string, unknown> = {}) {
+  const valueChange = vi.fn();
+  const view = await render(createTemplate(extraProps), {
+    imports,
+    componentProperties: { valueChange, ...props },
+  });
+  const rating = view.getByTestId('rating');
+  const stars = () => Array.from(view.container.querySelectorAll<HTMLElement>('.star'));
+  return { ...view, valueChange, rating, stars };
+}
+
+/** Give a star element a predictable box so pointer maths is deterministic. */
+function mockBox(el: HTMLElement, left = 0, width = 20): void {
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    left,
+    top: 0,
+    right: left + width,
+    bottom: 20,
+    width,
+    height: 20,
+    x: left,
+    y: 0,
+    toJSON: () => ({}),
+  });
+}
+
+describe('NgpRating', () => {
+  describe('slider semantics', () => {
+    it('exposes the slider role with value range on the root', async () => {
+      const { rating } = await renderRating(`[ngpRatingValue]="3" [ngpRatingCount]="5"`);
+
+      expect(rating).toHaveAttribute('role', 'slider');
+      expect(rating).toHaveAttribute('aria-valuemin', '0');
+      expect(rating).toHaveAttribute('aria-valuemax', '5');
+      expect(rating).toHaveAttribute('aria-valuenow', '3');
+      expect(rating).toHaveAttribute('aria-valuetext');
+      expect(rating).toHaveAttribute('tabindex', '0');
+    });
+
+    it('renders one item per count', async () => {
+      const { stars } = await renderRating(`[ngpRatingValue]="0" [ngpRatingCount]="5"`);
+      expect(stars()).toHaveLength(5);
+    });
+
+    it('reacts to a changing count', async () => {
+      const { stars, rerender, fixture } = await renderRating(
+        `[ngpRatingValue]="0" [ngpRatingCount]="count"`,
+        { count: 5 },
+      );
+      expect(stars()).toHaveLength(5);
+
+      await rerender({ componentProperties: { count: 3, valueChange: vi.fn() } });
+      fixture.detectChanges();
+      expect(stars()).toHaveLength(3);
+    });
+  });
+
+  describe('item state derivation', () => {
+    it('marks filled stars checked for a whole value', async () => {
+      const { stars } = await renderRating(`[ngpRatingValue]="3" [ngpRatingCount]="5"`);
+      const filled = stars().map(s => s.hasAttribute('data-checked'));
+      expect(filled).toEqual([true, true, true, false, false]);
+    });
+
+    it('marks the boundary star half when allowHalf and value is x.5', async () => {
+      const { stars } = await renderRating(
+        `[ngpRatingValue]="2.5" [ngpRatingCount]="5" ngpRatingAllowHalf`,
+      );
+      // stars 1,2 full; star 3 half; 4,5 empty
+      expect(stars().map(s => s.hasAttribute('data-checked'))).toEqual([
+        true,
+        true,
+        false,
+        false,
+        false,
+      ]);
+      expect(stars().map(s => s.hasAttribute('data-half'))).toEqual([
+        false,
+        false,
+        true,
+        false,
+        false,
+      ]);
+    });
+
+    it('exposes a 0-1 fraction per star for fractional (readonly average) values', async () => {
+      const { stars } = await renderRating(
+        `[ngpRatingValue]="3.7" [ngpRatingCount]="5" ngpRatingReadonly`,
+      );
+      const fractions = stars().map(s => Number(s.getAttribute('data-fraction')));
+      // first three fully filled, fourth 70%, fifth empty
+      expect(fractions[0]).toBe(1);
+      expect(fractions[2]).toBe(1);
+      expect(fractions[3]).toBeCloseTo(0.7);
+      expect(fractions[4]).toBe(0);
+    });
+
+    it('provides the item state for injection within the item view', async () => {
+      const { container } = await render(
+        `
+        <div ngpRating [ngpRatingValue]="3" [ngpRatingCount]="5">
+          <span
+            *ngpRatingItem="let star"
+            class="star"
+            probeItemState
+            #probe="probeItemState"
+            [attr.data-injected-checked]="probe.state().checked ? '' : null">
+          </span>
+        </div>
+      `,
+        { imports: [NgpRating, NgpRatingItem, ProbeItemState] },
+      );
+
+      const injected = Array.from(container.querySelectorAll<HTMLElement>('.star')).map(s =>
+        s.hasAttribute('data-injected-checked'),
+      );
+      // value 3 => first three stars report checked via the injected state
+      expect(injected).toEqual([true, true, true, false, false]);
+    });
+  });
+
+  describe('pointer', () => {
+    it('sets the value when a star is clicked', async () => {
+      const { stars, valueChange, rating } = await renderRating(
+        `[ngpRatingValue]="0" [ngpRatingCount]="5"`,
+      );
+      fireEvent.click(stars()[2]);
+      expect(valueChange).toHaveBeenCalledWith(3);
+      expect(rating).toHaveAttribute('aria-valuenow', '3');
+    });
+
+    it('clears to 0 when clicking the currently selected star (clearable)', async () => {
+      const { stars, valueChange } = await renderRating(
+        `[ngpRatingValue]="3" [ngpRatingCount]="5" [ngpRatingClearable]="true"`,
+      );
+      fireEvent.click(stars()[2]); // star index 3 == current value
+      expect(valueChange).toHaveBeenLastCalledWith(0);
+    });
+
+    it('does not clear when clicking the selected star by default', async () => {
+      const { stars, valueChange } = await renderRating(
+        `[ngpRatingValue]="3" [ngpRatingCount]="5"`,
+      );
+      fireEvent.click(stars()[2]); // star index 3 == current value
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+
+    it('selects a half value from the left half of a star when allowHalf', async () => {
+      const { stars, valueChange } = await renderRating(
+        `[ngpRatingValue]="0" [ngpRatingCount]="5" ngpRatingAllowHalf`,
+      );
+      const third = stars()[2];
+      mockBox(third, 40, 20); // occupies x 40..60
+      fireEvent.pointerMove(third, { clientX: 45 }); // left half
+      fireEvent.click(third, { clientX: 45 });
+      expect(valueChange).toHaveBeenLastCalledWith(2.5);
+    });
+
+    it('previews the hovered value without committing it', async () => {
+      const { stars, rating, valueChange } = await renderRating(
+        `[ngpRatingValue]="1" [ngpRatingCount]="5"`,
+      );
+      const fourth = stars()[3];
+      mockBox(fourth, 60, 20);
+      fireEvent.pointerMove(fourth, { clientX: 70 });
+
+      // preview: stars 1-4 highlighted, value/aria untouched
+      expect(
+        stars()
+          .slice(0, 4)
+          .every(s => s.hasAttribute('data-highlighted')),
+      ).toBe(true);
+      expect(rating).toHaveAttribute('aria-valuenow', '1');
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+
+    it('restores the committed value on pointer leave', async () => {
+      const { stars, rating } = await renderRating(`[ngpRatingValue]="1" [ngpRatingCount]="5"`);
+      const fourth = stars()[3];
+      mockBox(fourth, 60, 20);
+      fireEvent.pointerMove(fourth, { clientX: 70 });
+      fireEvent.pointerLeave(rating);
+
+      expect(stars().some(s => s.hasAttribute('data-highlighted'))).toBe(false);
+      // only the first star reflects the committed value of 1
+      expect(stars().map(s => s.hasAttribute('data-checked'))).toEqual([
+        true,
+        false,
+        false,
+        false,
+        false,
+      ]);
+    });
+  });
+
+  describe('keyboard', () => {
+    it('increments on ArrowRight/ArrowUp and decrements on ArrowLeft/ArrowDown', async () => {
+      const { rating, valueChange } = await renderRating(
+        `[ngpRatingValue]="2" [ngpRatingCount]="5"`,
+      );
+      fireEvent.keyDown(rating, { key: 'ArrowRight' });
+      expect(valueChange).toHaveBeenLastCalledWith(3);
+      fireEvent.keyDown(rating, { key: 'ArrowLeft' });
+      expect(valueChange).toHaveBeenLastCalledWith(2);
+      fireEvent.keyDown(rating, { key: 'ArrowUp' });
+      expect(valueChange).toHaveBeenLastCalledWith(3);
+      fireEvent.keyDown(rating, { key: 'ArrowDown' });
+      expect(valueChange).toHaveBeenLastCalledWith(2);
+    });
+
+    it('steps by 0.5 when allowHalf', async () => {
+      const { rating, valueChange } = await renderRating(
+        `[ngpRatingValue]="2" [ngpRatingCount]="5" ngpRatingAllowHalf`,
+      );
+      fireEvent.keyDown(rating, { key: 'ArrowRight' });
+      expect(valueChange).toHaveBeenLastCalledWith(2.5);
+    });
+
+    it('goes to 0 on Home when clearable and fills to count on End', async () => {
+      const { rating, valueChange } = await renderRating(
+        `[ngpRatingValue]="2" [ngpRatingCount]="5" [ngpRatingClearable]="true"`,
+      );
+      fireEvent.keyDown(rating, { key: 'Home' });
+      expect(valueChange).toHaveBeenLastCalledWith(0);
+      fireEvent.keyDown(rating, { key: 'End' });
+      expect(valueChange).toHaveBeenLastCalledWith(5);
+    });
+
+    it('does not go below 0 or above count', async () => {
+      const { rating, valueChange } = await renderRating(
+        `[ngpRatingValue]="0" [ngpRatingCount]="5"`,
+      );
+      fireEvent.keyDown(rating, { key: 'ArrowLeft' });
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+
+    it('inverts arrow direction in RTL', async () => {
+      const { rating, valueChange } = await renderRating(
+        `dir="rtl" [ngpRatingValue]="2" [ngpRatingCount]="5"`,
+      );
+      fireEvent.keyDown(rating, { key: 'ArrowLeft' });
+      expect(valueChange).toHaveBeenLastCalledWith(3);
+      fireEvent.keyDown(rating, { key: 'ArrowRight' });
+      expect(valueChange).toHaveBeenLastCalledWith(2);
+    });
+  });
+
+  describe('deselection (clearable)', () => {
+    it('does not clear when clicking the selected star if not clearable', async () => {
+      const { stars, valueChange, rating } = await renderRating(
+        `[ngpRatingValue]="3" [ngpRatingCount]="5" [ngpRatingClearable]="false"`,
+      );
+      fireEvent.click(stars()[2]); // star 3 == current value
+      expect(valueChange).not.toHaveBeenCalled();
+      expect(rating).toHaveAttribute('aria-valuenow', '3');
+    });
+
+    it('still selects a different star when not clearable', async () => {
+      const { stars, valueChange } = await renderRating(
+        `[ngpRatingValue]="3" [ngpRatingCount]="5" [ngpRatingClearable]="false"`,
+      );
+      fireEvent.click(stars()[4]);
+      expect(valueChange).toHaveBeenLastCalledWith(5);
+    });
+
+    it('does not decrease below 1 with the keyboard when not clearable', async () => {
+      const { rating, valueChange } = await renderRating(
+        `[ngpRatingValue]="1" [ngpRatingCount]="5" [ngpRatingClearable]="false"`,
+      );
+      fireEvent.keyDown(rating, { key: 'ArrowDown' });
+      expect(valueChange).not.toHaveBeenCalled();
+      expect(rating).toHaveAttribute('aria-valuenow', '1');
+    });
+
+    it('moves to 1 (not 0) on Home when not clearable', async () => {
+      const { rating, valueChange } = await renderRating(
+        `[ngpRatingValue]="3" [ngpRatingCount]="5" [ngpRatingClearable]="false"`,
+      );
+      fireEvent.keyDown(rating, { key: 'Home' });
+      expect(valueChange).toHaveBeenLastCalledWith(1);
+      expect(rating).toHaveAttribute('aria-valuenow', '1');
+    });
+
+    it('clears on re-select and Home when clearable is enabled', async () => {
+      const { stars, rating, valueChange } = await renderRating(
+        `[ngpRatingValue]="3" [ngpRatingCount]="5" [ngpRatingClearable]="true"`,
+      );
+      fireEvent.click(stars()[2]);
+      expect(valueChange).toHaveBeenLastCalledWith(0);
+      fireEvent.keyDown(rating, { key: 'Home' });
+      // already 0 after the click; Home keeps it at 0 (no new emit)
+      expect(rating).toHaveAttribute('aria-valuenow', '0');
+    });
+  });
+
+  describe('disabled and readonly', () => {
+    it('is inert and unfocusable when disabled', async () => {
+      const { rating, stars, valueChange } = await renderRating(
+        `[ngpRatingValue]="2" [ngpRatingCount]="5" ngpRatingDisabled`,
+      );
+      expect(rating).toHaveAttribute('tabindex', '-1');
+      expect(rating).toHaveAttribute('data-disabled', '');
+
+      fireEvent.click(stars()[4]);
+      fireEvent.keyDown(rating, { key: 'ArrowRight' });
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+
+    it('stays focusable but non-editable when readonly', async () => {
+      const { rating, stars, valueChange } = await renderRating(
+        `[ngpRatingValue]="2" [ngpRatingCount]="5" ngpRatingReadonly`,
+      );
+      expect(rating).toHaveAttribute('tabindex', '0');
+      expect(rating).toHaveAttribute('aria-readonly', 'true');
+      expect(rating).toHaveAttribute('data-readonly', '');
+
+      fireEvent.click(stars()[4]);
+      fireEvent.keyDown(rating, { key: 'ArrowRight' });
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
@@ -172,4 +172,22 @@ describe('Component Schematic', () => {
     expect(content).not.toContain('ChangeDetectionStrategy');
     expect(content).not.toContain('changeDetection');
   });
+
+  it('should generate a rating reusable component', async () => {
+    const options: AngularPrimitivesComponentSchema = {
+      primitive: 'rating',
+      path: 'projects/bar/src/app/rating',
+      fileSuffix: '',
+    };
+
+    const tree = await schematicRunner.runSchematic('primitive', options, appTree);
+    expect(tree.files).toContain('/projects/bar/src/app/rating/rating.ts');
+
+    const content = tree.readContent('/projects/bar/src/app/rating/rating.ts');
+    expect(content).toContain("selector: 'app-rating'");
+    expect(content).toContain('directive: NgpRating');
+    expect(content).toContain('ngpRatingItem');
+    expect(content).toContain('implements ControlValueAccessor');
+    expect(content).toContain('provideValueAccessor(RatingComponent)');
+  });
 });

--- a/packages/ng-primitives/schematics/ng-generate/schema.d.ts
+++ b/packages/ng-primitives/schematics/ng-generate/schema.d.ts
@@ -12,6 +12,7 @@ export interface AngularPrimitivesComponentSchema {
     | 'pagination'
     | 'progress'
     | 'radio'
+    | 'rating'
     | 'switch'
     | 'toggle'
     | 'toggle-group'

--- a/packages/ng-primitives/schematics/ng-generate/schema.json
+++ b/packages/ng-primitives/schematics/ng-generate/schema.json
@@ -29,6 +29,7 @@
         "popover",
         "progress",
         "radio",
+        "rating",
         "search",
         "select",
         "separator",

--- a/packages/ng-primitives/schematics/ng-generate/templates/rating/rating.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/rating/rating.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,116 @@
+import { Component } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { injectRatingState, NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<%= prefix %>-rating',
+  hostDirectives: [
+    {
+      directive: NgpRating,
+      inputs: [
+        'ngpRatingValue:value',
+        'ngpRatingCount:count',
+        'ngpRatingAllowHalf:allowHalf',
+        'ngpRatingDisabled:disabled',
+        'ngpRatingReadonly:readonly',
+        'ngpRatingClearable:clearable',
+      ],
+      outputs: ['ngpRatingValueChange:valueChange'],
+    },
+  ],
+  imports: [NgIcon, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid }), provideValueAccessor(Rating<%= componentSuffix %>)],
+  template: `
+    <span class="star" *ngpRatingItem="let star">
+      <ng-icon class="star-background" name="heroStarSolid" />
+      <span class="star-fill" [style.width.%]="star.fraction * 100">
+        <ng-icon name="heroStarSolid" />
+      </span>
+    </span>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      outline: none;
+      border-radius: 0.5rem;
+      cursor: pointer;
+    }
+
+    :host[data-disabled] {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    :host[data-readonly] {
+      cursor: default;
+    }
+
+    :host[data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    .star {
+      position: relative;
+      display: inline-flex;
+      font-size: 1.5rem;
+      line-height: 1;
+      color: var(--ngp-background-secondary);
+      transition: color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    .star-fill {
+      position: absolute;
+      inset-block-start: 0;
+      inset-inline-start: 0;
+      display: inline-flex;
+      overflow: hidden;
+      color: var(--ngp-primary);
+    }
+  `,
+  host: {
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Rating<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the rating state. */
+  private readonly state = injectRatingState();
+
+  /** The onChange callback function. */
+  private onChange?: ChangeFn<number>;
+
+  /** The onTouched callback function. */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    // Whenever the user interacts with the rating, call onChange with the new value.
+    this.state()
+      .valueChange.pipe(takeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value));
+  }
+
+  writeValue(value: number): void {
+    // writing a value from the model must not re-emit through onChange
+    this.state().setValue(value, { emit: false });
+  }
+
+  registerOnChange(fn: ChangeFn<number>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -73,7 +73,8 @@
       "ng-primitives/number-field": ["packages/ng-primitives/number-field/src/index.ts"],
       "ng-primitives/context-menu": ["packages/ng-primitives/context-menu/src/index.ts"],
       "ng-primitives/password": ["./packages/ng-primitives/password/src/index.ts"],
-      "ng-primitives/color": ["./packages/ng-primitives/color/src/index.ts"]
+      "ng-primitives/color": ["./packages/ng-primitives/color/src/index.ts"],
+      "ng-primitives/rating": ["./packages/ng-primitives/rating/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Feature

## Issue

No existing issue.

## What does this PR implement/fix?

Adds a headless **Rating** primitive.

- **`[ngpRating]`** — the root, built on the [Slider WAI-ARIA pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider/) (`role="slider"`, `aria-valuemin/max/now/valuetext`). It's a single focusable element that owns the value, keyboard, and form integration, and renders one item per `ngpRatingCount`.
- **`*ngpRatingItem`** — a structural directive that renders the star template once per item, exposing each item's derived state as the `let star` context (`index`, `checked`, `half`, `fraction`, `highlighted`) and reflecting it onto the element as `data-checked` / `data-half` / `data-highlighted`.

Features: half values (`ngpRatingAllowHalf`, pointer + keyboard), hover preview, click-selected-to-clear / `Home` to clear, read-only display of fractional averages, RTL-aware keyboard, and `ngpFormControl` integration (works with `ngModel` / reactive forms via the reusable component).

Why slider rather than a radio group: the slider pattern expresses half/fractional values natively with a single focusable element, avoiding the hidden-radio workarounds other libraries use.

Also included:

- **`renderList`** (new `ng-primitives/internal` utility) — reactively renders a template per item, owning the embedded-view lifecycle and per-item state wiring (each item gets a scoped injector providing its `ElementRef`, so an item `createPrimitive` factory works and its state is injectable within the item view). Used by `ngpRatingItem`; `date-picker`'s render directives are candidates to adopt it later.
- Reusable component (`apps/components`) + CVA forms fixture and tests.
- Docs page with CSS + Tailwind examples (default, half, read-only, disabled).
- Schematic (`ng g ng-primitives:primitive rating`) with a node test.

Verified: `nx test ng-primitives` (unit + forms + schematic node tests), `nx build ng-primitives`, `nx build documentation`, `nx build components`, and `nx lint ng-primitives` all green.

## Does this PR introduce a breaking change?

- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a headless rating primitive built on slider semantics with half steps, hover preview, optional deselection, and read-only fractional display. Also introduces `renderList` for reactive item rendering, a reusable CVA-based rating component and schematic, and docs with CSS/Tailwind examples.

- **New Features**
  - `ng-primitives/rating`: `[ngpRating]` root (slider ARIA with `aria-valuemin/max/now/valuetext`) and `*ngpRatingItem` exposing `index`, `checked`, `half`, `fraction`, `highlighted`; item state injectable via `injectRatingItemState`.
  - Interactions: half steps via `ngpRatingAllowHalf`, hover preview, deselection via `ngpRatingClearable` (off by default; reselect and Home clear when enabled), RTL-aware arrows, `Home`/`End`, `ngpRatingReadonly`, `ngpRatingDisabled`.
  - Forms: two-way via `[(ngpRatingValue)]`; reusable CVA component for `ngModel`/reactive forms (emits changes, respects disabled, marks touched on focusout).
  - Config & a11y: `provideRatingConfig` (defaults for `count`, `clearable`, `valueText`), `ngpRatingValueText` for custom `aria-valuetext`.
  - Internal & tooling: `renderList` in `ng-primitives/internal` for reactive list rendering with per-item injectors; export added; schematic `ng g ng-primitives:primitive rating`; docs page and examples (basic, half, clearable, read-only, disabled) with CSS/Tailwind; unit, forms, and schematic tests; path mapping for `ng-primitives/rating`.

<sup>Written for commit 99bc669969fa798587f0a4bd1dab2549e6bda329. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable star-rating control with keyboard, pointer, half-star, clearable, read-only, disabled, and form support.
  * Added a reusable rating component and generator option for creating rating components.
  * Added a rating showcase to the component navigation.

* **Documentation**
  * Added comprehensive rating guidance, API details, accessibility information, and interactive examples.

* **Tests**
  * Added coverage for interactions, accessibility, forms, states, and generated components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->