### PR TITLE
fix(dialog,toast): preserve caller injector for portal-rendered content

### DIFF
--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger-state.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Signal, TemplateRef, inject, signal } from '@angular/core';
+import { DestroyRef, Injector, Signal, TemplateRef, inject, signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
 import { NgpDismissGuard } from 'ng-primitives/portal';
 import { createPrimitive, emitter, listener, StateInjectionOptions } from 'ng-primitives/state';
@@ -55,6 +55,12 @@ export const [
     const elementRef = injectElementRef();
     const dialogManager = inject(NgpDialogManager);
     const destroyRef = inject(DestroyRef);
+    // Capture the trigger's own injector so the dialog content resolves DI from the
+    // component subtree that declared the template, rather than the root injector.
+    // Without this a DI-dependent pipe/directive inside the dialog template (e.g. a
+    // translate pipe backed by a component-scoped provider) resolves from the root
+    // injector. See https://github.com/ng-primitives/ng-primitives/issues/823.
+    const injector = inject(Injector);
 
     const closed = emitter<T>();
 
@@ -63,6 +69,7 @@ export const [
 
     function handleClick(): void {
       const dialogRef = dialogManager.open(template(), {
+        injector,
         closeOnEscape: closeOnEscape(),
         closeOnOutsideClick: closeOnOutsideClick(),
       });

--- a/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/dialog-trigger-state.ts
@@ -55,11 +55,8 @@ export const [
     const elementRef = injectElementRef();
     const dialogManager = inject(NgpDialogManager);
     const destroyRef = inject(DestroyRef);
-    // Capture the trigger's own injector so the dialog content resolves DI from the
-    // component subtree that declared the template, rather than the root injector.
-    // Without this a DI-dependent pipe/directive inside the dialog template (e.g. a
-    // translate pipe backed by a component-scoped provider) resolves from the root
-    // injector. See https://github.com/ng-primitives/ng-primitives/issues/823.
+    // Pass the trigger's injector so dialog content resolves DI from the component
+    // subtree, not the root injector. See #823.
     const injector = inject(Injector);
 
     const closed = emitter<T>();

--- a/packages/ng-primitives/dialog/src/dialog-trigger/tests/dialog-trigger-injector.test.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/tests/dialog-trigger-injector.test.ts
@@ -1,0 +1,100 @@
+import {
+  ApplicationRef,
+  Component,
+  Directive,
+  ElementRef,
+  EnvironmentInjector,
+  InjectionToken,
+  createComponent,
+  createEnvironmentInjector,
+  inject,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  NgpDialog,
+  NgpDialogManager,
+  NgpDialogOverlay,
+  NgpDialogTrigger,
+} from 'ng-primitives/dialog';
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
+ * A token that is only provided in a child environment injector (never at the
+ * application root), mirroring the micro-frontend / `provideChildTranslateService()`
+ * scenario from https://github.com/ng-primitives/ng-primitives/issues/823.
+ */
+const MESSAGE = new InjectionToken<string>('MESSAGE');
+
+/** Reads the token from DI and renders it, so we can assert which injector resolved it. */
+@Directive({ selector: '[readMessage]' })
+class ReadMessage {
+  constructor() {
+    const element = inject(ElementRef).nativeElement as HTMLElement;
+    element.textContent = inject(MESSAGE);
+  }
+}
+
+@Component({
+  selector: 'ngp-dialog-injector-host',
+  template: `
+    <button [ngpDialogTrigger]="dialog" data-testid="trigger">Open</button>
+
+    <ng-template #dialog>
+      <div ngpDialogOverlay>
+        <div ngpDialog>
+          <span readMessage data-testid="message"></span>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpDialogTrigger, NgpDialog, NgpDialogOverlay, ReadMessage],
+})
+class DialogInjectorHost {}
+
+describe('NgpDialogTrigger injector context', () => {
+  let dialogManager: NgpDialogManager | undefined;
+
+  afterEach(async () => {
+    dialogManager?.closeAll();
+    await Promise.resolve();
+    await Promise.resolve();
+    dialogManager = undefined;
+  });
+
+  it('resolves DI-dependent content from the trigger component injector, not the root injector', async () => {
+    const appRef = TestBed.inject(ApplicationRef);
+    dialogManager = TestBed.inject(NgpDialogManager);
+
+    // Create a child environment injector that provides MESSAGE. The root injector
+    // deliberately does NOT provide it, so if the dialog resolves from the root
+    // injector the content directive will throw NullInjectorError.
+    const parentEnvironmentInjector = TestBed.inject(EnvironmentInjector);
+    const childEnvironmentInjector = createEnvironmentInjector(
+      [{ provide: MESSAGE, useValue: 'child-injector-message' }],
+      parentEnvironmentInjector,
+    );
+
+    // Mount the host component within the child environment injector, emulating a
+    // remote/lazy component subtree that owns its own providers.
+    const hostElement = document.createElement('div');
+    document.body.appendChild(hostElement);
+
+    const componentRef = createComponent(DialogInjectorHost, {
+      environmentInjector: childEnvironmentInjector,
+      hostElement,
+    });
+    appRef.attachView(componentRef.hostView);
+    componentRef.changeDetectorRef.detectChanges();
+
+    const trigger = hostElement.querySelector('[data-testid="trigger"]') as HTMLElement;
+    trigger.click();
+    await Promise.resolve();
+
+    const message = document.querySelector('[data-testid="message"]');
+    expect(message?.textContent).toBe('child-injector-message');
+
+    componentRef.destroy();
+    hostElement.remove();
+    childEnvironmentInjector.destroy();
+  });
+});

--- a/packages/ng-primitives/dialog/src/dialog-trigger/tests/dialog-trigger-injector.test.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/tests/dialog-trigger-injector.test.ts
@@ -18,14 +18,11 @@ import {
 } from 'ng-primitives/dialog';
 import { afterEach, describe, expect, it } from 'vitest';
 
-/**
- * A token that is only provided in a child environment injector (never at the
- * application root), mirroring the micro-frontend / `provideChildTranslateService()`
- * scenario from https://github.com/ng-primitives/ng-primitives/issues/823.
- */
+// Provided only in a child environment injector (never at root), mirroring a
+// component-scoped provider in a micro-frontend subtree. See #823.
 const MESSAGE = new InjectionToken<string>('MESSAGE');
 
-/** Reads the token from DI and renders it, so we can assert which injector resolved it. */
+/** Renders the resolved token so we can assert which injector served it. */
 @Directive({ selector: '[readMessage]' })
 class ReadMessage {
   constructor() {
@@ -65,17 +62,14 @@ describe('NgpDialogTrigger injector context', () => {
     const appRef = TestBed.inject(ApplicationRef);
     dialogManager = TestBed.inject(NgpDialogManager);
 
-    // Create a child environment injector that provides MESSAGE. The root injector
-    // deliberately does NOT provide it, so if the dialog resolves from the root
-    // injector the content directive will throw NullInjectorError.
+    // MESSAGE lives only here — resolving from root would throw NullInjectorError.
     const parentEnvironmentInjector = TestBed.inject(EnvironmentInjector);
     const childEnvironmentInjector = createEnvironmentInjector(
       [{ provide: MESSAGE, useValue: 'child-injector-message' }],
       parentEnvironmentInjector,
     );
 
-    // Mount the host component within the child environment injector, emulating a
-    // remote/lazy component subtree that owns its own providers.
+    // Mount the host within the child environment injector (the remote's subtree).
     const hostElement = document.createElement('div');
     document.body.appendChild(hostElement);
 

--- a/packages/ng-primitives/dialog/src/dialog-trigger/tests/dialog-trigger-injector.test.ts
+++ b/packages/ng-primitives/dialog/src/dialog-trigger/tests/dialog-trigger-injector.test.ts
@@ -81,14 +81,21 @@ describe('NgpDialogTrigger injector context', () => {
     componentRef.changeDetectorRef.detectChanges();
 
     const trigger = hostElement.querySelector('[data-testid="trigger"]') as HTMLElement;
-    trigger.click();
-    await Promise.resolve();
+    try {
+      trigger.click();
+      await Promise.resolve();
 
-    const message = document.querySelector('[data-testid="message"]');
-    expect(message?.textContent).toBe('child-injector-message');
-
-    componentRef.destroy();
-    hostElement.remove();
-    childEnvironmentInjector.destroy();
+      const message = document.querySelector('[data-testid="message"]');
+      expect(message?.textContent).toBe('child-injector-message');
+    } finally {
+      // Close the dialog before tearing down the injector that renders it, and
+      // run cleanup even when the assertion fails.
+      dialogManager?.closeAll();
+      await Promise.resolve();
+      await Promise.resolve();
+      componentRef.destroy();
+      hostElement.remove();
+      childEnvironmentInjector.destroy();
+    }
   });
 });

--- a/packages/ng-primitives/toast/src/toast/tests/toast-manager-injector.test.ts
+++ b/packages/ng-primitives/toast/src/toast/tests/toast-manager-injector.test.ts
@@ -1,0 +1,101 @@
+import {
+  ApplicationRef,
+  Component,
+  Directive,
+  ElementRef,
+  EnvironmentInjector,
+  Injector,
+  InjectionToken,
+  TemplateRef,
+  createComponent,
+  createEnvironmentInjector,
+  inject,
+  viewChild,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NgpToast } from '../toast';
+import { NgpToastManager } from '../toast-manager';
+
+/**
+ * A token that is only provided in a child environment injector (never at the
+ * application root), mirroring the micro-frontend / `provideChildTranslateService()`
+ * scenario from https://github.com/ng-primitives/ng-primitives/issues/823.
+ */
+const MESSAGE = new InjectionToken<string>('MESSAGE');
+
+/** Reads the token from DI and renders it, so we can assert which injector resolved it. */
+@Directive({ selector: '[readMessage]' })
+class ReadMessage {
+  constructor() {
+    const element = inject(ElementRef).nativeElement as HTMLElement;
+    element.textContent = inject(MESSAGE);
+  }
+}
+
+@Component({
+  selector: 'ngp-toast-injector-host',
+  template: `
+    <ng-template #toast>
+      <div ngpToast>
+        <span readMessage data-testid="message"></span>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpToast, ReadMessage],
+})
+class ToastInjectorHost {
+  readonly toast = viewChild.required<TemplateRef<void>>('toast');
+  /** The component's own injector — what a real caller passes to `show()`. */
+  readonly injector = inject(Injector);
+}
+
+describe('NgpToastManager injector option', () => {
+  let manager: NgpToastManager | undefined;
+
+  afterEach(async () => {
+    manager?.toasts().forEach(t => manager?.dismiss(t.instance));
+    await Promise.resolve();
+    manager = undefined;
+    document
+      .querySelectorAll('[data-ngp-toast-container]')
+      .forEach(container => container.remove());
+  });
+
+  it('resolves DI-dependent content from the caller injector, not the root injector', async () => {
+    const appRef = TestBed.inject(ApplicationRef);
+    manager = TestBed.inject(NgpToastManager);
+
+    // Create a child environment injector that provides MESSAGE. The root injector
+    // deliberately does NOT provide it, so if the toast resolves from the root
+    // injector the content directive will throw NullInjectorError.
+    const parentEnvironmentInjector = TestBed.inject(EnvironmentInjector);
+    const childEnvironmentInjector = createEnvironmentInjector(
+      [{ provide: MESSAGE, useValue: 'child-injector-message' }],
+      parentEnvironmentInjector,
+    );
+
+    // Mount the host component within the child environment injector, emulating a
+    // remote/lazy component subtree that owns its own providers.
+    const hostElement = document.createElement('div');
+    document.body.appendChild(hostElement);
+
+    const componentRef = createComponent(ToastInjectorHost, {
+      environmentInjector: childEnvironmentInjector,
+      hostElement,
+    });
+    appRef.attachView(componentRef.hostView);
+    componentRef.changeDetectorRef.detectChanges();
+
+    const host = componentRef.instance;
+    manager.show(host.toast(), { injector: host.injector, persistent: true });
+    await Promise.resolve();
+
+    const message = document.querySelector('[data-testid="message"]');
+    expect(message?.textContent).toBe('child-injector-message');
+
+    componentRef.destroy();
+    hostElement.remove();
+    childEnvironmentInjector.destroy();
+  });
+});

--- a/packages/ng-primitives/toast/src/toast/tests/toast-manager-injector.test.ts
+++ b/packages/ng-primitives/toast/src/toast/tests/toast-manager-injector.test.ts
@@ -17,14 +17,11 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { NgpToast } from '../toast';
 import { NgpToastManager } from '../toast-manager';
 
-/**
- * A token that is only provided in a child environment injector (never at the
- * application root), mirroring the micro-frontend / `provideChildTranslateService()`
- * scenario from https://github.com/ng-primitives/ng-primitives/issues/823.
- */
+// Provided only in a child environment injector (never at root), mirroring a
+// component-scoped provider in a micro-frontend subtree. See #823.
 const MESSAGE = new InjectionToken<string>('MESSAGE');
 
-/** Reads the token from DI and renders it, so we can assert which injector resolved it. */
+/** Renders the resolved token so we can assert which injector served it. */
 @Directive({ selector: '[readMessage]' })
 class ReadMessage {
   constructor() {
@@ -66,17 +63,14 @@ describe('NgpToastManager injector option', () => {
     const appRef = TestBed.inject(ApplicationRef);
     manager = TestBed.inject(NgpToastManager);
 
-    // Create a child environment injector that provides MESSAGE. The root injector
-    // deliberately does NOT provide it, so if the toast resolves from the root
-    // injector the content directive will throw NullInjectorError.
+    // MESSAGE lives only here — resolving from root would throw NullInjectorError.
     const parentEnvironmentInjector = TestBed.inject(EnvironmentInjector);
     const childEnvironmentInjector = createEnvironmentInjector(
       [{ provide: MESSAGE, useValue: 'child-injector-message' }],
       parentEnvironmentInjector,
     );
 
-    // Mount the host component within the child environment injector, emulating a
-    // remote/lazy component subtree that owns its own providers.
+    // Mount the host within the child environment injector (the remote's subtree).
     const hostElement = document.createElement('div');
     document.body.appendChild(hostElement);
 

--- a/packages/ng-primitives/toast/src/toast/tests/toast-manager-injector.test.ts
+++ b/packages/ng-primitives/toast/src/toast/tests/toast-manager-injector.test.ts
@@ -51,8 +51,7 @@ describe('NgpToastManager injector option', () => {
   let manager: NgpToastManager | undefined;
 
   afterEach(async () => {
-    manager?.toasts().forEach(t => manager?.dismiss(t.instance));
-    await Promise.resolve();
+    await Promise.all((manager?.toasts() ?? []).map(t => manager!.dismiss(t.instance)));
     manager = undefined;
     document
       .querySelectorAll('[data-ngp-toast-container]')
@@ -82,14 +81,20 @@ describe('NgpToastManager injector option', () => {
     componentRef.changeDetectorRef.detectChanges();
 
     const host = componentRef.instance;
-    manager.show(host.toast(), { injector: host.injector, persistent: true });
-    await Promise.resolve();
+    const toastRef = manager.show(host.toast(), { injector: host.injector, persistent: true });
 
-    const message = document.querySelector('[data-testid="message"]');
-    expect(message?.textContent).toBe('child-injector-message');
+    try {
+      await Promise.resolve();
 
-    componentRef.destroy();
-    hostElement.remove();
-    childEnvironmentInjector.destroy();
+      const message = document.querySelector('[data-testid="message"]');
+      expect(message?.textContent).toBe('child-injector-message');
+    } finally {
+      // Dispose the toast before tearing down the injector that renders it, and
+      // run cleanup even when the assertion fails.
+      await toastRef.dismiss();
+      componentRef.destroy();
+      hostElement.remove();
+      childEnvironmentInjector.destroy();
+    }
   });
 });

--- a/packages/ng-primitives/toast/src/toast/toast-manager.ts
+++ b/packages/ng-primitives/toast/src/toast/toast-manager.ts
@@ -36,8 +36,7 @@ export class NgpToastManager {
   /** Show a toast notification */
   show(toast: TemplateRef<void> | Type<unknown>, options: NgpToastOptions = {}): NgpToastRef {
     // services can't access the view container directly, so this is a workaround.
-    // Fall back to the caller-provided injector's view container when no root
-    // component is available (e.g. certain embedded or test environments).
+    // Fall back to the caller's injector when no root component is available.
     const rootComponent = this.applicationRef.components[0];
     const viewContainerRef =
       rootComponent?.injector.get(ViewContainerRef) ??
@@ -53,11 +52,8 @@ export class NgpToastManager {
       toast,
       viewContainerRef,
       Injector.create({
-        // Allow callers to scope the toast content to their own injector so that
-        // DI-dependent pipes/directives (e.g. a translate pipe backed by a
-        // component-scoped provider) resolve from the caller's subtree rather than
-        // the root injector. Defaults to the manager's root injector.
-        // See https://github.com/ng-primitives/ng-primitives/issues/823.
+        // Scope toast content to the caller's injector when provided, so its DI
+        // resolves from their subtree rather than the root injector. See #823.
         parent: options.injector ?? this.injector,
         providers: [
           provideToastContext(options.context),
@@ -219,10 +215,8 @@ export interface NgpToastOptions<T = unknown> {
   persistent?: boolean;
 
   /**
-   * The injector to use when rendering the toast content. Provide the calling
-   * component's injector when the toast template depends on providers defined in a
-   * component subtree (e.g. a component-scoped translation service) rather than at
-   * the application root. Defaults to the root injector.
+   * The injector used to render the toast content. Provide the calling component's
+   * injector when the toast depends on component-scoped providers. Defaults to root.
    */
   injector?: Injector;
 }

--- a/packages/ng-primitives/toast/src/toast/toast-manager.ts
+++ b/packages/ng-primitives/toast/src/toast/toast-manager.ts
@@ -35,9 +35,14 @@ export class NgpToastManager {
 
   /** Show a toast notification */
   show(toast: TemplateRef<void> | Type<unknown>, options: NgpToastOptions = {}): NgpToastRef {
-    // services can't access the view container directly, so this is a workaround
+    // services can't access the view container directly, so this is a workaround.
+    // Fall back to the caller-provided injector's view container when no root
+    // component is available (e.g. certain embedded or test environments).
     const rootComponent = this.applicationRef.components[0];
-    const viewContainerRef = rootComponent?.injector.get(ViewContainerRef) ?? null;
+    const viewContainerRef =
+      rootComponent?.injector.get(ViewContainerRef) ??
+      options.injector?.get(ViewContainerRef, null) ??
+      null;
 
     let instance: NgpToast | null = null;
     const placement = options.placement ?? this.config.placement;
@@ -48,7 +53,12 @@ export class NgpToastManager {
       toast,
       viewContainerRef,
       Injector.create({
-        parent: this.injector,
+        // Allow callers to scope the toast content to their own injector so that
+        // DI-dependent pipes/directives (e.g. a translate pipe backed by a
+        // component-scoped provider) resolve from the caller's subtree rather than
+        // the root injector. Defaults to the manager's root injector.
+        // See https://github.com/ng-primitives/ng-primitives/issues/823.
+        parent: options.injector ?? this.injector,
         providers: [
           provideToastContext(options.context),
           provideToastOptions({
@@ -207,6 +217,14 @@ export interface NgpToastOptions<T = unknown> {
 
   /** When true, the toast will not auto-dismiss and must be dismissed explicitly */
   persistent?: boolean;
+
+  /**
+   * The injector to use when rendering the toast content. Provide the calling
+   * component's injector when the toast template depends on providers defined in a
+   * component subtree (e.g. a component-scoped translation service) rather than at
+   * the application root. Defaults to the root injector.
+   */
+  injector?: Injector;
 }
 
 interface NgpToastRecord {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## Issue

Closes #823

## What does this PR implement/fix?

`NgpDialogTrigger` opened dialogs through `NgpDialogManager` without passing an injector, so the dialog template's embedded view fell back to the root injector. DI-dependent pipes/directives inside the template (e.g. an `ngx-translate` pipe backed by `provideChildTranslateService()`) resolved from the root injector instead of the component subtree that declared the template. Overlay-based primitives such as the popover already thread the trigger's injector through, which is why they worked correctly.

Changes:

- **Dialog:** the trigger now captures its own `Injector` and passes it to `open()`, so the embedded view resolves DI from the declaring component subtree. `NgpDialogConfig` already accepted an `injector` — the trigger simply never supplied one. This also provides a `ViewContainerRef` fallback when no root component is present. VCR selection is otherwise unchanged (the root component's view container is still preferred).
- **Toast:** `NgpToastManager` had the same root-injector limitation with no way to scope content DI. `NgpToastOptions` gains an optional `injector` used as the portal injector parent (and view-container fallback), defaulting to the root injector.

Both paths are covered by new tests that mount a host inside a child `EnvironmentInjector` and assert the portal-rendered content resolves the component-scoped provider.

This is particularly impactful in micro-frontend architectures where providers must live in a remote's component subtree rather than at the application root.

## Does this PR introduce a breaking change?

- [x] No

The changes are additive and transparent: the dialog fix requires no API change and only corrects which injector resolves content DI (component subtree instead of root, matching the popover/menu/tooltip primitives), and the toast `injector` option is optional and defaults to the previous root-injector behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toasts can now be displayed using a caller-provided injector, including when no root component is available.
  * Toast content can resolve dependencies from the supplied injector.
  * Dialog content now resolves dependencies from the trigger component’s injector context.

* **Bug Fixes**
  * Improved dependency injection handling for dialogs and toasts, ensuring locally provided values are correctly available in displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->