### PR TITLE
fix(schematics): generate templates that compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
       - uses: nrwl/nx-set-shas@v4
 
       - run: pnpm exec nx format:check
+
+      # Runs unconditionally rather than through `nx affected`: a change to
+      # apps/components or to packages/tools never marks ng-primitives as affected, so
+      # these checks would otherwise never fire on the PRs that change what the templates
+      # are generated from.
+      - name: Schematic templates are in sync and compile
+        run: |
+          pnpm exec nx run ng-primitives:build:templates
+          git diff --exit-code -- packages/ng-primitives/schematics/ng-generate/templates \
+            || { echo "::error::Schematic templates are stale. Run: nx run ng-primitives:build:templates"; exit 1; }
+          pnpm exec nx run ng-primitives:test-node
+
       - run: pnpm exec nx affected -t lint,build,test
         env:
           NODE_OPTIONS: '--max-old-space-size=8192' # Increase memory to 8GB

--- a/packages/ng-primitives/project.json
+++ b/packages/ng-primitives/project.json
@@ -65,6 +65,7 @@
     },
     "build:schematics:test": {
       "executor": "@nx/js:tsc",
+      "dependsOn": ["build:templates"],
       "outputs": ["{options.outputPath}"],
       "options": {
         "clean": true,

--- a/packages/ng-primitives/schematics/ng-generate/compiles.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/compiles.node.test.ts
@@ -1,0 +1,164 @@
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import { performCompilation, readConfiguration } from '@angular/compiler-cli';
+import { Schema as ApplicationOptions } from '@schematics/angular/application/schema';
+import { Schema as WorkspaceOptions } from '@schematics/angular/workspace/schema';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Every primitive the schematic can generate must produce code that actually compiles.
+ *
+ * Nothing else in the repo checks this: the templates are generated build output that
+ * Prettier skips (`inferredParser: null` for `.template`), and the schematic's other
+ * tests assert on strings rather than compiling anything.
+ */
+describe('generated primitives compile', () => {
+  const workspaceRoot = resolve(fileURLToPath(new URL('../../../../', import.meta.url)));
+  const schematicRunner = new SchematicTestRunner(
+    'ng-primitives',
+    resolve(workspaceRoot, 'dist/ng-primitives-schematics-test/collection.json'),
+  );
+
+  const workspaceOptions: WorkspaceOptions = {
+    name: 'workspace',
+    newProjectRoot: 'projects',
+    version: '6.0.0',
+  };
+
+  const appOptions: ApplicationOptions = {
+    name: 'bar',
+    inlineStyle: false,
+    inlineTemplate: false,
+    routing: false,
+    skipTests: false,
+    skipPackageJson: false,
+  };
+
+  // Read at runtime rather than importing, so the gate covers the schema that ships.
+  const schemaPath = resolve(fileURLToPath(new URL('./schema.json', import.meta.url)));
+  const primitives: string[] = JSON.parse(readFileSync(schemaPath, 'utf-8')).properties.primitive
+    .enum;
+
+  /**
+   * The generated files have to live inside the repo: they import `@angular/core`,
+   * `@ng-icons/*` and friends, which resolve by walking up to the workspace
+   * `node_modules`. A directory under the OS temp dir would not resolve them.
+   */
+  let sandbox: string;
+  let appTree: UnitTestTree;
+
+  /** Absolute path of every generated file, by primitive. */
+  const generated = new Map<string, string[]>();
+
+  /** Files that do not parse, by absolute path. Kept out of the type-check program. */
+  const unparseable = new Map<string, string[]>();
+
+  beforeAll(async () => {
+    mkdirSync(join(workspaceRoot, 'tmp'), { recursive: true });
+    sandbox = mkdtempSync(join(workspaceRoot, 'tmp', 'schematics-compile-'));
+
+    appTree = await schematicRunner.runExternalSchematic(
+      '@schematics/angular',
+      'workspace',
+      workspaceOptions,
+    );
+    appTree = await schematicRunner.runExternalSchematic(
+      '@schematics/angular',
+      'application',
+      appOptions,
+      appTree,
+    );
+
+    for (const primitive of primitives) {
+      const tree = await schematicRunner.runSchematic(
+        'primitive',
+        { primitive, path: `projects/bar/src/app/${primitive}` },
+        appTree,
+      );
+
+      const files = tree.files.filter(file => file.includes(`/app/${primitive}/`));
+      const written: string[] = [];
+
+      for (const file of files) {
+        const target = join(sandbox, primitive, file.split('/').pop()!);
+        mkdirSync(dirname(target), { recursive: true });
+        writeFileSync(target, tree.readContent(file));
+        written.push(target);
+      }
+
+      generated.set(primitive, written);
+    }
+
+    for (const file of [...generated.values()].flat()) {
+      const source = ts.createSourceFile(
+        file,
+        readFileSync(file, 'utf-8'),
+        ts.ScriptTarget.Latest,
+        true,
+      );
+      // `parseDiagnostics` is internal, but it is the only way to separate a parse
+      // failure from a semantic one before handing the file to the compiler.
+      const diagnostics = (source as unknown as { parseDiagnostics?: ts.Diagnostic[] })
+        .parseDiagnostics;
+
+      if (diagnostics?.length) {
+        unparseable.set(file, diagnostics.map(describeDiagnostic));
+      }
+    }
+
+    // A tsconfig that reuses the workspace path mappings, so `ng-primitives/*` resolves
+    // to source rather than to a build artefact that may not exist yet.
+    //
+    // Unparseable files are excluded on purpose: `performCompilation` gives up on the
+    // first syntactic error, so leaving one in would hide every other diagnostic. They
+    // are reported by the parse test instead.
+    writeFileSync(
+      join(sandbox, 'tsconfig.json'),
+      JSON.stringify({
+        extends: join(workspaceRoot, 'tsconfig.base.json'),
+        compilerOptions: { baseUrl: workspaceRoot, noEmit: true, strict: true, types: [] },
+        angularCompilerOptions: { strictTemplates: true, strictInjectionParameters: true },
+        files: [...generated.values()].flat().filter(file => !unparseable.has(file)),
+      }),
+    );
+  }, 120_000);
+
+  afterAll(() => rmSync(sandbox, { recursive: true, force: true }));
+
+  /**
+   * Parsing is asserted on its own because `performCompilation` bails out on the first
+   * syntactic error, which would mask every semantic and template diagnostic behind it.
+   */
+  it('produces files that parse', () => {
+    expect([...unparseable.values()].flat()).toEqual([]);
+  });
+
+  it('produces files that type-check', () => {
+    const config = readConfiguration(join(sandbox, 'tsconfig.json'));
+    const { diagnostics } = performCompilation({
+      rootNames: config.rootNames,
+      options: { ...config.options, noEmit: true },
+    });
+
+    const failures = diagnostics
+      .filter(diagnostic => diagnostic.category === ts.DiagnosticCategory.Error)
+      .map(describeDiagnostic);
+
+    expect(failures).toEqual([]);
+  }, 60_000);
+
+  function describeDiagnostic(diagnostic: ts.Diagnostic): string {
+    const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
+
+    if (!diagnostic.file || diagnostic.start === undefined) {
+      return `TS${diagnostic.code}: ${message}`;
+    }
+
+    const { line } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+    const name = diagnostic.file.fileName.split('/').slice(-2).join('/');
+    return `${name}:${line + 1} TS${diagnostic.code}: ${message}`;
+  }
+});

--- a/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
@@ -173,6 +173,68 @@ describe('Component Schematic', () => {
     expect(content).not.toContain('changeDetection');
   });
 
+  describe('primitives split across several files', () => {
+    // These are the only primitives whose parts import each other, so they are the only
+    // ones where the generated file name and the generated class name have to line up.
+    const cases = [
+      { primitive: 'popover', part: 'popover-trigger', symbol: 'Popover' },
+      { primitive: 'tabs', part: 'tabs', symbol: 'Tab' },
+      { primitive: 'tooltip', part: 'tooltip-trigger', symbol: 'Tooltip' },
+    ];
+
+    for (const { primitive, part, symbol } of cases) {
+      it(`should cross-reference the ${primitive} parts using the default suffixes`, async () => {
+        const tree = await schematicRunner.runSchematic(
+          'primitive',
+          { primitive, path: `projects/bar/src/app/${primitive}` },
+          appTree,
+        );
+
+        const content = tree.readContent(`/projects/bar/src/app/${primitive}/${part}.component.ts`);
+
+        expect(content).toContain(`import { ${symbol}Component }`);
+        expect(content).toContain(`from './${symbol.toLowerCase()}.component'`);
+      });
+
+      it(`should cross-reference the ${primitive} parts with no file suffix`, async () => {
+        const tree = await schematicRunner.runSchematic(
+          'primitive',
+          { primitive, path: `projects/bar/src/app/${primitive}`, fileSuffix: '' },
+          appTree,
+        );
+
+        const content = tree.readContent(`/projects/bar/src/app/${primitive}/${part}.ts`);
+
+        // an absent file suffix must not leave a trailing dot on the import path
+        expect(content).toContain(`from './${symbol.toLowerCase()}'`);
+      });
+    }
+
+    it('should dasherize a camelCase file suffix in the import path', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'primitive',
+        { primitive: 'tabs', path: 'projects/bar/src/app/tabs', fileSuffix: 'myWidget' },
+        appTree,
+      );
+
+      expect(tree.files).toContain('/projects/bar/src/app/tabs/tabs.my-widget.ts');
+
+      const content = tree.readContent('/projects/bar/src/app/tabs/tabs.my-widget.ts');
+      expect(content).toContain("from './tab.my-widget'");
+    });
+
+    it('should reference the imported part at its usage sites, not just in the import', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'primitive',
+        { primitive: 'tabs', path: 'projects/bar/src/app/tabs' },
+        appTree,
+      );
+
+      const content = tree.readContent('/projects/bar/src/app/tabs/tabs.component.ts');
+      expect(content).toContain('contentChildren(TabComponent)');
+    });
+  });
+
   it('should generate a rating reusable component', async () => {
     const options: AngularPrimitivesComponentSchema = {
       primitive: 'rating',

--- a/packages/ng-primitives/schematics/ng-generate/index.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.ts
@@ -111,7 +111,8 @@ function processChangeDetection(
   const importRegex = /import\s*\{([^}]*)\}\s*from\s*['"]@angular\/core['"];/;
   if (importRegex.test(contentStr) && !contentStr.includes('ChangeDetectionStrategy')) {
     contentStr = contentStr.replace(importRegex, (_, imports) => {
-      const trimmed = imports.trim();
+      // a wrapped import list keeps a trailing comma, which would double up
+      const trimmed = imports.trim().replace(/,$/, '');
       return `import { ${trimmed}, ChangeDetectionStrategy } from '@angular/core';`;
     });
   }

--- a/packages/ng-primitives/schematics/ng-generate/templates/checkbox/checkbox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/checkbox/checkbox.__fileSuffix@dasherize__.ts.template
@@ -94,7 +94,8 @@ export class Checkbox<%= componentSuffix %> implements ControlValueAccessor {
   }
 
   writeValue(checked: boolean): void {
-    this.state().setChecked(checked);
+    // writing a value from the model must not re-emit through onChange
+    this.state().setChecked(checked, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<boolean>): void {

--- a/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
@@ -215,7 +215,7 @@ export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
   protected readonly formDisabled = signal(false);
 
   /** The on change callback */
-  private onChange?: ChangeFn<string>;
+  private onChange?: ChangeFn<string | undefined>;
 
   /** The on touch callback */
   protected onTouched?: TouchedFn;
@@ -254,9 +254,10 @@ export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
       return;
     }
 
-    // if the filter value is empty, set the value to undefined
+    // if the filter value is empty, clear the value and notify the form control
     if (this.filter() === '') {
       this.value.set(undefined);
+      this.onChange?.(undefined);
     } else {
       // otherwise set the filter value to the selected value
       this.filter.set(this.value() ?? '');

--- a/packages/ng-primitives/schematics/ng-generate/templates/date-picker/date-picker.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/date-picker/date-picker.__fileSuffix@dasherize__.ts.template
@@ -228,7 +228,8 @@ export class DatePicker<%= componentSuffix %> implements ControlValueAccessor {
   }
 
   writeValue(date: Date): void {
-    this.state().select(date);
+    // writing a value from the model must not re-emit through onChange
+    this.state().select(date, false, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<Date | undefined>): void {

--- a/packages/ng-primitives/schematics/ng-generate/templates/listbox/listbox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/listbox/listbox.__fileSuffix@dasherize__.ts.template
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Component, input, model } from '@angular/core';
+import { booleanAttribute, Component, input } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { provideIcons } from '@ng-icons/core';
 import { heroChevronDownSolid } from '@ng-icons/heroicons/solid';
@@ -17,7 +17,6 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
   imports: [NgpListbox],
   template: `
     <div
-      [(ngpListboxValue)]="value"
       [ngpListboxMode]="mode()"
       [ngpListboxDisabled]="disabled()"
       [ngpListboxCompareWith]="compareWith()"
@@ -43,23 +42,19 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
   `,
   host: {
     '[attr.aria-label]': 'null',
+    '(focusout)': 'onTouch?.()',
   },
 })
 export class Listbox<%= componentSuffix %> implements ControlValueAccessor {
   /**
    * Access the listbox state
    */
-  protected readonly state = injectListboxState<NgpListbox<string>>();
+  protected readonly state = injectListboxState<string>();
 
   /**
    * The listbox mode.
    */
   readonly mode = input<NgpSelectionMode>('single');
-
-  /**
-   * The listbox value.
-   */
-  readonly value = model<string[]>([]);
 
   /**
    * The listbox disabled state.
@@ -96,7 +91,8 @@ export class Listbox<%= componentSuffix %> implements ControlValueAccessor {
   protected onTouch?: TouchedFn;
 
   writeValue(value: string[]): void {
-    this.state()?.value.set(value);
+    // writing a value from the model must not re-emit through onChange
+    this.state()?.setValue(value, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<string[]>): void {
@@ -108,11 +104,10 @@ export class Listbox<%= componentSuffix %> implements ControlValueAccessor {
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.state()?.disabled.set(isDisabled);
+    this.state()?.setDisabled(isDisabled);
   }
 
   onListboxValueChange(value: string[]): void {
-    this.value.set(value);
-    if (this.onChange) this.onChange(value);
+    this.onChange?.(value);
   }
 }

--- a/packages/ng-primitives/schematics/ng-generate/templates/pagination/pagination.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/pagination/pagination.__fileSuffix@dasherize__.ts.template
@@ -168,7 +168,8 @@ export class Pagination<%= componentSuffix %> implements ControlValueAccessor {
 
   /** Write a new value to the control */
   writeValue(value: number): void {
-    this.state().page.set(value);
+    // writing a value from the model must not re-emit through onChange
+    this.state().setPage(value, { emit: false });
   }
 
   /** Register a callback to be called when the value changes */
@@ -179,5 +180,10 @@ export class Pagination<%= componentSuffix %> implements ControlValueAccessor {
   /** Register a callback to be called when the control is touched */
   registerOnTouched(fn: TouchedFn): void {
     this.onTouched = fn;
+  }
+
+  /** Reflect the form control's disabled state onto the pagination. */
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
   }
 }

--- a/packages/ng-primitives/schematics/ng-generate/templates/popover/popover-trigger.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/popover/popover-trigger.__fileSuffix@dasherize__.ts.template
@@ -1,7 +1,7 @@
 import { Directive, input } from '@angular/core';
 import { injectPopoverTriggerState } from 'ng-primitives/popover';
 import { NgpPopoverTrigger } from 'ng-primitives/popover';
-import { Popover } from './popover';
+import { Popover<%= componentSuffix %> } from './popover<% if (fileSuffix) { %>.<%= dasherize(fileSuffix) %><% } %>';
 
 @Directive({
   selector: '[appPopoverTrigger]',
@@ -34,6 +34,6 @@ export class PopoverTrigger {
   });
 
   constructor() {
-    this.popoverTrigger().popover.set(Popover);
+    this.popoverTrigger().popover.set(Popover<%= componentSuffix %>);
   }
 }

--- a/packages/ng-primitives/schematics/ng-generate/templates/range-slider/range-slider.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/range-slider/range-slider.__fileSuffix@dasherize__.ts.template
@@ -118,9 +118,10 @@ export class RangeSlider<%= componentSuffix %> implements ControlValueAccessor {
     }
 
     const [low, high] = value;
-    // Use the directive's clamping setters to respect min/max and ordering
-    this.state().setLowValue(low);
-    this.state().setHighValue(high);
+    // Use the directive's clamping setters to respect min/max and ordering.
+    // writing a value from the model must not re-emit through onChange
+    this.state().setLowValue(low, { emit: false });
+    this.state().setHighValue(high, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<[number, number]>): void {

--- a/packages/ng-primitives/schematics/ng-generate/templates/slider/slider.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/slider/slider.__fileSuffix@dasherize__.ts.template
@@ -108,7 +108,8 @@ export class Slider<%= componentSuffix %> implements ControlValueAccessor {
   }
 
   writeValue(value: number): void {
-    this.state().setValue(value);
+    // writing a value from the model must not re-emit through onChange
+    this.state().setValue(value, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<number>): void {

--- a/packages/ng-primitives/schematics/ng-generate/templates/switch/switch.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/switch/switch.__fileSuffix@dasherize__.ts.template
@@ -88,7 +88,8 @@ export class Switch<%= componentSuffix %> implements ControlValueAccessor {
 
   /** Write a new value to the switch. */
   writeValue(value: boolean): void {
-    this.switch().setChecked(value);
+    // writing a value from the model must not re-emit through onChange
+    this.switch().setChecked(value, { emit: false });
   }
 
   /** Register a callback function to be called when the value changes. */

--- a/packages/ng-primitives/schematics/ng-generate/templates/tabs/tabs.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/tabs/tabs.__fileSuffix@dasherize__.ts.template
@@ -1,7 +1,7 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { Component, contentChildren, model } from '@angular/core';
 import { NgpTabButton, NgpTabList, NgpTabPanel, NgpTabset } from 'ng-primitives/tabs';
-import { Tab } from './tab';
+import { Tab<%= componentSuffix %> } from './tab<% if (fileSuffix) { %>.<%= dasherize(fileSuffix) %><% } %>';
 
 @Component({
   selector: '<%= prefix %>-tabs',
@@ -78,5 +78,5 @@ export class Tabs<%= componentSuffix %> {
   /**
    * The tabs in the group.
    */
-  readonly tabs = contentChildren(Tab);
+  readonly tabs = contentChildren(Tab<%= componentSuffix %>);
 }

--- a/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group.__fileSuffix@dasherize__.ts.template
@@ -13,7 +13,6 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
         'ngpToggleGroupOrientation:orientation',
         'ngpToggleGroupType:type',
         'ngpToggleGroupValue:value',
-        'ngpToggleGroupCompareWith:compareWith',
         'ngpToggleGroupDisabled:disabled',
       ],
       outputs: ['ngpToggleGroupValueChange:valueChange'],

--- a/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip-trigger.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip-trigger.__fileSuffix@dasherize__.ts.template
@@ -1,6 +1,6 @@
 import { Directive, input } from '@angular/core';
 import { injectTooltipTriggerState, NgpTooltipTrigger } from 'ng-primitives/tooltip';
-import { Tooltip } from './tooltip';
+import { Tooltip<%= componentSuffix %> } from './tooltip<% if (fileSuffix) { %>.<%= dasherize(fileSuffix) %><% } %>';
 
 @Directive({
   selector: '[appTooltipTrigger]',
@@ -32,6 +32,6 @@ export class TooltipTrigger {
   });
 
   constructor() {
-    this.tooltipTrigger().tooltip.set(Tooltip);
+    this.tooltipTrigger().tooltip.set(Tooltip<%= componentSuffix %>);
   }
 }

--- a/packages/tools/src/generators/templates/templates.ts
+++ b/packages/tools/src/generators/templates/templates.ts
@@ -15,15 +15,28 @@ export async function templatesGenerator(tree: Tree) {
       continue;
     }
 
-    // read the files in the primitive folder
-    const files = tree.children(`${templatesPath}/${primitive}`);
+    // read the files in the primitive folder, skipping index.page.ts files as they are
+    // for example purposes only
+    const files = tree
+      .children(`${templatesPath}/${primitive}`)
+      .filter(file => file.endsWith('.ts') && !file.endsWith('index.page.ts'));
+
+    // Collect the component classes declared across the whole primitive first. A part
+    // that imports one of them from a sibling file has to refer to it by its suffixed
+    // name, and it cannot know that by looking at its own source alone.
+    const componentClasses = new Set<string>();
 
     for (const file of files) {
-      // skip any index.page.ts files as they are for example purposes only
-      if (file.endsWith('index.page.ts')) {
-        continue;
-      }
+      const content = tree.read(`${templatesPath}/${primitive}/${file}`, 'utf-8');
 
+      if (content) {
+        for (const className of findComponentClasses(content)) {
+          componentClasses.add(className);
+        }
+      }
+    }
+
+    for (const file of files) {
       const filePath = `${templatesPath}/${primitive}/${file}`;
 
       if (!tree.exists(filePath)) {
@@ -31,10 +44,14 @@ export async function templatesGenerator(tree: Tree) {
       }
 
       // read the file contents
-      let content = tree.read(filePath, 'utf-8');
+      const source = tree.read(filePath, 'utf-8');
+
+      if (source === null) {
+        throw new Error(`File could not be read: ${filePath}`);
+      }
 
       // process the template
-      content = processTemplate(content);
+      const content = processTemplate(source, componentClasses);
 
       // write the new file to packages/ng-primitives/schematics/ng-generate/templates
       tree.write(
@@ -54,123 +71,61 @@ export default templatesGenerator;
  * This does the following:
  * - Replace the prefix in the component selector with the <%= prefix %> placeholder
  * - Append any component class names with the <%= componentSuffix %> placeholder
- * - Replace .ts with .<%= componentSuffix %>.ts. in the import paths
+ * - Append the <%= fileSuffix %> placeholder to relative import paths, so a part still
+ *   resolves its siblings once they are generated under the consumer's own suffixes
+ * - Prefix the styles with a note about the theme variables they rely on
  */
-function processTemplate(content: string): string {
+function processTemplate(content: string, componentClasses: ReadonlySet<string>): string {
+  // Every rewrite is collected against a single parse and applied afterwards, right to
+  // left. Splicing as we go would invalidate the positions of every node we had not
+  // visited yet, and re-parsing a partially rewritten file silently matches fewer nodes.
+  const edits: Edit[] = [];
+
   // find the component selector
   const selectors = query<ts.StringLiteral>(
     content,
     'ClassDeclaration > Decorator > CallExpression ObjectLiteralExpression PropertyAssignment:has(Identifier[name="selector"]) > StringLiteral',
   );
 
-  if (!selectors) {
+  if (selectors.length === 0) {
     throw new Error('Component selector not found');
   }
 
+  // replace the prefix with the <%= prefix %> placeholder
   for (const selector of selectors) {
-    // replace the prefix with the <%= prefix %> placeholder
-    const selectorValue = selector.getText();
-
-    // determine the new selector value
-    const newSelectorValue = selectorValue.replace('app-', '<%= prefix %>-');
-
-    // replace the string exactly based on the position, not text matching
-    const start = selector.getStart();
-    const end = selector.getEnd();
-
-    content = content.substring(0, start) + newSelectorValue + content.substring(end);
+    edits.push({
+      start: selector.getStart(),
+      end: selector.getEnd(),
+      text: selector.getText().replace('app-', '<%= prefix %>-'),
+    });
   }
 
-  // replace import paths with the <%= componentSuffix %> placeholder
-  const imports = query(content, 'ImportDeclaration > StringLiteral');
-
-  for (const importPath of imports) {
-    // if the import path is not relative, skip it
-    if (!importPath.getText().startsWith('.')) {
+  // point relative imports at the sibling file's generated name
+  for (const specifier of query<ts.StringLiteral>(content, 'ImportDeclaration > StringLiteral')) {
+    // `.text` rather than `.getText()` - the latter keeps the surrounding quotes, so a
+    // relative path would never look relative
+    if (!specifier.text.startsWith('.')) {
       continue;
     }
 
-    const importValue = importPath.getText();
-    // append the <%= fileSuffix %> placeholder to the end
-    const newImportValue = importValue + '.<%= fileSuffix %>';
-
-    const start = importPath.getStart();
-    const end = importPath.getEnd();
-
-    content = content.substring(0, start) + newImportValue + content.substring(end);
+    edits.push({
+      start: specifier.getStart(),
+      end: specifier.getEnd(),
+      // the sibling file is named with the `__fileSuffix@dasherize__` placeholder, so the
+      // path has to be dasherized to match, and an absent suffix must not leave a dot
+      text: `'${specifier.text}<% if (fileSuffix) { %>.<%= dasherize(fileSuffix) %><% } %>'`,
+    });
   }
 
-  // find all class identifiers in imports from relative paths
-  const importDeclarations = query<ts.ImportDeclaration>(content, 'ImportDeclaration');
-
-  for (const importDeclaration of importDeclarations) {
-    // if this is a type import, skip it
-    if (importDeclaration.importClause?.isTypeOnly) {
-      continue;
-    }
-
-    // get the import path
-    const importPath = query(importDeclaration, 'StringLiteral')[0].getText();
-
-    // if the import path is not relative, skip it
-    if (!importPath.startsWith('.')) {
-      continue;
-    }
-
-    // get the named imports
-    const namedImports = query(importDeclaration, 'NamedImports');
-
-    if (namedImports.length === 0) {
-      continue;
-    }
-
-    // get the class identifiers - they are identifiers that are upper camel case and not type imports
-    const classIdentifiers = query<ts.Identifier>(importDeclaration, 'Identifier').filter(
-      identifier => {
-        const text = identifier.getText();
-        const isUpperCamelCase = /^[A-Z]/.test(text);
-
-        // Ensure it's not from a type-only import
-        const isTypeImport =
-          ts.isImportDeclaration(identifier.parent) && identifier.parent.importClause?.isTypeOnly;
-
-        return isUpperCamelCase && !isTypeImport;
-      },
-    );
-
-    for (const classIdentifier of classIdentifiers) {
-      // get the class name
-      const className = classIdentifier.getText();
-
-      // determine the new class name
-      const newClassName = `${className}<%= suffix %>`;
-      const start = classIdentifier.getStart();
-      const end = classIdentifier.getEnd();
-
-      content = content.substring(0, start) + newClassName + content.substring(end);
-    }
-  }
-
-  // find any Angular component class names in the file and append the <%= componentSuffix %> placeholder
-  const componentClassNames = query(
-    content,
-    'ClassDeclaration:has(Decorator > CallExpression > Identifier[name="Component"]) > Identifier',
-  );
-
-  for (const className of componentClassNames) {
-    // find all the matching identifiers in the file
-    const identifiers = query<ts.Identifier>(content, `Identifier[name="${className.getText()}"]`);
-
-    // Sort identifiers in reverse order (by start position)
-    identifiers.sort((a, b) => b.getStart() - a.getStart());
-
-    for (const identifier of identifiers) {
-      // determine the new class name
-      const newClassName = `${className.getText()}<%= componentSuffix %>`;
-      const start = identifier.getStart();
-      const end = identifier.getEnd();
-
-      content = content.substring(0, start) + newClassName + content.substring(end);
+  // append the suffix to every component class in this primitive, at its declaration and
+  // at every usage - including the files that import it from a sibling
+  for (const className of componentClasses) {
+    for (const identifier of query<ts.Identifier>(content, `Identifier[name="${className}"]`)) {
+      edits.push({
+        start: identifier.getStart(),
+        end: identifier.getEnd(),
+        text: `${className}<%= componentSuffix %>`,
+      });
     }
   }
 
@@ -184,21 +139,40 @@ function processTemplate(content: string): string {
 
   // the styles may be a no substitution template string or a string literal
   for (const style of styles) {
-    let styleValue = style.initializer.getText();
+    // strip the surrounding quotes or backticks from the raw text
+    const styleValue = style.initializer.getText().replace(/^['"`]|['"`]$/g, '');
 
-    // remove any surrounding quotes or backticks
-    styleValue = styleValue.replace(/^['"`]|['"`]$/g, '');
-
-    // determine the new style value
-    const newStyleValue = `\n/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */\n${styleValue}`;
-
-    // replace the string exactly based on the position, not text matching
-    // but we must add 1 to the start to account for the opening quote
-    const start = style.initializer.getStart() + 1;
-    const end = style.initializer.getEnd() - 1;
-
-    content = content.substring(0, start) + newStyleValue + content.substring(end);
+    edits.push({
+      // offset by one to sit inside the opening quote
+      start: style.initializer.getStart() + 1,
+      end: style.initializer.getEnd() - 1,
+      text: `\n/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */\n${styleValue}`,
+    });
   }
 
-  return content;
+  return applyEdits(content, edits);
+}
+
+/** The names of the classes in a file that Angular treats as components. */
+function findComponentClasses(content: string): string[] {
+  return query<ts.Identifier>(
+    content,
+    'ClassDeclaration:has(Decorator > CallExpression > Identifier[name="Component"]) > Identifier',
+  ).map(identifier => identifier.text);
+}
+
+interface Edit {
+  readonly start: number;
+  readonly end: number;
+  readonly text: string;
+}
+
+/** Apply edits from the end of the file backwards, so earlier offsets stay valid. */
+function applyEdits(content: string, edits: readonly Edit[]): string {
+  return [...edits]
+    .sort((a, b) => b.start - a.start)
+    .reduce(
+      (result, edit) => result.slice(0, edit.start) + edit.text + result.slice(edit.end),
+      content,
+    );
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #840 

## What does this PR implement/fix?

`ng g ng-primitives:primitive popover`, `tabs` or `tooltip` generates code that does not
compile, and `input-otp` generates code that does not parse.

### What was broken

The templates generator's guard for relative imports read the string literal with
`getText()`, which keeps the surrounding quotes, so `"'./popover'"` never looked relative
and both import transforms were permanent no-ops. The generated part therefore imported
`{ Popover } from './popover'` next to a file named `popover.component.ts` exporting
`PopoverComponent`. It only resolved if you passed both `--file-suffix ""` and
`--component-suffix ""`.

Rewriting the specifier alone was not enough. Imported symbols were renamed only inside
the import declaration, so `tabs.ts`'s `contentChildren(Tab)` kept the unsuffixed name.
Whether a symbol takes the suffix depends on the sibling declaring it as a component — a
file cannot know that from its own source — so the generator now collects the component
classes of the whole primitive before rewriting anything. `@Directive` parts such as
`PopoverTrigger` deliberately keep their name.

Rewrites are now collected against a single parse and applied right to left. The four
mutation loops used to splice while iterating nodes from a stale parse, and were correct
only because every file happens to have one class, one selector and at most one relative
import.

Separately, `processChangeDetection`'s import rewrite left a double comma on a wrapped
import list, so `input-otp` generated a file that did not parse. That fired by default,
since `OnPush` is the default.

### Why nothing caught it

Prettier reports `inferredParser: null` for `.template`, so `nx format:check` skips them,
and the schematic tests assert on strings rather than compiling anything. The 46 template
files had never been compiled by anything.

This PR adds a gate that generates every primitive in the schema and type-checks it with
`performCompilation` from `@angular/compiler-cli` under `strictTemplates` (~5s, on the
existing `test-node` target). It is what surfaced all four bugs. Parsing is asserted
separately, because `performCompilation` gives up on the first syntactic error and would
otherwise hide everything behind it.

The gate runs unconditionally in CI rather than through `nx affected`, alongside a
`git diff --exit-code` sync check:

```
$ npx nx show projects --affected --files=apps/components/.../switch/switch.ts
["components"]
$ npx nx show projects --affected --files=packages/tools/.../templates.ts
["tools"]
```

`ng-primitives` is never affected by a change to either of the two inputs its templates are
generated from, so an `affected`-driven check would never fire on the PRs that matter.

### The regenerated templates

Three change because of the fix. The other nine were stale for the same reason: nothing
regenerates them on a pull request. No consumer was affected — `nx-release-publish` depends
on `build`, which regenerates before packing, so npm has always shipped a freshly generated
copy. The second commit only makes the committed files match what is published.

### Tests and docs

`compiles.node.test.ts` is new; `index.node.test.ts` gains eight cases covering the three
multi-file primitives across suffix combinations, the dasherised file suffix, and the usage
sites. Six of them fail against the previous templates.

No documentation change: nothing user-facing is documented about how a generated part
imports its sibling.

### Not included

Found while working on this, each worth its own issue rather than widening this PR: the
`build:schematics` asset glob names `migrations.json` while the file is `migration.json`;
the selector rewrite is a literal `'app-'` replace, so `--prefix` is silently ignored for
the two camelCase attribute selectors; and four primitives have templates but are missing
from `schema.json`'s enum, two of which publish an `ng g` command in their docs page that
fails validation today.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Generated output changes for `popover`, `tabs`, `tooltip` and `input-otp`, but only from
code that did not compile to code that does. Existing generated components in consumer
projects are untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the schematics generator so all generated primitives compile and adds a CI gate to prevent regressions. Regenerates templates with ControlValueAccessor and disabled-state fixes.

- **Bug Fixes**
  - Cross-file references resolve for `popover`, `tabs`, and `tooltip`: rewrite relative import paths with an optional dasherized `<%= fileSuffix %>` and apply `<%= componentSuffix %>` to component classes and all usage sites.
  - Fixed `ChangeDetectionStrategy` import rewrite to avoid a trailing double comma that broke `input-otp`.
  - CVA and UX fixes:
    - Prevent re-emitting on `writeValue` in `checkbox`, `date-picker`, `slider`, `range-slider`, `switch`, and `pagination`.
    - Propagate form disabled state (`listbox`, `pagination`) and mark touch on `listbox` focusout.
    - `combobox`: accept `undefined` in `onChange` and clear the form value when the filter is cleared.
    - Corrected `toggle-group` input mappings.

- **Refactors**
  - Generator collects component classes across a primitive and applies all AST edits in one pass; skips example-only `index.page.ts` files.
  - Added a `test-node` gate that generates every primitive and type-checks with `@angular/compiler-cli` (`strictTemplates`); runs unconditionally in CI with a sync check (`nx run ng-primitives:build:templates` + `git diff --exit-code`).
  - Made `build:schematics:test` depend on `build:templates`.

<sup>Written for commit 98c48346c2dcb9ed11484357152b9a333d972a6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved form control synchronisation across generated primitives by suppressing duplicate change emissions during model-to-view updates (checkbox, date-picker, combobox, range-slider, slider, switch, listbox, pagination).
  - Disabled-state handling now propagates correctly where supported.
  - Fixed generated typing and imports for suffixed primitives (tabs, popover-trigger, tooltip-trigger), and corrected toggle-group input mappings.
- **Quality Improvements**
  - Added stronger validation to ensure schematic templates stay in sync and that all generated primitives compile/type-check successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->