### PR TITLE
feat(meter): migrate meter state

### DIFF
--- a/packages/ng-primitives/meter/src/index.ts
+++ b/packages/ng-primitives/meter/src/index.ts
@@ -1,6 +1,18 @@
-export { NgpMeter } from './meter/meter';
-export { provideMeterState, injectMeterState } from './meter/meter-state';
-export { NgpMeterTrack } from './meter-track/meter-track';
+export { NgpMeter, NgpMeterValueTextFn } from './meter/meter';
+export {
+  injectMeterState,
+  ngpMeter,
+  NgpMeterProps,
+  NgpMeterState,
+  provideMeterState,
+} from './meter/meter-state';
 export { NgpMeterIndicator } from './meter-indicator/meter-indicator';
-export { NgpMeterValue } from './meter-value/meter-value';
+export {
+  ngpMeterIndicator,
+  NgpMeterIndicatorStateToken,
+} from './meter-indicator/meter-indicator-state';
 export { NgpMeterLabel } from './meter-label/meter-label';
+export { ngpMeterLabel, NgpMeterLabelStateToken } from './meter-label/meter-label-state';
+export { NgpMeterTrack } from './meter-track/meter-track';
+export { NgpMeterValue } from './meter-value/meter-value';
+export { ngpMeterValue, NgpMeterValueStateToken } from './meter-value/meter-value-state';

--- a/packages/ng-primitives/meter/src/meter-indicator/meter-indicator-state.ts
+++ b/packages/ng-primitives/meter/src/meter-indicator/meter-indicator-state.ts
@@ -1,0 +1,33 @@
+import { computed } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { createPrimitive, styleBinding } from 'ng-primitives/state';
+import { injectMeterState } from '../meter/meter-state';
+
+export interface NgpMeterIndicatorState {}
+
+export interface NgpMeterIndicatorProps {}
+
+export const [NgpMeterIndicatorStateToken, ngpMeterIndicator] = createPrimitive(
+  'NgpMeterIndicator',
+  ({}: NgpMeterIndicatorProps) => {
+    const element = injectElementRef();
+
+    const state = injectMeterState();
+
+    const percentage = computed(() => {
+      const value = state().value();
+      const min = state().min();
+      const max = state().max();
+      // guard the zero-length range so we never divide by zero (NaN width)
+      if (max <= min) {
+        return value >= max ? 100 : 0;
+      }
+      // clamp so an out-of-range value can't push the bar past its track or negative
+      return Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100));
+    });
+
+    styleBinding(element, 'width.%', percentage);
+
+    return {} satisfies NgpMeterIndicatorState;
+  },
+);

--- a/packages/ng-primitives/meter/src/meter-indicator/meter-indicator.ts
+++ b/packages/ng-primitives/meter/src/meter-indicator/meter-indicator.ts
@@ -1,14 +1,12 @@
 import { Directive } from '@angular/core';
-import { injectMeterState } from '../meter/meter-state';
+import { ngpMeterIndicator } from './meter-indicator-state';
 
 @Directive({
   selector: '[ngpMeterIndicator]',
   exportAs: 'ngpMeterIndicator',
-  host: {
-    '[style.width.%]': 'meter().percentage()',
-  },
 })
 export class NgpMeterIndicator {
-  /** Access the meter */
-  protected readonly meter = injectMeterState();
+  constructor() {
+    ngpMeterIndicator({});
+  }
 }

--- a/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
+++ b/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
@@ -1,0 +1,32 @@
+import { effect, signal, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { injectMeterState } from '../meter/meter-state';
+
+export interface NgpMeterLabelState {}
+
+export interface NgpMeterLabelProps {
+  /**
+   * The unique identifier for the meter label.
+   */
+  readonly id?: Signal<string>;
+}
+
+export const [NgpMeterLabelStateToken, ngpMeterLabel] = createPrimitive(
+  'NgpMeterLabel',
+  ({ id = signal(uniqueId('ngp-meter-label')) }: NgpMeterLabelProps) => {
+    const element = injectElementRef();
+
+    const state = injectMeterState();
+
+    attrBinding(element, 'id', id);
+
+    // Keep the meter's `aria-labelledby` in sync with the label id. The factory runs
+    // during construction, before Angular has assigned the `id` input, so track it
+    // reactively rather than capturing the default value once.
+    effect(() => state().labelId.set(id()));
+
+    return {} satisfies NgpMeterLabelState;
+  },
+);

--- a/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
+++ b/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
@@ -24,8 +24,18 @@ export const [NgpMeterLabelStateToken, ngpMeterLabel] = createPrimitive(
 
     // Keep the meter's `aria-labelledby` in sync with the label id. The factory runs
     // during construction, before Angular has assigned the `id` input, so track it
-    // reactively rather than capturing the default value once.
-    effect(() => state().labelId.set(id()));
+    // reactively rather than capturing the default value once. On teardown, clear the
+    // id (unless another label has since taken over) so `aria-labelledby` never points
+    // at a label that has been removed from the DOM.
+    effect(onCleanup => {
+      const currentId = id();
+      state().labelId.set(currentId);
+      onCleanup(() => {
+        if (state().labelId() === currentId) {
+          state().labelId.set(undefined);
+        }
+      });
+    });
 
     return {} satisfies NgpMeterLabelState;
   },

--- a/packages/ng-primitives/meter/src/meter-label/meter-label.ts
+++ b/packages/ng-primitives/meter/src/meter-label/meter-label.ts
@@ -1,23 +1,16 @@
 import { Directive, input } from '@angular/core';
 import { uniqueId } from 'ng-primitives/utils';
-import { injectMeterState } from '../meter/meter-state';
+import { ngpMeterLabel } from './meter-label-state';
 
 @Directive({
   selector: '[ngpMeterLabel]',
   exportAs: 'ngpMeterLabel',
-  host: {
-    '[attr.id]': 'id()',
-  },
 })
 export class NgpMeterLabel {
-  /** Access the meter */
-  protected readonly meter = injectMeterState();
-
   /** The id of the meter label */
   readonly id = input(uniqueId('ngp-meter-label'));
 
   constructor() {
-    // Register the label with the meter
-    this.meter().label.set(this);
+    ngpMeterLabel({ id: this.id });
   }
 }

--- a/packages/ng-primitives/meter/src/meter-value/meter-value-state.ts
+++ b/packages/ng-primitives/meter/src/meter-value/meter-value-state.ts
@@ -1,0 +1,17 @@
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+
+export interface NgpMeterValueState {}
+
+export interface NgpMeterValueProps {}
+
+export const [NgpMeterValueStateToken, ngpMeterValue] = createPrimitive(
+  'NgpMeterValue',
+  ({}: NgpMeterValueProps) => {
+    const element = injectElementRef();
+
+    attrBinding(element, 'aria-hidden', 'true');
+
+    return {} satisfies NgpMeterValueState;
+  },
+);

--- a/packages/ng-primitives/meter/src/meter-value/meter-value.ts
+++ b/packages/ng-primitives/meter/src/meter-value/meter-value.ts
@@ -1,10 +1,12 @@
 import { Directive } from '@angular/core';
+import { ngpMeterValue } from './meter-value-state';
 
 @Directive({
   selector: '[ngpMeterValue]',
   exportAs: 'ngpMeterValue',
-  host: {
-    'aria-hidden': 'true',
-  },
 })
-export class NgpMeterValue {}
+export class NgpMeterValue {
+  constructor() {
+    ngpMeterValue({});
+  }
+}

--- a/packages/ng-primitives/meter/src/meter/meter-state.ts
+++ b/packages/ng-primitives/meter/src/meter/meter-state.ts
@@ -1,27 +1,112 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpMeter } from './meter';
+import { computed, Signal, signal, WritableSignal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, controlled, createPrimitive } from 'ng-primitives/state';
+import { NgpMeterValueTextFn } from './meter';
 
-/**
- * The state token  for the Meter primitive.
- */
-export const NgpMeterStateToken = createStateToken<NgpMeter>('Meter');
+export interface NgpMeterProps {
+  /**
+   * Define the meter value.
+   * @default 0
+   */
+  readonly value?: Signal<number>;
 
-/**
- * Provides the Meter state.
- */
-export const provideMeterState = createStateProvider(NgpMeterStateToken);
+  /**
+   * Define the meter min value.
+   * @default 0
+   */
+  readonly min?: Signal<number>;
 
-/**
- * Injects the Meter state.
- */
-export const injectMeterState = createStateInjector<NgpMeter>(NgpMeterStateToken);
+  /**
+   * Define the meter max value.
+   * @default 100
+   */
+  readonly max?: Signal<number>;
 
-/**
- * The Meter state registration function.
- */
-export const meterState = createState(NgpMeterStateToken);
+  /**
+   * Define a function that returns the meter value label.
+   * @param value The current value
+   * @param max The maximum value
+   * @param min The minimum value
+   * @returns The value label
+   */
+  readonly valueLabel?: Signal<NgpMeterValueTextFn>;
+}
+
+export interface NgpMeterState {
+  /**
+   * Define the meter value.
+   */
+  readonly value: WritableSignal<number>;
+
+  /**
+   * Define the meter min value.
+   */
+  readonly min: WritableSignal<number>;
+
+  /**
+   * Define the meter max value.
+   */
+  readonly max: WritableSignal<number>;
+
+  /**
+   * Define a function that returns the meter value label.
+   */
+  readonly valueLabel: WritableSignal<NgpMeterValueTextFn>;
+
+  /**
+   * The raw value exposed via `aria-valuenow`, clamped to the [min, max] range.
+   * @internal
+   */
+  readonly valueNow: Signal<number>;
+
+  /**
+   * The id of the label associated with the meter.
+   * @internal
+   */
+  readonly labelId: WritableSignal<string | undefined>;
+}
+
+export const [NgpMeterStateToken, ngpMeter, injectMeterState, provideMeterState] = createPrimitive(
+  'NgpMeter',
+  ({
+    value: _value = signal(0),
+    min: _min = signal(0),
+    max: _max = signal(100),
+    valueLabel: _valueLabel = signal(
+      (value, max, min) => `${max === min ? 0 : Math.round(((value - min) / (max - min)) * 100)}%`,
+    ),
+  }: NgpMeterProps): NgpMeterState => {
+    const element = injectElementRef();
+
+    // Controlled properties
+    const value = controlled(_value);
+    const min = controlled(_min);
+    const max = controlled(_max);
+    const valueLabel = controlled(_valueLabel);
+
+    const labelId = signal<string | undefined>(undefined);
+
+    /**
+     * The raw value exposed via `aria-valuenow`, clamped to the [min, max] range.
+     * Per the ARIA meter pattern, `aria-valuenow` is the actual value, not a percentage.
+     */
+    const valueNow = computed(() => Math.min(Math.max(value(), min()), max()));
+
+    // Attribute bindings
+    attrBinding(element, 'role', 'meter');
+    attrBinding(element, 'aria-valuemin', min);
+    attrBinding(element, 'aria-valuemax', max);
+    attrBinding(element, 'aria-valuenow', valueNow);
+    attrBinding(element, 'aria-valuetext', () => valueLabel()(value(), max(), min()));
+    attrBinding(element, 'aria-labelledby', () => labelId() ?? null);
+
+    return {
+      value,
+      min,
+      max,
+      valueLabel,
+      valueNow,
+      labelId,
+    } satisfies NgpMeterState;
+  },
+);

--- a/packages/ng-primitives/meter/src/meter/meter.ts
+++ b/packages/ng-primitives/meter/src/meter/meter.ts
@@ -1,20 +1,11 @@
 import { NumberInput } from '@angular/cdk/coercion';
-import { computed, Directive, input, numberAttribute, signal } from '@angular/core';
-import type { NgpMeterLabel } from '../meter-label/meter-label';
-import { meterState, provideMeterState } from './meter-state';
+import { Directive, input, numberAttribute } from '@angular/core';
+import { ngpMeter, provideMeterState } from './meter-state';
 
 @Directive({
   selector: '[ngpMeter]',
   exportAs: 'ngpMeter',
   providers: [provideMeterState()],
-  host: {
-    role: 'meter',
-    '[attr.aria-valuenow]': 'valueNow()',
-    '[attr.aria-valuemin]': 'min()',
-    '[attr.aria-valuemax]': 'max()',
-    '[attr.aria-valuetext]': 'valueLabel()(value(), max(), min())',
-    '[attr.aria-labelledby]': 'label()?.id()',
-  },
 })
 export class NgpMeter {
   /** The value of the meter. */
@@ -49,49 +40,16 @@ export class NgpMeter {
     },
   );
 
-  /** @internal Store the label instance */
-  readonly label = signal<NgpMeterLabel | null>(null);
-
-  /** @internal The percentage of the meter, used for the visual indicator width. */
-  readonly percentage = computed(() => {
-    const value = this.state.value();
-    const min = this.state.min();
-    const max = this.state.max();
-
-    if (value == null) {
-      return 0;
-    }
-
-    if (value < min) {
-      return 0;
-    }
-
-    if (value > max) {
-      return 100;
-    }
-
-    return ((value - min) / (max - min)) * 100;
-  });
-
   /**
+   * The state of the meter.
    * @internal
-   * The raw value exposed via `aria-valuenow`, clamped to the [min, max] range.
-   * Per the ARIA meter pattern, `aria-valuenow` is the actual value, not a percentage.
    */
-  readonly valueNow = computed(() => {
-    const value = this.state.value();
-    const min = this.state.min();
-    const max = this.state.max();
-
-    if (value == null) {
-      return min;
-    }
-
-    return Math.min(Math.max(value, min), max);
+  private readonly state = ngpMeter({
+    value: this.value,
+    min: this.min,
+    max: this.max,
+    valueLabel: this.valueLabel,
   });
-
-  /** The state of the meter. */
-  private readonly state = meterState<NgpMeter>(this);
 }
 
 export type NgpMeterValueTextFn = (value: number, max: number, min: number) => string;

--- a/packages/ng-primitives/meter/src/meter/tests/meter-component.test.ts
+++ b/packages/ng-primitives/meter/src/meter/tests/meter-component.test.ts
@@ -30,13 +30,14 @@ describe('Meter (reusable component) — standalone', () => {
   });
 
   it('updates the indicator width when value changes', async () => {
-    const { container, rerender } = await render(
+    const { container, rerender, detectChanges } = await render(
       `<app-meter label="Label" [value]="value"></app-meter>`,
       { imports: [MeterFixture], componentProperties: { value: 40 } },
     );
     const indicator = container.querySelector('[ngpMeterIndicator]') as HTMLElement;
     expect(indicator.style.width).toBe('40%');
     await rerender({ componentProperties: { value: 75 } });
+    detectChanges();
     expect(indicator.style.width).toBe('75%');
   });
 });

--- a/packages/ng-primitives/meter/src/meter/tests/meter-primitive.test.ts
+++ b/packages/ng-primitives/meter/src/meter/tests/meter-primitive.test.ts
@@ -101,6 +101,24 @@ describe('NgpMeter', () => {
       expect(labelId).toMatch(/^ngp-meter-label-/);
       expect(container.getByTestId('meter')).toHaveAttribute('aria-labelledby', labelId);
     });
+
+    it('should clear aria-labelledby when the label is removed', async () => {
+      const container = await render(
+        `<div ngpMeter data-testid="meter">
+          @if (showLabel) {
+            <label ngpMeterLabel id="my-label">CPU Usage</label>
+          }
+        </div>`,
+        { imports, componentProperties: { showLabel: true } },
+      );
+      const meter = container.getByTestId('meter');
+      expect(meter).toHaveAttribute('aria-labelledby', 'my-label');
+
+      // Removing the label must not leave aria-labelledby pointing at a missing id.
+      await container.rerender({ componentProperties: { showLabel: false } });
+      container.detectChanges();
+      expect(meter).not.toHaveAttribute('aria-labelledby');
+    });
   });
 
   describe('aria-valuenow clamping', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated — N/A (see below)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other

## Issue

Closes #829

## What does this PR implement/fix?

Migrates the `meter` primitive from the legacy `createStateToken` / `createState` state pattern to the current `createPrimitive` pattern, matching already-migrated primitives like `progress`.

- `meter-state.ts` now uses `createPrimitive`, returning the `[NgpMeterStateToken, ngpMeter, injectMeterState, provideMeterState]` tuple. All host bindings (`role="meter"`, `aria-valuemin/max/now/text`, `aria-labelledby`) moved into the factory via `attrBinding`.
- Added a `-state.ts` for each part that carries host bindings: `meter-indicator` (percentage → `styleBinding` on `width.%`), `meter-label` (own `id` + registers the meter's `aria-labelledby`), and `meter-value` (`aria-hidden`). `meter-track` has no host bindings, so it stays a thin directive.
- Directives are now thin shells: they declare inputs and register state.
- Exposed the new state factories/tokens/types from `index.ts` (additive — the existing directive/selector/input API is unchanged).

No consumer-facing behavior changes: selectors, inputs (`value`/`min`/`max`/`valueLabel`) and their aliases, `exportAs`, and the ARIA output are all preserved, so the auto-generated API docs and usage examples stay identical (no doc changes needed).

One existing reusable-component test now calls `detectChanges()` after `rerender()` to flush the `afterRenderEffect`-based bindings under zoneless change detection — the same pattern the primitive tests and `progress-component.test.ts` already use. The assertion is unchanged.

Verified green: lint (0 errors), Prettier, AOT build, and the full meter test suite (29/29).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the `meter` primitive to `createPrimitive`, moving host bindings into state factories while keeping the public API the same. Also fixed `aria-labelledby` to clear when a label is removed.

- **Refactors**
  - Replaced legacy state with `createPrimitive` in `meter-state.ts`, exposing `[NgpMeterStateToken, ngpMeter, injectMeterState, provideMeterState]` with ARIA via `attrBinding`.
  - Added part factories: `meter-indicator` (`styleBinding` on `width.%` with clamped percentage), `meter-label` (own `id` + ARIA registration), `meter-value` (`aria-hidden`); `meter-track` unchanged.
  - Directives are thin shells calling their factories; selectors, inputs (`value`, `min`, `max`, `valueLabel`), and `exportAs` unchanged.
  - Exported tokens/factories/types in `index.ts` (e.g., `ngpMeter`, `ngpMeterIndicator`, `ngpMeterLabel`, `ngpMeterValue`); updated one component test to call `detectChanges()` after `rerender()`.

- **Bug Fixes**
  - Clear `aria-labelledby` when the `ngpMeterLabel` is removed; added a regression test.

<sup>Written for commit 01bb437785c2ed9714b89a1cb7d732c04e2d127b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the public meter API with additional configuration, state, and helper exports for indicators, labels, and values.
  * Improved accessibility wiring for labels and meter elements, including automatic association via `aria-labelledby`.
* **Bug Fixes**
  * Prevented invalid indicator percentages when the meter range is empty or when values are outside the configured min/max (clamped within 0–100%).
  * Ensured `aria-labelledby` is cleared when an associated label is conditionally removed.
* **Tests**
  * Strengthened meter tests to confirm indicator width updates after value changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->