### PR TITLE
fix(form-field): gate aria-invalid on interaction

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
@@ -145,3 +145,5 @@ The following directives are available to import from the `ng-primitives/form-fi
 ## Accessibility
 
 The label and description elements should be associated with the form control using the `aria-labelledby` and `aria-describedby` attributes, respectively. This will ensure that screen readers can provide the necessary context to users.
+
+The form control exposes `aria-invalid="true"` to assistive technology once it is invalid and has been touched, so validation errors are not announced before the user has had a chance to interact with the field.

--- a/packages/ng-primitives/form-field/src/form-control/form-control-state.ts
+++ b/packages/ng-primitives/form-field/src/form-control/form-control-state.ts
@@ -49,9 +49,11 @@ export function ngpFormControl({
   attrBinding(elementRef, 'id', id);
   attrBinding(elementRef, 'aria-labelledby', ariaLabelledBy);
   attrBinding(elementRef, 'aria-describedby', ariaDescribedBy);
-  // Expose the validity to assistive technology. `aria-invalid="true"` is only
-  // present while the control is invalid; a valid or untracked control omits it.
-  attrBinding(elementRef, 'aria-invalid', () => (status().invalid ? 'true' : null));
+  // Expose the validity to assistive technology once the control has been
+  // touched; a pristine/untouched control never advertises aria-invalid.
+  attrBinding(elementRef, 'aria-invalid', () =>
+    status().invalid && status().touched ? 'true' : null,
+  );
   dataBinding(elementRef, 'data-invalid', () => status().invalid);
   dataBinding(elementRef, 'data-valid', () => status().valid);
   dataBinding(elementRef, 'data-touched', () => status().touched);

--- a/packages/ng-primitives/form-field/src/form-field/tests/form-control.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/form-control.test.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
-import { render } from '@testing-library/angular';
+import { fireEvent, render } from '@testing-library/angular';
 import { NgpDescription, NgpFormControl, NgpFormField, NgpLabel } from 'ng-primitives/form-field';
 import { describe, expect, it } from 'vitest';
 
@@ -384,7 +384,7 @@ describe('NgpFormControl', () => {
       expect(getByTestId('control')).not.toHaveAttribute('aria-invalid');
     });
 
-    it('should expose aria-invalid="true" when the control is invalid', async () => {
+    it('should not expose aria-invalid while the control is invalid but untouched', async () => {
       const formControl = new FormControl('', [Validators.required]);
       const { getByTestId } = await render(
         `<input ngpFormControl data-testid="control" [formControl]="formControl" />`,
@@ -393,10 +393,10 @@ describe('NgpFormControl', () => {
           componentProperties: { formControl },
         },
       );
-      expect(getByTestId('control')).toHaveAttribute('aria-invalid', 'true');
+      expect(getByTestId('control')).not.toHaveAttribute('aria-invalid');
     });
 
-    it('should toggle aria-invalid as validity changes', async () => {
+    it('should expose aria-invalid="true" once an invalid control is touched', async () => {
       const formControl = new FormControl('', [Validators.required]);
       const { getByTestId, fixture } = await render(
         `<input ngpFormControl data-testid="control" [formControl]="formControl" />`,
@@ -406,14 +406,70 @@ describe('NgpFormControl', () => {
         },
       );
       const control = getByTestId('control');
+      expect(control).not.toHaveAttribute('aria-invalid');
+
+      formControl.markAsTouched();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(control).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('should expose aria-invalid="true" after an invalid control is blurred', async () => {
+      const formControl = new FormControl('', [Validators.required]);
+      const { getByTestId, fixture } = await render(
+        `<input ngpFormControl data-testid="control" [formControl]="formControl" />`,
+        {
+          imports: [NgpFormControl, ReactiveFormsModule],
+          componentProperties: { formControl },
+        },
+      );
+      const control = getByTestId('control');
+      expect(control).not.toHaveAttribute('aria-invalid');
+
+      fireEvent.blur(control);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(control).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('should keep data-invalid ungated while aria-invalid waits for interaction', async () => {
+      const formControl = new FormControl('', [Validators.required]);
+      const { getByTestId } = await render(
+        `<input ngpFormControl data-testid="control" [formControl]="formControl" />`,
+        {
+          imports: [NgpFormControl, ReactiveFormsModule],
+          componentProperties: { formControl },
+        },
+      );
+      const control = getByTestId('control');
+      expect(control).toHaveAttribute('data-invalid');
+      expect(control).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('should toggle aria-invalid as validity changes once touched', async () => {
+      const formControl = new FormControl('', [Validators.required]);
+      const { getByTestId, fixture } = await render(
+        `<input ngpFormControl data-testid="control" [formControl]="formControl" />`,
+        {
+          imports: [NgpFormControl, ReactiveFormsModule],
+          componentProperties: { formControl },
+        },
+      );
+      const control = getByTestId('control');
+
+      formControl.markAsTouched();
+      fixture.detectChanges();
+      await fixture.whenStable();
       expect(control).toHaveAttribute('aria-invalid', 'true');
 
-      fixture.componentInstance.formControl.setValue('now valid');
+      formControl.setValue('now valid');
       fixture.detectChanges();
       await fixture.whenStable();
       expect(control).not.toHaveAttribute('aria-invalid');
 
-      fixture.componentInstance.formControl.setValue('');
+      formControl.setValue('');
       fixture.detectChanges();
       await fixture.whenStable();
       expect(control).toHaveAttribute('aria-invalid', 'true');

--- a/packages/ng-primitives/form-field/src/form-field/tests/form-field-component.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/form-field-component.test.ts
@@ -89,8 +89,14 @@ describe('FormField (reusable component) — standalone', () => {
     const input = container.querySelector('input');
 
     expect(formField).toHaveAttribute('data-invalid');
-    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).not.toHaveAttribute('aria-invalid');
     expect(input).toHaveAttribute('aria-describedby', 'required');
+
+    fixture.componentInstance.control.markAsTouched();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
 
     fixture.componentInstance.control.setValue('ada');
     await fixture.whenStable();

--- a/packages/ng-primitives/form-field/src/form-field/tests/form-field-primitive.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/form-field-primitive.test.ts
@@ -351,7 +351,7 @@ describe('NgpFormField', () => {
       expect(input).toHaveAttribute('aria-describedby', 'hint');
     });
 
-    it('should expose aria-invalid on the control while it is invalid', async () => {
+    it('should expose aria-invalid on the control once it is invalid and touched', async () => {
       const control = new FormControl('', [Validators.required]);
       const { container, fixture } = await render(
         `<div ngpFormField>
@@ -364,9 +364,15 @@ describe('NgpFormField', () => {
       );
       const input = container.querySelector('input');
 
+      expect(input).not.toHaveAttribute('aria-invalid');
+
+      control.markAsTouched();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
       expect(input).toHaveAttribute('aria-invalid', 'true');
 
-      fixture.componentInstance.control.setValue('valid');
+      control.setValue('valid');
       await fixture.whenStable();
 
       expect(input).not.toHaveAttribute('aria-invalid');

--- a/packages/ng-primitives/form-field/src/form-field/tests/integration.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/integration.test.ts
@@ -51,7 +51,7 @@ describe('Form Field Integration Tests', () => {
     expect(input).toHaveAttribute('id', 'name-input');
     expect(input).toHaveAttribute('aria-labelledby', 'name-label');
     expect(input).toHaveAttribute('aria-describedby', 'name-help name-required');
-    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).not.toHaveAttribute('aria-invalid');
     expect(label).toHaveAttribute('for', 'name-input');
 
     expect(formField).toHaveAttribute('data-invalid');
@@ -96,7 +96,7 @@ describe('Form Field Integration Tests', () => {
 
     expect(formField).toHaveAttribute('data-invalid');
     expect(input).toHaveAttribute('data-invalid');
-    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(input).not.toHaveAttribute('aria-invalid');
     expect(label).toHaveAttribute('data-invalid');
     expect(description).toHaveAttribute('data-invalid');
 
@@ -111,6 +111,7 @@ describe('Form Field Integration Tests', () => {
     expect(input).toHaveAttribute('data-invalid');
     expect(input).toHaveAttribute('data-touched');
     expect(input).toHaveAttribute('data-dirty');
+    expect(input).toHaveAttribute('aria-invalid', 'true');
 
     input.value = 'test@example.com';
     fireEvent.input(input);


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated

## PR Type

- [x] Bugfix

## Issue

Closes #826

## What does this PR implement/fix?

`ngpFormControl` bound `aria-invalid` straight off the control's validity:

    attrBinding(elementRef, 'aria-invalid', () => (status().invalid ? 'true' : null));

So a required-but-empty control advertised `aria-invalid="true"` on first render,
before any interaction. Because `NgpInput` composes `ngpFormControl`, it was
affected too. The attribute (and the tests asserting this behaviour) landed in #812.

This gates the attribute on `touched` — the approach agreed on the issue, used by
Angular Material (`touched || submitted`) and recommended by WAI-ARIA (W3C WAI
ARIA21):

    attrBinding(elementRef, 'aria-invalid', () =>
      status().invalid && status().touched ? 'true' : null,
    );

- A pristine/untouched invalid control no longer exposes `aria-invalid`; it
  appears once the control is touched (blur) and clears when it becomes valid.
- The `data-invalid` styling hook stays **ungated** (raw validity), so consumers
  keep composing error styling with `data-touched` / `data-dirty`.
- Tests: the specs that asserted the untouched → `aria-invalid` behaviour now
  assert the gated behaviour, plus dedicated cases for untouched (absent),
  touched/blurred (present), the `data-invalid` vs `aria-invalid` split, and the
  toggle-once-touched flow.
- Docs: the form-field accessibility section now notes that the control exposes
  `aria-invalid` once invalid and touched.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The observable output of `aria-invalid` changes (untouched invalid controls no
longer receive it), but this is a bugfix on a 0.x line and the approach was
approved by a maintainer on #826. No inputs or public API change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate `aria-invalid` in `ngpFormControl` (and `NgpInput` via composition) so errors are announced only after interaction. Untouched invalid fields no longer expose `aria-invalid`; it appears after touch/blur and clears when valid.

- **Bug Fixes**
  - Bind `aria-invalid` to `invalid && touched`, aligning with WAI-ARIA ARIA21 and Angular Material.
  - Keep `data-invalid` ungated for styling alongside `data-touched`/`data-dirty`.
  - Update tests to cover untouched vs touched and toggling; update docs in `ng-primitives/form-field` to note the behavior.

<sup>Written for commit 783d0e4da39bee49c644d35aa42f042934b4f3ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Form controls now expose `aria-invalid="true"` only after they are both invalid and touched.
  * Prevents validation errors from being announced before the user interacts with the field.
  * Other invalid-state indicators remain available immediately for styling and state handling.

* **Documentation**
  * Clarified the updated `aria-invalid` behaviour in the Form Field accessibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->