### PR TITLE
feat(meter): migrate meter state

### DIFF
--- a/.claude/rules/state-management.md
+++ b/.claude/rules/state-management.md
@@ -79,6 +79,24 @@ them (`this.selected()`), which the `prefer-state` lint rule forbids.
   through the output so parent bindings round-trip (`avoid-state-emit`).
 - `controlled(inputSignal, defaultValue)` wraps an input in a writable
   `linkedSignal` for internal mutation that still tracks the input.
+- **Only reach for `controlled`/`controlledState` when the factory itself
+  mutates the value.** A read-only input that the part just reflects, or that
+  child parts read, is passed straight through as a `Signal` - bind it
+  (`attrBinding(element, 'aria-valuemin', min)`) and return it (`return { min }`)
+  unchanged. Wrapping an input in `controlled` when nothing ever calls `.set()`
+  on it is misleading and adds a needless `linkedSignal`. Grep the factory for
+  `.set(` on the signal before wrapping it. (`progress` wraps `value`/`min`/`max`
+  only because it exposes deprecated `setValue`/`setMin`/`setMax` setters;
+  `meter`, which has none, passes them through read-only.)
+
+## Return only what other parts read
+
+The object the factory returns is the part's inter-part / public API, exposed via
+`injectXState()`. Return only what another part or the directive actually
+consumes. A value used **solely** for the factory's own bindings - e.g. a clamped
+`valueNow` bound once to `aria-valuenow`, or an internal `labelId` signal - stays
+a local `const`/`signal` inside the factory and is **not** put on the state
+interface.
 
 ## Compose state functions to reuse behaviour
 
@@ -88,6 +106,47 @@ behaviour rather than reimplementing it. `ngpInput` composes `ngpFormControl`,
 `ngpRovingFocusItem`; `ngpPasswordInput` composes `ngpInput`. If a new part
 needs the behaviour of an existing primitive, call its `ngpX({...})` factory and
 return/extend its state instead of duplicating bindings.
+
+## Child parts register with the parent through functions, not raw signals
+
+A part that feeds something back to its container - a label id, a focusable item,
+an option - does so by calling a **dedicated function on the parent state**, never
+by mutating a signal the parent returned. Expose a paired `setX`/`removeX` (or
+`register`/`unregister`) on the parent, keep the backing signal private to the
+factory, and register/deregister from the child with `onChange` + `onDestroy`:
+
+```ts
+// parent -state.ts — labelId stays private; only the functions are returned
+const labelId = signal<string | undefined>(undefined);
+function setLabel(id: string): void {
+  labelId.set(id);
+}
+function removeLabel(id: string): void {
+  // only clear if this child is still the active one, so a newer child that has
+  // taken over isn't clobbered when an old one is torn down
+  if (labelId() === id) {
+    labelId.set(undefined);
+  }
+}
+attrBinding(element, 'aria-labelledby', () => labelId() ?? null);
+return { setLabel, removeLabel } satisfies NgpXState;
+
+// child -state.ts — register reactively, and always deregister on teardown
+onChange(id, (current, previous) => {
+  if (previous) {
+    state().removeLabel(previous);
+  }
+  state().setLabel(current);
+});
+onDestroy(() => state().removeLabel(id()));
+```
+
+A child that pokes `state().labelId.set(...)` directly bypasses the guard and
+forgets to deregister, leaving a stale `aria-labelledby`/`aria-describedby`
+pointing at DOM that has been removed. `dialog` (`setLabelledBy`/`removeLabelledBy`),
+`roving-focus` (`register`/`unregister`) and `select` (`registerOption`/
+`unregisterOption`) all follow this. `onChange` fires with the initial value **and**
+every change; `onDestroy` (from `ng-primitives/state`) handles teardown.
 
 ## `@internal`
 

--- a/.claude/skills/ngp-code-review/SKILL.md
+++ b/.claude/skills/ngp-code-review/SKILL.md
@@ -65,6 +65,12 @@ Flag as HIGH:
 
 - **New use of the legacy state pattern.** Any added file — or any changed line in the diff — that calls `createStateToken`, `createStateProvider`, `createStateInjector`, or `createState` (from `ng-primitives/state`). These are the pre-`createPrimitive` primitives (`search`-era) and are deprecated for new code. Grep the diff: `git diff next...HEAD | grep -nE '^\+.*\bcreateState(Token|Provider|Injector)?\b'`. A hit on an added (`+`) line is a finding — the part must be rewritten with `createPrimitive`. Editing an existing legacy primitive in place does **not** require migrating it (don't force-migrate untouched primitives), but a **new** primitive or part using the quadruple is a HIGH finding.
 - **A part directive that inlines host bindings / listeners** in the directive constructor instead of a `-state.ts` factory, or that omits `provideXState()` from its `providers`.
+- **A child part writing a parent's returned signal directly** — `state().x.set(...)` from a sub-part. The parent must expose a `setX`/`removeX` (or `register`/`unregister`) function and keep the backing signal private; the child calls it, registering with `onChange` and deregistering with `onDestroy`. A part that registers but never deregisters (no `onDestroy`/`removeX`) is a HIGH finding when it drives an ARIA relationship (`aria-labelledby`/`aria-describedby`) — the stale id points at removed DOM. See `dialog`, `roving-focus`, `select`.
+
+Flag as MEDIUM (convention, not lint-enforced):
+
+- **`controlled` on a value nothing mutates.** `controlled(input)` / `controlledState(...)` is only for values the factory itself `.set()`s. Grep the factory (and any composed factory) for `.set(` on the wrapped signal; if nothing writes it, the input should pass straight through as a read-only `Signal` and the `controlled` wrapper dropped.
+- **Internal-only values exposed on the state.** A computed/signal used _solely_ for the factory's own bindings (not read by any other part or the directive) should be a local `const`, not returned on the `NgpXState` interface. Verify no other part reads it (grep `injectXState`) before flagging.
 
 Specific rule violations (early state, missing generic, emitting state, reading raw input) are owned by §4.
 

--- a/packages/ng-primitives/meter/src/index.ts
+++ b/packages/ng-primitives/meter/src/index.ts
@@ -1,6 +1,18 @@
-export { NgpMeter } from './meter/meter';
-export { provideMeterState, injectMeterState } from './meter/meter-state';
-export { NgpMeterTrack } from './meter-track/meter-track';
+export { NgpMeter, NgpMeterValueTextFn } from './meter/meter';
+export {
+  injectMeterState,
+  ngpMeter,
+  NgpMeterProps,
+  NgpMeterState,
+  provideMeterState,
+} from './meter/meter-state';
 export { NgpMeterIndicator } from './meter-indicator/meter-indicator';
-export { NgpMeterValue } from './meter-value/meter-value';
+export {
+  ngpMeterIndicator,
+  NgpMeterIndicatorStateToken,
+} from './meter-indicator/meter-indicator-state';
 export { NgpMeterLabel } from './meter-label/meter-label';
+export { ngpMeterLabel, NgpMeterLabelStateToken } from './meter-label/meter-label-state';
+export { NgpMeterTrack } from './meter-track/meter-track';
+export { NgpMeterValue } from './meter-value/meter-value';
+export { ngpMeterValue, NgpMeterValueStateToken } from './meter-value/meter-value-state';

--- a/packages/ng-primitives/meter/src/meter-indicator/meter-indicator-state.ts
+++ b/packages/ng-primitives/meter/src/meter-indicator/meter-indicator-state.ts
@@ -1,0 +1,33 @@
+import { computed } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { createPrimitive, styleBinding } from 'ng-primitives/state';
+import { injectMeterState } from '../meter/meter-state';
+
+export interface NgpMeterIndicatorState {}
+
+export interface NgpMeterIndicatorProps {}
+
+export const [NgpMeterIndicatorStateToken, ngpMeterIndicator] = createPrimitive(
+  'NgpMeterIndicator',
+  ({}: NgpMeterIndicatorProps) => {
+    const element = injectElementRef();
+
+    const state = injectMeterState();
+
+    const percentage = computed(() => {
+      const value = state().value();
+      const min = state().min();
+      const max = state().max();
+      // guard the zero-length range so we never divide by zero (NaN width)
+      if (max <= min) {
+        return value >= max ? 100 : 0;
+      }
+      // clamp so an out-of-range value can't push the bar past its track or negative
+      return Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100));
+    });
+
+    styleBinding(element, 'width.%', percentage);
+
+    return {} satisfies NgpMeterIndicatorState;
+  },
+);

--- a/packages/ng-primitives/meter/src/meter-indicator/meter-indicator.ts
+++ b/packages/ng-primitives/meter/src/meter-indicator/meter-indicator.ts
@@ -1,14 +1,12 @@
 import { Directive } from '@angular/core';
-import { injectMeterState } from '../meter/meter-state';
+import { ngpMeterIndicator } from './meter-indicator-state';
 
 @Directive({
   selector: '[ngpMeterIndicator]',
   exportAs: 'ngpMeterIndicator',
-  host: {
-    '[style.width.%]': 'meter().percentage()',
-  },
 })
 export class NgpMeterIndicator {
-  /** Access the meter */
-  protected readonly meter = injectMeterState();
+  constructor() {
+    ngpMeterIndicator({});
+  }
 }

--- a/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
+++ b/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
@@ -1,0 +1,32 @@
+import { effect, signal, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { injectMeterState } from '../meter/meter-state';
+
+export interface NgpMeterLabelState {}
+
+export interface NgpMeterLabelProps {
+  /**
+   * The unique identifier for the meter label.
+   */
+  readonly id?: Signal<string>;
+}
+
+export const [NgpMeterLabelStateToken, ngpMeterLabel] = createPrimitive(
+  'NgpMeterLabel',
+  ({ id = signal(uniqueId('ngp-meter-label')) }: NgpMeterLabelProps) => {
+    const element = injectElementRef();
+
+    const state = injectMeterState();
+
+    attrBinding(element, 'id', id);
+
+    // Keep the meter's `aria-labelledby` in sync with the label id. The factory runs
+    // during construction, before Angular has assigned the `id` input, so track it
+    // reactively rather than capturing the default value once.
+    effect(() => state().labelId.set(id()));
+
+    return {} satisfies NgpMeterLabelState;
+  },
+);

--- a/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
+++ b/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
@@ -24,8 +24,18 @@ export const [NgpMeterLabelStateToken, ngpMeterLabel] = createPrimitive(
 
     // Keep the meter's `aria-labelledby` in sync with the label id. The factory runs
     // during construction, before Angular has assigned the `id` input, so track it
-    // reactively rather than capturing the default value once.
-    effect(() => state().labelId.set(id()));
+    // reactively rather than capturing the default value once. On teardown, clear the
+    // id (unless another label has since taken over) so `aria-labelledby` never points
+    // at a label that has been removed from the DOM.
+    effect(onCleanup => {
+      const currentId = id();
+      state().labelId.set(currentId);
+      onCleanup(() => {
+        if (state().labelId() === currentId) {
+          state().labelId.set(undefined);
+        }
+      });
+    });
 
     return {} satisfies NgpMeterLabelState;
   },

--- a/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
+++ b/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
@@ -1,7 +1,7 @@
-import { effect, signal, Signal } from '@angular/core';
+import { signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive } from 'ng-primitives/state';
-import { uniqueId } from 'ng-primitives/utils';
+import { attrBinding, createPrimitive, onDestroy } from 'ng-primitives/state';
+import { onChange, uniqueId } from 'ng-primitives/utils';
 import { injectMeterState } from '../meter/meter-state';
 
 export interface NgpMeterLabelState {}
@@ -22,20 +22,17 @@ export const [NgpMeterLabelStateToken, ngpMeterLabel] = createPrimitive(
 
     attrBinding(element, 'id', id);
 
-    // Keep the meter's `aria-labelledby` in sync with the label id. The factory runs
-    // during construction, before Angular has assigned the `id` input, so track it
-    // reactively rather than capturing the default value once. On teardown, clear the
-    // id (unless another label has since taken over) so `aria-labelledby` never points
-    // at a label that has been removed from the DOM.
-    effect(onCleanup => {
-      const currentId = id();
-      state().labelId.set(currentId);
-      onCleanup(() => {
-        if (state().labelId() === currentId) {
-          state().labelId.set(undefined);
-        }
-      });
+    // Keep the meter's `aria-labelledby` in sync with the label id. On teardown the
+    // label removes itself so `aria-labelledby` never points at an element that has
+    // been removed from the DOM.
+    onChange(id, (currentId, previousId) => {
+      if (previousId) {
+        state().removeLabel(previousId);
+      }
+      state().setLabel(currentId);
     });
+
+    onDestroy(() => state().removeLabel(id()));
 
     return {} satisfies NgpMeterLabelState;
   },

--- a/packages/ng-primitives/meter/src/meter-label/meter-label.ts
+++ b/packages/ng-primitives/meter/src/meter-label/meter-label.ts
@@ -1,23 +1,16 @@
 import { Directive, input } from '@angular/core';
 import { uniqueId } from 'ng-primitives/utils';
-import { injectMeterState } from '../meter/meter-state';
+import { ngpMeterLabel } from './meter-label-state';
 
 @Directive({
   selector: '[ngpMeterLabel]',
   exportAs: 'ngpMeterLabel',
-  host: {
-    '[attr.id]': 'id()',
-  },
 })
 export class NgpMeterLabel {
-  /** Access the meter */
-  protected readonly meter = injectMeterState();
-
   /** The id of the meter label */
   readonly id = input(uniqueId('ngp-meter-label'));
 
   constructor() {
-    // Register the label with the meter
-    this.meter().label.set(this);
+    ngpMeterLabel({ id: this.id });
   }
 }

--- a/packages/ng-primitives/meter/src/meter-value/meter-value-state.ts
+++ b/packages/ng-primitives/meter/src/meter-value/meter-value-state.ts
@@ -1,0 +1,17 @@
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+
+export interface NgpMeterValueState {}
+
+export interface NgpMeterValueProps {}
+
+export const [NgpMeterValueStateToken, ngpMeterValue] = createPrimitive(
+  'NgpMeterValue',
+  ({}: NgpMeterValueProps) => {
+    const element = injectElementRef();
+
+    attrBinding(element, 'aria-hidden', 'true');
+
+    return {} satisfies NgpMeterValueState;
+  },
+);

--- a/packages/ng-primitives/meter/src/meter-value/meter-value.ts
+++ b/packages/ng-primitives/meter/src/meter-value/meter-value.ts
@@ -1,10 +1,12 @@
 import { Directive } from '@angular/core';
+import { ngpMeterValue } from './meter-value-state';
 
 @Directive({
   selector: '[ngpMeterValue]',
   exportAs: 'ngpMeterValue',
-  host: {
-    'aria-hidden': 'true',
-  },
 })
-export class NgpMeterValue {}
+export class NgpMeterValue {
+  constructor() {
+    ngpMeterValue({});
+  }
+}

--- a/packages/ng-primitives/meter/src/meter/meter-state.ts
+++ b/packages/ng-primitives/meter/src/meter/meter-state.ts
@@ -1,27 +1,112 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpMeter } from './meter';
+import { computed, Signal, signal, WritableSignal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, controlled, createPrimitive } from 'ng-primitives/state';
+import { NgpMeterValueTextFn } from './meter';
 
-/**
- * The state token  for the Meter primitive.
- */
-export const NgpMeterStateToken = createStateToken<NgpMeter>('Meter');
+export interface NgpMeterProps {
+  /**
+   * Define the meter value.
+   * @default 0
+   */
+  readonly value?: Signal<number>;
 
-/**
- * Provides the Meter state.
- */
-export const provideMeterState = createStateProvider(NgpMeterStateToken);
+  /**
+   * Define the meter min value.
+   * @default 0
+   */
+  readonly min?: Signal<number>;
 
-/**
- * Injects the Meter state.
- */
-export const injectMeterState = createStateInjector<NgpMeter>(NgpMeterStateToken);
+  /**
+   * Define the meter max value.
+   * @default 100
+   */
+  readonly max?: Signal<number>;
 
-/**
- * The Meter state registration function.
- */
-export const meterState = createState(NgpMeterStateToken);
+  /**
+   * Define a function that returns the meter value label.
+   * @param value The current value
+   * @param max The maximum value
+   * @param min The minimum value
+   * @returns The value label
+   */
+  readonly valueLabel?: Signal<NgpMeterValueTextFn>;
+}
+
+export interface NgpMeterState {
+  /**
+   * Define the meter value.
+   */
+  readonly value: WritableSignal<number>;
+
+  /**
+   * Define the meter min value.
+   */
+  readonly min: WritableSignal<number>;
+
+  /**
+   * Define the meter max value.
+   */
+  readonly max: WritableSignal<number>;
+
+  /**
+   * Define a function that returns the meter value label.
+   */
+  readonly valueLabel: WritableSignal<NgpMeterValueTextFn>;
+
+  /**
+   * The raw value exposed via `aria-valuenow`, clamped to the [min, max] range.
+   * @internal
+   */
+  readonly valueNow: Signal<number>;
+
+  /**
+   * The id of the label associated with the meter.
+   * @internal
+   */
+  readonly labelId: WritableSignal<string | undefined>;
+}
+
+export const [NgpMeterStateToken, ngpMeter, injectMeterState, provideMeterState] = createPrimitive(
+  'NgpMeter',
+  ({
+    value: _value = signal(0),
+    min: _min = signal(0),
+    max: _max = signal(100),
+    valueLabel: _valueLabel = signal(
+      (value, max, min) => `${max === min ? 0 : Math.round(((value - min) / (max - min)) * 100)}%`,
+    ),
+  }: NgpMeterProps): NgpMeterState => {
+    const element = injectElementRef();
+
+    // Controlled properties
+    const value = controlled(_value);
+    const min = controlled(_min);
+    const max = controlled(_max);
+    const valueLabel = controlled(_valueLabel);
+
+    const labelId = signal<string | undefined>(undefined);
+
+    /**
+     * The raw value exposed via `aria-valuenow`, clamped to the [min, max] range.
+     * Per the ARIA meter pattern, `aria-valuenow` is the actual value, not a percentage.
+     */
+    const valueNow = computed(() => Math.min(Math.max(value(), min()), max()));
+
+    // Attribute bindings
+    attrBinding(element, 'role', 'meter');
+    attrBinding(element, 'aria-valuemin', min);
+    attrBinding(element, 'aria-valuemax', max);
+    attrBinding(element, 'aria-valuenow', valueNow);
+    attrBinding(element, 'aria-valuetext', () => valueLabel()(value(), max(), min()));
+    attrBinding(element, 'aria-labelledby', () => labelId() ?? null);
+
+    return {
+      value,
+      min,
+      max,
+      valueLabel,
+      valueNow,
+      labelId,
+    } satisfies NgpMeterState;
+  },
+);

--- a/packages/ng-primitives/meter/src/meter/meter-state.ts
+++ b/packages/ng-primitives/meter/src/meter/meter-state.ts
@@ -1,6 +1,6 @@
-import { computed, Signal, signal, WritableSignal } from '@angular/core';
+import { computed, signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, controlled, createPrimitive } from 'ng-primitives/state';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
 import { NgpMeterValueTextFn } from './meter';
 
 export interface NgpMeterProps {
@@ -36,53 +36,42 @@ export interface NgpMeterState {
   /**
    * Define the meter value.
    */
-  readonly value: WritableSignal<number>;
+  readonly value: Signal<number>;
 
   /**
    * Define the meter min value.
    */
-  readonly min: WritableSignal<number>;
+  readonly min: Signal<number>;
 
   /**
    * Define the meter max value.
    */
-  readonly max: WritableSignal<number>;
+  readonly max: Signal<number>;
 
   /**
-   * Define a function that returns the meter value label.
-   */
-  readonly valueLabel: WritableSignal<NgpMeterValueTextFn>;
-
-  /**
-   * The raw value exposed via `aria-valuenow`, clamped to the [min, max] range.
+   * Register the id of the label associated with the meter.
    * @internal
    */
-  readonly valueNow: Signal<number>;
+  setLabel(id: string): void;
 
   /**
-   * The id of the label associated with the meter.
+   * Remove the id of the label associated with the meter.
    * @internal
    */
-  readonly labelId: WritableSignal<string | undefined>;
+  removeLabel(id: string): void;
 }
 
 export const [NgpMeterStateToken, ngpMeter, injectMeterState, provideMeterState] = createPrimitive(
   'NgpMeter',
   ({
-    value: _value = signal(0),
-    min: _min = signal(0),
-    max: _max = signal(100),
-    valueLabel: _valueLabel = signal(
+    value = signal(0),
+    min = signal(0),
+    max = signal(100),
+    valueLabel = signal(
       (value, max, min) => `${max === min ? 0 : Math.round(((value - min) / (max - min)) * 100)}%`,
     ),
   }: NgpMeterProps): NgpMeterState => {
     const element = injectElementRef();
-
-    // Controlled properties
-    const value = controlled(_value);
-    const min = controlled(_min);
-    const max = controlled(_max);
-    const valueLabel = controlled(_valueLabel);
 
     const labelId = signal<string | undefined>(undefined);
 
@@ -100,13 +89,24 @@ export const [NgpMeterStateToken, ngpMeter, injectMeterState, provideMeterState]
     attrBinding(element, 'aria-valuetext', () => valueLabel()(value(), max(), min()));
     attrBinding(element, 'aria-labelledby', () => labelId() ?? null);
 
+    function setLabel(id: string): void {
+      labelId.set(id);
+    }
+
+    function removeLabel(id: string): void {
+      // Only clear if this label is still the active one, so a newer label that has
+      // taken over isn't clobbered when an old label is torn down.
+      if (labelId() === id) {
+        labelId.set(undefined);
+      }
+    }
+
     return {
       value,
       min,
       max,
-      valueLabel,
-      valueNow,
-      labelId,
+      setLabel,
+      removeLabel,
     } satisfies NgpMeterState;
   },
 );

--- a/packages/ng-primitives/meter/src/meter/meter.ts
+++ b/packages/ng-primitives/meter/src/meter/meter.ts
@@ -1,20 +1,11 @@
 import { NumberInput } from '@angular/cdk/coercion';
-import { computed, Directive, input, numberAttribute, signal } from '@angular/core';
-import type { NgpMeterLabel } from '../meter-label/meter-label';
-import { meterState, provideMeterState } from './meter-state';
+import { Directive, input, numberAttribute } from '@angular/core';
+import { ngpMeter, provideMeterState } from './meter-state';
 
 @Directive({
   selector: '[ngpMeter]',
   exportAs: 'ngpMeter',
   providers: [provideMeterState()],
-  host: {
-    role: 'meter',
-    '[attr.aria-valuenow]': 'valueNow()',
-    '[attr.aria-valuemin]': 'min()',
-    '[attr.aria-valuemax]': 'max()',
-    '[attr.aria-valuetext]': 'valueLabel()(value(), max(), min())',
-    '[attr.aria-labelledby]': 'label()?.id()',
-  },
 })
 export class NgpMeter {
   /** The value of the meter. */
@@ -49,49 +40,16 @@ export class NgpMeter {
     },
   );
 
-  /** @internal Store the label instance */
-  readonly label = signal<NgpMeterLabel | null>(null);
-
-  /** @internal The percentage of the meter, used for the visual indicator width. */
-  readonly percentage = computed(() => {
-    const value = this.state.value();
-    const min = this.state.min();
-    const max = this.state.max();
-
-    if (value == null) {
-      return 0;
-    }
-
-    if (value < min) {
-      return 0;
-    }
-
-    if (value > max) {
-      return 100;
-    }
-
-    return ((value - min) / (max - min)) * 100;
-  });
-
   /**
+   * The state of the meter.
    * @internal
-   * The raw value exposed via `aria-valuenow`, clamped to the [min, max] range.
-   * Per the ARIA meter pattern, `aria-valuenow` is the actual value, not a percentage.
    */
-  readonly valueNow = computed(() => {
-    const value = this.state.value();
-    const min = this.state.min();
-    const max = this.state.max();
-
-    if (value == null) {
-      return min;
-    }
-
-    return Math.min(Math.max(value, min), max);
+  private readonly state = ngpMeter({
+    value: this.value,
+    min: this.min,
+    max: this.max,
+    valueLabel: this.valueLabel,
   });
-
-  /** The state of the meter. */
-  private readonly state = meterState<NgpMeter>(this);
 }
 
 export type NgpMeterValueTextFn = (value: number, max: number, min: number) => string;

--- a/packages/ng-primitives/meter/src/meter/tests/meter-component.test.ts
+++ b/packages/ng-primitives/meter/src/meter/tests/meter-component.test.ts
@@ -30,13 +30,14 @@ describe('Meter (reusable component) — standalone', () => {
   });
 
   it('updates the indicator width when value changes', async () => {
-    const { container, rerender } = await render(
+    const { container, rerender, detectChanges } = await render(
       `<app-meter label="Label" [value]="value"></app-meter>`,
       { imports: [MeterFixture], componentProperties: { value: 40 } },
     );
     const indicator = container.querySelector('[ngpMeterIndicator]') as HTMLElement;
     expect(indicator.style.width).toBe('40%');
     await rerender({ componentProperties: { value: 75 } });
+    detectChanges();
     expect(indicator.style.width).toBe('75%');
   });
 });

--- a/packages/ng-primitives/meter/src/meter/tests/meter-primitive.test.ts
+++ b/packages/ng-primitives/meter/src/meter/tests/meter-primitive.test.ts
@@ -101,6 +101,24 @@ describe('NgpMeter', () => {
       expect(labelId).toMatch(/^ngp-meter-label-/);
       expect(container.getByTestId('meter')).toHaveAttribute('aria-labelledby', labelId);
     });
+
+    it('should clear aria-labelledby when the label is removed', async () => {
+      const container = await render(
+        `<div ngpMeter data-testid="meter">
+          @if (showLabel) {
+            <label ngpMeterLabel id="my-label">CPU Usage</label>
+          }
+        </div>`,
+        { imports, componentProperties: { showLabel: true } },
+      );
+      const meter = container.getByTestId('meter');
+      expect(meter).toHaveAttribute('aria-labelledby', 'my-label');
+
+      // Removing the label must not leave aria-labelledby pointing at a missing id.
+      await container.rerender({ componentProperties: { showLabel: false } });
+      container.detectChanges();
+      expect(meter).not.toHaveAttribute('aria-labelledby');
+    });
   });
 
   describe('aria-valuenow clamping', () => {

--- a/packages/ng-primitives/progress/src/progress-label/progress-label-state.ts
+++ b/packages/ng-primitives/progress/src/progress-label/progress-label-state.ts
@@ -1,7 +1,7 @@
 import { signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive, dataBinding } from 'ng-primitives/state';
-import { uniqueId } from 'ng-primitives/utils';
+import { attrBinding, createPrimitive, dataBinding, onDestroy } from 'ng-primitives/state';
+import { onChange, uniqueId } from 'ng-primitives/utils';
 import { injectProgressState } from '../progress/progress-state';
 
 export interface NgpProgressLabelState {}
@@ -26,7 +26,17 @@ export const [NgpProgressLabelStateToken, ngpProgressLabel] = createPrimitive(
     dataBinding(element, 'data-indeterminate', () => state().indeterminate());
     dataBinding(element, 'data-complete', () => state().complete());
 
-    state().labelId.set(id());
+    // Keep the progress `aria-labelledby` in sync with the label id. On teardown the
+    // label removes itself so `aria-labelledby` never points at an element that has
+    // been removed from the DOM.
+    onChange(id, (currentId, previousId) => {
+      if (previousId) {
+        state().removeLabel(previousId);
+      }
+      state().setLabel(currentId);
+    });
+
+    onDestroy(() => state().removeLabel(id()));
 
     return {} satisfies NgpProgressLabelState;
   },

--- a/packages/ng-primitives/progress/src/progress/progress-state.ts
+++ b/packages/ng-primitives/progress/src/progress/progress-state.ts
@@ -101,6 +101,11 @@ export interface NgpProgressState {
   setLabel(id: string): void;
 
   /**
+   * Remove the label of the progress bar.
+   */
+  removeLabel(id: string): void;
+
+  /**
    * Set the value of the progress bar.
    * @param value The progress value
    */
@@ -195,6 +200,14 @@ export const [NgpProgressStateToken, ngpProgress, injectProgressState, providePr
         labelId.set(id);
       }
 
+      function removeLabel(id: string): void {
+        // Only clear if this label is still the active one, so a newer label that has
+        // taken over isn't clobbered when an old label is torn down.
+        if (labelId() === id) {
+          labelId.set(undefined);
+        }
+      }
+
       // Attribute bindings
       attrBinding(element, 'role', 'progressbar');
       attrBinding(element, 'id', id);
@@ -231,6 +244,7 @@ export const [NgpProgressStateToken, ngpProgress, injectProgressState, providePr
         progressing,
         complete,
         setLabel,
+        removeLabel,
         setValue,
         setMin,
         setMax,

--- a/packages/ng-primitives/progress/src/progress/tests/progress-primitive.test.ts
+++ b/packages/ng-primitives/progress/src/progress/tests/progress-primitive.test.ts
@@ -395,6 +395,24 @@ describe('NgpProgress', () => {
       );
       expect(container.getByTestId('progress')).not.toHaveAttribute('aria-labelledby');
     });
+
+    it('should clear aria-labelledby when the label is removed', async () => {
+      const container = await render(
+        `<div ngpProgress ngpProgressValue="50" data-testid="progress">
+          @if (showLabel) {
+            <label ngpProgressLabel id="my-label">Loading</label>
+          }
+        </div>`,
+        { imports, componentProperties: { showLabel: true } },
+      );
+      const progress = container.getByTestId('progress');
+      expect(progress).toHaveAttribute('aria-labelledby', 'my-label');
+
+      // Removing the label must not leave aria-labelledby pointing at a missing id.
+      await container.rerender({ componentProperties: { showLabel: false } });
+      container.detectChanges();
+      expect(progress).not.toHaveAttribute('aria-labelledby');
+    });
   });
 
   describe('NgpProgressValue', () => {


### PR DESCRIPTION
Migrate the meter primitive from the legacy createStateToken/createState pattern to the current createPrimitive pattern, mirroring progress. Host bindings move into per-part state factories and the directives become thin shells. No consumer-facing API or behaviour changes.

Closes #829

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the `meter` primitive to `createPrimitive` with per-part state factories, aligned with `progress`. Fixed stale `aria-labelledby` when a label is removed. No breaking API changes.

- **Refactors**
  - Converted `meter`, `meter-label`, `meter-indicator`, and `meter-value` to state factories; directives are thin constructors.
  - Kept `value`, `min`, `max`, and `valueLabel` as read-only inputs; `valueNow` and `labelId` are local to the factory.
  - Added `setLabel`/`removeLabel` on meter state; child parts register via `onChange` and deregister via `onDestroy`.
  - Updated `index.ts` exports to expose `ngpMeter*` factories and state tokens; documented conventions in `.claude/rules/state-management.md` and the review skill.

- **Bug Fixes**
  - Clear `aria-labelledby` when a label unmounts in both `meter` and `progress`; added regression tests.

<sup>Written for commit 2148570832f1cd288cc80b92352d4a45f78982b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the public meter API with additional state, indicator, label and value primitives.
  * Meter indicators now update their width reliably based on the current value.
* **Bug Fixes**
  * Improved meter and progress label handling when labels are changed or removed.
  * Prevented stale `aria-labelledby` references from remaining after label removal.
  * Improved ARIA value and label synchronisation for meters.
* **Tests**
  * Added coverage for indicator updates and label removal behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->