### PR TITLE
feat(listbox): migrate listbox state

### DIFF
--- a/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
+++ b/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
@@ -40,6 +40,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
   `,
   host: {
     '[attr.aria-label]': 'null',
+    '(focusout)': 'onTouch?.()',
   },
 })
 export class Listbox implements ControlValueAccessor {

--- a/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
+++ b/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Component, input, model } from '@angular/core';
+import { booleanAttribute, Component, input, model, signal } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { provideIcons } from '@ng-icons/core';
 import { heroChevronDownSolid } from '@ng-icons/heroicons/solid';
@@ -19,7 +19,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
     <div
       [(ngpListboxValue)]="value"
       [ngpListboxMode]="mode()"
-      [ngpListboxDisabled]="disabled()"
+      [ngpListboxDisabled]="disabled() || formDisabled()"
       [ngpListboxCompareWith]="compareWith()"
       [attr.aria-label]="ariaLabel()"
       (ngpListboxValueChange)="onListboxValueChange($event)"
@@ -93,8 +93,14 @@ export class Listbox implements ControlValueAccessor {
    */
   protected onTouch?: TouchedFn;
 
+  /**
+   * Form-driven disabled state, combined with the `disabled` input.
+   */
+  protected readonly formDisabled = signal(false);
+
   writeValue(value: string[]): void {
-    this.state()?.value.set(value);
+    // drive the value through the bound model so the controlled input reflects it
+    this.value.set(value);
   }
 
   registerOnChange(fn: ChangeFn<string[]>): void {
@@ -106,7 +112,7 @@ export class Listbox implements ControlValueAccessor {
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.state()?.disabled.set(isDisabled);
+    this.formDisabled.set(isDisabled);
   }
 
   onListboxValueChange(value: string[]): void {

--- a/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
+++ b/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Component, input, model } from '@angular/core';
+import { booleanAttribute, Component, input } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { provideIcons } from '@ng-icons/core';
 import { heroChevronDownSolid } from '@ng-icons/heroicons/solid';
@@ -17,7 +17,6 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
   imports: [NgpListbox],
   template: `
     <div
-      [(ngpListboxValue)]="value"
       [ngpListboxMode]="mode()"
       [ngpListboxDisabled]="disabled()"
       [ngpListboxCompareWith]="compareWith()"
@@ -55,11 +54,6 @@ export class Listbox implements ControlValueAccessor {
   readonly mode = input<NgpSelectionMode>('single');
 
   /**
-   * The listbox value.
-   */
-  readonly value = model<string[]>([]);
-
-  /**
    * The listbox disabled state.
    */
   readonly disabled = input<boolean, BooleanInput>(false, {
@@ -94,8 +88,8 @@ export class Listbox implements ControlValueAccessor {
   protected onTouch?: TouchedFn;
 
   writeValue(value: string[]): void {
-    // drive the value through the bound model so the controlled input reflects it
-    this.value.set(value);
+    // writing a value from the model must not re-emit through onChange
+    this.state()?.setValue(value, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<string[]>): void {
@@ -111,7 +105,6 @@ export class Listbox implements ControlValueAccessor {
   }
 
   onListboxValueChange(value: string[]): void {
-    this.value.set(value);
-    if (this.onChange) this.onChange(value);
+    this.onChange?.(value);
   }
 }

--- a/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
+++ b/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Component, input, model, signal } from '@angular/core';
+import { booleanAttribute, Component, input, model } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { provideIcons } from '@ng-icons/core';
 import { heroChevronDownSolid } from '@ng-icons/heroicons/solid';
@@ -19,7 +19,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
     <div
       [(ngpListboxValue)]="value"
       [ngpListboxMode]="mode()"
-      [ngpListboxDisabled]="disabled() || formDisabled()"
+      [ngpListboxDisabled]="disabled()"
       [ngpListboxCompareWith]="compareWith()"
       [attr.aria-label]="ariaLabel()"
       (ngpListboxValueChange)="onListboxValueChange($event)"
@@ -93,11 +93,6 @@ export class Listbox implements ControlValueAccessor {
    */
   protected onTouch?: TouchedFn;
 
-  /**
-   * Form-driven disabled state, combined with the `disabled` input.
-   */
-  protected readonly formDisabled = signal(false);
-
   writeValue(value: string[]): void {
     // drive the value through the bound model so the controlled input reflects it
     this.value.set(value);
@@ -112,7 +107,7 @@ export class Listbox implements ControlValueAccessor {
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.formDisabled.set(isDisabled);
+    this.state()?.setDisabled(isDisabled);
   }
 
   onListboxValueChange(value: string[]): void {

--- a/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
+++ b/apps/components/src/app/pages/reusable-components/listbox/listbox.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Component, input, model, signal } from '@angular/core';
+import { booleanAttribute, Component, input, model } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { provideIcons } from '@ng-icons/core';
 import { heroChevronDownSolid } from '@ng-icons/heroicons/solid';
@@ -19,7 +19,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
     <div
       [(ngpListboxValue)]="value"
       [ngpListboxMode]="mode()"
-      [ngpListboxDisabled]="disabled() || formDisabled()"
+      [ngpListboxDisabled]="disabled()"
       [ngpListboxCompareWith]="compareWith()"
       [attr.aria-label]="ariaLabel()"
       (ngpListboxValueChange)="onListboxValueChange($event)"
@@ -41,14 +41,13 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
   `,
   host: {
     '[attr.aria-label]': 'null',
-    '(focusout)': 'onTouch?.()',
   },
 })
 export class Listbox implements ControlValueAccessor {
   /**
    * Access the listbox state
    */
-  protected readonly state = injectListboxState<NgpListbox<string>>();
+  protected readonly state = injectListboxState<string>();
 
   /**
    * The listbox mode.
@@ -94,12 +93,8 @@ export class Listbox implements ControlValueAccessor {
    */
   protected onTouch?: TouchedFn;
 
-  /** Form-driven disabled state, combined with the `disabled` input. */
-  protected readonly formDisabled = signal(false);
-
   writeValue(value: string[]): void {
-    // drive the value through the bound model so the controlled input reflects it
-    this.value.set(value);
+    this.state()?.value.set(value);
   }
 
   registerOnChange(fn: ChangeFn<string[]>): void {
@@ -111,7 +106,7 @@ export class Listbox implements ControlValueAccessor {
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.formDisabled.set(isDisabled);
+    this.state()?.disabled.set(isDisabled);
   }
 
   onListboxValueChange(value: string[]): void {

--- a/apps/documentation/src/app/examples/listbox/listbox-sections.example.ts
+++ b/apps/documentation/src/app/examples/listbox/listbox-sections.example.ts
@@ -15,9 +15,9 @@ import {
   template: `
     <div [(ngpListboxValue)]="selection" ngpListbox aria-label="Sections">
       @for (section of sections; track section.name) {
-        <header class="listbox-header" ngpListboxHeader>{{ section.name }}</header>
-
         <div ngpListboxSection>
+          <header class="listbox-header" ngpListboxHeader>{{ section.name }}</header>
+
           @for (option of section.options; track option.id) {
             <div [ngpListboxOptionValue]="option" ngpListboxOption>
               <ng-icon name="heroCheckSolid" size="16px" />

--- a/apps/documentation/src/app/examples/listbox/listbox-sections.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/listbox/listbox-sections.tailwind.example.ts
@@ -20,14 +20,14 @@ import {
       aria-label="Sections"
     >
       @for (section of sections; track section.name) {
-        <header
-          class="flex px-3 pt-1.5 pb-1 text-[0.6875rem] font-[590] tracking-[0.04em] text-gray-400 uppercase dark:text-zinc-500"
-          ngpListboxHeader
-        >
-          {{ section.name }}
-        </header>
-
         <div ngpListboxSection>
+          <header
+            class="flex px-3 pt-1.5 pb-1 text-[0.6875rem] font-[590] tracking-[0.04em] text-gray-400 uppercase dark:text-zinc-500"
+            ngpListboxHeader
+          >
+            {{ section.name }}
+          </header>
+
           @for (option of section.options; track option.id) {
             <div
               class="flex h-[2.125rem] w-[200px] cursor-pointer items-center gap-2 rounded-lg px-3 py-1 text-sm tracking-[-0.006em] text-gray-600 transition-colors hover:bg-gray-50 data-active:bg-gray-100 data-press:bg-gray-100 data-selected:font-[510] data-selected:text-gray-900 dark:text-gray-300 dark:hover:bg-white/5 dark:data-active:bg-white/10 dark:data-press:bg-white/10 dark:data-selected:text-gray-100"

--- a/apps/documentation/src/app/examples/listbox/listbox-select.example.ts
+++ b/apps/documentation/src/app/examples/listbox/listbox-select.example.ts
@@ -96,9 +96,15 @@ import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
       border-radius: 0.75rem;
       outline: none;
       position: absolute;
-      animation: popover-show 0.1s ease-out;
       width: var(--ngp-popover-trigger-width);
       box-shadow: var(--ngp-shadow-lg);
+    }
+
+    /* Only animate once the overlay has been positioned (data-enter is applied on
+       the frame after the popover is placed) so it doesn't flash at the top-left
+       before floating-ui positions it. */
+    [ngpListbox][data-enter] {
+      animation: popover-show 0.1s ease-out;
     }
 
     [ngpListboxOption] {

--- a/packages/ng-primitives/a11y/src/active-descendant/active-descendant.ts
+++ b/packages/ng-primitives/a11y/src/active-descendant/active-descendant.ts
@@ -277,9 +277,12 @@ export function activeDescendantManager({
       return;
     }
 
-    // when a single character is repeated, start after the current item so repeated
-    // presses cycle through the items whose label starts with that character
-    const startOffset = typeaheadBuffer.length === 1 ? 1 : 0;
+    // when every buffered character is the same, treat it as a single-character
+    // search that starts after the current item, so repeating a character cycles
+    // through the items whose label starts with it
+    const isRepeatedChar = [...typeaheadBuffer].every(char => char === typeaheadBuffer[0]);
+    const search = isRepeatedChar ? typeaheadBuffer[0] : typeaheadBuffer;
+    const startOffset = isRepeatedChar ? 1 : 0;
     const base = activeIndex() < 0 ? 0 : activeIndex();
 
     for (let i = 0; i < total; i++) {
@@ -291,7 +294,7 @@ export function activeDescendantManager({
 
       const label = (getItemLabel(index) ?? '').toLowerCase().trim();
 
-      if (label.startsWith(typeaheadBuffer)) {
+      if (label.startsWith(search)) {
         activateByIndex(index, { origin: 'keyboard', ...options });
         return;
       }

--- a/packages/ng-primitives/a11y/src/active-descendant/active-descendant.ts
+++ b/packages/ng-primitives/a11y/src/active-descendant/active-descendant.ts
@@ -280,10 +280,13 @@ export function activeDescendantManager({
     // when every buffered character is the same, treat it as a single-character
     // search that starts after the current item, so repeating a character cycles
     // through the items whose label starts with it
+    const hasActive = activeIndex() >= 0;
     const isRepeatedChar = [...typeaheadBuffer].every(char => char === typeaheadBuffer[0]);
     const search = isRepeatedChar ? typeaheadBuffer[0] : typeaheadBuffer;
-    const startOffset = isRepeatedChar ? 1 : 0;
-    const base = activeIndex() < 0 ? 0 : activeIndex();
+    // only skip past the current item when there is one to cycle from; with no
+    // active item the search must start at index 0 so the first match is found
+    const startOffset = isRepeatedChar && hasActive ? 1 : 0;
+    const base = hasActive ? activeIndex() : 0;
 
     for (let i = 0; i < total; i++) {
       const index = (base + startOffset + i) % total;

--- a/packages/ng-primitives/a11y/src/active-descendant/active-descendant.ts
+++ b/packages/ng-primitives/a11y/src/active-descendant/active-descendant.ts
@@ -25,6 +25,12 @@ export interface NgpActiveDescendantManagerProps {
   isItemDisabled: (index: number) => boolean;
 
   /**
+   * Get the label of the item at a given index. When provided, enables typeahead
+   * (letter-key) navigation through the `typeahead` method.
+   */
+  getItemLabel?: (index: number) => string;
+
+  /**
    * Scroll the active descendant item into view.
    */
   scrollIntoView: (index: number) => void;
@@ -81,6 +87,11 @@ export interface NgpActiveDescendantManagerState {
    * Reset the active descendant group, clearing the active index.
    */
   reset: (options?: ActivationOptions) => void;
+  /**
+   * Activate the next enabled item whose label matches the typed characters.
+   * No-op unless `getItemLabel` was provided.
+   */
+  typeahead: (key: string, options?: ActivationOptions) => void;
 }
 
 export function activeDescendantManager({
@@ -89,6 +100,7 @@ export function activeDescendantManager({
   count,
   getItemId,
   isItemDisabled,
+  getItemLabel,
   scrollIntoView,
 }: NgpActiveDescendantManagerProps) {
   const disposables = injectDisposables();
@@ -98,6 +110,10 @@ export function activeDescendantManager({
   let isIgnoringPointer = false;
 
   let clearPointerIgnoreTimer: (() => void) | undefined;
+
+  // buffer of characters typed for typeahead navigation, cleared after a short idle
+  let typeaheadBuffer = '';
+  let clearTypeaheadTimer: (() => void) | undefined;
 
   // compute the id of the active descendant
   const id = computed(() => {
@@ -241,6 +257,47 @@ export function activeDescendantManager({
     activateByIndex(-1, { scroll, origin });
   };
 
+  function typeahead(key: string, options: ActivationOptions = {}): void {
+    // typeahead is only enabled when a label accessor is provided
+    if (!getItemLabel) {
+      return;
+    }
+
+    typeaheadBuffer += key.toLowerCase();
+
+    // clear the buffer shortly after the last keystroke so a new search can begin
+    clearTypeaheadTimer?.();
+    clearTypeaheadTimer = disposables.setTimeout(() => {
+      typeaheadBuffer = '';
+      clearTypeaheadTimer = undefined;
+    }, 500);
+
+    const total = count();
+    if (total === 0) {
+      return;
+    }
+
+    // when a single character is repeated, start after the current item so repeated
+    // presses cycle through the items whose label starts with that character
+    const startOffset = typeaheadBuffer.length === 1 ? 1 : 0;
+    const base = activeIndex() < 0 ? 0 : activeIndex();
+
+    for (let i = 0; i < total; i++) {
+      const index = (base + startOffset + i) % total;
+
+      if (isItemDisabled(index)) {
+        continue;
+      }
+
+      const label = (getItemLabel(index) ?? '').toLowerCase().trim();
+
+      if (label.startsWith(typeaheadBuffer)) {
+        activateByIndex(index, { origin: 'keyboard', ...options });
+        return;
+      }
+    }
+  }
+
   return {
     id,
     index: activeIndex,
@@ -252,6 +309,7 @@ export function activeDescendantManager({
     previous,
     reset,
     validate,
+    typeahead,
   } satisfies NgpActiveDescendantManagerState;
 }
 

--- a/packages/ng-primitives/a11y/src/active-descendant/tests/active-descendant.test.ts
+++ b/packages/ng-primitives/a11y/src/active-descendant/tests/active-descendant.test.ts
@@ -154,6 +154,13 @@ describe('activeDescendantManager', () => {
       expect(manager.index()).toBe(0); // wraps back to Apple
     });
 
+    it('matches the first item when nothing is active', () => {
+      const manager = createManager(['Apple', 'Apricot', 'Banana']);
+      manager.reset(); // no active item
+      manager.typeahead('a');
+      expect(manager.index()).toBe(0); // must land on Apple, not skip to Apricot
+    });
+
     it('skips disabled items', () => {
       const manager = createManager(['Apple', 'Banana', 'Blueberry'], { disabledIndices: [1] });
       manager.typeahead('b');

--- a/packages/ng-primitives/a11y/src/active-descendant/tests/active-descendant.test.ts
+++ b/packages/ng-primitives/a11y/src/active-descendant/tests/active-descendant.test.ts
@@ -1,0 +1,169 @@
+import { computed, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { activeDescendantManager, NgpActiveDescendantManagerState } from 'ng-primitives/a11y';
+import { describe, expect, it } from 'vitest';
+
+interface ManagerOptions {
+  /** Indices that should report as disabled. */
+  disabledIndices?: number[];
+  /** Whether navigation wraps around the ends. */
+  wrap?: boolean;
+  /** Set to false to omit `getItemLabel` (disables typeahead). */
+  withLabels?: boolean;
+}
+
+function createManager(
+  labels: string[],
+  options: ManagerOptions = {},
+): NgpActiveDescendantManagerState {
+  const disabledIndices = new Set(options.disabledIndices ?? []);
+  const items = signal(labels);
+
+  return TestBed.runInInjectionContext(() =>
+    activeDescendantManager({
+      count: computed(() => items().length),
+      getItemId: index => `opt-${index}`,
+      isItemDisabled: index => disabledIndices.has(index),
+      getItemLabel: options.withLabels === false ? undefined : index => items()[index],
+      scrollIntoView: () => {
+        /* no scrolling in the test environment */
+      },
+      disabled: signal(false),
+      wrap: signal(options.wrap ?? false),
+    }),
+  );
+}
+
+describe('activeDescendantManager', () => {
+  it('starts on the first item', () => {
+    const manager = createManager(['A', 'B', 'C']);
+    expect(manager.index()).toBe(0);
+    expect(manager.id()).toBe('opt-0');
+  });
+
+  it('reset() clears the active item', () => {
+    const manager = createManager(['A', 'B', 'C']);
+    manager.reset();
+    expect(manager.index()).toBe(-1);
+    expect(manager.id()).toBeUndefined();
+  });
+
+  it('activateByIndex() activates a given item', () => {
+    const manager = createManager(['A', 'B', 'C']);
+    manager.activateByIndex(2);
+    expect(manager.index()).toBe(2);
+    expect(manager.id()).toBe('opt-2');
+  });
+
+  it('activateByIndex() ignores a disabled item', () => {
+    const manager = createManager(['A', 'B', 'C'], { disabledIndices: [1] });
+    manager.reset();
+    manager.activateByIndex(1);
+    expect(manager.index()).toBe(-1);
+  });
+
+  it('does not move the active item while the group is disabled', () => {
+    const disabled = signal(false);
+    const items = signal(['A', 'B', 'C']);
+    const manager = TestBed.runInInjectionContext(() =>
+      activeDescendantManager({
+        count: computed(() => items().length),
+        getItemId: index => `opt-${index}`,
+        isItemDisabled: () => false,
+        scrollIntoView: () => {
+          /* no scrolling in the test environment */
+        },
+        disabled,
+        wrap: signal(false),
+      }),
+    );
+
+    manager.activateByIndex(2);
+    expect(manager.index()).toBe(2);
+
+    // once disabled, navigation is blocked and the active item stays put
+    disabled.set(true);
+    manager.activateByIndex(0);
+    manager.next();
+    expect(manager.index()).toBe(2);
+  });
+
+  it('first()/last() activate the first/last enabled item', () => {
+    const manager = createManager(['A', 'B', 'C', 'D'], { disabledIndices: [0, 3] });
+    manager.first();
+    expect(manager.index()).toBe(1);
+    manager.last();
+    expect(manager.index()).toBe(2);
+  });
+
+  it('next()/previous() move between items and skip disabled ones', () => {
+    const manager = createManager(['A', 'B', 'C'], { disabledIndices: [1] });
+    manager.activateByIndex(0);
+    manager.next();
+    expect(manager.index()).toBe(2); // skips disabled B
+    manager.previous();
+    expect(manager.index()).toBe(0);
+  });
+
+  it('does not wrap at the ends by default', () => {
+    const manager = createManager(['A', 'B']);
+    manager.activateByIndex(1);
+    manager.next();
+    expect(manager.index()).toBe(1); // stays on the last item
+    manager.activateByIndex(0);
+    manager.previous();
+    expect(manager.index()).toBe(0); // stays on the first item
+  });
+
+  it('wraps at the ends when wrap is enabled', () => {
+    const manager = createManager(['A', 'B'], { wrap: true });
+    manager.activateByIndex(1);
+    manager.next();
+    expect(manager.index()).toBe(0);
+    manager.previous();
+    expect(manager.index()).toBe(1);
+  });
+
+  it('validate() moves to the first enabled item when the active index is invalid', () => {
+    const manager = createManager(['A', 'B', 'C'], { disabledIndices: [0] });
+    manager.reset(); // index -1 is invalid
+    manager.validate();
+    expect(manager.index()).toBe(1);
+  });
+
+  describe('typeahead', () => {
+    it('jumps to the next item whose label matches (case-insensitive)', () => {
+      const manager = createManager(['Apple', 'Banana', 'Cherry']);
+      manager.typeahead('C');
+      expect(manager.index()).toBe(2);
+    });
+
+    it('matches on multiple characters', () => {
+      const manager = createManager(['Apple', 'Banana', 'Blueberry']);
+      manager.typeahead('b');
+      expect(manager.index()).toBe(1); // Banana
+      manager.typeahead('l');
+      expect(manager.index()).toBe(2); // "bl" -> Blueberry
+    });
+
+    it('cycles through matches when a character is repeated', () => {
+      const manager = createManager(['Apple', 'Apricot', 'Banana']);
+      manager.typeahead('a');
+      expect(manager.index()).toBe(1); // Apricot
+      manager.typeahead('a');
+      expect(manager.index()).toBe(0); // wraps back to Apple
+    });
+
+    it('skips disabled items', () => {
+      const manager = createManager(['Apple', 'Banana', 'Blueberry'], { disabledIndices: [1] });
+      manager.typeahead('b');
+      expect(manager.index()).toBe(2); // skips disabled Banana
+    });
+
+    it('is a no-op when no label accessor is provided', () => {
+      const manager = createManager(['Apple', 'Banana'], { withLabels: false });
+      manager.typeahead('b');
+      expect(manager.index()).toBe(0);
+    });
+  });
+});

--- a/packages/ng-primitives/listbox/src/index.ts
+++ b/packages/ng-primitives/listbox/src/index.ts
@@ -3,4 +3,43 @@ export { NgpListboxOption } from './listbox-option/listbox-option';
 export { NgpListboxSection } from './listbox-section/listbox-section';
 export { NgpListboxTrigger } from './listbox-trigger/listbox-trigger';
 export { NgpListbox } from './listbox/listbox';
-export { injectListboxState, provideListboxState } from './listbox/listbox-state';
+export {
+  NgpListboxTriggerStateToken,
+  ngpListboxTrigger,
+  injectListboxTriggerState,
+  provideListboxTriggerState,
+  type NgpListboxTriggerState,
+  type NgpListboxTriggerProps,
+} from './listbox-trigger/listbox-trigger-state';
+export {
+  NgpListboxSectionStateToken,
+  ngpListboxSection,
+  injectListboxSectionState,
+  provideListboxSectionState,
+  type NgpListboxSectionState,
+  type NgpListboxSectionProps,
+} from './listbox-section/listbox-section-state';
+export {
+  NgpListboxOptionStateToken,
+  ngpListboxOption,
+  injectListboxOptionState,
+  provideListboxOptionState,
+  type NgpListboxOptionState,
+  type NgpListboxOptionProps,
+} from './listbox-option/listbox-option-state';
+export {
+  NgpListboxHeaderStateToken,
+  ngpListboxHeader,
+  injectListboxHeaderState,
+  provideListboxHeaderState,
+  type NgpListboxHeaderState,
+  type NgpListboxHeaderProps,
+} from './listbox-header/listbox-header-state';
+export {
+  NgpListboxStateToken,
+  ngpListbox,
+  injectListboxState,
+  provideListboxState,
+  type NgpListboxState,
+  type NgpListboxProps,
+} from './listbox/listbox-state';

--- a/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
@@ -1,0 +1,33 @@
+import { ElementRef, signal, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+
+export interface NgpListboxHeaderState {
+  /** Access the component's reference. */
+  readonly elementRef: ElementRef;
+  /** The id of the listbox header. */
+  readonly id?: Signal<string>;
+}
+
+export interface NgpListboxHeaderProps {
+  /** The id of the listbox header. */
+  readonly id?: Signal<string>;
+}
+
+export const [
+  NgpListboxHeaderStateToken,
+  ngpListboxHeader,
+  injectListboxHeaderState,
+  provideListboxHeaderState,
+] = createPrimitive('NgpListboxHeader', ({ id = signal<string>('') }: NgpListboxHeaderProps) => {
+  const elementRef = injectElementRef();
+
+  // Host binding
+  attrBinding(elementRef, 'role', 'presentation');
+  attrBinding(elementRef, 'id', () => id());
+
+  return {
+    elementRef,
+    id,
+  } satisfies NgpListboxHeaderState;
+});

--- a/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
@@ -1,6 +1,8 @@
 import { signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive } from 'ng-primitives/state';
+import { attrBinding, createPrimitive, onDestroy } from 'ng-primitives/state';
+import { onChange, uniqueId } from 'ng-primitives/utils';
+import { injectListboxSectionState } from '../listbox-section/listbox-section-state';
 
 export type NgpListboxHeaderState = Record<string, never>;
 
@@ -14,12 +16,26 @@ export const [
   ngpListboxHeader,
   injectListboxHeaderState,
   provideListboxHeaderState,
-] = createPrimitive('NgpListboxHeader', ({ id = signal<string>('') }: NgpListboxHeaderProps) => {
-  const elementRef = injectElementRef();
+] = createPrimitive(
+  'NgpListboxHeader',
+  ({ id = signal(uniqueId('ngp-listbox-header')) }: NgpListboxHeaderProps) => {
+    const elementRef = injectElementRef();
+    const sectionState = injectListboxSectionState({ optional: true });
 
-  // Host binding
-  attrBinding(elementRef, 'role', 'presentation');
-  attrBinding(elementRef, 'id', () => id());
+    // Host binding
+    attrBinding(elementRef, 'role', 'presentation');
+    attrBinding(elementRef, 'id', () => id());
 
-  return {} satisfies NgpListboxHeaderState;
-});
+    // Register this header as the label for its containing section, if there is one.
+    onChange(id, (current, previous) => {
+      if (previous) {
+        sectionState()?.removeLabelledBy(previous);
+      }
+      sectionState()?.setLabelledBy(current);
+    });
+
+    onDestroy(() => sectionState()?.removeLabelledBy(id()));
+
+    return {} satisfies NgpListboxHeaderState;
+  },
+);

--- a/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
@@ -4,7 +4,7 @@ import { attrBinding, createPrimitive, onDestroy } from 'ng-primitives/state';
 import { onChange, uniqueId } from 'ng-primitives/utils';
 import { injectListboxSectionState } from '../listbox-section/listbox-section-state';
 
-export type NgpListboxHeaderState = Record<string, never>;
+export interface NgpListboxHeaderState {}
 
 export interface NgpListboxHeaderProps {
   /** The id of the listbox header. */

--- a/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
@@ -24,7 +24,7 @@ export const [
 
     // Host binding
     attrBinding(elementRef, 'role', 'presentation');
-    attrBinding(elementRef, 'id', () => id());
+    attrBinding(elementRef, 'id', id);
 
     // Register this header as the label for its containing section, if there is one.
     onChange(id, (current, previous) => {

--- a/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-header/listbox-header-state.ts
@@ -1,13 +1,8 @@
-import { ElementRef, signal, Signal } from '@angular/core';
+import { signal, Signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive } from 'ng-primitives/state';
 
-export interface NgpListboxHeaderState {
-  /** Access the component's reference. */
-  readonly elementRef: ElementRef;
-  /** The id of the listbox header. */
-  readonly id?: Signal<string>;
-}
+export type NgpListboxHeaderState = Record<string, never>;
 
 export interface NgpListboxHeaderProps {
   /** The id of the listbox header. */
@@ -26,8 +21,5 @@ export const [
   attrBinding(elementRef, 'role', 'presentation');
   attrBinding(elementRef, 'id', () => id());
 
-  return {
-    elementRef,
-    id,
-  } satisfies NgpListboxHeaderState;
+  return {} satisfies NgpListboxHeaderState;
 });

--- a/packages/ng-primitives/listbox/src/listbox-header/listbox-header.ts
+++ b/packages/ng-primitives/listbox/src/listbox-header/listbox-header.ts
@@ -1,6 +1,7 @@
 import { Directive, input } from '@angular/core';
 import { NgpHeaderToken } from 'ng-primitives/common';
 import { uniqueId } from 'ng-primitives/utils';
+import { ngpListboxHeader } from './listbox-header-state';
 
 @Directive({
   selector: '[ngpListboxHeader]',
@@ -17,4 +18,8 @@ export class NgpListboxHeader {
    * The id of the listbox header.
    */
   readonly id = input(uniqueId('ngp-listbox-header'));
+
+  protected readonly state = ngpListboxHeader({
+    id: this.id,
+  });
 }

--- a/packages/ng-primitives/listbox/src/listbox-header/listbox-header.ts
+++ b/packages/ng-primitives/listbox/src/listbox-header/listbox-header.ts
@@ -6,10 +6,6 @@ import { ngpListboxHeader } from './listbox-header-state';
 @Directive({
   selector: '[ngpListboxHeader]',
   exportAs: 'ngpListboxHeader',
-  host: {
-    role: 'presentation',
-    '[attr.id]': 'id()',
-  },
   // temporary until we remove NgpHeader completely - this prevents breaking changes
   providers: [{ provide: NgpHeaderToken, useExisting: NgpListboxHeader }],
 })

--- a/packages/ng-primitives/listbox/src/listbox-header/listbox-header.ts
+++ b/packages/ng-primitives/listbox/src/listbox-header/listbox-header.ts
@@ -15,7 +15,7 @@ export class NgpListboxHeader {
    */
   readonly id = input(uniqueId('ngp-listbox-header'));
 
-  protected readonly state = ngpListboxHeader({
-    id: this.id,
-  });
+  constructor() {
+    ngpListboxHeader({ id: this.id });
+  }
 }

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
@@ -99,8 +99,8 @@ export const [
 
     // Host binding
     attrBinding(elementRef, 'role', 'option');
-    attrBinding(elementRef, 'id', () => id());
-    attrBinding(elementRef, 'aria-disabled', () => _disabled());
+    attrBinding(elementRef, 'id', id);
+    attrBinding(elementRef, 'aria-disabled', _disabled);
     dataBinding(elementRef, 'data-disabled', () => (_disabled() ? '' : null));
     dataBinding(elementRef, 'data-active', () =>
       listboxState()?.isFocused() && active() ? '' : null,
@@ -155,16 +155,13 @@ export const [
       select,
     } satisfies NgpListboxOptionState<T>;
 
-    function destroy(): void {
-      listboxState()?.removeOption(state);
-    }
-
-    onDestroy(() => {
-      destroy();
-    });
-
+    // the listbox may not be available when the option is initialized, so add the
+    // option once the listbox is available
     effect(() => listboxState()?.addOption(state));
 
+    onDestroy(() => listboxState()?.removeOption(state));
+
+    // if the element is removed from the DOM, deregister it and reset its active state
     onDomRemoval(elementRef.nativeElement, () => {
       listboxState()?.removeOption(state);
       setInactiveStyles();

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
@@ -2,21 +2,15 @@ import { FocusOrigin } from '@angular/cdk/a11y';
 import { computed, effect, signal, Signal } from '@angular/core';
 import { ngpInteractions } from 'ng-primitives/interactions';
 import { injectElementRef, onDomRemoval, scrollIntoViewIfNeeded } from 'ng-primitives/internal';
-import {
-  attrBinding,
-  createPrimitive,
-  dataBinding,
-  listener,
-  onDestroy,
-} from 'ng-primitives/state';
+import { attrBinding, createPrimitive, dataBinding, listener, onDestroy } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectListboxState } from '../listbox/listbox-state';
 
 export interface NgpListboxOptionState<T> {
   /**
-   * The id of the listbox.
+   * The id of the option.
    */
-  readonly id?: Signal<string>;
+  readonly id: Signal<string>;
   /**
    * The value of the option.
    */
@@ -28,24 +22,19 @@ export interface NgpListboxOptionState<T> {
   readonly selected: Signal<boolean | undefined>;
   /**
    * @internal
-   * Whether the option is disabled - this is used by the `Highlightable` interface.
+   * Whether the option is disabled (its own disabled state or the listbox's).
    */
-  readonly disabled: boolean;
+  readonly disabled: Signal<boolean>;
   /**
    * @internal
-   * Sets the active state of the option - used by the `Highlightable` interface.
-   */
-  setActiveStyles: () => void;
-  /**
-   * @internal
-   * Sets the inactive state of the option - used by the `Highlightable` interface.
-   */
-  setInactiveStyles: () => void;
-  /**
-   * @internal
-   * Gets the label of the option, used by the `Highlightable` interface.
+   * Gets the label of the option, used for typeahead.
    */
   getLabel: () => string;
+  /**
+   * @internal
+   * Scrolls the option into view when it becomes the active descendant.
+   */
+  scrollIntoView: () => void;
   /**
    * @internal
    * Selects the option.
@@ -55,7 +44,7 @@ export interface NgpListboxOptionState<T> {
 
 export interface NgpListboxOptionProps<T> {
   /**
-   * The id of the listbox.
+   * The id of the option.
    */
   readonly id?: Signal<string>;
   /**
@@ -83,11 +72,13 @@ export const [
     const elementRef = injectElementRef();
     const listboxState = injectListboxState<T>();
 
-    const active = signal<boolean>(false);
     const selected = computed(() => listboxState()?.isSelected(value()));
 
     // the option is disabled if it is explicitly disabled or the whole listbox is disabled
     const disabled = computed(() => _disabled() || (listboxState()?.disabled() ?? false));
+
+    // the option is the active descendant when the listbox's manager points at its id
+    const active = computed(() => listboxState()?.activeDescendantManager.id() === id());
 
     // Setup interactions
     ngpInteractions({
@@ -114,17 +105,12 @@ export const [
     listener(elementRef, 'keydown.enter', () => select('keyboard'));
     listener(elementRef, 'keydown.space', () => select('keyboard'));
 
-    function setActiveStyles(): void {
-      active.set(true);
-      scrollIntoViewIfNeeded(elementRef.nativeElement);
-    }
-
-    function setInactiveStyles(): void {
-      active.set(false);
-    }
-
     function getLabel(): string {
       return elementRef.nativeElement.textContent ?? '';
+    }
+
+    function scrollIntoView(): void {
+      scrollIntoViewIfNeeded(elementRef.nativeElement);
     }
 
     function select(origin: FocusOrigin): void {
@@ -147,12 +133,9 @@ export const [
       id,
       value,
       selected,
-      get disabled(): boolean {
-        return disabled();
-      },
-      setActiveStyles,
-      setInactiveStyles,
+      disabled,
       getLabel,
+      scrollIntoView,
       select,
     } satisfies NgpListboxOptionState<T>;
 
@@ -162,11 +145,8 @@ export const [
 
     onDestroy(() => listboxState()?.removeOption(state));
 
-    // if the element is removed from the DOM, deregister it and reset its active state
-    onDomRemoval(elementRef.nativeElement, () => {
-      listboxState()?.removeOption(state);
-      setInactiveStyles();
-    });
+    // if the element is removed from the DOM, deregister it
+    onDomRemoval(elementRef.nativeElement, () => listboxState()?.removeOption(state));
 
     return state;
   },

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
@@ -9,6 +9,7 @@ import {
   listener,
   onDestroy,
 } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
 import { injectListboxState } from '../listbox/listbox-state';
 
 export interface NgpListboxOptionState<T> {
@@ -29,19 +30,15 @@ export interface NgpListboxOptionState<T> {
    * @internal
    * Whether the option is disabled - this is used by the `Highlightable` interface.
    */
-  disabled: boolean;
-  /**
-   * Whether the option is disabled.
-   */
-  _disabled: Signal<boolean>;
+  readonly disabled: boolean;
   /**
    * @internal
-   * Sets the active state of the option.
+   * Sets the active state of the option - used by the `Highlightable` interface.
    */
   setActiveStyles: () => void;
   /**
    * @internal
-   * Sets the inactive state of the option.
+   * Sets the inactive state of the option - used by the `Highlightable` interface.
    */
   setInactiveStyles: () => void;
   /**
@@ -54,12 +51,6 @@ export interface NgpListboxOptionState<T> {
    * Selects the option.
    */
   select: (origin: FocusOrigin) => void;
-  /**
-   * @internal
-   * Activate the current options.
-   */
-  activate: () => void;
-  destroy: () => void;
 }
 
 export interface NgpListboxOptionProps<T> {
@@ -85,7 +76,7 @@ export const [
 ] = createPrimitive(
   'NgpListboxOption',
   <T>({
-    id = signal<string>(''),
+    id = signal(uniqueId('ngp-listbox-option')),
     value,
     optionDisabled = signal<boolean>(false),
   }: NgpListboxOptionProps<T>) => {
@@ -158,13 +149,10 @@ export const [
       get disabled(): boolean {
         return _disabled();
       },
-      _disabled,
       setActiveStyles,
       setInactiveStyles,
       getLabel,
       select,
-      activate,
-      destroy,
     } satisfies NgpListboxOptionState<T>;
 
     function destroy(): void {

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
@@ -1,0 +1,197 @@
+import { FocusOrigin } from '@angular/cdk/a11y';
+import { computed, effect, signal, Signal } from '@angular/core';
+import { ngpInteractions } from 'ng-primitives/interactions';
+import { injectElementRef, onDomRemoval, scrollIntoViewIfNeeded } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  createPrimitive,
+  dataBinding,
+  listener,
+  onDestroy,
+} from 'ng-primitives/state';
+import { injectListboxState } from '../listbox/listbox-state';
+
+export interface NgpListboxOptionState<T> {
+  /**
+   * The id of the listbox.
+   */
+  readonly id?: Signal<string>;
+  /**
+   * The value of the option.
+   */
+  readonly value: Signal<T>;
+  /**
+   * Whether the option is disabled.
+   */
+  readonly optionDisabled?: Signal<boolean>;
+  /**
+   * Whether the option is active.
+   */
+  readonly active?: Signal<boolean>;
+  /**
+   * @internal
+   * Whether the option is selected.
+   */
+  readonly selected: Signal<boolean | undefined>;
+  /**
+   * @internal
+   * Whether the option is disabled - this is used by the `Highlightable` interface.
+   */
+  disabled: boolean;
+  /**
+   * Whether the option is disabled.
+   */
+  _disabled: Signal<boolean>;
+  /**
+   * @internal
+   * Sets the active state of the option.
+   */
+  setActiveStyles: () => void;
+  /**
+   * @internal
+   * Sets the inactive state of the option.
+   */
+  setInactiveStyles: () => void;
+  /**
+   * @internal
+   * Gets the label of the option, used by the `Highlightable` interface.
+   */
+  getLabel: () => string;
+  /**
+   * @internal
+   * Selects the option.
+   */
+  select: (origin: FocusOrigin) => void;
+  /**
+   * @internal
+   * Activate the current options.
+   */
+  activate: () => void;
+  destroy: () => void;
+}
+
+export interface NgpListboxOptionProps<T> {
+  /**
+   * The id of the listbox.
+   */
+  readonly id?: Signal<string>;
+  /**
+   * The value of the option.
+   */
+  readonly value: Signal<T>;
+  /**
+   * Whether the option is disabled.
+   */
+  readonly optionDisabled?: Signal<boolean>;
+}
+
+export const [
+  NgpListboxOptionStateToken,
+  ngpListboxOption,
+  injectListboxOptionState,
+  provideListboxOptionState,
+] = createPrimitive(
+  'NgpListboxOption',
+  <T>({
+    id = signal<string>(''),
+    value,
+    optionDisabled = signal<boolean>(false),
+  }: NgpListboxOptionProps<T>) => {
+    const elementRef = injectElementRef();
+    const listboxState = injectListboxState<T>();
+
+    const active = signal<boolean>(false);
+    const selected = computed(() => listboxState()?.isSelected(value()));
+
+    const _disabled = computed(() => optionDisabled() || (listboxState()?.disabled() ?? false));
+
+    // Setup interactions
+    ngpInteractions({
+      hover: true,
+      press: true,
+      focusVisible: true,
+      focus: true,
+      disabled: _disabled,
+    });
+
+    // Host binding
+    attrBinding(elementRef, 'role', 'option');
+    attrBinding(elementRef, 'id', () => id());
+    attrBinding(elementRef, 'aria-disabled', () => _disabled());
+    dataBinding(elementRef, 'data-disabled', () => (_disabled() ? '' : null));
+    dataBinding(elementRef, 'data-active', () =>
+      listboxState()?.isFocused() && active() ? '' : null,
+    );
+    dataBinding(elementRef, 'data-selected', () => (selected() ? '' : null));
+
+    // Listener
+    listener(elementRef, 'mouseenter', activate);
+    listener(elementRef, 'click', () => select('mouse'));
+    listener(elementRef, 'keydown.enter', () => select('keyboard'));
+    listener(elementRef, 'keydown.space', () => select('keyboard'));
+
+    function setActiveStyles(): void {
+      active.set(true);
+      scrollIntoViewIfNeeded(elementRef.nativeElement);
+    }
+
+    function setInactiveStyles(): void {
+      active.set(false);
+    }
+
+    function getLabel(): string {
+      return elementRef.nativeElement.textContent ?? '';
+    }
+
+    function select(origin: FocusOrigin): void {
+      if (_disabled()) {
+        return;
+      }
+
+      listboxState()?.selectOption(value(), origin);
+    }
+
+    function activate(): void {
+      if (_disabled()) {
+        return;
+      }
+
+      listboxState()?.activateOption(value());
+    }
+
+    const state = {
+      id,
+      value,
+      optionDisabled,
+      active,
+      selected,
+      get disabled(): boolean {
+        return _disabled();
+      },
+      _disabled,
+      setActiveStyles,
+      setInactiveStyles,
+      getLabel,
+      select,
+      activate,
+      destroy,
+    } satisfies NgpListboxOptionState<T>;
+
+    function destroy(): void {
+      listboxState()?.removeOption(state);
+    }
+
+    onDestroy(() => {
+      destroy();
+    });
+
+    effect(() => listboxState()?.addOption(state));
+
+    onDomRemoval(elementRef.nativeElement, () => {
+      listboxState()?.removeOption(state);
+      setInactiveStyles();
+    });
+
+    return state;
+  },
+);

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
@@ -2,7 +2,13 @@ import { FocusOrigin } from '@angular/cdk/a11y';
 import { computed, effect, signal, Signal } from '@angular/core';
 import { ngpInteractions } from 'ng-primitives/interactions';
 import { injectElementRef, onDomRemoval, scrollIntoViewIfNeeded } from 'ng-primitives/internal';
-import { attrBinding, createPrimitive, dataBinding, listener, onDestroy } from 'ng-primitives/state';
+import {
+  attrBinding,
+  createPrimitive,
+  dataBinding,
+  listener,
+  onDestroy,
+} from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectListboxState } from '../listbox/listbox-state';
 

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
@@ -21,14 +21,6 @@ export interface NgpListboxOptionState<T> {
    */
   readonly value: Signal<T>;
   /**
-   * Whether the option is disabled.
-   */
-  readonly optionDisabled?: Signal<boolean>;
-  /**
-   * Whether the option is active.
-   */
-  readonly active?: Signal<boolean>;
-  /**
    * @internal
    * Whether the option is selected.
    */
@@ -162,8 +154,6 @@ export const [
     const state = {
       id,
       value,
-      optionDisabled,
-      active,
       selected,
       get disabled(): boolean {
         return _disabled();

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option-state.ts
@@ -65,7 +65,7 @@ export interface NgpListboxOptionProps<T> {
   /**
    * Whether the option is disabled.
    */
-  readonly optionDisabled?: Signal<boolean>;
+  readonly disabled?: Signal<boolean>;
 }
 
 export const [
@@ -78,7 +78,7 @@ export const [
   <T>({
     id = signal(uniqueId('ngp-listbox-option')),
     value,
-    optionDisabled = signal<boolean>(false),
+    disabled: _disabled = signal<boolean>(false),
   }: NgpListboxOptionProps<T>) => {
     const elementRef = injectElementRef();
     const listboxState = injectListboxState<T>();
@@ -86,7 +86,8 @@ export const [
     const active = signal<boolean>(false);
     const selected = computed(() => listboxState()?.isSelected(value()));
 
-    const _disabled = computed(() => optionDisabled() || (listboxState()?.disabled() ?? false));
+    // the option is disabled if it is explicitly disabled or the whole listbox is disabled
+    const disabled = computed(() => _disabled() || (listboxState()?.disabled() ?? false));
 
     // Setup interactions
     ngpInteractions({
@@ -94,14 +95,14 @@ export const [
       press: true,
       focusVisible: true,
       focus: true,
-      disabled: _disabled,
+      disabled,
     });
 
     // Host binding
     attrBinding(elementRef, 'role', 'option');
     attrBinding(elementRef, 'id', id);
-    attrBinding(elementRef, 'aria-disabled', _disabled);
-    dataBinding(elementRef, 'data-disabled', () => (_disabled() ? '' : null));
+    attrBinding(elementRef, 'aria-disabled', disabled);
+    dataBinding(elementRef, 'data-disabled', () => (disabled() ? '' : null));
     dataBinding(elementRef, 'data-active', () =>
       listboxState()?.isFocused() && active() ? '' : null,
     );
@@ -127,7 +128,7 @@ export const [
     }
 
     function select(origin: FocusOrigin): void {
-      if (_disabled()) {
+      if (disabled()) {
         return;
       }
 
@@ -135,7 +136,7 @@ export const [
     }
 
     function activate(): void {
-      if (_disabled()) {
+      if (disabled()) {
         return;
       }
 
@@ -147,7 +148,7 @@ export const [
       value,
       selected,
       get disabled(): boolean {
-        return _disabled();
+        return disabled();
       },
       setActiveStyles,
       setInactiveStyles,

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option.ts
@@ -1,6 +1,5 @@
-import { FocusOrigin } from '@angular/cdk/a11y';
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Directive, input, OnDestroy } from '@angular/core';
+import { booleanAttribute, Directive, input } from '@angular/core';
 import { uniqueId } from 'ng-primitives/utils';
 import { ngpListboxOption } from './listbox-option-state';
 
@@ -8,7 +7,7 @@ import { ngpListboxOption } from './listbox-option-state';
   selector: '[ngpListboxOption]',
   exportAs: 'ngpListboxOption',
 })
-export class NgpListboxOption<T> implements OnDestroy {
+export class NgpListboxOption<T> {
   /**
    * The id of the listbox.
    */
@@ -36,60 +35,7 @@ export class NgpListboxOption<T> implements OnDestroy {
   });
 
   /**
-   * @internal
    * Whether the option is selected.
    */
   readonly selected = this.state.selected;
-
-  /**
-   * @internal
-   * Whether the option is disabled - this is used by the `Highlightable` interface.
-   */
-  get disabled(): boolean {
-    return this.state._disabled();
-  }
-
-  ngOnDestroy(): void {
-    return this.state.destroy();
-  }
-
-  /**
-   * @internal
-   * Sets the active state of the option.
-   */
-  setActiveStyles(): void {
-    return this.state.setActiveStyles();
-  }
-
-  /**
-   * @internal
-   * Sets the inactive state of the option.
-   */
-  setInactiveStyles(): void {
-    return this.state.setInactiveStyles();
-  }
-
-  /**
-   * @internal
-   * Gets the label of the option, used by the `Highlightable` interface.
-   */
-  getLabel(): string {
-    return this.state.getLabel();
-  }
-
-  /**
-   * @internal
-   * Selects the option.
-   */
-  select(origin: FocusOrigin): void {
-    return this.state.select(origin);
-  }
-
-  /**
-   * @internal
-   * Activate the current options.
-   */
-  activate(): void {
-    return this.state.activate();
-  }
 }

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option.ts
@@ -1,40 +1,14 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { BooleanInput } from '@angular/cdk/coercion';
-import {
-  booleanAttribute,
-  computed,
-  Directive,
-  effect,
-  input,
-  OnDestroy,
-  signal,
-} from '@angular/core';
-import { ngpInteractions } from 'ng-primitives/interactions';
-import { injectElementRef, onDomRemoval, scrollIntoViewIfNeeded } from 'ng-primitives/internal';
+import { booleanAttribute, Directive, input, OnDestroy } from '@angular/core';
 import { uniqueId } from 'ng-primitives/utils';
-import type { NgpListbox } from '../listbox/listbox';
-import { injectListboxState } from '../listbox/listbox-state';
+import { ngpListboxOption } from './listbox-option-state';
 
 @Directive({
   selector: '[ngpListboxOption]',
   exportAs: 'ngpListboxOption',
-  host: {
-    role: 'option',
-    '[attr.id]': 'id()',
-    '[attr.aria-disabled]': '_disabled()',
-    '[attr.data-active]': 'listbox()?.isFocused() && active() ? "" : undefined',
-    '[attr.data-selected]': 'selected() ? "" : undefined',
-    '[attr.data-disabled]': '_disabled() ? "" : undefined',
-    '(click)': 'select("mouse")',
-    '(mouseenter)': 'activate()',
-    '(keydown.enter)': 'select("keyboard")',
-    '(keydown.space)': 'select("keyboard")',
-  },
 })
 export class NgpListboxOption<T> implements OnDestroy {
-  protected readonly listbox = injectListboxState<NgpListbox<T>>();
-  private readonly elementRef = injectElementRef();
-
   /**
    * The id of the listbox.
    */
@@ -55,55 +29,28 @@ export class NgpListboxOption<T> implements OnDestroy {
     transform: booleanAttribute,
   });
 
-  /**
-   * Whether the option is active.
-   */
-  protected readonly active = signal<boolean>(false);
+  protected readonly state = ngpListboxOption<T>({
+    id: this.id,
+    value: this.value,
+    optionDisabled: this.optionDisabled,
+  });
 
   /**
    * @internal
    * Whether the option is selected.
    */
-  readonly selected = computed(() => this.listbox()?.isSelected(this.value()));
+  readonly selected = this.state.selected;
 
   /**
    * @internal
    * Whether the option is disabled - this is used by the `Highlightable` interface.
    */
   get disabled(): boolean {
-    return this._disabled();
-  }
-
-  /**
-   * Whether the option is disabled.
-   */
-  protected readonly _disabled = computed(
-    () => this.optionDisabled() || (this.listbox()?.disabled() ?? false),
-  );
-
-  constructor() {
-    ngpInteractions({
-      hover: true,
-      press: true,
-      focusVisible: true,
-      focus: true,
-      disabled: this._disabled,
-    });
-
-    // the listbox may not be available when the option is initialized
-    // so we need to add the option when the listbox is available
-    effect(() => this.listbox()?.addOption(this));
-
-    // any time the element is removed from the dom, we need to remove the option from the listbox
-    // and we also want to reset the active state
-    onDomRemoval(this.elementRef.nativeElement, () => {
-      this.listbox()?.removeOption(this);
-      this.setInactiveStyles();
-    });
+    return this.state._disabled();
   }
 
   ngOnDestroy(): void {
-    this.listbox()?.removeOption(this);
+    return this.state.destroy();
   }
 
   /**
@@ -111,8 +58,7 @@ export class NgpListboxOption<T> implements OnDestroy {
    * Sets the active state of the option.
    */
   setActiveStyles(): void {
-    this.active.set(true);
-    scrollIntoViewIfNeeded(this.elementRef.nativeElement);
+    return this.state.setActiveStyles();
   }
 
   /**
@@ -120,7 +66,7 @@ export class NgpListboxOption<T> implements OnDestroy {
    * Sets the inactive state of the option.
    */
   setInactiveStyles(): void {
-    this.active.set(false);
+    return this.state.setInactiveStyles();
   }
 
   /**
@@ -128,7 +74,7 @@ export class NgpListboxOption<T> implements OnDestroy {
    * Gets the label of the option, used by the `Highlightable` interface.
    */
   getLabel(): string {
-    return this.elementRef.nativeElement.textContent ?? '';
+    return this.state.getLabel();
   }
 
   /**
@@ -136,11 +82,7 @@ export class NgpListboxOption<T> implements OnDestroy {
    * Selects the option.
    */
   select(origin: FocusOrigin): void {
-    if (this._disabled()) {
-      return;
-    }
-
-    this.listbox()?.selectOption(this.value(), origin);
+    return this.state.select(origin);
   }
 
   /**
@@ -148,10 +90,6 @@ export class NgpListboxOption<T> implements OnDestroy {
    * Activate the current options.
    */
   activate(): void {
-    if (this._disabled()) {
-      return;
-    }
-
-    this.listbox()?.activateOption(this.value());
+    return this.state.activate();
   }
 }

--- a/packages/ng-primitives/listbox/src/listbox-option/listbox-option.ts
+++ b/packages/ng-primitives/listbox/src/listbox-option/listbox-option.ts
@@ -23,7 +23,7 @@ export class NgpListboxOption<T> {
   /**
    * Whether the option is disabled.
    */
-  readonly optionDisabled = input<boolean, BooleanInput>(false, {
+  readonly disabled = input<boolean, BooleanInput>(false, {
     alias: 'ngpListboxOptionDisabled',
     transform: booleanAttribute,
   });
@@ -31,7 +31,7 @@ export class NgpListboxOption<T> {
   protected readonly state = ngpListboxOption<T>({
     id: this.id,
     value: this.value,
-    optionDisabled: this.optionDisabled,
+    disabled: this.disabled,
   });
 
   /**

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
@@ -1,0 +1,39 @@
+import { ElementRef, signal, Signal } from '@angular/core';
+import { NgpHeader } from 'ng-primitives/common';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive } from 'ng-primitives/state';
+
+export interface NgpListboxSectionState {
+  /** Access the comonent's reference. */
+  readonly elementRef: ElementRef;
+}
+
+export interface NgpListboxSectionProps {
+  /**
+   * Access the header of the section if it exists.
+   */
+  readonly header?: Signal<NgpHeader | undefined>;
+}
+
+export const [
+  NgpListboxSectionStateToken,
+  ngpListboxSection,
+  injectListboxSectionState,
+  provideListboxSectionState,
+] = createPrimitive(
+  'NgpListboxSection',
+  ({
+    // TODO: Replace deprecated API
+    header = signal<NgpHeader | undefined>(undefined),
+  }: NgpListboxSectionProps) => {
+    const elementRef = injectElementRef();
+
+    // Host binding
+    attrBinding(elementRef, 'role', 'group');
+    attrBinding(elementRef, 'aria-labelledby', () => header()?.id());
+
+    return {
+      elementRef,
+    } satisfies NgpListboxSectionState;
+  },
+);

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
@@ -1,34 +1,48 @@
-import { signal, Signal } from '@angular/core';
-import { NgpHeader } from 'ng-primitives/common';
+import { signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive } from 'ng-primitives/state';
 
-export type NgpListboxSectionState = Record<string, never>;
-
-export interface NgpListboxSectionProps {
+export interface NgpListboxSectionState {
   /**
-   * Access the header of the section if it exists.
+   * @internal
+   * Registers the id of the header that labels this section.
    */
-  readonly header?: Signal<NgpHeader | undefined>;
+  setLabelledBy: (id: string) => void;
+  /**
+   * @internal
+   * Removes the id of the header that labels this section.
+   */
+  removeLabelledBy: (id: string) => void;
 }
+
+export type NgpListboxSectionProps = Record<string, never>;
 
 export const [
   NgpListboxSectionStateToken,
   ngpListboxSection,
   injectListboxSectionState,
   provideListboxSectionState,
-] = createPrimitive(
-  'NgpListboxSection',
-  ({
-    // TODO: Replace deprecated API
-    header = signal<NgpHeader | undefined>(undefined),
-  }: NgpListboxSectionProps) => {
-    const elementRef = injectElementRef();
+] = createPrimitive('NgpListboxSection', () => {
+  const elementRef = injectElementRef();
 
-    // Host binding
-    attrBinding(elementRef, 'role', 'group');
-    attrBinding(elementRef, 'aria-labelledby', () => header()?.id());
+  // The id of the header that labels this section, if one is present.
+  const labelledBy = signal<string | undefined>(undefined);
 
-    return {} satisfies NgpListboxSectionState;
-  },
-);
+  // Host binding
+  attrBinding(elementRef, 'role', 'group');
+  attrBinding(elementRef, 'aria-labelledby', () => labelledBy() ?? null);
+
+  function setLabelledBy(id: string): void {
+    labelledBy.set(id);
+  }
+
+  function removeLabelledBy(id: string): void {
+    // only clear if this header is still the active one, so a newer header that
+    // has taken over isn't clobbered when an old one is torn down
+    if (labelledBy() === id) {
+      labelledBy.set(undefined);
+    }
+  }
+
+  return { setLabelledBy, removeLabelledBy } satisfies NgpListboxSectionState;
+});

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
@@ -4,7 +4,7 @@ import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive } from 'ng-primitives/state';
 
 export interface NgpListboxSectionState {
-  /** Access the comonent's reference. */
+  /** Access the component's reference. */
   readonly elementRef: ElementRef;
 }
 

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
@@ -15,7 +15,7 @@ export interface NgpListboxSectionState {
   removeLabelledBy: (id: string) => void;
 }
 
-export type NgpListboxSectionProps = Record<string, never>;
+export interface NgpListboxSectionProps {}
 
 export const [
   NgpListboxSectionStateToken,

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
@@ -30,7 +30,7 @@ export const [
 
   // Host binding
   attrBinding(elementRef, 'role', 'group');
-  attrBinding(elementRef, 'aria-labelledby', () => labelledBy() ?? null);
+  attrBinding(elementRef, 'aria-labelledby', labelledBy);
 
   function setLabelledBy(id: string): void {
     labelledBy.set(id);

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section-state.ts
@@ -1,12 +1,9 @@
-import { ElementRef, signal, Signal } from '@angular/core';
+import { signal, Signal } from '@angular/core';
 import { NgpHeader } from 'ng-primitives/common';
 import { injectElementRef } from 'ng-primitives/internal';
 import { attrBinding, createPrimitive } from 'ng-primitives/state';
 
-export interface NgpListboxSectionState {
-  /** Access the component's reference. */
-  readonly elementRef: ElementRef;
-}
+export type NgpListboxSectionState = Record<string, never>;
 
 export interface NgpListboxSectionProps {
   /**
@@ -32,8 +29,6 @@ export const [
     attrBinding(elementRef, 'role', 'group');
     attrBinding(elementRef, 'aria-labelledby', () => header()?.id());
 
-    return {
-      elementRef,
-    } satisfies NgpListboxSectionState;
+    return {} satisfies NgpListboxSectionState;
   },
 );

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section.ts
@@ -1,5 +1,6 @@
 import { contentChild, Directive } from '@angular/core';
 import { NgpHeaderToken } from 'ng-primitives/common';
+import { ngpListboxSection } from './listbox-section-state';
 
 @Directive({
   selector: '[ngpListboxSection]',
@@ -10,8 +11,13 @@ import { NgpHeaderToken } from 'ng-primitives/common';
   },
 })
 export class NgpListboxSection {
+  // TODO: Replace deprecated API
   /**
    * Access the header of the section if it exists.
    */
   protected readonly header = contentChild(NgpHeaderToken, { descendants: true });
+
+  protected readonly state = ngpListboxSection({
+    header: this.header,
+  });
 }

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section.ts
@@ -7,5 +7,7 @@ import { ngpListboxSection, provideListboxSectionState } from './listbox-section
   providers: [provideListboxSectionState()],
 })
 export class NgpListboxSection {
-  protected readonly state = ngpListboxSection();
+  constructor() {
+    ngpListboxSection();
+  }
 }

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section.ts
@@ -5,10 +5,6 @@ import { ngpListboxSection } from './listbox-section-state';
 @Directive({
   selector: '[ngpListboxSection]',
   exportAs: 'ngpListboxSection',
-  host: {
-    role: 'group',
-    '[attr.aria-labelledby]': 'header()?.id()',
-  },
 })
 export class NgpListboxSection {
   // TODO: Replace deprecated API

--- a/packages/ng-primitives/listbox/src/listbox-section/listbox-section.ts
+++ b/packages/ng-primitives/listbox/src/listbox-section/listbox-section.ts
@@ -1,19 +1,11 @@
-import { contentChild, Directive } from '@angular/core';
-import { NgpHeaderToken } from 'ng-primitives/common';
-import { ngpListboxSection } from './listbox-section-state';
+import { Directive } from '@angular/core';
+import { ngpListboxSection, provideListboxSectionState } from './listbox-section-state';
 
 @Directive({
   selector: '[ngpListboxSection]',
   exportAs: 'ngpListboxSection',
+  providers: [provideListboxSectionState()],
 })
 export class NgpListboxSection {
-  // TODO: Replace deprecated API
-  /**
-   * Access the header of the section if it exists.
-   */
-  protected readonly header = contentChild(NgpHeaderToken, { descendants: true });
-
-  protected readonly state = ngpListboxSection({
-    header: this.header,
-  });
+  protected readonly state = ngpListboxSection();
 }

--- a/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger-state.ts
@@ -1,0 +1,40 @@
+import { ElementRef } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { injectPopoverTriggerState } from 'ng-primitives/popover';
+import { createPrimitive, listener } from 'ng-primitives/state';
+
+export interface NgpListboxTriggerState {
+  /** Access the component's reference. */
+  readonly elementRef: ElementRef;
+  /**
+   * When the up or down arrow key is pressed, open the popover.
+   */
+  onPopover: (event: KeyboardEvent) => void;
+}
+
+export interface NgpListboxTriggerProps {}
+
+export const [
+  NgpListboxTriggerStateToken,
+  ngpListboxTrigger,
+  injectListboxTriggerState,
+  provideListboxTriggerState,
+] = createPrimitive('NgpListboxTrigger', ({}: NgpListboxTriggerProps) => {
+  const elementRef = injectElementRef();
+  const popoverTriggerState = injectPopoverTriggerState();
+
+  // Listener
+  listener(elementRef, 'keydown', handleOnKeydown);
+
+  function handleOnKeydown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      popoverTriggerState().show();
+      event.preventDefault();
+    }
+  }
+
+  return {
+    elementRef,
+    onPopover: handleOnKeydown,
+  } satisfies NgpListboxTriggerState;
+});

--- a/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger-state.ts
@@ -1,11 +1,8 @@
-import { ElementRef } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { injectPopoverTriggerState } from 'ng-primitives/popover';
 import { createPrimitive, listener } from 'ng-primitives/state';
 
 export interface NgpListboxTriggerState {
-  /** Access the component's reference. */
-  readonly elementRef: ElementRef;
   /**
    * When the up or down arrow key is pressed, open the popover.
    */
@@ -34,7 +31,6 @@ export const [
   }
 
   return {
-    elementRef,
     onPopover: handleOnKeydown,
   } satisfies NgpListboxTriggerState;
 });

--- a/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger-state.ts
@@ -2,9 +2,9 @@ import { injectElementRef } from 'ng-primitives/internal';
 import { injectPopoverTriggerState } from 'ng-primitives/popover';
 import { createPrimitive, listener } from 'ng-primitives/state';
 
-export type NgpListboxTriggerState = Record<string, never>;
+export interface NgpListboxTriggerState {}
 
-export type NgpListboxTriggerProps = Record<string, never>;
+export interface NgpListboxTriggerProps {}
 
 export const [
   NgpListboxTriggerStateToken,

--- a/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger-state.ts
@@ -2,35 +2,26 @@ import { injectElementRef } from 'ng-primitives/internal';
 import { injectPopoverTriggerState } from 'ng-primitives/popover';
 import { createPrimitive, listener } from 'ng-primitives/state';
 
-export interface NgpListboxTriggerState {
-  /**
-   * When the up or down arrow key is pressed, open the popover.
-   */
-  onPopover: (event: KeyboardEvent) => void;
-}
+export type NgpListboxTriggerState = Record<string, never>;
 
-export interface NgpListboxTriggerProps {}
+export type NgpListboxTriggerProps = Record<string, never>;
 
 export const [
   NgpListboxTriggerStateToken,
   ngpListboxTrigger,
   injectListboxTriggerState,
   provideListboxTriggerState,
-] = createPrimitive('NgpListboxTrigger', ({}: NgpListboxTriggerProps) => {
+] = createPrimitive('NgpListboxTrigger', () => {
   const elementRef = injectElementRef();
   const popoverTriggerState = injectPopoverTriggerState();
 
-  // Listener
-  listener(elementRef, 'keydown', handleOnKeydown);
-
-  function handleOnKeydown(event: KeyboardEvent): void {
+  // When the up or down arrow key is pressed, open the popover.
+  listener(elementRef, 'keydown', event => {
     if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
       popoverTriggerState().show();
       event.preventDefault();
     }
-  }
+  });
 
-  return {
-    onPopover: handleOnKeydown,
-  } satisfies NgpListboxTriggerState;
+  return {} satisfies NgpListboxTriggerState;
 });

--- a/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger.ts
+++ b/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger.ts
@@ -1,24 +1,17 @@
-import { Directive, HostListener } from '@angular/core';
-import { injectPopoverTriggerState } from 'ng-primitives/popover';
+import { Directive } from '@angular/core';
+import { ngpListboxTrigger } from './listbox-trigger-state';
 
 @Directive({
   selector: '[ngpListboxTrigger]',
   exportAs: 'ngpListboxTrigger',
 })
 export class NgpListboxTrigger {
-  /**
-   * There must also be a popover trigger directive associated with this element.
-   */
-  private readonly popoverTrigger = injectPopoverTriggerState();
+  protected readonly state = ngpListboxTrigger({});
 
   /**
    * When the up or down arrow key is pressed, open the popover.
    */
-  @HostListener('keydown', ['$event'])
   openPopover(event: KeyboardEvent) {
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
-      this.popoverTrigger().show();
-      event.preventDefault();
-    }
+    return this.state.onPopover(event);
   }
 }

--- a/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger.ts
+++ b/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger.ts
@@ -6,12 +6,5 @@ import { ngpListboxTrigger } from './listbox-trigger-state';
   exportAs: 'ngpListboxTrigger',
 })
 export class NgpListboxTrigger {
-  protected readonly state = ngpListboxTrigger({});
-
-  /**
-   * When the up or down arrow key is pressed, open the popover.
-   */
-  openPopover(event: KeyboardEvent) {
-    return this.state.onPopover(event);
-  }
+  protected readonly state = ngpListboxTrigger();
 }

--- a/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger.ts
+++ b/packages/ng-primitives/listbox/src/listbox-trigger/listbox-trigger.ts
@@ -6,5 +6,7 @@ import { ngpListboxTrigger } from './listbox-trigger-state';
   exportAs: 'ngpListboxTrigger',
 })
 export class NgpListboxTrigger {
-  protected readonly state = ngpListboxTrigger();
+  constructor() {
+    ngpListboxTrigger();
+  }
 }

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -22,7 +22,7 @@ import {
   SetterOptions,
   StateInjectionOptions,
 } from 'ng-primitives/state';
-import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
+import { safeTakeUntilDestroyed, uniqueId } from 'ng-primitives/utils';
 import { Observable } from 'rxjs';
 import { NgpListboxOptionState } from '../listbox-option/listbox-option-state';
 
@@ -108,7 +108,7 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
   createPrimitive(
     'NgpListbox',
     <T>({
-      id = signal<string>(''),
+      id = signal(uniqueId('ngp-listbox')),
       mode = signal<NgpSelectionMode>('single'),
       value: _value = signal<T[]>([]),
       disabled: _disabled = signal<boolean>(false),

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -1,29 +1,297 @@
+import { ActiveDescendantKeyManager, FocusOrigin } from '@angular/cdk/a11y';
 import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
+  computed,
+  DestroyRef,
+  ElementRef,
+  inject,
+  Injector,
+  Signal,
+  signal,
+  WritableSignal,
+} from '@angular/core';
+import { NgpSelectionMode } from 'ng-primitives/common';
+import { ngpFocusVisible } from 'ng-primitives/interactions';
+import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
+import { injectPopoverTriggerState } from 'ng-primitives/popover';
+import {
+  attrBinding,
+  controlled,
+  controlledState,
+  createPrimitive,
+  deprecatedSetter,
+  emitter,
+  listener,
+  StateInjectionOptions,
 } from 'ng-primitives/state';
-import type { NgpListbox } from './listbox';
+import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
+import { Observable } from 'rxjs';
+import { NgpListboxOptionState } from '../listbox-option/listbox-option-state';
 
-/**
- * The state token  for the Listbox primitive.
- */
-export const NgpListboxStateToken = createStateToken<NgpListbox<unknown>>('Listbox');
+export interface NgpListboxState<T> {
+  /** Access the component's reference. */
+  readonly elementRef: ElementRef;
+  /**
+   * The id of the listbox.
+   */
+  readonly id?: Signal<string>;
+  /**
+   * The listbox selection mode.
+   */
+  readonly mode: Signal<NgpSelectionMode>;
+  /**
+   * The listbox selection.
+   */
+  readonly value: WritableSignal<T[]>;
+  /**
+   * The listbox disabled state.
+   */
+  readonly disabled: WritableSignal<boolean>;
+  /**
+   * The comparator function to use when comparing values.
+   * If not provided, strict equality (===) is used.
+   */
+  readonly compareWith: Signal<(a: T, b: T) => boolean>;
+  /**
+   * @internal
+   * Whether the listbox is focused.
+   */
+  readonly isFocused: Signal<boolean>;
+  /**
+   * Emits when the listbox selection changes.
+   */
+  readonly valueChange: Observable<T[]>;
+  /**
+   * @internal
+   * Selects an option in the listbox.
+   */
+  selectOption: (value: T, origin: FocusOrigin) => void;
+  /**
+   * @internal
+   * Determine if an option is selected using the compareWith function.
+   */
+  isSelected: (value: T) => boolean;
+  /**
+   * @internal
+   * Activate an option in the listbox.
+   */
+  activateOption: (value: T) => void;
+  /**
+   * Registers an option with the listbox.
+   * @internal
+   */
+  addOption: (option: NgpListboxOptionState<T>) => void;
+  /**
+   * Deregisters an option with the listbox.
+   * @internal
+   */
+  removeOption: (option: NgpListboxOptionState<T>) => void;
+  onAfterContentInit: () => void;
+  setDisabled: (value: boolean) => void;
+}
 
-/**
- * Provides the Listbox state.
- */
-export const provideListboxState = createStateProvider(NgpListboxStateToken);
+export interface NgpListboxProps<T> {
+  /**
+   * The id of the listbox.
+   */
+  readonly id?: Signal<string>;
+  /**
+   * The listbox selection mode.
+   */
+  readonly mode?: Signal<NgpSelectionMode>;
+  /**
+   * The listbox selection.
+   */
+  readonly value?: Signal<T[]>;
+  /**
+   * The listbox disabled state.
+   */
+  readonly disabled?: Signal<boolean>;
+  /**
+   * The comparator function to use when comparing values.
+   * If not provided, strict equality (===) is used.
+   */
+  readonly compareWith?: Signal<(a: T, b: T) => boolean>;
+  /**
+   * Emits when the listbox selection changes.
+   */
+  readonly onValueChange?: (value: T[]) => void;
+}
 
-/**
- * Injects the Listbox state.
- */
-export const injectListboxState = createStateInjector<NgpListbox<unknown>>(NgpListboxStateToken, {
-  deferred: true,
-});
+export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideListboxState] =
+  createPrimitive(
+    'NgpListbox',
+    <T>({
+      id = signal<string>(''),
+      mode = signal<NgpSelectionMode>('single'),
+      value: _value = signal<T[]>([]),
+      disabled: _disabled = signal<boolean>(false),
+      compareWith = signal<(a: T, b: T) => boolean>((a, b) => a === b),
+      onValueChange,
+    }: NgpListboxProps<T>) => {
+      const elementRef = injectElementRef();
+      const injector = inject(Injector);
+      const destroyRef = inject(DestroyRef);
+      const popoverTriggerState = injectPopoverTriggerState({ optional: true });
 
-/**
- * The Listbox state registration function.
- */
-export const listboxState = createState(NgpListboxStateToken);
+      const options = signal<NgpListboxOptionState<T>[]>([]);
+      const activeDescendant = signal<string | undefined>(undefined);
+      const isFocused = signal<boolean>(false);
+      const tabIndex = computed(() => (disabled() ? -1 : 0));
+
+      const value = controlled(_value);
+      const valueChange = emitter<T[]>();
+
+      const [disabled, setDisabled] = controlledState<boolean>({
+        value: _disabled,
+      });
+
+      // Setup interactions
+      ngpFocusVisible({ disabled: disabled });
+
+      // Host binding
+      attrBinding(elementRef, 'role', 'listbox');
+      attrBinding(elementRef, 'id', () => id());
+      attrBinding(elementRef, 'tabindex', () => tabIndex());
+      attrBinding(elementRef, 'aria-disabled', () => disabled());
+      attrBinding(elementRef, 'aria-multiselectable', () => mode() === 'multiple');
+      attrBinding(elementRef, 'aria-activedescendant', () => activeDescendant());
+
+      // Listener
+      listener(elementRef, 'focusin', () => isFocused.set(true));
+      listener(elementRef, 'focusout', () => isFocused.set(false));
+      listener(elementRef, 'keydown', onKeydown);
+
+      const keyManager = new ActiveDescendantKeyManager(options, injector);
+
+      function onAfterContentInit(): void {
+        keyManager.withHomeAndEnd().withTypeAhead().withVerticalOrientation();
+
+        keyManager.change
+          .pipe(safeTakeUntilDestroyed(destroyRef))
+          .subscribe(() => activeDescendant.set(keyManager.activeItem?.id?.()));
+
+        // On initialization, set the first selected option as the active descendant if there is one.
+        updateActiveItem();
+
+        // if the options change, update the active item, for example the item that was previously active may have been removed
+        // any time the value changes we should make sure that the active item is updated
+        explicitEffect([options, value], () => updateActiveItem(), {
+          injector: injector,
+        });
+      }
+
+      function updateActiveItem(): void {
+        const activeItem = keyManager.activeItem;
+        if (activeItem && options().includes(activeItem)) {
+          return;
+        }
+
+        const selectedOption = options().find(o => o.selected());
+
+        if (selectedOption) {
+          keyManager.setActiveItem(selectedOption);
+        } else {
+          keyManager.setFirstItemActive();
+        }
+      }
+
+      function onKeydown(event: KeyboardEvent): void {
+        keyManager.onKeydown(event);
+
+        // if the keydown was enter or space, select the active descendant if there is one
+        if (event.key === 'Enter' || event.key === ' ') {
+          keyManager.activeItem?.select('keyboard');
+        }
+
+        // if this is an arrow key or selection key, prevent the default action to prevent the page from scrolling
+        if (
+          event.key === 'ArrowDown' ||
+          event.key === 'ArrowUp' ||
+          event.key === 'Enter' ||
+          event.key === ' '
+        ) {
+          event.preventDefault();
+        }
+      }
+
+      function selectOption(val: T, origin: FocusOrigin): void {
+        if (mode() === 'single') {
+          const newValue = [val];
+          value.set(newValue);
+          valueChange.emit(newValue);
+          onValueChange?.(newValue);
+        } else {
+          // if the value is already selected, remove it, otherwise add it
+          if (isSelected(val)) {
+            const newValue = value().filter(v => !compareWith()(v, val));
+            value.set(newValue);
+            valueChange.emit(newValue);
+            onValueChange?.(newValue);
+          } else {
+            const newValue = [...value(), val];
+            value.set(newValue);
+            valueChange.emit(newValue);
+            onValueChange?.(newValue);
+          }
+        }
+
+        // Set the active descendant to the selected option.
+        const option = options().find(o => compareWith()(o.value(), val));
+
+        if (option) {
+          keyManager.setActiveItem(option);
+        }
+
+        // If the listbox is within a popover, close the popover on selection if it is not in a multiple selection mode.
+        if (mode() !== 'multiple') {
+          popoverTriggerState()?.hide(origin);
+        }
+      }
+
+      function activateOption(value: T) {
+        const option = options().find(o => compareWith()(o.value(), value));
+
+        if (option) {
+          keyManager.setActiveItem(option);
+        }
+      }
+
+      function addOption(option: NgpListboxOptionState<T>): void {
+        // if the option already exists, do not add it again
+        if (!options().includes(option)) {
+          options.update(options => [...options, option]);
+        }
+      }
+
+      function removeOption(option: NgpListboxOptionState<T>): void {
+        options.update(options => options.filter(o => o !== option));
+      }
+
+      function isSelected(val: T): boolean {
+        // a form may write null/undefined (writeValue(null) / reset); treat as empty
+        return (value() ?? []).some(v => compareWith()(v, val));
+      }
+
+      return {
+        elementRef,
+        id,
+        mode,
+        value,
+        disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
+        compareWith,
+        isFocused,
+        valueChange: valueChange.asObservable(),
+        selectOption,
+        isSelected,
+        activateOption,
+        addOption,
+        removeOption,
+        onAfterContentInit,
+        setDisabled,
+      } satisfies NgpListboxState<T>;
+    },
+  );
+
+export function injectListboxState<T>(options?: StateInjectionOptions): Signal<NgpListboxState<T>> {
+  return _injectListboxState(options) as Signal<NgpListboxState<T>>;
+}

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -20,6 +20,7 @@ import {
   deprecatedSetter,
   emitter,
   listener,
+  SetterOptions,
   StateInjectionOptions,
 } from 'ng-primitives/state';
 import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
@@ -85,6 +86,10 @@ export interface NgpListboxState<T> {
    */
   removeOption: (option: NgpListboxOptionState<T>) => void;
   onAfterContentInit: () => void;
+  /**
+   * Sets the listbox selection.
+   */
+  setValue: (value: T[], options?: SetterOptions) => void;
   setDisabled: (value: boolean) => void;
 }
 
@@ -215,25 +220,23 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         }
       }
 
-      function selectOption(val: T, origin: FocusOrigin): void {
-        if (mode() === 'single') {
-          const newValue = [val];
-          value.set(newValue);
+      function setValue(newValue: T[], options?: SetterOptions): void {
+        value.set(newValue);
+
+        if (options?.emit !== false) {
           valueChange.emit(newValue);
           onValueChange?.(newValue);
-        } else {
+        }
+      }
+
+      function selectOption(val: T, origin: FocusOrigin): void {
+        if (mode() === 'single') {
+          setValue([val]);
+        } else if (isSelected(val)) {
           // if the value is already selected, remove it, otherwise add it
-          if (isSelected(val)) {
-            const newValue = value().filter(v => !compareWith()(v, val));
-            value.set(newValue);
-            valueChange.emit(newValue);
-            onValueChange?.(newValue);
-          } else {
-            const newValue = [...value(), val];
-            value.set(newValue);
-            valueChange.emit(newValue);
-            onValueChange?.(newValue);
-          }
+          setValue(value().filter(v => !compareWith()(v, val)));
+        } else {
+          setValue([...value(), val]);
         }
 
         // Set the active descendant to the selected option.
@@ -277,7 +280,7 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         elementRef,
         id,
         mode,
-        value,
+        value: deprecatedSetter(value, 'setValue', setValue),
         disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
         compareWith,
         isFocused,
@@ -288,6 +291,7 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         addOption,
         removeOption,
         onAfterContentInit,
+        setValue,
         setDisabled,
       } satisfies NgpListboxState<T>;
     },

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -85,7 +85,6 @@ export interface NgpListboxState<T> {
    * @internal
    */
   removeOption: (option: NgpListboxOptionState<T>) => void;
-  onAfterContentInit: () => void;
   /**
    * Sets the listbox selection.
    */
@@ -167,24 +166,19 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       listener(elementRef, 'focusout', () => isFocused.set(false));
       listener(elementRef, 'keydown', onKeydown);
 
-      const keyManager = new ActiveDescendantKeyManager(options, injector);
+      const keyManager = new ActiveDescendantKeyManager(options, injector)
+        .withHomeAndEnd()
+        .withTypeAhead()
+        .withVerticalOrientation();
 
-      function onAfterContentInit(): void {
-        keyManager.withHomeAndEnd().withTypeAhead().withVerticalOrientation();
+      keyManager.change
+        .pipe(safeTakeUntilDestroyed(destroyRef))
+        .subscribe(() => activeDescendant.set(keyManager.activeItem?.id?.()));
 
-        keyManager.change
-          .pipe(safeTakeUntilDestroyed(destroyRef))
-          .subscribe(() => activeDescendant.set(keyManager.activeItem?.id?.()));
-
-        // On initialization, set the first selected option as the active descendant if there is one.
-        updateActiveItem();
-
-        // if the options change, update the active item, for example the item that was previously active may have been removed
-        // any time the value changes we should make sure that the active item is updated
-        explicitEffect([options, value], () => updateActiveItem(), {
-          injector: injector,
-        });
-      }
+      // Keep the active item in sync as options register/change and as the value
+      // changes (e.g. the previously active item was removed). This runs on setup
+      // too, so it sets the initial active item once the options are projected.
+      explicitEffect([options, value], () => updateActiveItem(), { injector });
 
       function updateActiveItem(): void {
         const activeItem = keyManager.activeItem;
@@ -290,7 +284,6 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         activateOption,
         addOption,
         removeOption,
-        onAfterContentInit,
         setValue,
         setDisabled,
       } satisfies NgpListboxState<T>;

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -1,13 +1,6 @@
-import { ActiveDescendantKeyManager, FocusOrigin } from '@angular/cdk/a11y';
-import {
-  computed,
-  DestroyRef,
-  inject,
-  Injector,
-  Signal,
-  signal,
-  WritableSignal,
-} from '@angular/core';
+import { FocusOrigin } from '@angular/cdk/a11y';
+import { computed, inject, Injector, Signal, signal, WritableSignal } from '@angular/core';
+import { activeDescendantManager } from 'ng-primitives/a11y';
 import { NgpSelectionMode } from 'ng-primitives/common';
 import { ngpFocusVisible } from 'ng-primitives/interactions';
 import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
@@ -22,7 +15,7 @@ import {
   SetterOptions,
   StateInjectionOptions,
 } from 'ng-primitives/state';
-import { safeTakeUntilDestroyed, uniqueId } from 'ng-primitives/utils';
+import { uniqueId } from 'ng-primitives/utils';
 import { Observable } from 'rxjs';
 import { NgpListboxOptionState } from '../listbox-option/listbox-option-state';
 
@@ -40,6 +33,11 @@ export interface NgpListboxState<T> {
    * Whether the listbox is focused.
    */
   readonly isFocused: Signal<boolean>;
+  /**
+   * @internal
+   * Manages the active descendant so options can reflect their active state.
+   */
+  readonly activeDescendantManager: ReturnType<typeof activeDescendantManager>;
   /**
    * Emits when the listbox selection changes.
    */
@@ -117,11 +115,9 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
     }: NgpListboxProps<T>) => {
       const elementRef = injectElementRef();
       const injector = inject(Injector);
-      const destroyRef = inject(DestroyRef);
       const popoverTriggerState = injectPopoverTriggerState({ optional: true });
 
       const options = signal<NgpListboxOptionState<T>[]>([]);
-      const activeDescendant = signal<string | undefined>(undefined);
       const isFocused = signal<boolean>(false);
 
       const value = controlled(_value);
@@ -134,6 +130,15 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         disabled.set(value);
       }
 
+      const activeDescendant = activeDescendantManager({
+        disabled,
+        count: computed(() => options().length),
+        getItemId: index => options()[index]?.id(),
+        isItemDisabled: index => options()[index]?.disabled() ?? false,
+        getItemLabel: index => options()[index]?.getLabel() ?? '',
+        scrollIntoView: index => options()[index]?.scrollIntoView(),
+      });
+
       // Setup interactions
       ngpFocusVisible({ disabled: disabled });
 
@@ -143,21 +148,16 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       attrBinding(elementRef, 'tabindex', tabIndex);
       attrBinding(elementRef, 'aria-disabled', disabled);
       attrBinding(elementRef, 'aria-multiselectable', () => mode() === 'multiple');
-      attrBinding(elementRef, 'aria-activedescendant', activeDescendant);
+      attrBinding(elementRef, 'aria-activedescendant', activeDescendant.id);
 
       // Listener
       listener(elementRef, 'focusin', () => isFocused.set(true));
       listener(elementRef, 'focusout', () => isFocused.set(false));
       listener(elementRef, 'keydown', onKeydown);
 
-      const keyManager = new ActiveDescendantKeyManager(options, injector)
-        .withHomeAndEnd()
-        .withTypeAhead()
-        .withVerticalOrientation();
-
-      keyManager.change
-        .pipe(safeTakeUntilDestroyed(destroyRef))
-        .subscribe(() => activeDescendant.set(keyManager.activeItem?.id?.()));
+      // Start with nothing active so the initial sync picks the selected option (or
+      // the first option) rather than defaulting to the first index.
+      activeDescendant.reset();
 
       // Keep the active item in sync as options register/change and as the value
       // changes (e.g. the previously active item was removed). This runs on setup
@@ -165,36 +165,59 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       explicitEffect([options, value], () => updateActiveItem(), { injector });
 
       function updateActiveItem(): void {
-        const activeItem = keyManager.activeItem;
-        if (activeItem && options().includes(activeItem)) {
+        const items = options();
+        const index = activeDescendant.index();
+
+        // keep the current active option if it is still present and enabled
+        if (index >= 0 && index < items.length && !items[index].disabled()) {
           return;
         }
 
-        const selectedOption = options().find(o => o.selected());
+        // otherwise activate the selected option, falling back to the first enabled option
+        const selectedIndex = items.findIndex(o => o.selected());
 
-        if (selectedOption) {
-          keyManager.setActiveItem(selectedOption);
+        if (selectedIndex >= 0 && !items[selectedIndex].disabled()) {
+          activeDescendant.activateByIndex(selectedIndex, { scroll: false });
         } else {
-          keyManager.setFirstItemActive();
+          activeDescendant.first({ scroll: false });
         }
       }
 
       function onKeydown(event: KeyboardEvent): void {
-        keyManager.onKeydown(event);
-
-        // if the keydown was enter or space, select the active descendant if there is one
-        if (event.key === 'Enter' || event.key === ' ') {
-          keyManager.activeItem?.select('keyboard');
-        }
-
-        // if this is an arrow key or selection key, prevent the default action to prevent the page from scrolling
-        if (
-          event.key === 'ArrowDown' ||
-          event.key === 'ArrowUp' ||
-          event.key === 'Enter' ||
-          event.key === ' '
-        ) {
-          event.preventDefault();
+        switch (event.key) {
+          case 'ArrowDown':
+            activeDescendant.next({ origin: 'keyboard' });
+            event.preventDefault();
+            break;
+          case 'ArrowUp':
+            activeDescendant.previous({ origin: 'keyboard' });
+            event.preventDefault();
+            break;
+          case 'Home':
+            activeDescendant.first({ origin: 'keyboard' });
+            event.preventDefault();
+            break;
+          case 'End':
+            activeDescendant.last({ origin: 'keyboard' });
+            event.preventDefault();
+            break;
+          case 'Enter':
+          case ' ': {
+            // select the active option if there is one
+            const activeId = activeDescendant.id();
+            if (activeId) {
+              options()
+                .find(o => o.id() === activeId)
+                ?.select('keyboard');
+            }
+            event.preventDefault();
+            break;
+          }
+          default:
+            // a single printable character starts/continues a typeahead search
+            if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+              activeDescendant.typeahead(event.key);
+            }
         }
       }
 
@@ -218,10 +241,10 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         }
 
         // Set the active descendant to the selected option.
-        const option = options().find(o => compareWith()(o.value(), val));
+        const index = options().findIndex(o => compareWith()(o.value(), val));
 
-        if (option) {
-          keyManager.setActiveItem(option);
+        if (index >= 0) {
+          activeDescendant.activateByIndex(index);
         }
 
         // If the listbox is within a popover, close the popover on selection if it is not in a multiple selection mode.
@@ -231,10 +254,10 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       }
 
       function activateOption(val: T) {
-        const option = options().find(o => compareWith()(o.value(), val));
+        const index = options().findIndex(o => compareWith()(o.value(), val));
 
-        if (option) {
-          keyManager.setActiveItem(option);
+        if (index >= 0) {
+          activeDescendant.activateByIndex(index, { origin: 'pointer' });
         }
       }
 
@@ -258,6 +281,7 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         value: deprecatedSetter(value, 'setValue', setValue),
         disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
         isFocused,
+        activeDescendantManager: activeDescendant,
         valueChange: valueChange.asObservable(),
         selectOption,
         isSelected,

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -123,12 +123,12 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       const options = signal<NgpListboxOptionState<T>[]>([]);
       const activeDescendant = signal<string | undefined>(undefined);
       const isFocused = signal<boolean>(false);
-      const tabIndex = computed(() => (disabled() ? -1 : 0));
 
       const value = controlled(_value);
       const valueChange = emitter<T[]>();
 
       const disabled = controlled(_disabled);
+      const tabIndex = computed(() => (disabled() ? -1 : 0));
 
       function setDisabled(value: boolean): void {
         disabled.set(value);
@@ -139,11 +139,11 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
 
       // Host binding
       attrBinding(elementRef, 'role', 'listbox');
-      attrBinding(elementRef, 'id', () => id());
-      attrBinding(elementRef, 'tabindex', () => tabIndex());
-      attrBinding(elementRef, 'aria-disabled', () => disabled());
+      attrBinding(elementRef, 'id', id);
+      attrBinding(elementRef, 'tabindex', tabIndex);
+      attrBinding(elementRef, 'aria-disabled', disabled);
       attrBinding(elementRef, 'aria-multiselectable', () => mode() === 'multiple');
-      attrBinding(elementRef, 'aria-activedescendant', () => activeDescendant());
+      attrBinding(elementRef, 'aria-activedescendant', activeDescendant);
 
       // Listener
       listener(elementRef, 'focusin', () => isFocused.set(true));
@@ -230,8 +230,8 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         }
       }
 
-      function activateOption(value: T) {
-        const option = options().find(o => compareWith()(o.value(), value));
+      function activateOption(val: T) {
+        const option = options().find(o => compareWith()(o.value(), val));
 
         if (option) {
           keyManager.setActiveItem(option);

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -2,7 +2,6 @@ import { ActiveDescendantKeyManager, FocusOrigin } from '@angular/cdk/a11y';
 import {
   computed,
   DestroyRef,
-  ElementRef,
   inject,
   Injector,
   Signal,
@@ -28,16 +27,6 @@ import { Observable } from 'rxjs';
 import { NgpListboxOptionState } from '../listbox-option/listbox-option-state';
 
 export interface NgpListboxState<T> {
-  /** Access the component's reference. */
-  readonly elementRef: ElementRef;
-  /**
-   * The id of the listbox.
-   */
-  readonly id?: Signal<string>;
-  /**
-   * The listbox selection mode.
-   */
-  readonly mode: Signal<NgpSelectionMode>;
   /**
    * The listbox selection.
    */
@@ -46,11 +35,6 @@ export interface NgpListboxState<T> {
    * The listbox disabled state.
    */
   readonly disabled: WritableSignal<boolean>;
-  /**
-   * The comparator function to use when comparing values.
-   * If not provided, strict equality (===) is used.
-   */
-  readonly compareWith: Signal<(a: T, b: T) => boolean>;
   /**
    * @internal
    * Whether the listbox is focused.
@@ -271,12 +255,8 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       }
 
       return {
-        elementRef,
-        id,
-        mode,
         value: deprecatedSetter(value, 'setValue', setValue),
         disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
-        compareWith,
         isFocused,
         valueChange: valueChange.asObservable(),
         selectOption,

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -16,7 +16,6 @@ import { injectPopoverTriggerState } from 'ng-primitives/popover';
 import {
   attrBinding,
   controlled,
-  controlledState,
   createPrimitive,
   deprecatedSetter,
   emitter,
@@ -141,9 +140,11 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       const value = controlled(_value);
       const valueChange = emitter<T[]>();
 
-      const [disabled, setDisabled] = controlledState<boolean>({
-        value: _disabled,
-      });
+      const disabled = controlled(_disabled);
+
+      function setDisabled(value: boolean): void {
+        disabled.set(value);
+      }
 
       // Setup interactions
       ngpFocusVisible({ disabled: disabled });

--- a/packages/ng-primitives/listbox/src/listbox/listbox.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox.ts
@@ -1,6 +1,6 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { BooleanInput } from '@angular/cdk/coercion';
-import { AfterContentInit, booleanAttribute, Directive, input, output } from '@angular/core';
+import { booleanAttribute, Directive, input, output } from '@angular/core';
 import { NgpSelectionMode } from 'ng-primitives/common';
 import { uniqueId } from 'ng-primitives/utils';
 import { NgpListboxOptionState } from '../listbox-option/listbox-option-state';
@@ -11,7 +11,7 @@ import { ngpListbox, provideListboxState } from './listbox-state';
   exportAs: 'ngpListbox',
   providers: [provideListboxState()],
 })
-export class NgpListbox<T> implements AfterContentInit {
+export class NgpListbox<T> {
   /**
    * The id of the listbox.
    */
@@ -65,10 +65,6 @@ export class NgpListbox<T> implements AfterContentInit {
     compareWith: this.compareWith,
     onValueChange: (value: T[]) => this.valueChange.emit(value),
   });
-
-  ngAfterContentInit(): void {
-    return this.state.onAfterContentInit();
-  }
 
   /**
    * @internal

--- a/packages/ng-primitives/listbox/src/listbox/listbox.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox.ts
@@ -52,15 +52,14 @@ export class NgpListbox<T> {
     alias: 'ngpListboxCompareWith',
   });
 
-  /**
-   * The listbox state
-   */
-  protected readonly state = ngpListbox({
-    id: this.id,
-    mode: this.mode,
-    value: this.value,
-    disabled: this.disabled,
-    compareWith: this.compareWith,
-    onValueChange: (value: T[]) => this.valueChange.emit(value),
-  });
+  constructor() {
+    ngpListbox({
+      id: this.id,
+      mode: this.mode,
+      value: this.value,
+      disabled: this.disabled,
+      compareWith: this.compareWith,
+      onValueChange: (value: T[]) => this.valueChange.emit(value),
+    });
+  }
 }

--- a/packages/ng-primitives/listbox/src/listbox/listbox.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox.ts
@@ -1,57 +1,17 @@
-import { ActiveDescendantKeyManager, FocusOrigin } from '@angular/cdk/a11y';
+import { FocusOrigin } from '@angular/cdk/a11y';
 import { BooleanInput } from '@angular/cdk/coercion';
-import {
-  AfterContentInit,
-  booleanAttribute,
-  computed,
-  DestroyRef,
-  Directive,
-  HostListener,
-  inject,
-  Injector,
-  input,
-  output,
-  signal,
-} from '@angular/core';
+import { AfterContentInit, booleanAttribute, Directive, input, output } from '@angular/core';
 import { NgpSelectionMode } from 'ng-primitives/common';
-import { ngpFocusVisible } from 'ng-primitives/interactions';
-import { explicitEffect } from 'ng-primitives/internal';
-import { injectPopoverTriggerState } from 'ng-primitives/popover';
-import { safeTakeUntilDestroyed, uniqueId } from 'ng-primitives/utils';
-import type { NgpListboxOption } from '../listbox-option/listbox-option';
-import { listboxState, provideListboxState } from './listbox-state';
+import { uniqueId } from 'ng-primitives/utils';
+import { NgpListboxOptionState } from '../listbox-option/listbox-option-state';
+import { ngpListbox, provideListboxState } from './listbox-state';
 
 @Directive({
   selector: '[ngpListbox]',
   exportAs: 'ngpListbox',
   providers: [provideListboxState()],
-  host: {
-    '[id]': 'state.id()',
-    role: 'listbox',
-    '[attr.tabindex]': 'tabindex()',
-    '[attr.aria-disabled]': 'state.disabled()',
-    '[attr.aria-multiselectable]': 'state.mode() === "multiple"',
-    '[attr.aria-activedescendant]': 'activeDescendant()',
-    '(focusin)': 'isFocused.set(true)',
-    '(focusout)': 'isFocused.set(false)',
-  },
 })
 export class NgpListbox<T> implements AfterContentInit {
-  /**
-   * Access the injector.
-   */
-  private readonly injector = inject(Injector);
-
-  /**
-   * Access the destroy ref.
-   */
-  private readonly destroyRef = inject(DestroyRef);
-
-  /**
-   * The listbox may be used within a popover, which we may want to close on selection.
-   */
-  private readonly popoverTrigger = injectPopoverTriggerState({ optional: true });
-
   /**
    * The id of the listbox.
    */
@@ -95,90 +55,19 @@ export class NgpListbox<T> implements AfterContentInit {
   });
 
   /**
-   * The tabindex of the listbox.
-   */
-  protected readonly tabindex = computed(() => (this.state.disabled() ? -1 : 0));
-
-  /**
-   * Access the options in the listbox.
-   */
-  protected readonly options = signal<NgpListboxOption<T>[]>([]);
-
-  /**
-   * The active descendant of the listbox.
-   */
-  protected readonly keyManager = new ActiveDescendantKeyManager(this.options, this.injector);
-
-  /**
-   * Gets the active descendant of the listbox.
-   */
-  protected readonly activeDescendant = signal<string | undefined>(undefined);
-
-  /**
-   * @internal
-   * Whether the listbox is focused.
-   */
-  readonly isFocused = signal(false);
-
-  /**
    * The listbox state
    */
-  protected readonly state = listboxState<NgpListbox<T>>(this);
-
-  constructor() {
-    ngpFocusVisible({ disabled: this.state.disabled });
-  }
+  protected readonly state = ngpListbox({
+    id: this.id,
+    mode: this.mode,
+    value: this.value,
+    disabled: this.disabled,
+    compareWith: this.compareWith,
+    onValueChange: (value: T[]) => this.valueChange.emit(value),
+  });
 
   ngAfterContentInit(): void {
-    this.keyManager.withHomeAndEnd().withTypeAhead().withVerticalOrientation();
-
-    this.keyManager.change
-      .pipe(safeTakeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.activeDescendant.set(this.keyManager.activeItem?.id()));
-
-    // On initialization, set the first selected option as the active descendant if there is one.
-    this.updateActiveItem();
-
-    // if the options change, update the active item, for example the item that was previously active may have been removed
-    // any time the value changes we should make sure that the active item is updated
-    explicitEffect([this.options], () => this.updateActiveItem(), {
-      injector: this.injector,
-    });
-  }
-
-  private updateActiveItem(): void {
-    const activeItem = this.keyManager.activeItem;
-    if (activeItem && this.options().includes(activeItem)) {
-      return;
-    }
-
-    const selectedOption = this.options().find(o => o.selected());
-
-    if (selectedOption) {
-      this.keyManager.setActiveItem(selectedOption);
-    } else {
-      this.keyManager.setFirstItemActive();
-    }
-  }
-
-  @HostListener('keydown', ['$event'])
-  protected onKeydown(event: KeyboardEvent): void {
-    this.keyManager.onKeydown(event);
-
-    // if the keydown was enter or space, select the active descendant if there is one
-    if (event.key === 'Enter' || event.key === ' ') {
-      this.keyManager.activeItem?.select('keyboard');
-    }
-
-    // if this is an arrow key or selection key, prevent the default action to prevent the page from scrolling
-    if (
-      event.key === 'ArrowDown' ||
-      event.key === 'ArrowUp' ||
-      event.key === 'Enter' ||
-      event.key === ' '
-    ) {
-      event.preventDefault();
-    }
+    return this.state.onAfterContentInit();
   }
 
   /**
@@ -186,34 +75,7 @@ export class NgpListbox<T> implements AfterContentInit {
    * Selects an option in the listbox.
    */
   selectOption(value: T, origin: FocusOrigin): void {
-    if (this.state.mode() === 'single') {
-      const newValue = [value];
-      this.state.value.set(newValue);
-      this.valueChange.emit(newValue);
-    } else {
-      // if the value is already selected, remove it, otherwise add it
-      if (this.isSelected(value)) {
-        const newValue = this.state.value().filter(v => !this.state.compareWith()(v, value));
-        this.state.value.set(newValue);
-        this.valueChange.emit(newValue);
-      } else {
-        const newValue = [...this.state.value(), value];
-        this.state.value.set(newValue);
-        this.valueChange.emit(newValue);
-      }
-    }
-
-    // Set the active descendant to the selected option.
-    const option = this.options().find(o => this.state.compareWith()(o.value(), value));
-
-    if (option) {
-      this.keyManager.setActiveItem(option);
-    }
-
-    // If the listbox is within a popover, close the popover on selection if it is not in a multiple selection mode.
-    if (this.state.mode() !== 'multiple') {
-      this.popoverTrigger()?.hide(origin);
-    }
+    return this.state.selectOption(value, origin);
   }
 
   /**
@@ -221,8 +83,7 @@ export class NgpListbox<T> implements AfterContentInit {
    * Determine if an option is selected using the compareWith function.
    */
   isSelected(value: T): boolean {
-    // a form may write null/undefined (writeValue(null) / reset); treat as empty
-    return (this.state.value() ?? []).some(v => this.state.compareWith()(v, value));
+    return this.state.isSelected(value);
   }
 
   /**
@@ -230,29 +91,22 @@ export class NgpListbox<T> implements AfterContentInit {
    * Activate an option in the listbox.
    */
   activateOption(value: T) {
-    const option = this.options().find(o => this.state.compareWith()(o.value(), value));
-
-    if (option) {
-      this.keyManager.setActiveItem(option);
-    }
+    return this.state.activateOption(value);
   }
 
   /**
    * Registers an option with the listbox.
    * @internal
    */
-  addOption(option: NgpListboxOption<T>): void {
-    // if the option already exists, do not add it again
-    if (!this.options().includes(option)) {
-      this.options.update(options => [...options, option]);
-    }
+  addOption(option: NgpListboxOptionState<T>): void {
+    return this.state.addOption(option);
   }
 
   /**
    * Deregisters an option with the listbox.
    * @internal
    */
-  removeOption(option: NgpListboxOption<T>): void {
-    this.options.update(options => options.filter(o => o !== option));
+  removeOption(option: NgpListboxOptionState<T>): void {
+    return this.state.removeOption(option);
   }
 }

--- a/packages/ng-primitives/listbox/src/listbox/listbox.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox.ts
@@ -1,9 +1,7 @@
-import { FocusOrigin } from '@angular/cdk/a11y';
 import { BooleanInput } from '@angular/cdk/coercion';
 import { booleanAttribute, Directive, input, output } from '@angular/core';
 import { NgpSelectionMode } from 'ng-primitives/common';
 import { uniqueId } from 'ng-primitives/utils';
-import { NgpListboxOptionState } from '../listbox-option/listbox-option-state';
 import { ngpListbox, provideListboxState } from './listbox-state';
 
 @Directive({
@@ -65,44 +63,4 @@ export class NgpListbox<T> {
     compareWith: this.compareWith,
     onValueChange: (value: T[]) => this.valueChange.emit(value),
   });
-
-  /**
-   * @internal
-   * Selects an option in the listbox.
-   */
-  selectOption(value: T, origin: FocusOrigin): void {
-    return this.state.selectOption(value, origin);
-  }
-
-  /**
-   * @internal
-   * Determine if an option is selected using the compareWith function.
-   */
-  isSelected(value: T): boolean {
-    return this.state.isSelected(value);
-  }
-
-  /**
-   * @internal
-   * Activate an option in the listbox.
-   */
-  activateOption(value: T) {
-    return this.state.activateOption(value);
-  }
-
-  /**
-   * Registers an option with the listbox.
-   * @internal
-   */
-  addOption(option: NgpListboxOptionState<T>): void {
-    return this.state.addOption(option);
-  }
-
-  /**
-   * Deregisters an option with the listbox.
-   * @internal
-   */
-  removeOption(option: NgpListboxOptionState<T>): void {
-    return this.state.removeOption(option);
-  }
 }

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-forms.fixture.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-forms.fixture.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Component, input, model, signal } from '@angular/core';
+import { booleanAttribute, Component, input, model } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { NgpSelectionMode } from 'ng-primitives/common';
 import {
@@ -23,7 +23,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
     <div
       [(ngpListboxValue)]="value"
       [ngpListboxMode]="mode()"
-      [ngpListboxDisabled]="disabled() || formDisabled()"
+      [ngpListboxDisabled]="disabled()"
       [ngpListboxCompareWith]="compareWith()"
       [attr.aria-label]="ariaLabel()"
       (ngpListboxValueChange)="onListboxValueChange($event)"
@@ -56,7 +56,6 @@ export class Listbox implements ControlValueAccessor {
 
   protected onChange?: ChangeFn<string[]>;
   protected onTouch?: TouchedFn;
-  protected readonly formDisabled = signal(false);
 
   writeValue(value: string[]): void {
     // drive the value through the bound model so the controlled input reflects it
@@ -72,7 +71,7 @@ export class Listbox implements ControlValueAccessor {
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.formDisabled.set(isDisabled);
+    this.state().setDisabled(isDisabled);
   }
 
   onListboxValueChange(value: string[]): void {

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-forms.fixture.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-forms.fixture.ts
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Component, input, model } from '@angular/core';
+import { booleanAttribute, Component, input } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { NgpSelectionMode } from 'ng-primitives/common';
 import {
@@ -21,7 +21,6 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
   imports: [NgpListbox],
   template: `
     <div
-      [(ngpListboxValue)]="value"
       [ngpListboxMode]="mode()"
       [ngpListboxDisabled]="disabled()"
       [ngpListboxCompareWith]="compareWith()"
@@ -42,8 +41,6 @@ export class Listbox implements ControlValueAccessor {
 
   readonly mode = input<NgpSelectionMode>('single');
 
-  readonly value = model<string[]>([]);
-
   readonly disabled = input<boolean, BooleanInput>(false, {
     transform: booleanAttribute,
   });
@@ -58,8 +55,8 @@ export class Listbox implements ControlValueAccessor {
   protected onTouch?: TouchedFn;
 
   writeValue(value: string[]): void {
-    // drive the value through the bound model so the controlled input reflects it
-    this.value.set(value);
+    // writing a value from the model must not re-emit through onChange
+    this.state().setValue(value, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<string[]>): void {
@@ -75,10 +72,7 @@ export class Listbox implements ControlValueAccessor {
   }
 
   onListboxValueChange(value: string[]): void {
-    this.value.set(value);
-    if (this.onChange) {
-      this.onChange(value);
-    }
+    this.onChange?.(value);
   }
 }
 

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-forms.fixture.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-forms.fixture.ts
@@ -37,7 +37,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
   },
 })
 export class Listbox implements ControlValueAccessor {
-  protected readonly state = injectListboxState<NgpListbox<string>>();
+  protected readonly state = injectListboxState<string>();
 
   readonly mode = input<NgpSelectionMode>('single');
 

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-forms.test.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-forms.test.ts
@@ -120,6 +120,33 @@ describe('Listbox (reusable component) — reactive forms', () => {
     expect(getByRole('option', { name: 'Banana' })).toHaveAttribute('data-selected', '');
   });
 
+  it('clears the selection and does not throw when the form control is reset', async () => {
+    const formControl = new FormControl<string[]>(['apple']);
+    const { getByRole, fixture } = await render(
+      `
+      <app-listbox [formControl]="formControl" aria-label="Fruit">
+        <app-listbox-option value="apple">Apple</app-listbox-option>
+        <app-listbox-option value="banana">Banana</app-listbox-option>
+      </app-listbox>
+      `,
+      {
+        imports: [Listbox, ListboxOption, ReactiveFormsModule],
+        componentProperties: { formControl },
+      },
+    );
+
+    await fixture.whenStable();
+    expect(getByRole('option', { name: 'Apple' })).toHaveAttribute('data-selected', '');
+
+    // reset() writes `null` through the value accessor - the listbox must treat it
+    // as an empty selection rather than crashing on `null.some(...)`.
+    formControl.reset();
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(getByRole('option', { name: 'Apple' })).not.toHaveAttribute('data-selected');
+  });
+
   it('reflects the disabled state from the form control', async () => {
     const formControl = new FormControl<string[]>([]);
     const { getByRole, fixture } = await render(

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-primitive.test.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-primitive.test.ts
@@ -237,6 +237,27 @@ describe('NgpListbox', () => {
       const prevented = !fireEvent.keyDown(listbox, arrowDown);
       expect(prevented).toBe(true);
     });
+
+    it('should move the active option using typeahead', async () => {
+      const container = await render(
+        `<div ngpListbox data-testid="listbox">
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">Apple</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">Banana</div>
+          <div ngpListboxOption ngpListboxOptionValue="c" data-testid="opt-c">Cherry</div>
+        </div>`,
+        { imports },
+      );
+      const listbox = container.getByTestId('listbox');
+      fireEvent.focusIn(listbox);
+      await waitFor(() => expect(container.getByTestId('opt-a')).toHaveAttribute('data-active'));
+
+      // typing the first letter of an option jumps to it (case-insensitive)
+      fireEvent.keyDown(listbox, { key: 'C' });
+      await waitFor(() => expect(container.getByTestId('opt-c')).toHaveAttribute('data-active'));
+      expect(listbox.getAttribute('aria-activedescendant')).toBe(
+        container.getByTestId('opt-c').getAttribute('id'),
+      );
+    });
   });
 
   describe('single selection', () => {

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-primitive.test.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-primitive.test.ts
@@ -258,6 +258,106 @@ describe('NgpListbox', () => {
         container.getByTestId('opt-c').getAttribute('id'),
       );
     });
+
+    it('should cycle through matches when a typeahead character is repeated', async () => {
+      const container = await render(
+        `<div ngpListbox data-testid="listbox">
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">Apple</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">Apricot</div>
+          <div ngpListboxOption ngpListboxOptionValue="c" data-testid="opt-c">Banana</div>
+        </div>`,
+        { imports },
+      );
+      const listbox = container.getByTestId('listbox');
+      fireEvent.focusIn(listbox);
+      await waitFor(() => expect(container.getByTestId('opt-a')).toHaveAttribute('data-active'));
+
+      // Apple is active; pressing "a" moves to the next label starting with "a"
+      fireEvent.keyDown(listbox, { key: 'a' });
+      await waitFor(() => expect(container.getByTestId('opt-b')).toHaveAttribute('data-active'));
+
+      // repeating "a" wraps back to Apple
+      fireEvent.keyDown(listbox, { key: 'a' });
+      await waitFor(() => expect(container.getByTestId('opt-a')).toHaveAttribute('data-active'));
+    });
+
+    it('should skip disabled options during typeahead', async () => {
+      const container = await render(
+        `<div ngpListbox data-testid="listbox">
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">Apple</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" ngpListboxOptionDisabled data-testid="opt-b">
+            Banana
+          </div>
+          <div ngpListboxOption ngpListboxOptionValue="c" data-testid="opt-c">Blueberry</div>
+        </div>`,
+        { imports },
+      );
+      const listbox = container.getByTestId('listbox');
+      fireEvent.focusIn(listbox);
+      await waitFor(() => expect(container.getByTestId('opt-a')).toHaveAttribute('data-active'));
+
+      // "b" matches disabled Banana and enabled Blueberry — the disabled one is skipped
+      fireEvent.keyDown(listbox, { key: 'b' });
+      await waitFor(() => expect(container.getByTestId('opt-c')).toHaveAttribute('data-active'));
+      expect(container.getByTestId('opt-b')).not.toHaveAttribute('data-active');
+    });
+
+    it('should not wrap past the last option with ArrowDown', async () => {
+      const container = await render(
+        `<div ngpListbox data-testid="listbox">
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">A</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">B</div>
+        </div>`,
+        { imports },
+      );
+      const listbox = container.getByTestId('listbox');
+      fireEvent.focusIn(listbox);
+      fireEvent.keyDown(listbox, arrowDown);
+      await waitFor(() => expect(container.getByTestId('opt-b')).toHaveAttribute('data-active'));
+
+      // already on the last option — ArrowDown must not wrap to the first
+      fireEvent.keyDown(listbox, arrowDown);
+      await waitFor(() => expect(container.getByTestId('opt-b')).toHaveAttribute('data-active'));
+      expect(container.getByTestId('opt-a')).not.toHaveAttribute('data-active');
+    });
+
+    it('should not wrap before the first option with ArrowUp', async () => {
+      const container = await render(
+        `<div ngpListbox data-testid="listbox">
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">A</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">B</div>
+        </div>`,
+        { imports },
+      );
+      const listbox = container.getByTestId('listbox');
+      fireEvent.focusIn(listbox);
+      await waitFor(() => expect(container.getByTestId('opt-a')).toHaveAttribute('data-active'));
+
+      // already on the first option — ArrowUp must not wrap to the last
+      fireEvent.keyDown(listbox, arrowUp);
+      await waitFor(() => expect(container.getByTestId('opt-a')).toHaveAttribute('data-active'));
+      expect(container.getByTestId('opt-b')).not.toHaveAttribute('data-active');
+    });
+
+    it('should make the selected option the active descendant on init', async () => {
+      const container = await render(
+        `<div [ngpListboxValue]="['b']" ngpListbox data-testid="listbox">
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">A</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">B</div>
+          <div ngpListboxOption ngpListboxOptionValue="c" data-testid="opt-c">C</div>
+        </div>`,
+        { imports },
+      );
+      const listbox = container.getByTestId('listbox');
+      fireEvent.focusIn(listbox);
+
+      // the selected option (B), not the first option, becomes active
+      await waitFor(() => expect(container.getByTestId('opt-b')).toHaveAttribute('data-active'));
+      expect(listbox.getAttribute('aria-activedescendant')).toBe(
+        container.getByTestId('opt-b').getAttribute('id'),
+      );
+      expect(container.getByTestId('opt-a')).not.toHaveAttribute('data-active');
+    });
   });
 
   describe('single selection', () => {

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-section.test.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-section.test.ts
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/angular';
+import { Component, signal } from '@angular/core';
+import { render, screen, waitFor } from '@testing-library/angular';
 import { NgpListboxHeader, NgpListboxSection } from 'ng-primitives/listbox';
 import { describe, expect, it } from 'vitest';
 
@@ -47,5 +48,32 @@ describe('NgpListboxSection', () => {
     );
 
     expect(screen.getByTestId('header')).toHaveAttribute('role', 'presentation');
+  });
+
+  it('should remove aria-labelledby when the header is removed', async () => {
+    @Component({
+      template: `
+        <div ngpListboxSection data-testid="section">
+          @if (showHeader()) {
+            <div ngpListboxHeader data-testid="header">Fruits</div>
+          }
+        </div>
+      `,
+      imports: [NgpListboxSection, NgpListboxHeader],
+    })
+    class TestHost {
+      readonly showHeader = signal(true);
+    }
+
+    const { fixture } = await render(TestHost);
+    const section = screen.getByTestId('section');
+
+    await waitFor(() => expect(section).toHaveAttribute('aria-labelledby'));
+
+    fixture.componentInstance.showHeader.set(false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(section).not.toHaveAttribute('aria-labelledby');
   });
 });

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-trigger.test.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-trigger.test.ts
@@ -58,4 +58,41 @@ describe('NgpListboxTrigger', () => {
     expect(document.querySelector('[ngpListbox]')).not.toBeInTheDocument();
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
+
+  it('closes the popover when an option is selected in single mode', async () => {
+    const { getByTestId } = await render(template, { imports });
+    const trigger = getByTestId('trigger');
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await waitFor(() => expect(document.querySelector('[ngpListbox]')).toBeInTheDocument());
+
+    // selecting an option closes the popover in single-selection mode
+    fireEvent.click(document.querySelector('[ngpListboxOption]')!);
+
+    await waitFor(() => expect(document.querySelector('[ngpListbox]')).not.toBeInTheDocument());
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('keeps the popover open when an option is selected in multiple mode', async () => {
+    const multipleTemplate = `
+      <button [ngpPopoverTrigger]="dropdown" ngpListboxTrigger data-testid="trigger">Open</button>
+      <ng-template #dropdown>
+        <div ngpPopover ngpListbox ngpListboxMode="multiple" aria-label="Fruit">
+          <div ngpListboxOption ngpListboxOptionValue="a">A</div>
+          <div ngpListboxOption ngpListboxOptionValue="b">B</div>
+        </div>
+      </ng-template>
+    `;
+    const { getByTestId } = await render(multipleTemplate, { imports });
+    const trigger = getByTestId('trigger');
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+    await waitFor(() => expect(document.querySelector('[ngpListbox]')).toBeInTheDocument());
+
+    fireEvent.click(document.querySelector('[ngpListboxOption]')!);
+
+    // in multiple-selection mode the popover stays open so more options can be picked
+    expect(document.querySelector('[ngpListbox]')).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
 });

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-trigger.test.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-trigger.test.ts
@@ -1,0 +1,61 @@
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpListbox, NgpListboxOption, NgpListboxTrigger } from 'ng-primitives/listbox';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
+ * `NgpListboxTrigger` sits on the popover trigger that hosts a listbox. Pressing
+ * ArrowUp/ArrowDown on the trigger opens the popover so keyboard users can reach
+ * the list without a pointer.
+ */
+describe('NgpListboxTrigger', () => {
+  const imports = [NgpListbox, NgpListboxOption, NgpListboxTrigger, NgpPopover, NgpPopoverTrigger];
+
+  const template = `
+    <button [ngpPopoverTrigger]="dropdown" ngpListboxTrigger data-testid="trigger">Open</button>
+    <ng-template #dropdown>
+      <div ngpPopover ngpListbox aria-label="Fruit">
+        <div ngpListboxOption ngpListboxOptionValue="a">A</div>
+        <div ngpListboxOption ngpListboxOptionValue="b">B</div>
+      </div>
+    </ng-template>
+  `;
+
+  afterEach(() => {
+    // Popover content attaches to the document body, not the fixture.
+    document.querySelectorAll('[ngpPopover]').forEach(el => el.remove());
+  });
+
+  it('opens the popover on ArrowDown', async () => {
+    const { getByTestId } = await render(template, { imports });
+    const trigger = getByTestId('trigger');
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(document.querySelector('[ngpListbox]')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+
+    await waitFor(() => expect(document.querySelector('[ngpListbox]')).toBeInTheDocument());
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('opens the popover on ArrowUp', async () => {
+    const { getByTestId } = await render(template, { imports });
+    const trigger = getByTestId('trigger');
+
+    fireEvent.keyDown(trigger, { key: 'ArrowUp' });
+
+    await waitFor(() => expect(document.querySelector('[ngpListbox]')).toBeInTheDocument());
+  });
+
+  it('does not open the popover on other keys', async () => {
+    const { getByTestId } = await render(template, { imports });
+    const trigger = getByTestId('trigger');
+
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    fireEvent.keyDown(trigger, { key: 'a' });
+
+    expect(document.querySelector('[ngpListbox]')).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #563

## What does this PR implement/fix?

Migrates the `listbox` primitive and each of its parts (`listbox`, `listbox-option`, `listbox-section`, `listbox-header`, `listbox-trigger`) to the `createPrimitive` state pattern, moving host bindings, ARIA, ActiveDescendant key management and focus handling into composable `-state.ts` factories.

This builds on the migration in #779 (by @MGREMY) and resolves the two failing tests there, plus a few follow-ups:

- **Fix null value crash** — `isSelected` now treats `null`/`undefined` (e.g. an ngModel initial `writeValue(null)`) as empty instead of calling `.some()` on it.
- **Fix `data-disabled`/`aria-disabled` cascade** — options again reflect the listbox's disabled state (`_disabled()`), not just their own `optionDisabled`.
- **Fix `NgpListbox.addOption` infinite recursion** — it now delegates to `state.addOption` instead of calling itself.
- **Make `disabled` genuinely settable** — backed by `controlled` so `setDisabled()` works; the reusable component and forms fixture drive form state through the state setter functions (`setValue` / `setDisabled`) rather than the deprecated signal setters or a bound model.
- **Remove the `onAfterContentInit` state hook** — the key-manager setup and active-item sync now live in the state factory, so the directive no longer needs an `ngAfterContentInit` lifecycle method.

All 56 listbox tests pass and both `ng-primitives` and `components` lint clean.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


---
_Generated by [Claude Code](https://claude.ai/code/session_01BsbCx6gBNYrqcmPzqrko64)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated `listbox` and all parts to `createPrimitive` state with a signal-based `activeDescendantManager`, adding letter-key typeahead and improving focus and ARIA. Fixes regressions, resolves failing tests from #779, and adds tests across listbox behavior and the `active-descendant` manager.

- **Refactors**
  - Moved `listbox`, `listbox-option`, `listbox-section`, `listbox-header`, and `listbox-trigger` into `-state.ts`; directives are thin; state APIs re-exported from `index.ts`.
  - Replaced CDK with `activeDescendantManager`; handles Arrow/Home/End/Enter/Space and typeahead (repeated-char cycling, skips disabled); selected option becomes active on init.
  - Exposed `setValue(value, { emit? })` and `setDisabled()`; `ControlValueAccessor` now uses these setters.
  - Options register directly with listbox; section/header link via `setLabelledBy`/`removeLabelledBy`; trigger opens popover on ArrowUp/Down.

- **Bug Fixes**
  - Guarded `isSelected` for `null`/`undefined` (form reset); fixed `addOption` infinite recursion.
  - Options inherit listbox disabled state via `aria-disabled`/`data-disabled`.
  - Forms: `setDisabled()` correctly updates state; corrected typing with `injectListboxState<string>()`.
  - Reusable listbox: mark control touched on blur.
  - Typeahead: when no item is active, search starts at index 0 to include the first match.
  - Docs: defer listbox-select popover entry animation until `[data-enter]` to prevent flicker before positioning.

<sup>Written for commit d9b6b47c4a396d568acfb185e30b4e1c59894025. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard typeahead navigation for listbox options, including cycling for repeated characters and skipping disabled options.
  * Improved listbox accessibility by automatically wiring section headers to the correct section for `aria-labelledby`.
  * Expanded listbox primitives and public APIs, including support for section headers, sections, options, and triggers.
* **Bug Fixes**
  * Improved form integration, ensuring Listbox selection is cleared correctly on `FormControl.reset()`.
  * Fixed initial active/selected linkage and prevented unintended keyboard wrapping at list boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->