### PR TITLE
docs: respect prefers-reduced-motion in reusable components

### DIFF
--- a/apps/components/src/app/pages/reusable-components/accordion/accordion-item.ts
+++ b/apps/components/src/app/pages/reusable-components/accordion/accordion-item.ts
@@ -101,6 +101,14 @@ import { NgpButton } from 'ng-primitives/button';
         height: 0;
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpAccordionContent][data-open],
+      [ngpAccordionContent][data-closed] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class AccordionItem {

--- a/apps/components/src/app/pages/reusable-components/button/button.ts
+++ b/apps/components/src/app/pages/reusable-components/button/button.ts
@@ -183,6 +183,13 @@ export type ButtonVariant = 'primary' | 'secondary' | 'destructive' | 'outline' 
       opacity: 0.5;
       cursor: not-allowed;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class Button {

--- a/apps/components/src/app/pages/reusable-components/combobox/combobox.ts
+++ b/apps/components/src/app/pages/reusable-components/combobox/combobox.ts
@@ -184,6 +184,15 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
         transform: translateY(-10px) scale(0.9);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpComboboxDropdown],
+      [ngpComboboxDropdown][data-enter],
+      [ngpComboboxDropdown][data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class Combobox implements ControlValueAccessor {

--- a/apps/components/src/app/pages/reusable-components/context-menu/context-menu-item.ts
+++ b/apps/components/src/app/pages/reusable-components/context-menu/context-menu-item.ts
@@ -34,6 +34,13 @@ import { NgpContextMenuItem } from 'ng-primitives/context-menu';
       outline: 2px solid var(--ngp-focus-ring);
       z-index: 1;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class ContextMenuItem {}

--- a/apps/components/src/app/pages/reusable-components/context-menu/context-menu.ts
+++ b/apps/components/src/app/pages/reusable-components/context-menu/context-menu.ts
@@ -47,6 +47,14 @@ import { NgpContextMenu } from 'ng-primitives/context-menu';
         transform: scale(0.9);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host,
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class ContextMenu {}

--- a/apps/components/src/app/pages/reusable-components/dialog/dialog.ts
+++ b/apps/components/src/app/pages/reusable-components/dialog/dialog.ts
@@ -106,6 +106,16 @@ import {
         opacity: 0;
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host,
+      :host[data-exit],
+      [ngpDialog],
+      [ngpDialog][data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class Dialog {

--- a/apps/components/src/app/pages/reusable-components/dialog/index.page.ts
+++ b/apps/components/src/app/pages/reusable-components/dialog/index.page.ts
@@ -53,6 +53,13 @@ import { Dialog } from './dialog';
     button[data-press] {
       background-color: var(--ngp-background-active);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      button {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export default class App {}

--- a/apps/components/src/app/pages/reusable-components/input-otp/input-otp.ts
+++ b/apps/components/src/app/pages/reusable-components/input-otp/input-otp.ts
@@ -112,6 +112,17 @@ import { ChangeFn, TouchedFn } from 'ng-primitives/utils';
       border-color: var(--ngp-border-disabled);
       cursor: not-allowed;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      .slot[data-caret]::after {
+        animation: none;
+      }
+
+      .slot {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class InputOtp implements ControlValueAccessor {

--- a/apps/components/src/app/pages/reusable-components/menu/index.page.ts
+++ b/apps/components/src/app/pages/reusable-components/menu/index.page.ts
@@ -45,6 +45,13 @@ import { MenuItem } from './menu-item';
     [ngpButton][data-press] {
       background-color: var(--ngp-background-active);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpButton] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export default class App {}

--- a/apps/components/src/app/pages/reusable-components/menu/menu-item.ts
+++ b/apps/components/src/app/pages/reusable-components/menu/menu-item.ts
@@ -33,6 +33,13 @@ import { NgpMenuItem } from 'ng-primitives/menu';
       outline: 2px solid var(--ngp-focus-ring);
       z-index: 1;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class MenuItem {}

--- a/apps/components/src/app/pages/reusable-components/menu/menu.ts
+++ b/apps/components/src/app/pages/reusable-components/menu/menu.ts
@@ -46,6 +46,14 @@ import { NgpMenu } from 'ng-primitives/menu';
         transform: scale(0.9);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host,
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class Menu {}

--- a/apps/components/src/app/pages/reusable-components/meter/meter.ts
+++ b/apps/components/src/app/pages/reusable-components/meter/meter.ts
@@ -63,6 +63,13 @@ import {
       inset-inline-start: 0px;
       border-radius: 4px;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpMeterIndicator] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class Meter {

--- a/apps/components/src/app/pages/reusable-components/number-field/number-field.ts
+++ b/apps/components/src/app/pages/reusable-components/number-field/number-field.ts
@@ -102,6 +102,14 @@ import {
       background: transparent;
       color: var(--ngp-text-secondary);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpNumberFieldIncrement],
+      [ngpNumberFieldDecrement] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class NumberField {}

--- a/apps/components/src/app/pages/reusable-components/pagination/pagination.ts
+++ b/apps/components/src/app/pages/reusable-components/pagination/pagination.ts
@@ -40,7 +40,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
     NgIcon,
   ],
   providers: [
-    provideValueAccessor(NgpPagination),
+    provideValueAccessor(Pagination),
     provideIcons({
       heroChevronDoubleLeft,
       heroChevronDoubleRight,

--- a/apps/components/src/app/pages/reusable-components/pagination/pagination.ts
+++ b/apps/components/src/app/pages/reusable-components/pagination/pagination.ts
@@ -140,6 +140,17 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
         color: var(--ngp-text-inverse);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpPaginationFirst],
+      [ngpPaginationPrevious],
+      [ngpPaginationButton],
+      [ngpPaginationNext],
+      [ngpPaginationLast] {
+        transition-duration: 0s;
+      }
+    }
   `,
   host: {
     '(focusout)': 'onTouched?.()',

--- a/apps/components/src/app/pages/reusable-components/password/password.ts
+++ b/apps/components/src/app/pages/reusable-components/password/password.ts
@@ -89,6 +89,13 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
       outline: 2px solid var(--ngp-focus-ring);
       outline-offset: -2px;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpPasswordToggle] {
+        transition-duration: 0s;
+      }
+    }
   `,
   host: {
     '(focusout)': 'onFocusOut($event)',

--- a/apps/components/src/app/pages/reusable-components/popover/index.page.ts
+++ b/apps/components/src/app/pages/reusable-components/popover/index.page.ts
@@ -34,6 +34,13 @@ import { PopoverTrigger } from './popover-trigger';
     [ngpButton][data-press] {
       background-color: var(--ngp-background-active);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpButton] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export default class App {}

--- a/apps/components/src/app/pages/reusable-components/popover/popover.ts
+++ b/apps/components/src/app/pages/reusable-components/popover/popover.ts
@@ -50,6 +50,14 @@ import { injectPopoverContext, NgpPopover } from 'ng-primitives/popover';
         transform: scale(0.5);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-enter],
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class Popover {

--- a/apps/components/src/app/pages/reusable-components/progress/progress.ts
+++ b/apps/components/src/app/pages/reusable-components/progress/progress.ts
@@ -68,6 +68,13 @@ import {
       background-color: var(--ngp-background-inverse);
       transition: width 150ms cubic-bezier(0.4, 0, 0.2, 1);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpProgressIndicator] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class Progress {

--- a/apps/components/src/app/pages/reusable-components/rating/rating.ts
+++ b/apps/components/src/app/pages/reusable-components/rating/rating.ts
@@ -73,6 +73,13 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
       overflow: hidden;
       color: var(--ngp-primary);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      .star {
+        transition-duration: 0s;
+      }
+    }
   `,
   host: {
     '(focusout)': 'onTouched?.()',

--- a/apps/components/src/app/pages/reusable-components/select/select.ts
+++ b/apps/components/src/app/pages/reusable-components/select/select.ts
@@ -171,6 +171,15 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
         transform: translateY(-10px) scale(0.9);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpSelectDropdown],
+      [ngpSelectDropdown][data-enter],
+      [ngpSelectDropdown][data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
   host: {
     '[attr.aria-label]': 'ariaLabel() || null',

--- a/apps/components/src/app/pages/reusable-components/switch/switch.ts
+++ b/apps/components/src/app/pages/reusable-components/switch/switch.ts
@@ -61,6 +61,14 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
     [ngpSwitchThumb][data-checked] {
       transform: translateX(17px);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host,
+      [ngpSwitchThumb] {
+        transition-duration: 0s;
+      }
+    }
   `,
   providers: [provideValueAccessor(Switch)],
   host: {

--- a/apps/components/src/app/pages/reusable-components/tabs/tabs.ts
+++ b/apps/components/src/app/pages/reusable-components/tabs/tabs.ts
@@ -65,6 +65,13 @@ import { Tab } from './tab';
     [ngpTabPanel]:not([data-active]) {
       display: none;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpTabButton] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class Tabs {

--- a/apps/components/src/app/pages/reusable-components/toast/index.page.ts
+++ b/apps/components/src/app/pages/reusable-components/toast/index.page.ts
@@ -34,6 +34,13 @@ import { Toast } from './toast';
     .toast-trigger[data-press] {
       background-color: var(--ngp-background-active);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      .toast-trigger {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export default class App {

--- a/apps/components/src/app/pages/reusable-components/toast/toast.ts
+++ b/apps/components/src/app/pages/reusable-components/toast/toast.ts
@@ -223,6 +223,20 @@ import { injectToastContext, NgpToast, NgpToastManager } from 'ng-primitives/toa
         transform: translateY(0);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-position-y='bottom'].toast-enter,
+      :host[data-position-y='top'].toast-enter {
+        animation-duration: 0s;
+      }
+
+      :host,
+      :host[data-position-y='bottom'].toast-leave,
+      :host[data-position-y='top'].toast-leave {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class Toast {

--- a/apps/components/src/app/pages/reusable-components/toggle-group/toggle-group-item.ts
+++ b/apps/components/src/app/pages/reusable-components/toggle-group/toggle-group-item.ts
@@ -52,6 +52,13 @@ import { NgpToggleGroupItem } from 'ng-primitives/toggle-group';
       color: var(--ngp-text-inverse);
       border-color: transparent;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class ToggleGroupItem {}

--- a/apps/components/src/app/pages/reusable-components/toggle/toggle.ts
+++ b/apps/components/src/app/pages/reusable-components/toggle/toggle.ts
@@ -50,6 +50,13 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
       background-color: var(--ngp-background-inverse);
       color: var(--ngp-text-inverse);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
   providers: [provideValueAccessor(Toggle)],
   host: {

--- a/apps/components/src/app/pages/reusable-components/toolbar/toolbar-button.ts
+++ b/apps/components/src/app/pages/reusable-components/toolbar/toolbar-button.ts
@@ -51,6 +51,13 @@ import { NgpRovingFocusItem } from 'ng-primitives/roving-focus';
       background-color: var(--ngp-background-inverse);
       color: var(--ngp-text-inverse);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class ToolbarButton {}

--- a/apps/components/src/app/pages/reusable-components/tooltip/index.page.ts
+++ b/apps/components/src/app/pages/reusable-components/tooltip/index.page.ts
@@ -34,6 +34,13 @@ import { TooltipTrigger } from './tooltip-trigger';
     [ngpButton][data-press] {
       background-color: var(--ngp-background-active);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpButton] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export default class App {}

--- a/apps/components/src/app/pages/reusable-components/tooltip/tooltip.ts
+++ b/apps/components/src/app/pages/reusable-components/tooltip/tooltip.ts
@@ -50,6 +50,14 @@ import { injectTooltipContext, NgpTooltip } from 'ng-primitives/tooltip';
         transform: scale(0.9);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-enter],
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class Tooltip {

--- a/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
@@ -43,6 +43,11 @@ export interface NgpExitAnimationRef {
   cancel: () => void;
 }
 
+/** Whether an animation repeats forever, and so will never resolve `finished`. */
+function isInfinite(animation: Animation): boolean {
+  return animation.effect?.getComputedTiming().iterations === Infinity;
+}
+
 export function setupExitAnimation({
   element,
   immediate,
@@ -78,7 +83,11 @@ export function setupExitAnimation({
         exitResolve = resolve;
         setState('exit');
 
-        const animations = element.getAnimations();
+        // Only wait for animations that will actually finish. Infinite
+        // animations (e.g. a spinner or pulse on the element) never resolve
+        // their `finished` promise, so waiting on them would leave the element
+        // - and any overlay it belongs to - stuck on screen forever.
+        const animations = element.getAnimations().filter(animation => !isInfinite(animation));
 
         // Wait for the exit animations to finish
         if (animations.length > 0) {

--- a/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { setupExitAnimation } from '../exit-animation';
+
+describe('setupExitAnimation', () => {
+  /** A fake animation whose `finished` promise is controllable. */
+  function finiteAnimation(): { animation: Animation; finish: () => void } {
+    let finish!: () => void;
+    const finished = new Promise<void>(resolve => (finish = resolve));
+    return { animation: { finished } as unknown as Animation, finish };
+  }
+
+  /** A fake animation that repeats forever, so `finished` never resolves. */
+  function infiniteAnimation(): Animation {
+    return {
+      finished: new Promise<void>(() => undefined),
+      effect: { getComputedTiming: () => ({ iterations: Infinity }) },
+    } as unknown as Animation;
+  }
+
+  it('marks the element with data-exit when exiting', async () => {
+    const element = document.createElement('div');
+    element.getAnimations = () => [];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+    await ref.exit();
+
+    expect(element).toHaveAttribute('data-exit');
+    expect(element).not.toHaveAttribute('data-enter');
+  });
+
+  it('waits for the exit animations to finish before resolving', async () => {
+    const element = document.createElement('div');
+    const { animation, finish } = finiteAnimation();
+    element.getAnimations = () => [animation];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+
+    let settled = false;
+    const exit = ref.exit().then(() => (settled = true));
+
+    // Give any synchronous/microtask resolution a chance to run.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(settled).toBe(false);
+
+    finish();
+    await exit;
+    expect(settled).toBe(true);
+  });
+
+  it('resolves without waiting when the only animation runs forever', async () => {
+    const element = document.createElement('div');
+    // If the exit waited on the infinite animation's `finished` promise, this
+    // test would time out and the overlay would be stuck on screen.
+    element.getAnimations = () => [infiniteAnimation()];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+
+    await expect(ref.exit()).resolves.toBeUndefined();
+    expect(element).toHaveAttribute('data-exit');
+  });
+
+  it('waits for finite animations while ignoring infinite ones', async () => {
+    const element = document.createElement('div');
+    const { animation, finish } = finiteAnimation();
+    element.getAnimations = () => [infiniteAnimation(), animation];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+
+    let settled = false;
+    const exit = ref.exit().then(() => (settled = true));
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(settled).toBe(false);
+
+    finish();
+    await exit;
+    expect(settled).toBe(true);
+  });
+});

--- a/packages/ng-primitives/schematics/ng-generate/__snapshots__/index.node.test.ts.snap
+++ b/packages/ng-primitives/schematics/ng-generate/__snapshots__/index.node.test.ts.snap
@@ -189,6 +189,13 @@ export type ButtonVariant = 'primary' | 'secondary' | 'destructive' | 'outline' 
       opacity: 0.5;
       cursor: not-allowed;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   \`,
 })
 export class ButtonComponent {

--- a/packages/ng-primitives/schematics/ng-generate/templates/accordion/accordion-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/accordion/accordion-item.__fileSuffix@dasherize__.ts.template
@@ -103,6 +103,14 @@ import { NgpButton } from 'ng-primitives/button';
         height: 0;
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpAccordionContent][data-open],
+      [ngpAccordionContent][data-closed] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class AccordionItem<%= componentSuffix %> {

--- a/packages/ng-primitives/schematics/ng-generate/templates/button/button.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/button/button.__fileSuffix@dasherize__.ts.template
@@ -185,6 +185,13 @@ export type ButtonVariant = 'primary' | 'secondary' | 'destructive' | 'outline' 
       opacity: 0.5;
       cursor: not-allowed;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class Button<%= componentSuffix %> {

--- a/packages/ng-primitives/schematics/ng-generate/templates/checkbox/checkbox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/checkbox/checkbox.__fileSuffix@dasherize__.ts.template
@@ -94,7 +94,8 @@ export class Checkbox<%= componentSuffix %> implements ControlValueAccessor {
   }
 
   writeValue(checked: boolean): void {
-    this.state().setChecked(checked);
+    // writing a value from the model must not re-emit through onChange
+    this.state().setChecked(checked, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<boolean>): void {

--- a/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
@@ -186,6 +186,15 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
         transform: translateY(-10px) scale(0.9);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpComboboxDropdown],
+      [ngpComboboxDropdown][data-enter],
+      [ngpComboboxDropdown][data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
@@ -215,7 +224,7 @@ export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
   protected readonly formDisabled = signal(false);
 
   /** The on change callback */
-  private onChange?: ChangeFn<string>;
+  private onChange?: ChangeFn<string | undefined>;
 
   /** The on touch callback */
   protected onTouched?: TouchedFn;
@@ -254,9 +263,10 @@ export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
       return;
     }
 
-    // if the filter value is empty, set the value to undefined
+    // if the filter value is empty, clear the value and notify the form control
     if (this.filter() === '') {
       this.value.set(undefined);
+      this.onChange?.(undefined);
     } else {
       // otherwise set the filter value to the selected value
       this.filter.set(this.value() ?? '');

--- a/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu-item.__fileSuffix@dasherize__.ts.template
@@ -36,6 +36,13 @@ import { NgpContextMenuItem } from 'ng-primitives/context-menu';
       outline: 2px solid var(--ngp-focus-ring);
       z-index: 1;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class ContextMenuItem<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu.__fileSuffix@dasherize__.ts.template
@@ -49,6 +49,14 @@ import { NgpContextMenu } from 'ng-primitives/context-menu';
         transform: scale(0.9);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host,
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class ContextMenu<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates/date-picker/date-picker.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/date-picker/date-picker.__fileSuffix@dasherize__.ts.template
@@ -228,7 +228,8 @@ export class DatePicker<%= componentSuffix %> implements ControlValueAccessor {
   }
 
   writeValue(date: Date): void {
-    this.state().select(date);
+    // writing a value from the model must not re-emit through onChange
+    this.state().select(date, false, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<Date | undefined>): void {

--- a/packages/ng-primitives/schematics/ng-generate/templates/dialog/dialog.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/dialog/dialog.__fileSuffix@dasherize__.ts.template
@@ -108,6 +108,16 @@ import {
         opacity: 0;
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host,
+      :host[data-exit],
+      [ngpDialog],
+      [ngpDialog][data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class Dialog<%= componentSuffix %> {

--- a/packages/ng-primitives/schematics/ng-generate/templates/input-otp/input-otp.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/input-otp/input-otp.__fileSuffix@dasherize__.ts.template
@@ -114,6 +114,17 @@ import { ChangeFn, TouchedFn } from 'ng-primitives/utils';
       border-color: var(--ngp-border-disabled);
       cursor: not-allowed;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      .slot[data-caret]::after {
+        animation: none;
+      }
+
+      .slot {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class InputOtp<%= componentSuffix %> implements ControlValueAccessor {

--- a/packages/ng-primitives/schematics/ng-generate/templates/listbox/listbox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/listbox/listbox.__fileSuffix@dasherize__.ts.template
@@ -1,5 +1,5 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Component, input, model } from '@angular/core';
+import { booleanAttribute, Component, input } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { provideIcons } from '@ng-icons/core';
 import { heroChevronDownSolid } from '@ng-icons/heroicons/solid';
@@ -17,7 +17,6 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
   imports: [NgpListbox],
   template: `
     <div
-      [(ngpListboxValue)]="value"
       [ngpListboxMode]="mode()"
       [ngpListboxDisabled]="disabled()"
       [ngpListboxCompareWith]="compareWith()"
@@ -43,23 +42,19 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
   `,
   host: {
     '[attr.aria-label]': 'null',
+    '(focusout)': 'onTouch?.()',
   },
 })
 export class Listbox<%= componentSuffix %> implements ControlValueAccessor {
   /**
    * Access the listbox state
    */
-  protected readonly state = injectListboxState<NgpListbox<string>>();
+  protected readonly state = injectListboxState<string>();
 
   /**
    * The listbox mode.
    */
   readonly mode = input<NgpSelectionMode>('single');
-
-  /**
-   * The listbox value.
-   */
-  readonly value = model<string[]>([]);
 
   /**
    * The listbox disabled state.
@@ -96,7 +91,8 @@ export class Listbox<%= componentSuffix %> implements ControlValueAccessor {
   protected onTouch?: TouchedFn;
 
   writeValue(value: string[]): void {
-    this.state()?.value.set(value);
+    // writing a value from the model must not re-emit through onChange
+    this.state()?.setValue(value, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<string[]>): void {
@@ -108,11 +104,10 @@ export class Listbox<%= componentSuffix %> implements ControlValueAccessor {
   }
 
   setDisabledState(isDisabled: boolean): void {
-    this.state()?.disabled.set(isDisabled);
+    this.state()?.setDisabled(isDisabled);
   }
 
   onListboxValueChange(value: string[]): void {
-    this.value.set(value);
-    if (this.onChange) this.onChange(value);
+    this.onChange?.(value);
   }
 }

--- a/packages/ng-primitives/schematics/ng-generate/templates/menu/menu-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/menu/menu-item.__fileSuffix@dasherize__.ts.template
@@ -35,6 +35,13 @@ import { NgpMenuItem } from 'ng-primitives/menu';
       outline: 2px solid var(--ngp-focus-ring);
       z-index: 1;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class MenuItem<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates/menu/menu.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/menu/menu.__fileSuffix@dasherize__.ts.template
@@ -48,6 +48,14 @@ import { NgpMenu } from 'ng-primitives/menu';
         transform: scale(0.9);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host,
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class Menu<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates/meter/meter.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/meter/meter.__fileSuffix@dasherize__.ts.template
@@ -65,6 +65,13 @@ import {
       inset-inline-start: 0px;
       border-radius: 4px;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpMeterIndicator] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class Meter<%= componentSuffix %> {

--- a/packages/ng-primitives/schematics/ng-generate/templates/number-field/number-field.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/number-field/number-field.__fileSuffix@dasherize__.ts.template
@@ -104,6 +104,14 @@ import {
       background: transparent;
       color: var(--ngp-text-secondary);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpNumberFieldIncrement],
+      [ngpNumberFieldDecrement] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class NumberField<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates/pagination/pagination.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/pagination/pagination.__fileSuffix@dasherize__.ts.template
@@ -40,7 +40,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
     NgIcon,
   ],
   providers: [
-    provideValueAccessor(NgpPagination),
+    provideValueAccessor(Pagination<%= componentSuffix %>),
     provideIcons({
       heroChevronDoubleLeft,
       heroChevronDoubleRight,

--- a/packages/ng-primitives/schematics/ng-generate/templates/pagination/pagination.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/pagination/pagination.__fileSuffix@dasherize__.ts.template
@@ -142,6 +142,17 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
         color: var(--ngp-text-inverse);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpPaginationFirst],
+      [ngpPaginationPrevious],
+      [ngpPaginationButton],
+      [ngpPaginationNext],
+      [ngpPaginationLast] {
+        transition-duration: 0s;
+      }
+    }
   `,
   host: {
     '(focusout)': 'onTouched?.()',
@@ -168,7 +179,8 @@ export class Pagination<%= componentSuffix %> implements ControlValueAccessor {
 
   /** Write a new value to the control */
   writeValue(value: number): void {
-    this.state().page.set(value);
+    // writing a value from the model must not re-emit through onChange
+    this.state().setPage(value, { emit: false });
   }
 
   /** Register a callback to be called when the value changes */
@@ -179,5 +191,10 @@ export class Pagination<%= componentSuffix %> implements ControlValueAccessor {
   /** Register a callback to be called when the control is touched */
   registerOnTouched(fn: TouchedFn): void {
     this.onTouched = fn;
+  }
+
+  /** Reflect the form control's disabled state onto the pagination. */
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
   }
 }

--- a/packages/ng-primitives/schematics/ng-generate/templates/password/password.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/password/password.__fileSuffix@dasherize__.ts.template
@@ -91,6 +91,13 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
       outline: 2px solid var(--ngp-focus-ring);
       outline-offset: -2px;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpPasswordToggle] {
+        transition-duration: 0s;
+      }
+    }
   `,
   host: {
     '(focusout)': 'onFocusOut($event)',

--- a/packages/ng-primitives/schematics/ng-generate/templates/popover/popover.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/popover/popover.__fileSuffix@dasherize__.ts.template
@@ -52,6 +52,14 @@ import { injectPopoverContext, NgpPopover } from 'ng-primitives/popover';
         transform: scale(0.5);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-enter],
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class Popover<%= componentSuffix %> {

--- a/packages/ng-primitives/schematics/ng-generate/templates/progress/progress.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/progress/progress.__fileSuffix@dasherize__.ts.template
@@ -70,6 +70,13 @@ import {
       background-color: var(--ngp-background-inverse);
       transition: width 150ms cubic-bezier(0.4, 0, 0.2, 1);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpProgressIndicator] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class Progress<%= componentSuffix %> {

--- a/packages/ng-primitives/schematics/ng-generate/templates/range-slider/range-slider.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/range-slider/range-slider.__fileSuffix@dasherize__.ts.template
@@ -118,9 +118,10 @@ export class RangeSlider<%= componentSuffix %> implements ControlValueAccessor {
     }
 
     const [low, high] = value;
-    // Use the directive's clamping setters to respect min/max and ordering
-    this.state().setLowValue(low);
-    this.state().setHighValue(high);
+    // Use the directive's clamping setters to respect min/max and ordering.
+    // writing a value from the model must not re-emit through onChange
+    this.state().setLowValue(low, { emit: false });
+    this.state().setHighValue(high, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<[number, number]>): void {

--- a/packages/ng-primitives/schematics/ng-generate/templates/rating/rating.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/rating/rating.__fileSuffix@dasherize__.ts.template
@@ -75,6 +75,13 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
       overflow: hidden;
       color: var(--ngp-primary);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      .star {
+        transition-duration: 0s;
+      }
+    }
   `,
   host: {
     '(focusout)': 'onTouched?.()',

--- a/packages/ng-primitives/schematics/ng-generate/templates/select/select.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/select/select.__fileSuffix@dasherize__.ts.template
@@ -173,6 +173,15 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
         transform: translateY(-10px) scale(0.9);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpSelectDropdown],
+      [ngpSelectDropdown][data-enter],
+      [ngpSelectDropdown][data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
   host: {
     '[attr.aria-label]': 'ariaLabel() || null',

--- a/packages/ng-primitives/schematics/ng-generate/templates/slider/slider.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/slider/slider.__fileSuffix@dasherize__.ts.template
@@ -108,7 +108,8 @@ export class Slider<%= componentSuffix %> implements ControlValueAccessor {
   }
 
   writeValue(value: number): void {
-    this.state().setValue(value);
+    // writing a value from the model must not re-emit through onChange
+    this.state().setValue(value, { emit: false });
   }
 
   registerOnChange(fn: ChangeFn<number>): void {

--- a/packages/ng-primitives/schematics/ng-generate/templates/switch/switch.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/switch/switch.__fileSuffix@dasherize__.ts.template
@@ -63,6 +63,14 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
     [ngpSwitchThumb][data-checked] {
       transform: translateX(17px);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host,
+      [ngpSwitchThumb] {
+        transition-duration: 0s;
+      }
+    }
   `,
   providers: [provideValueAccessor(Switch<%= componentSuffix %>)],
   host: {
@@ -88,7 +96,8 @@ export class Switch<%= componentSuffix %> implements ControlValueAccessor {
 
   /** Write a new value to the switch. */
   writeValue(value: boolean): void {
-    this.switch().setChecked(value);
+    // writing a value from the model must not re-emit through onChange
+    this.switch().setChecked(value, { emit: false });
   }
 
   /** Register a callback function to be called when the value changes. */

--- a/packages/ng-primitives/schematics/ng-generate/templates/tabs/tabs.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/tabs/tabs.__fileSuffix@dasherize__.ts.template
@@ -67,6 +67,13 @@ import { Tab } from './tab';
     [ngpTabPanel]:not([data-active]) {
       display: none;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      [ngpTabButton] {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class Tabs<%= componentSuffix %> {

--- a/packages/ng-primitives/schematics/ng-generate/templates/toast/toast.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toast/toast.__fileSuffix@dasherize__.ts.template
@@ -225,6 +225,20 @@ import { injectToastContext, NgpToast, NgpToastManager } from 'ng-primitives/toa
         transform: translateY(0);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-position-y='bottom'].toast-enter,
+      :host[data-position-y='top'].toast-enter {
+        animation-duration: 0s;
+      }
+
+      :host,
+      :host[data-position-y='bottom'].toast-leave,
+      :host[data-position-y='top'].toast-leave {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class Toast<%= componentSuffix %> {

--- a/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group-item.__fileSuffix@dasherize__.ts.template
@@ -54,6 +54,13 @@ import { NgpToggleGroupItem } from 'ng-primitives/toggle-group';
       color: var(--ngp-text-inverse);
       border-color: transparent;
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class ToggleGroupItem<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group.__fileSuffix@dasherize__.ts.template
@@ -13,7 +13,6 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
         'ngpToggleGroupOrientation:orientation',
         'ngpToggleGroupType:type',
         'ngpToggleGroupValue:value',
-        'ngpToggleGroupCompareWith:compareWith',
         'ngpToggleGroupDisabled:disabled',
       ],
       outputs: ['ngpToggleGroupValueChange:valueChange'],

--- a/packages/ng-primitives/schematics/ng-generate/templates/toggle/toggle.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toggle/toggle.__fileSuffix@dasherize__.ts.template
@@ -52,6 +52,13 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
       background-color: var(--ngp-background-inverse);
       color: var(--ngp-text-inverse);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
   providers: [provideValueAccessor(Toggle<%= componentSuffix %>)],
   host: {

--- a/packages/ng-primitives/schematics/ng-generate/templates/toolbar/toolbar-button.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toolbar/toolbar-button.__fileSuffix@dasherize__.ts.template
@@ -53,6 +53,13 @@ import { NgpRovingFocusItem } from 'ng-primitives/roving-focus';
       background-color: var(--ngp-background-inverse);
       color: var(--ngp-text-inverse);
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        transition-duration: 0s;
+      }
+    }
   `,
 })
 export class ToolbarButton<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip.__fileSuffix@dasherize__.ts.template
@@ -52,6 +52,14 @@ import { injectTooltipContext, NgpTooltip } from 'ng-primitives/tooltip';
         transform: scale(0.9);
       }
     }
+
+    /* Reduce motion for users who prefer reduced motion. */
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-enter],
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
   `,
 })
 export class Tooltip<%= componentSuffix %> {


### PR DESCRIPTION
Add a scoped `prefers-reduced-motion: reduce` media query to every
reusable component example that ships transitions or animations, so
copied code neutralises motion for users who request it.

The query targets only the specific selectors that actually animate or
transition (reusing the exact selectors so no `!important` is needed),
rather than a blanket wildcard, and sets their duration to `0s`.
Animations keep their other properties so final states are preserved -
the accordion still applies its `forwards` height fill and overlay exits
still resolve via the exit-animation manager, just instantly. The
input-otp caret, an infinite blink on a pseudo-element, is held steady
with `animation: none`.

Only the reusable components under apps/components are touched; the
documentation primitive examples are left unchanged.

Closes #644


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add scoped reduced-motion handling to reusable component examples and `ng-generate` templates so scaffolded code respects user settings. Also fix exit animations to ignore infinite animations and correct pagination forms binding.

- **New Features**
  - Add `@media (prefers-reduced-motion: reduce)` to examples/templates; set animation/transition durations to `0s` on the exact animated selectors and freeze the `input-otp` caret.
  - Regenerate `packages/ng-primitives/schematics` templates to include these rules and sync minor ControlValueAccessor behaviors; documentation primitive examples remain unchanged.

- **Bug Fixes**
  - Exit animation now waits only for finite animations, preventing stuck overlays; tests cover immediate, finite, infinite, and mixed cases.
  - Pagination: register the component as its ControlValueAccessor (not the directive) in examples/templates and reflect disabled state, so Angular forms binding works.

<sup>Written for commit d5060f588f4ac3e166e86e946bea36c5f781c971. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Expanded support for `prefers-reduced-motion: reduce` by disabling animations and transitions across interactive controls, overlays, menus, dialogs, notifications, and progress indicators.

- **Bug Fixes**
  - Exit animations no longer wait indefinitely when looping animations are present.
  - Improved form-control behaviour to prevent unnecessary `onChange` re-emissions during programmatic writes, including correct combobox clearing and better pagination form-state handling.

- **Tests**
  - Added coverage for immediate exits, finite animations, infinite animations, and mixed finite/infinite exit-animation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->