### PR TITLE
docs: add title route metadata

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/getting-started/get-started.md
+++ b/apps/documentation/src/app/pages/(documentation)/getting-started/get-started.md
@@ -1,4 +1,5 @@
 ---
+title: Get Started | Angular Primitives
 name: Get Started
 order: 2
 icon: phosphorRocketLaunchDuotone

--- a/apps/documentation/src/app/pages/(documentation)/getting-started/introduction.md
+++ b/apps/documentation/src/app/pages/(documentation)/getting-started/introduction.md
@@ -1,4 +1,5 @@
 ---
+title: Introduction | Angular Primitives
 name: Introduction
 order: 1
 icon: phosphorBookOpenDuotone

--- a/apps/documentation/src/app/pages/(documentation)/getting-started/llms.md
+++ b/apps/documentation/src/app/pages/(documentation)/getting-started/llms.md
@@ -1,4 +1,5 @@
 ---
+title: llms.txt | Angular Primitives
 name: llms.txt
 order: 5
 icon: phosphorRobotDuotone

--- a/apps/documentation/src/app/pages/(documentation)/getting-started/mcp.md
+++ b/apps/documentation/src/app/pages/(documentation)/getting-started/mcp.md
@@ -1,4 +1,5 @@
 ---
+title: MCP | Angular Primitives
 name: MCP
 order: 6
 icon: phosphorPlugDuotone

--- a/apps/documentation/src/app/pages/(documentation)/getting-started/styling.md
+++ b/apps/documentation/src/app/pages/(documentation)/getting-started/styling.md
@@ -1,4 +1,5 @@
 ---
+title: Styling | Angular Primitives
 name: Styling
 order: 3
 icon: phosphorPaletteDuotone

--- a/apps/documentation/src/app/pages/(documentation)/getting-started/usage.md
+++ b/apps/documentation/src/app/pages/(documentation)/getting-started/usage.md
@@ -1,4 +1,5 @@
 ---
+title: Usage | Angular Primitives
 name: Usage
 order: 4
 icon: phosphorLightbulbDuotone

--- a/apps/documentation/src/app/pages/(documentation)/interactions/focus-visible.md
+++ b/apps/documentation/src/app/pages/(documentation)/interactions/focus-visible.md
@@ -1,4 +1,5 @@
 ---
+title: Focus Visible | Angular Primitives
 name: 'Focus Visible'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/interactions/src/focus-visible'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/interactions/focus.md
+++ b/apps/documentation/src/app/pages/(documentation)/interactions/focus.md
@@ -1,4 +1,5 @@
 ---
+title: Focus | Angular Primitives
 name: 'Focus'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/interactions/src/focus'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/interactions/hover.md
+++ b/apps/documentation/src/app/pages/(documentation)/interactions/hover.md
@@ -1,4 +1,5 @@
 ---
+title: Hover | Angular Primitives
 name: 'Hover'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/interactions/src/hover'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/interactions/move.md
+++ b/apps/documentation/src/app/pages/(documentation)/interactions/move.md
@@ -1,4 +1,5 @@
 ---
+title: Move | Angular Primitives
 name: 'Move'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/interactions/src/move'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/interactions/press.md
+++ b/apps/documentation/src/app/pages/(documentation)/interactions/press.md
@@ -1,4 +1,5 @@
 ---
+title: Press | Angular Primitives
 name: 'Press'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/interactions/src/press'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/accordion.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/accordion.md
@@ -1,4 +1,5 @@
 ---
+title: Accordion | Angular Primitives
 name: 'Accordion'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/accordion'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/ai-assistant.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/ai-assistant.md
@@ -1,4 +1,5 @@
 ---
+title: AI Assistant | Angular Primitives
 name: AI Assistant
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/ai-assistant'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/avatar.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/avatar.md
@@ -1,4 +1,5 @@
 ---
+title: Avatar | Angular Primitives
 name: 'Avatar'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/avatar'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/breadcrumbs.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/breadcrumbs.md
@@ -1,4 +1,5 @@
 ---
+title: Breadcrumbs | Angular Primitives
 name: 'Breadcrumbs'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/breadcrumbs'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/button.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/button.md
@@ -1,4 +1,5 @@
 ---
+title: Button | Angular Primitives
 name: 'Button'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/button'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
@@ -1,4 +1,5 @@
 ---
+title: Checkbox | Angular Primitives
 name: 'Checkbox'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/checkbox'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/collapsible.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/collapsible.md
@@ -1,4 +1,5 @@
 ---
+title: Collapsible | Angular Primitives
 name: 'Collapsible'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/collapsible'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/color-picker.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/color-picker.md
@@ -1,4 +1,5 @@
 ---
+title: Color Picker | Angular Primitives
 name: 'Color Picker'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/color'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -1,4 +1,5 @@
 ---
+title: Combobox | Angular Primitives
 name: 'Combobox'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/combobox'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/context-menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/context-menu.md
@@ -1,4 +1,5 @@
 ---
+title: Context Menu | Angular Primitives
 name: 'Context Menu'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/context-menu'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
@@ -1,4 +1,5 @@
 ---
+title: Date Picker | Angular Primitives
 name: 'Date Picker'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/date-picker'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
@@ -1,4 +1,5 @@
 ---
+title: Dialog | Angular Primitives
 name: 'Dialog'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/dialog'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
@@ -1,4 +1,5 @@
 ---
+title: File Upload | Angular Primitives
 name: 'File Upload'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/file-upload'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
@@ -1,4 +1,5 @@
 ---
+title: Form Field | Angular Primitives
 name: 'Form Field'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/form-field'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/icons.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/icons.md
@@ -1,4 +1,5 @@
 ---
+title: Icons | Angular Primitives
 name: 'Icons'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/icons'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/input-otp.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/input-otp.md
@@ -1,4 +1,5 @@
 ---
+title: Input OTP | Angular Primitives
 name: 'Input OTP'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/input-otp'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/input.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/input.md
@@ -1,4 +1,5 @@
 ---
+title: Input | Angular Primitives
 name: 'Input'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/input'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/listbox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/listbox.md
@@ -1,4 +1,5 @@
 ---
+title: Listbox | Angular Primitives
 name: 'Listbox'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/listbox'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -1,4 +1,5 @@
 ---
+title: Menu | Angular Primitives
 name: 'Menu'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/menu'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/meter.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/meter.md
@@ -1,4 +1,5 @@
 ---
+title: Meter | Angular Primitives
 name: 'Meter'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/meter'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/navigation-menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/navigation-menu.md
@@ -1,4 +1,5 @@
 ---
+title: Navigation Menu | Angular Primitives
 name: 'Navigation Menu'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/navigation-menu'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/number-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/number-field.md
@@ -1,4 +1,5 @@
 ---
+title: Number Field | Angular Primitives
 name: 'Number Field'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/number-field'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/pagination.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/pagination.md
@@ -1,4 +1,5 @@
 ---
+title: Pagination | Angular Primitives
 name: 'Pagination'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/pagination'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/password.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/password.md
@@ -1,4 +1,5 @@
 ---
+title: Password | Angular Primitives
 name: 'Password'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/password'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -1,4 +1,5 @@
 ---
+title: Popover | Angular Primitives
 name: 'Popover'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/popover'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/progress.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/progress.md
@@ -1,4 +1,5 @@
 ---
+title: Progress | Angular Primitives
 name: 'Progress'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/progress'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/radio.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/radio.md
@@ -1,4 +1,5 @@
 ---
+title: Radio | Angular Primitives
 name: 'Radio'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/radio'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/range-slider.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/range-slider.md
@@ -1,4 +1,5 @@
 ---
+title: Range Slider | Angular Primitives
 name: 'Range Slider'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/range-slider'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/rating.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/rating.md
@@ -1,4 +1,5 @@
 ---
+title: Rating | Angular Primitives
 name: 'Rating'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/rating'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/resize.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/resize.md
@@ -1,4 +1,5 @@
 ---
+title: Resize | Angular Primitives
 name: 'Resize'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/resize'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/roving-focus.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/roving-focus.md
@@ -1,4 +1,5 @@
 ---
+title: Roving Focus | Angular Primitives
 name: 'Roving Focus'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/roving-focus'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/search.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/search.md
@@ -1,4 +1,5 @@
 ---
+title: Search | Angular Primitives
 name: 'Search'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/search'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -1,4 +1,5 @@
 ---
+title: Select | Angular Primitives
 name: 'Select'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/select'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/separator.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/separator.md
@@ -1,4 +1,5 @@
 ---
+title: Separator | Angular Primitives
 name: 'Separator'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/separator'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/slider.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/slider.md
@@ -1,4 +1,5 @@
 ---
+title: Slider | Angular Primitives
 name: 'Slider'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/slider'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/switch.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/switch.md
@@ -1,4 +1,5 @@
 ---
+title: Switch | Angular Primitives
 name: 'Switch'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/switch'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/table.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/table.md
@@ -1,4 +1,5 @@
 ---
+title: Table | Angular Primitives
 name: 'Table'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/table'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tabs.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tabs.md
@@ -1,4 +1,5 @@
 ---
+title: Tabs | Angular Primitives
 name: 'Tabs'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/tabs'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/textarea.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/textarea.md
@@ -1,4 +1,5 @@
 ---
+title: Textarea | Angular Primitives
 name: 'Textarea'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/textarea'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
@@ -1,4 +1,5 @@
 ---
+title: Toast | Angular Primitives
 name: 'Toast'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/toast'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toggle-group.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toggle-group.md
@@ -1,4 +1,5 @@
 ---
+title: Toggle Group | Angular Primitives
 name: 'Toggle Group'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/toggle-group'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toggle.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toggle.md
@@ -1,4 +1,5 @@
 ---
+title: Toggle | Angular Primitives
 name: 'Toggle'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/toggle'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toolbar.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toolbar.md
@@ -1,4 +1,5 @@
 ---
+title: Toolbar | Angular Primitives
 name: 'Toolbar'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/toolbar'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -1,4 +1,5 @@
 ---
+title: Tooltip | Angular Primitives
 name: 'Tooltip'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/tooltip'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/utilities/autofill.md
+++ b/apps/documentation/src/app/pages/(documentation)/utilities/autofill.md
@@ -1,4 +1,5 @@
 ---
+title: Autofill | Angular Primitives
 name: 'Autofill'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/autofill'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/utilities/date-adapter.md
+++ b/apps/documentation/src/app/pages/(documentation)/utilities/date-adapter.md
@@ -1,4 +1,5 @@
 ---
+title: Date Adapter | Angular Primitives
 name: 'Date Adapter'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/date-adapter'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/utilities/focus-trap.md
+++ b/apps/documentation/src/app/pages/(documentation)/utilities/focus-trap.md
@@ -1,4 +1,5 @@
 ---
+title: Focus Trap | Angular Primitives
 name: 'Focus Trap'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/focus-trap'
 ---

--- a/apps/documentation/src/app/pages/(documentation)/utilities/visually-hidden.md
+++ b/apps/documentation/src/app/pages/(documentation)/utilities/visually-hidden.md
@@ -1,4 +1,5 @@
 ---
+title: Visually Hidden | Angular Primitives
 name: 'Visually Hidden'
 sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/visually-hidden'
 ---

--- a/apps/documentation/src/app/pages/index.page.ts
+++ b/apps/documentation/src/app/pages/index.page.ts
@@ -1,3 +1,4 @@
+import { RouteMeta } from '@analogjs/router';
 import { Clipboard } from '@angular/cdk/clipboard';
 import { isPlatformBrowser } from '@angular/common';
 import { Component, HostListener, inject, OnInit, PLATFORM_ID, signal } from '@angular/core';
@@ -15,6 +16,10 @@ import {
   heroUsers,
 } from '@ng-icons/heroicons/outline';
 import { ThemeToggle } from '../components/theme-toggle/theme-toggle';
+
+export const routeMeta: RouteMeta = {
+  title: 'Angular Primitives',
+};
 
 @Component({
   selector: 'docs-navbar',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Each page uses the same title "Angular Primitives", making it difficult when multiple tabs are open.

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

Add title route metadata to each page to make them distinguishable like `Get Started | Angular Primitives`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added consistent page titles across Getting Started, Interactions, Primitives and Utilities documentation.
  * Added the “Angular Primitives” title to the documentation home page.
  * Improved browser-tab titles and metadata consistency throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->