### PR TITLE
docs(input-otp): add tailwind example variant

### DIFF
--- a/apps/documentation/src/app/examples/input-otp/input-otp.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/input-otp/input-otp.tailwind.example.ts
@@ -1,0 +1,49 @@
+import { Component, signal } from '@angular/core';
+import { NgpInputOtp, NgpInputOtpInput, NgpInputOtpSlot } from 'ng-primitives/input-otp';
+
+@Component({
+  selector: 'app-input-otp',
+  imports: [NgpInputOtp, NgpInputOtpInput, NgpInputOtpSlot],
+  template: `
+    <div
+      class="group relative flex flex-col items-center gap-4"
+      [(ngpInputOtpValue)]="value"
+      (ngpInputOtpComplete)="onComplete($event)"
+      ngpInputOtp
+    >
+      <input ngpInputOtpInput />
+
+      <div class="flex items-center gap-2">
+        @for (i of [1, 2, 3, 4, 5, 6]; track i) {
+          <div
+            class="relative flex h-12 w-12 cursor-pointer items-center justify-center overflow-hidden rounded-lg border-[1.5px] border-gray-200 bg-white text-xl font-[590] text-gray-900 transition-all duration-200 ease-in-out group-data-disabled:cursor-default group-data-disabled:opacity-50 hover:border-gray-300 data-active:border-blue-500 data-active:ring-1 data-active:ring-blue-500 data-caret:after:absolute data-caret:after:h-6 data-caret:after:w-px data-caret:after:bg-blue-500 data-caret:after:content-[''] data-placeholder:text-gray-400 dark:border-zinc-800 dark:bg-zinc-950 dark:text-gray-100 dark:hover:border-zinc-700 dark:data-active:border-blue-400 dark:data-active:ring-blue-400 dark:data-caret:after:bg-blue-400 dark:data-placeholder:text-gray-500"
+            ngpInputOtpSlot
+          ></div>
+        }
+      </div>
+    </div>
+  `,
+  styles: `
+    [ngpInputOtpSlot][data-caret]::after {
+      animation: blink 1s infinite;
+    }
+
+    @keyframes blink {
+      0%,
+      50% {
+        opacity: 1;
+      }
+      51%,
+      100% {
+        opacity: 0;
+      }
+    }
+  `,
+})
+export default class InputOtpExample {
+  readonly value = signal<string>('');
+
+  protected onComplete(value: string): void {
+    console.log('OTP Complete:', value);
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

## Issue

N/A — input OTP shipped with only the CSS example variant; this fills the missing Tailwind variant. Related: #833.

## What does this PR implement/fix?

Adds the Tailwind variant of the input OTP documentation example (`input-otp.tailwind.example.ts`), so the primitive offers both the CSS-token and Tailwind versions like the rest of the library. The `docs-example` component auto-discovers it by filename, so no Markdown changes are needed.

The variant is visually identical to the existing CSS example:

- State colours follow the convention — the active slot border/ring and the caret are **focus** indicators, so they use blue (`blue-500` / `blue-400`), never the brand red.
- Dark mode, hover, active and placeholder states, and the disabled treatment are all expressed with Tailwind utilities.
- The animated caret (a `::after` pseudo-element with custom keyframes, which Tailwind can't express) keeps a minimal `styles` block for the `@keyframes`; its colour is driven by a `--otp-caret` CSS variable set with Tailwind classes so it still respects dark mode.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tailwind variant of the Input OTP docs example for `ng-primitives/input-otp`. It matches the CSS example visually (six slots, caret blink) and is auto-discovered by the docs (no Markdown changes).

<sup>Written for commit 5e149c40ae8588b9a521e72b97bcacb08cadc2e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new documentation example demonstrating a six-digit one-time password (OTP) input.
  * Included a blinking caret animation for the active slot.
  * Showcased two-way binding for the OTP value and handling of the completion event by logging the completed code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->