### PR TITLE
refactor: migration cleanup and skill updates

### DIFF
--- a/.claude/rules/state-management.md
+++ b/.claude/rules/state-management.md
@@ -79,6 +79,24 @@ them (`this.selected()`), which the `prefer-state` lint rule forbids.
   through the output so parent bindings round-trip (`avoid-state-emit`).
 - `controlled(inputSignal, defaultValue)` wraps an input in a writable
   `linkedSignal` for internal mutation that still tracks the input.
+- **Only reach for `controlled`/`controlledState` when the factory itself
+  mutates the value.** A read-only input that the part just reflects, or that
+  child parts read, is passed straight through as a `Signal` - bind it
+  (`attrBinding(element, 'aria-valuemin', min)`) and return it (`return { min }`)
+  unchanged. Wrapping an input in `controlled` when nothing ever calls `.set()`
+  on it is misleading and adds a needless `linkedSignal`. Grep the factory for
+  `.set(` on the signal before wrapping it. (`progress` wraps `value`/`min`/`max`
+  only because it exposes deprecated `setValue`/`setMin`/`setMax` setters;
+  `meter`, which has none, passes them through read-only.)
+
+## Return only what other parts read
+
+The object the factory returns is the part's inter-part / public API, exposed via
+`injectXState()`. Return only what another part or the directive actually
+consumes. A value used **solely** for the factory's own bindings - e.g. a clamped
+`valueNow` bound once to `aria-valuenow`, or an internal `labelId` signal - stays
+a local `const`/`signal` inside the factory and is **not** put on the state
+interface.
 
 ## Compose state functions to reuse behaviour
 
@@ -88,6 +106,47 @@ behaviour rather than reimplementing it. `ngpInput` composes `ngpFormControl`,
 `ngpRovingFocusItem`; `ngpPasswordInput` composes `ngpInput`. If a new part
 needs the behaviour of an existing primitive, call its `ngpX({...})` factory and
 return/extend its state instead of duplicating bindings.
+
+## Child parts register with the parent through functions, not raw signals
+
+A part that feeds something back to its container - a label id, a focusable item,
+an option - does so by calling a **dedicated function on the parent state**, never
+by mutating a signal the parent returned. Expose a paired `setX`/`removeX` (or
+`register`/`unregister`) on the parent, keep the backing signal private to the
+factory, and register/deregister from the child with `onChange` + `onDestroy`:
+
+```ts
+// parent -state.ts — labelId stays private; only the functions are returned
+const labelId = signal<string | undefined>(undefined);
+function setLabel(id: string): void {
+  labelId.set(id);
+}
+function removeLabel(id: string): void {
+  // only clear if this child is still the active one, so a newer child that has
+  // taken over isn't clobbered when an old one is torn down
+  if (labelId() === id) {
+    labelId.set(undefined);
+  }
+}
+attrBinding(element, 'aria-labelledby', () => labelId() ?? null);
+return { setLabel, removeLabel } satisfies NgpXState;
+
+// child -state.ts — register reactively, and always deregister on teardown
+onChange(id, (current, previous) => {
+  if (previous) {
+    state().removeLabel(previous);
+  }
+  state().setLabel(current);
+});
+onDestroy(() => state().removeLabel(id()));
+```
+
+A child that pokes `state().labelId.set(...)` directly bypasses the guard and
+forgets to deregister, leaving a stale `aria-labelledby`/`aria-describedby`
+pointing at DOM that has been removed. `dialog` (`setLabelledBy`/`removeLabelledBy`),
+`roving-focus` (`register`/`unregister`) and `select` (`registerOption`/
+`unregisterOption`) all follow this. `onChange` fires with the initial value **and**
+every change; `onDestroy` (from `ng-primitives/state`) handles teardown.
 
 ## `@internal`
 

--- a/.claude/skills/ngp-code-review/SKILL.md
+++ b/.claude/skills/ngp-code-review/SKILL.md
@@ -65,6 +65,12 @@ Flag as HIGH:
 
 - **New use of the legacy state pattern.** Any added file — or any changed line in the diff — that calls `createStateToken`, `createStateProvider`, `createStateInjector`, or `createState` (from `ng-primitives/state`). These are the pre-`createPrimitive` primitives (`search`-era) and are deprecated for new code. Grep the diff: `git diff next...HEAD | grep -nE '^\+.*\bcreateState(Token|Provider|Injector)?\b'`. A hit on an added (`+`) line is a finding — the part must be rewritten with `createPrimitive`. Editing an existing legacy primitive in place does **not** require migrating it (don't force-migrate untouched primitives), but a **new** primitive or part using the quadruple is a HIGH finding.
 - **A part directive that inlines host bindings / listeners** in the directive constructor instead of a `-state.ts` factory, or that omits `provideXState()` from its `providers`.
+- **A child part writing a parent's returned signal directly** — `state().x.set(...)` from a sub-part. The parent must expose a `setX`/`removeX` (or `register`/`unregister`) function and keep the backing signal private; the child calls it, registering with `onChange` and deregistering with `onDestroy`. A part that registers but never deregisters (no `onDestroy`/`removeX`) is a HIGH finding when it drives an ARIA relationship (`aria-labelledby`/`aria-describedby`) — the stale id points at removed DOM. See `dialog`, `roving-focus`, `select`.
+
+Flag as MEDIUM (convention, not lint-enforced):
+
+- **`controlled` on a value nothing mutates.** `controlled(input)` / `controlledState(...)` is only for values the factory itself `.set()`s. Grep the factory (and any composed factory) for `.set(` on the wrapped signal; if nothing writes it, the input should pass straight through as a read-only `Signal` and the `controlled` wrapper dropped.
+- **Internal-only values exposed on the state.** A computed/signal used _solely_ for the factory's own bindings (not read by any other part or the directive) should be a local `const`, not returned on the `NgpXState` interface. Verify no other part reads it (grep `injectXState`) before flagging.
 
 Specific rule violations (early state, missing generic, emitting state, reading raw input) are owned by §4.
 

--- a/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
+++ b/packages/ng-primitives/meter/src/meter-label/meter-label-state.ts
@@ -1,7 +1,7 @@
-import { effect, signal, Signal } from '@angular/core';
+import { signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive } from 'ng-primitives/state';
-import { uniqueId } from 'ng-primitives/utils';
+import { attrBinding, createPrimitive, onDestroy } from 'ng-primitives/state';
+import { onChange, uniqueId } from 'ng-primitives/utils';
 import { injectMeterState } from '../meter/meter-state';
 
 export interface NgpMeterLabelState {}
@@ -22,20 +22,17 @@ export const [NgpMeterLabelStateToken, ngpMeterLabel] = createPrimitive(
 
     attrBinding(element, 'id', id);
 
-    // Keep the meter's `aria-labelledby` in sync with the label id. The factory runs
-    // during construction, before Angular has assigned the `id` input, so track it
-    // reactively rather than capturing the default value once. On teardown, clear the
-    // id (unless another label has since taken over) so `aria-labelledby` never points
-    // at a label that has been removed from the DOM.
-    effect(onCleanup => {
-      const currentId = id();
-      state().labelId.set(currentId);
-      onCleanup(() => {
-        if (state().labelId() === currentId) {
-          state().labelId.set(undefined);
-        }
-      });
+    // Keep the meter's `aria-labelledby` in sync with the label id. On teardown the
+    // label removes itself so `aria-labelledby` never points at an element that has
+    // been removed from the DOM.
+    onChange(id, (currentId, previousId) => {
+      if (previousId) {
+        state().removeLabel(previousId);
+      }
+      state().setLabel(currentId);
     });
+
+    onDestroy(() => state().removeLabel(id()));
 
     return {} satisfies NgpMeterLabelState;
   },

--- a/packages/ng-primitives/meter/src/meter/meter-state.ts
+++ b/packages/ng-primitives/meter/src/meter/meter-state.ts
@@ -1,6 +1,6 @@
-import { computed, Signal, signal, WritableSignal } from '@angular/core';
+import { computed, signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, controlled, createPrimitive } from 'ng-primitives/state';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
 import { NgpMeterValueTextFn } from './meter';
 
 export interface NgpMeterProps {
@@ -36,53 +36,42 @@ export interface NgpMeterState {
   /**
    * Define the meter value.
    */
-  readonly value: WritableSignal<number>;
+  readonly value: Signal<number>;
 
   /**
    * Define the meter min value.
    */
-  readonly min: WritableSignal<number>;
+  readonly min: Signal<number>;
 
   /**
    * Define the meter max value.
    */
-  readonly max: WritableSignal<number>;
+  readonly max: Signal<number>;
 
   /**
-   * Define a function that returns the meter value label.
-   */
-  readonly valueLabel: WritableSignal<NgpMeterValueTextFn>;
-
-  /**
-   * The raw value exposed via `aria-valuenow`, clamped to the [min, max] range.
+   * Register the id of the label associated with the meter.
    * @internal
    */
-  readonly valueNow: Signal<number>;
+  setLabel(id: string): void;
 
   /**
-   * The id of the label associated with the meter.
+   * Remove the id of the label associated with the meter.
    * @internal
    */
-  readonly labelId: WritableSignal<string | undefined>;
+  removeLabel(id: string): void;
 }
 
 export const [NgpMeterStateToken, ngpMeter, injectMeterState, provideMeterState] = createPrimitive(
   'NgpMeter',
   ({
-    value: _value = signal(0),
-    min: _min = signal(0),
-    max: _max = signal(100),
-    valueLabel: _valueLabel = signal(
+    value = signal(0),
+    min = signal(0),
+    max = signal(100),
+    valueLabel = signal(
       (value, max, min) => `${max === min ? 0 : Math.round(((value - min) / (max - min)) * 100)}%`,
     ),
   }: NgpMeterProps): NgpMeterState => {
     const element = injectElementRef();
-
-    // Controlled properties
-    const value = controlled(_value);
-    const min = controlled(_min);
-    const max = controlled(_max);
-    const valueLabel = controlled(_valueLabel);
 
     const labelId = signal<string | undefined>(undefined);
 
@@ -100,13 +89,24 @@ export const [NgpMeterStateToken, ngpMeter, injectMeterState, provideMeterState]
     attrBinding(element, 'aria-valuetext', () => valueLabel()(value(), max(), min()));
     attrBinding(element, 'aria-labelledby', () => labelId() ?? null);
 
+    function setLabel(id: string): void {
+      labelId.set(id);
+    }
+
+    function removeLabel(id: string): void {
+      // Only clear if this label is still the active one, so a newer label that has
+      // taken over isn't clobbered when an old label is torn down.
+      if (labelId() === id) {
+        labelId.set(undefined);
+      }
+    }
+
     return {
       value,
       min,
       max,
-      valueLabel,
-      valueNow,
-      labelId,
+      setLabel,
+      removeLabel,
     } satisfies NgpMeterState;
   },
 );

--- a/packages/ng-primitives/progress/src/progress-label/progress-label-state.ts
+++ b/packages/ng-primitives/progress/src/progress-label/progress-label-state.ts
@@ -1,7 +1,7 @@
 import { signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive, dataBinding } from 'ng-primitives/state';
-import { uniqueId } from 'ng-primitives/utils';
+import { attrBinding, createPrimitive, dataBinding, onDestroy } from 'ng-primitives/state';
+import { onChange, uniqueId } from 'ng-primitives/utils';
 import { injectProgressState } from '../progress/progress-state';
 
 export interface NgpProgressLabelState {}
@@ -26,7 +26,17 @@ export const [NgpProgressLabelStateToken, ngpProgressLabel] = createPrimitive(
     dataBinding(element, 'data-indeterminate', () => state().indeterminate());
     dataBinding(element, 'data-complete', () => state().complete());
 
-    state().labelId.set(id());
+    // Keep the progress `aria-labelledby` in sync with the label id. On teardown the
+    // label removes itself so `aria-labelledby` never points at an element that has
+    // been removed from the DOM.
+    onChange(id, (currentId, previousId) => {
+      if (previousId) {
+        state().removeLabel(previousId);
+      }
+      state().setLabel(currentId);
+    });
+
+    onDestroy(() => state().removeLabel(id()));
 
     return {} satisfies NgpProgressLabelState;
   },

--- a/packages/ng-primitives/progress/src/progress/progress-state.ts
+++ b/packages/ng-primitives/progress/src/progress/progress-state.ts
@@ -101,6 +101,11 @@ export interface NgpProgressState {
   setLabel(id: string): void;
 
   /**
+   * Remove the label of the progress bar.
+   */
+  removeLabel(id: string): void;
+
+  /**
    * Set the value of the progress bar.
    * @param value The progress value
    */
@@ -195,6 +200,14 @@ export const [NgpProgressStateToken, ngpProgress, injectProgressState, providePr
         labelId.set(id);
       }
 
+      function removeLabel(id: string): void {
+        // Only clear if this label is still the active one, so a newer label that has
+        // taken over isn't clobbered when an old label is torn down.
+        if (labelId() === id) {
+          labelId.set(undefined);
+        }
+      }
+
       // Attribute bindings
       attrBinding(element, 'role', 'progressbar');
       attrBinding(element, 'id', id);
@@ -231,6 +244,7 @@ export const [NgpProgressStateToken, ngpProgress, injectProgressState, providePr
         progressing,
         complete,
         setLabel,
+        removeLabel,
         setValue,
         setMin,
         setMax,

--- a/packages/ng-primitives/progress/src/progress/tests/progress-primitive.test.ts
+++ b/packages/ng-primitives/progress/src/progress/tests/progress-primitive.test.ts
@@ -395,6 +395,24 @@ describe('NgpProgress', () => {
       );
       expect(container.getByTestId('progress')).not.toHaveAttribute('aria-labelledby');
     });
+
+    it('should clear aria-labelledby when the label is removed', async () => {
+      const container = await render(
+        `<div ngpProgress ngpProgressValue="50" data-testid="progress">
+          @if (showLabel) {
+            <label ngpProgressLabel id="my-label">Loading</label>
+          }
+        </div>`,
+        { imports, componentProperties: { showLabel: true } },
+      );
+      const progress = container.getByTestId('progress');
+      expect(progress).toHaveAttribute('aria-labelledby', 'my-label');
+
+      // Removing the label must not leave aria-labelledby pointing at a missing id.
+      await container.rerender({ componentProperties: { showLabel: false } });
+      container.detectChanges();
+      expect(progress).not.toHaveAttribute('aria-labelledby');
+    });
   });
 
   describe('NgpProgressValue', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) — internal `.claude` rules/skill; no public docs needed (see below)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Documentation changes — internal contributor rules / review skill only

## Issue

Follow-up cleanup on top of the merged meter migration (#830).

## What does this PR implement/fix?

Refinements surfaced while reviewing the `meter` migration, plus the matching fix for the same latent issue in `progress`, and the conventions those findings expose written up for contributors.

**Meter**

- Keep `value` / `min` / `max` / `valueLabel` as read-only inputs instead of wrapping them in `controlled()`. Nothing in the factory mutates them (the meter has no setters, unlike `progress`), so the `linkedSignal` wrappers were unnecessary — they now pass straight through as `Signal`s.
- Keep `valueNow` and `valueLabel` local to the factory rather than on the public `NgpMeterState` interface — they're only read by the factory's own ARIA bindings (matches `progress`, which keeps `valueNow` local).
- Register the label through dedicated `setLabel` / `removeLabel` functions on the meter state (driven by `onChange` + `onDestroy`), instead of the child writing the parent's raw `labelId` signal from an `effect`. This matches how `dialog`, `roving-focus`, and `select` wire parts to their parent, and lets `labelId` stay private.

**Progress**

- Give the progress label the same `removeLabel` treatment so `aria-labelledby` is cleared when a conditionally-rendered label is removed (previously it registered with a deprecated direct `labelId.set()` and never deregistered, leaving a stale reference). Adds a regression test.

**Contributor docs**

- `.claude/rules/state-management.md`: codify (1) only use `controlled` for values the factory itself mutates, (2) return only what other parts read, and (3) how child parts register with the parent via dedicated functions + `onChange`/`onDestroy`.
- `.claude/skills/ngp-code-review/SKILL.md`: matching review flags.

No consumer-facing API changes: selectors, inputs/aliases, `exportAs`, and the ARIA output are all unchanged. Verified green: lint (0 errors), AOT build, and the full `ng-primitives` test suite (2245/2245).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---
_Generated by [Claude Code](https://claude.ai/code/session_019UoGUaNgzmZoDRGBVxbpa9)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Finalizes the `createPrimitive` migration for `meter` by simplifying state and moving label wiring to explicit functions. Aligns `progress` label behavior and codifies conventions; no consumer-facing API changes.

- **Refactors**
  - `meter`: pass `value`/`min`/`max`/`valueLabel` as read‑only `Signal`s (drop `controlled`); keep `valueNow`/`labelId` internal; add `setLabel`/`removeLabel` and register via `onChange`/`onDestroy`.
  - `progress`: label part now uses `setLabel`/`removeLabel` and cleans up on destroy.
  - Docs: update `.claude/rules/state-management.md` and `.claude/skills/ngp-code-review/SKILL.md` to define when to use `controlled` and how child parts register/deregister with parents.

- **Bug Fixes**
  - `progress`: clear `aria-labelledby` when a conditional label is removed; add regression test.

<sup>Written for commit 41403915387a3dc2c4d3cad31d0830c686b3572c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed meter and progress labels so accessibility references stay synchronised when labels change or are removed.
  * Prevented `aria-labelledby` from continuing to reference elements that no longer exist.
  * Improved handling when labels are replaced, ensuring older label references do not overwrite newer ones.

* **Tests**
  * Added coverage for dynamically removing progress labels and verifying that accessibility attributes are cleared correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->