### PR TITLE
feat(search): migrate search state

### DIFF
--- a/packages/ng-primitives/search/src/index.ts
+++ b/packages/ng-primitives/search/src/index.ts
@@ -1,3 +1,14 @@
-export { NgpSearchClear } from './search-clear/search-clear';
 export { NgpSearch } from './search/search';
-export { injectSearchState, provideSearchState } from './search/search-state';
+export {
+  injectSearchState,
+  ngpSearch,
+  NgpSearchState,
+  provideSearchState,
+} from './search/search-state';
+export { NgpSearchClear } from './search-clear/search-clear';
+export {
+  injectSearchClearState,
+  ngpSearchClear,
+  NgpSearchClearState,
+  provideSearchClearState,
+} from './search-clear/search-clear-state';

--- a/packages/ng-primitives/search/src/search-clear/search-clear-state.ts
+++ b/packages/ng-primitives/search/src/search-clear/search-clear-state.ts
@@ -1,0 +1,32 @@
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
+import { injectSearchState } from '../search/search-state';
+
+export interface NgpSearchClearState {
+  /**
+   * Clear the search field.
+   */
+  clear(): void;
+}
+
+export const [
+  NgpSearchClearStateToken,
+  ngpSearchClear,
+  injectSearchClearState,
+  provideSearchClearState,
+] = createPrimitive('NgpSearchClear', (): NgpSearchClearState => {
+  const element = injectElementRef<HTMLElement>();
+  const search = injectSearchState();
+
+  // Host bindings
+  attrBinding(element, 'tabindex', '-1');
+  dataBinding(element, 'data-empty', search().empty);
+
+  function clear(): void {
+    search().clear();
+  }
+
+  listener(element, 'click', clear);
+
+  return { clear } satisfies NgpSearchClearState;
+});

--- a/packages/ng-primitives/search/src/search-clear/search-clear.ts
+++ b/packages/ng-primitives/search/src/search-clear/search-clear.ts
@@ -1,28 +1,17 @@
-import { Directive, HostListener } from '@angular/core';
-import { injectSearchState } from '../search/search-state';
+import { Directive } from '@angular/core';
+import { ngpSearchClear, provideSearchClearState } from './search-clear-state';
 
 /**
- * The `NgpSearchClear` directive is can be added to a button to clear the search field on click.
+ * The `NgpSearchClear` directive can be added to a button to clear the search field on click.
  */
 @Directive({
   selector: '[ngpSearchClear]',
   exportAs: 'ngpSearchClear',
-  host: {
-    '[tabindex]': '-1',
-    '[attr.data-empty]': 'search().empty() ? "" : null',
-  },
+  providers: [provideSearchClearState()],
 })
 export class NgpSearchClear {
   /**
-   * Access the Search instance.
+   * The search clear state.
    */
-  protected readonly search = injectSearchState();
-
-  /**
-   * Clear the input field.
-   */
-  @HostListener('click')
-  protected clear(): void {
-    this.search().clear();
-  }
+  private readonly state = ngpSearchClear();
 }

--- a/packages/ng-primitives/search/src/search/search-state.ts
+++ b/packages/ng-primitives/search/src/search/search-state.ts
@@ -1,27 +1,71 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpSearch } from './search';
+import { computed, inject, Injector, signal, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { createPrimitive, dataBinding, listener } from 'ng-primitives/state';
 
-/**
- * The state token  for the Search primitive.
- */
-export const NgpSearchStateToken = createStateToken<NgpSearch>('Search');
+export interface NgpSearchState {
+  /**
+   * Whether the search field is empty.
+   * @internal
+   */
+  readonly empty: Signal<boolean>;
 
-/**
- * Provides the Search state.
- */
-export const provideSearchState = createStateProvider(NgpSearchStateToken);
+  /**
+   * Clear the search field.
+   */
+  clear(): void;
 
-/**
- * Injects the Search state.
- */
-export const injectSearchState = createStateInjector<NgpSearch>(NgpSearchStateToken);
+  /**
+   * Register the input field with the search.
+   * @internal
+   */
+  registerInput(input: HTMLInputElement): void;
+}
 
-/**
- * The Search state registration function.
- */
-export const searchState = createState(NgpSearchStateToken);
+export const [NgpSearchStateToken, ngpSearch, injectSearchState, provideSearchState] =
+  createPrimitive('NgpSearch', (): NgpSearchState => {
+    const element = injectElementRef<HTMLElement>();
+    const injector = inject(Injector);
+
+    /** The registered input field. */
+    const input = signal<HTMLInputElement | null>(null);
+
+    /** The current value of the input. */
+    const value = signal<string>('');
+
+    /** Whether the input field is empty. */
+    const empty = computed(() => value() === '');
+
+    // Reflect the empty state on the host.
+    dataBinding(element, 'data-empty', empty);
+
+    // Clear the field on Escape. The listener sits on the container, so the
+    // keydown bubbles up from the input.
+    listener(element, 'keydown', (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        clear();
+      }
+    });
+
+    function clear(): void {
+      const el = input();
+
+      // a disabled input must not be clearable (via Escape or the clear button)
+      if (!el || el.disabled) {
+        return;
+      }
+
+      el.value = '';
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    function registerInput(el: HTMLInputElement): void {
+      input.set(el);
+      value.set(el.value);
+
+      // Track the value as the user types. Cleanup is tied to the search's
+      // lifecycle via its injector, not the input's.
+      listener(el, 'input', () => value.set(el.value), { injector });
+    }
+
+    return { empty, clear, registerInput } satisfies NgpSearchState;
+  });

--- a/packages/ng-primitives/search/src/search/search.ts
+++ b/packages/ng-primitives/search/src/search/search.ts
@@ -1,7 +1,5 @@
-import { computed, DestroyRef, Directive, HostListener, inject, signal } from '@angular/core';
-import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
-import { fromEvent } from 'rxjs';
-import { provideSearchState, searchState } from './search-state';
+import { Directive } from '@angular/core';
+import { ngpSearch, provideSearchState } from './search-state';
 
 /**
  * The `NgpSearch` directive is a container for the search field components.
@@ -10,61 +8,23 @@ import { provideSearchState, searchState } from './search-state';
   selector: '[ngpSearch]',
   exportAs: 'ngpSearch',
   providers: [provideSearchState()],
-  host: {
-    '[attr.data-empty]': 'empty() ? "" : null',
-  },
 })
 export class NgpSearch {
   /**
-   * The destroy reference.
+   * The search field state.
    */
-  private readonly destroyRef = inject(DestroyRef);
-
-  /**
-   * The input field.
-   */
-  private readonly input = signal<HTMLInputElement | null>(null);
-
-  /**
-   * The value of the input.
-   */
-  private readonly value = signal<string>('');
+  private readonly state = ngpSearch();
 
   /**
    * Whether the input field is empty.
    * @internal
    */
-  readonly empty = computed(() => this.value() === '');
+  readonly empty = this.state.empty;
 
   /**
-   * The search field state.
+   * Clear the input field.
    */
-  protected readonly state = searchState<NgpSearch>(this);
-
-  @HostListener('keydown.escape')
   clear(): void {
-    const input = this.input();
-
-    // a disabled input must not be clearable (via Escape or the clear button)
-    if (!input || input.disabled) {
-      return;
-    }
-
-    input.value = '';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-  }
-
-  /**
-   * Register the input field.
-   * @param input The input field.
-   * @internal
-   */
-  registerInput(input: HTMLInputElement): void {
-    this.input.set(input);
-    this.value.set(input.value);
-
-    fromEvent(input, 'input')
-      .pipe(safeTakeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.value.set(input.value));
+    this.state.clear();
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #837

## What does this PR implement/fix?

Migrates the search primitive from the legacy `createStateToken`/`createStateProvider`/`createStateInjector`/`createState` quadruple to the current `createPrimitive` state pattern, in line with the recent meter (#830, #832) and `input-otp` (#834) migrations.

### What moved

- **`search`**: the input and value signals, the empty computed, the data-empty binding and the Escape-to-clear handler all move into a `createPrimitive` factory. The directive keeps a public `empty` signal and `clear()` that delegate to the state; input and value stay private, and only `empty`, `clear` and `registerInput` are returned.
- **`search-clear`**: `new -state.ts` factory owns the `tabindex` and `data-empty` bindings and the click listener; the directive is a thin shell.
- **`registerInput`** passes the search's own injector to `listener()`, so the input-event subscription stays tied to the search lifecycle rather than the caller's, matching the previous `safeTakeUntilDestroyed(this.destroyRef)` behaviour.
- The barrel now exports the factories, injectors, providers and state types for both parts, in line with the other migrated primitives.

### Tests and docs

No new tests: behaviour is unchanged, and the existing suite already covers what moved - `data-empty` tracking, Escape-to-clear, the clear button, the disabled guard, and the directive's `empty()`/`clear()` API. No docs change either, since there is no consumer-facing API change.

Full ng-primitives suite green (2246/2246), plus lint (0 errors) and AOT build.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the `search` primitive to the `createPrimitive` pattern, moving host bindings and listeners into state factories and leaving directives as thin shells. No behavior or public API changes.

- **Refactors**
  - Introduced `ngpSearch` state with `empty`, `clear()`, and `registerInput()`; `data-empty` and Escape-to-clear handled inside state.
  - Added `ngpSearchClear` state that manages `tabindex`, `data-empty`, and click-to-clear; directive now only provides state.
  - Input event listener is registered with the search’s injector to match the search lifecycle.
  - Updated exports in `index.ts` to include tokens, factories, injectors, providers, and state types for both parts.
  - Internal implementation uses `ng-primitives/state` and `ng-primitives/internal`.

<sup>Written for commit a091d6ee47fdfaeedf626fbdeb3d774229f158f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved search field behaviour, including reliable tracking of input contents and empty-state indicators.
  - Added support for clearing searches with the Escape key.
  - Added dedicated clear controls that reset the search field and update results immediately.
  - Clear controls now indicate when the search field is empty and are keyboard-friendly.

- **Refactor**
  - Reorganised search functionality for more consistent behaviour across search fields and clear controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->