### PR TITLE
feat(ai): migrate ai state

### DIFF
--- a/packages/ng-primitives/ai/src/index.ts
+++ b/packages/ng-primitives/ai/src/index.ts
@@ -7,31 +7,63 @@ export { NgpPromptComposerDictation } from './prompt-composer-dictation/prompt-c
 export { NgpThreadViewport } from './thread-viewport/thread-viewport';
 export { NgpThreadSuggestion } from './thread-suggestion/thread-suggestion';
 export {
+  NgpPromptComposerStateToken,
+  ngpPromptComposer,
   providePromptComposerState,
   injectPromptComposerState,
+  type NgpPromptComposerState,
+  type NgpPromptComposerProps,
 } from './prompt-composer/prompt-composer-state';
 export {
+  NgpPromptComposerDictationStateToken,
+  ngpPromptComposerDictation,
   providePromptComposerDictationState,
   injectPromptComposerDictationState,
+  type NgpPromptComposerDictationState,
+  type NgpPromptComposerDictationProps,
 } from './prompt-composer-dictation/prompt-composer-dictation-state';
 export {
+  NgpPromptComposerInputStateToken,
+  ngpPromptComposerInput,
   providePromptComposerInputState,
   injectPromptComposerInputState,
+  type NgpPromptComposerInputState,
 } from './prompt-composer-input/prompt-composer-input-state';
 export {
+  NgpPromptComposerSubmitStateToken,
+  ngpPromptComposerSubmit,
   providePromptComposerSubmitState,
   injectPromptComposerSubmitState,
+  type NgpPromptComposerSubmitState,
+  type NgpPromptComposerSubmitProps,
 } from './prompt-composer-submit/prompt-composer-submit-state';
-export { provideThreadState, injectThreadState } from './thread/thread-state';
 export {
+  NgpThreadStateToken,
+  ngpThread,
+  provideThreadState,
+  injectThreadState,
+  type NgpThreadState,
+} from './thread/thread-state';
+export {
+  NgpThreadSuggestionStateToken,
+  ngpThreadSuggestion,
   provideThreadSuggestionState,
   injectThreadSuggestionState,
+  type NgpThreadSuggestionState,
+  type NgpThreadSuggestionProps,
 } from './thread-suggestion/thread-suggestion-state';
 export {
+  NgpThreadViewportStateToken,
+  ngpThreadViewport,
   provideThreadViewportState,
   injectThreadViewportState,
+  type NgpThreadViewportState,
+  type NgpThreadViewportProps,
 } from './thread-viewport/thread-viewport-state';
 export {
+  NgpThreadMessageStateToken,
+  ngpThreadMessage,
   provideThreadMessageState,
   injectThreadMessageState,
+  type NgpThreadMessageState,
 } from './thread-message/thread-message-state';

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
@@ -1,32 +1,158 @@
+import { DOCUMENT } from '@angular/common';
+import { computed, inject, signal, Signal } from '@angular/core';
+import { ngpButton } from 'ng-primitives/button';
+import { injectElementRef } from 'ng-primitives/internal';
 import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
+  attrBinding,
+  createPrimitive,
+  dataBinding,
+  listener,
+  onDestroy,
 } from 'ng-primitives/state';
-import type { NgpPromptComposerDictation } from './prompt-composer-dictation';
+import { injectPromptComposerState } from '../prompt-composer/prompt-composer-state';
 
-/**
- * The state token  for the PromptComposerDictation primitive.
- */
-export const NgpPromptComposerDictationStateToken =
-  createStateToken<NgpPromptComposerDictation>('PromptComposerDictation');
+declare global {
+  interface Window {
+    SpeechRecognition: any;
+    webkitSpeechRecognition: any;
+  }
+}
 
-/**
- * Provides the PromptComposerDictation state.
- */
-export const providePromptComposerDictationState = createStateProvider(
+export interface NgpPromptComposerDictationState {
+  /**
+   * Whether dictation is currently active.
+   */
+  readonly isDictating: Signal<boolean>;
+}
+
+export interface NgpPromptComposerDictationProps {
+  /**
+   * Whether the dictation button should be disabled.
+   */
+  readonly disabled?: Signal<boolean>;
+}
+
+export const [
   NgpPromptComposerDictationStateToken,
-);
+  ngpPromptComposerDictation,
+  injectPromptComposerDictationState,
+  providePromptComposerDictationState,
+] = createPrimitive(
+  'NgpPromptComposerDictation',
+  ({
+    disabled = signal(false),
+  }: NgpPromptComposerDictationProps): NgpPromptComposerDictationState => {
+    const element = injectElementRef<HTMLElement>();
+    const document = inject(DOCUMENT);
+    const composer = injectPromptComposerState();
 
-/**
- * Injects the PromptComposerDictation state.
- */
-export const injectPromptComposerDictationState = createStateInjector<NgpPromptComposerDictation>(
-  NgpPromptComposerDictationStateToken,
-);
+    const isDictating = computed(() => composer().isDictating());
 
-/**
- * The PromptComposerDictation state registration function.
- */
-export const promptComposerDictationState = createState(NgpPromptComposerDictationStateToken);
+    let recognition: any = null;
+
+    // Store the prompt before dictation started
+    let basePrompt = '';
+
+    ngpButton({
+      disabled: computed(() => disabled() || composer().dictationSupported === false),
+    });
+
+    // Host bindings
+    attrBinding(element, 'type', 'button');
+    dataBinding(element, 'data-dictating', isDictating);
+    dataBinding(element, 'data-dictation-supported', () => composer().dictationSupported);
+    dataBinding(element, 'data-prompt', () => composer().hasPrompt());
+
+    // Listener
+    listener(element, 'click', onClick);
+    listener(document, 'keydown', onKeydown);
+
+    onDestroy(() => {
+      recognition?.stop();
+      recognition = null;
+    });
+
+    function onClick(): void {
+      if (!recognition) {
+        console.warn('Speech recognition is not supported in this browser');
+        return;
+      }
+
+      if (composer().isDictating()) {
+        stopDictation();
+      } else {
+        startDictation();
+      }
+    }
+
+    function onKeydown(event: KeyboardEvent): void {
+      if (event.key === 'Escape' && composer().isDictating()) {
+        event.preventDefault();
+        stopDictation();
+      }
+    }
+
+    function initializeSpeechRecognition(): void {
+      const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+
+      if (!SpeechRecognition) {
+        return;
+      }
+
+      recognition = new SpeechRecognition();
+      recognition.continuous = true; // Enable continuous listening
+      recognition.interimResults = true; // Enable interim results for live updates
+      recognition.lang = 'en-US';
+
+      recognition.onstart = () => {
+        composer().setDictating(true);
+        // Store the current prompt as the base
+        basePrompt = composer().prompt();
+      };
+
+      recognition.onresult = (event: any) => {
+        let interimTranscript = '';
+        let finalTranscript = '';
+
+        // Process all results
+        for (let i = 0; i < event.results.length; i++) {
+          const transcript = event.results[i][0].transcript;
+          if (event.results[i].isFinal) {
+            finalTranscript += transcript;
+          } else {
+            interimTranscript += transcript;
+          }
+        }
+
+        // Combine base prompt with final transcript and interim transcript
+        const separator = basePrompt ? ' ' : '';
+        const newPrompt = basePrompt + separator + finalTranscript + interimTranscript;
+
+        composer().setPrompt(newPrompt.trim());
+      };
+
+      recognition.onend = () => composer().setDictating(false);
+
+      recognition.onerror = (event: any) => {
+        console.error('Speech recognition error:', event.error);
+        composer().setDictating(false);
+      };
+    }
+
+    function startDictation(): void {
+      if (recognition && !composer().isDictating()) {
+        recognition.start();
+      }
+    }
+
+    function stopDictation(): void {
+      if (recognition && composer().isDictating()) {
+        recognition.stop();
+      }
+    }
+
+    initializeSpeechRecognition();
+
+    return { isDictating } satisfies NgpPromptComposerDictationState;
+  },
+);

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation.ts
@@ -1,151 +1,24 @@
 import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input } from '@angular/core';
 import {
-  booleanAttribute,
-  computed,
-  Directive,
-  HostListener,
-  input,
-  OnDestroy,
-  signal,
-} from '@angular/core';
-import { ngpButton } from 'ng-primitives/button';
-import { injectPromptComposerState } from '../prompt-composer/prompt-composer-state';
-import {
-  promptComposerDictationState,
+  ngpPromptComposerDictation,
   providePromptComposerDictationState,
 } from './prompt-composer-dictation-state';
-
-declare global {
-  interface Window {
-    SpeechRecognition: any;
-    webkitSpeechRecognition: any;
-  }
-}
 
 @Directive({
   selector: 'button[ngpPromptComposerDictation]',
   exportAs: 'ngpPromptComposerDictation',
   providers: [providePromptComposerDictationState()],
-  host: {
-    type: 'button',
-    '[attr.data-dictating]': 'isDictating() ? "" : null',
-    '[attr.data-dictation-supported]': 'composer().dictationSupported ? "" : null',
-    '[attr.data-prompt]': 'composer().hasPrompt() ? "" : null',
-  },
 })
-export class NgpPromptComposerDictation implements OnDestroy {
-  protected readonly composer = injectPromptComposerState();
-  private recognition: any = null;
-  private basePrompt = signal<string>(''); // Store the prompt before dictation started
-
-  /** Whether the submit button should be disabled. */
+export class NgpPromptComposerDictation {
+  /** Whether the dictation button should be disabled. */
   readonly disabled = input<boolean, BooleanInput>(false, {
     transform: booleanAttribute,
   });
 
+  /** The state of the prompt composer dictation. */
+  protected readonly state = ngpPromptComposerDictation({ disabled: this.disabled });
+
   /** Whether dictation is currently active */
-  readonly isDictating = computed(() => this.composer().isDictating());
-
-  /** The state of the prompt composer. */
-  protected readonly state = promptComposerDictationState<NgpPromptComposerDictation>(this);
-
-  constructor() {
-    ngpButton({
-      disabled: computed(
-        () => this.state.disabled() || this.composer().dictationSupported === false,
-      ),
-    });
-    this.initializeSpeechRecognition();
-  }
-
-  ngOnDestroy(): void {
-    if (this.recognition) {
-      this.recognition.stop();
-      this.recognition = null;
-    }
-  }
-
-  @HostListener('click')
-  protected onClick(): void {
-    if (!this.recognition) {
-      console.warn('Speech recognition is not supported in this browser');
-      return;
-    }
-
-    if (this.composer().isDictating()) {
-      this.stopDictation();
-    } else {
-      this.startDictation();
-    }
-  }
-
-  @HostListener('document:keydown', ['$event'])
-  protected onKeydown(event: KeyboardEvent): void {
-    if (event.key === 'Escape' && this.composer().isDictating()) {
-      event.preventDefault();
-      this.stopDictation();
-    }
-  }
-
-  private initializeSpeechRecognition(): void {
-    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-
-    if (!SpeechRecognition) {
-      return;
-    }
-
-    this.recognition = new SpeechRecognition();
-    this.recognition.continuous = true; // Enable continuous listening
-    this.recognition.interimResults = true; // Enable interim results for live updates
-    this.recognition.lang = 'en-US';
-
-    this.recognition.onstart = () => {
-      this.composer().isDictating.set(true);
-      // Store the current prompt as the base
-      this.basePrompt.set(this.composer().prompt());
-    };
-
-    this.recognition.onresult = (event: any) => {
-      let interimTranscript = '';
-      let finalTranscript = '';
-
-      // Process all results
-      for (let i = 0; i < event.results.length; i++) {
-        const transcript = event.results[i][0].transcript;
-        if (event.results[i].isFinal) {
-          finalTranscript += transcript;
-        } else {
-          interimTranscript += transcript;
-        }
-      }
-
-      // Combine base prompt with final transcript and interim transcript
-      const baseText = this.basePrompt();
-      const separator = baseText ? ' ' : '';
-      const newPrompt = baseText + separator + finalTranscript + interimTranscript;
-
-      this.composer().prompt.set(newPrompt.trim());
-    };
-
-    this.recognition.onend = () => {
-      this.composer().isDictating.set(false);
-    };
-
-    this.recognition.onerror = (event: any) => {
-      console.error('Speech recognition error:', event.error);
-      this.composer().isDictating.set(false);
-    };
-  }
-
-  private startDictation(): void {
-    if (this.recognition && !this.composer().isDictating()) {
-      this.recognition.start();
-    }
-  }
-
-  private stopDictation(): void {
-    if (this.recognition && this.composer().isDictating()) {
-      this.recognition.stop();
-    }
-  }
+  readonly isDictating = this.state.isDictating;
 }

--- a/packages/ng-primitives/ai/src/prompt-composer-input/prompt-composer-input-state.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-input/prompt-composer-input-state.ts
@@ -1,32 +1,69 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpPromptComposerInput } from './prompt-composer-input';
+import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
+import { createPrimitive, listener, onDestroy } from 'ng-primitives/state';
+import { injectPromptComposerState } from '../prompt-composer/prompt-composer-state';
+import { injectThreadState } from '../thread/thread-state';
 
-/**
- * The state token  for the PromptComposerInput primitive.
- */
-export const NgpPromptComposerInputStateToken =
-  createStateToken<NgpPromptComposerInput>('PromptComposerInput');
+export interface NgpPromptComposerInputState {
+  /**
+   * @internal
+   * Set the prompt text, moving the cursor to the end and focusing the input.
+   */
+  setPrompt(value: string): void;
+}
 
-/**
- * Provides the PromptComposerInput state.
- */
-export const providePromptComposerInputState = createStateProvider(
+export const [
   NgpPromptComposerInputStateToken,
-);
+  ngpPromptComposerInput,
+  injectPromptComposerInputState,
+  providePromptComposerInputState,
+] = createPrimitive('NgpPromptComposerInput', (): NgpPromptComposerInputState => {
+  const element = injectElementRef<HTMLInputElement | HTMLTextAreaElement>();
+  const thread = injectThreadState();
+  const composer = injectPromptComposerState();
 
-/**
- * Injects the PromptComposerInput state.
- */
-export const injectPromptComposerInputState = createStateInjector<NgpPromptComposerInput>(
-  NgpPromptComposerInputStateToken,
-);
+  // set the initial state
+  composer().setPrompt(element.nativeElement.value);
 
-/**
- * The PromptComposerInput state registration function.
- */
-export const promptComposerInputState = createState(NgpPromptComposerInputStateToken);
+  // listen for changes to the text content
+  listener(element, 'input', () => composer().setPrompt(element.nativeElement.value));
+
+  /**
+   * If the user presses Enter, the form will be submitted, unless they are holding Shift.
+   * This primitive automatically handles that behavior.
+   */
+  listener(element, 'keydown', (event: KeyboardEvent) => {
+    if (event.key !== 'Enter' || event.shiftKey) {
+      return;
+    }
+
+    event.preventDefault();
+
+    // if there is no text content, do nothing
+    if (element.nativeElement.value.trim().length === 0) {
+      return;
+    }
+
+    composer().submitPrompt();
+  });
+
+  // any time the prompt changes, update the input value if needed
+  explicitEffect([composer().prompt], ([prompt]) => (element.nativeElement.value = prompt));
+
+  function setPrompt(value: string): void {
+    composer().setPrompt(value);
+    // write the value now rather than waiting for the effect above, so the cursor is
+    // placed against the text we just set
+    element.nativeElement.value = value;
+    // set the cursor to the end
+    element.nativeElement.setSelectionRange(value.length, value.length);
+    element.nativeElement.focus();
+  }
+
+  const state = { setPrompt } satisfies NgpPromptComposerInputState;
+
+  // the thread routes suggestions to the input that is currently registered
+  thread().setPromptInput(state);
+  onDestroy(() => thread().removePromptInput(state));
+
+  return state;
+});

--- a/packages/ng-primitives/ai/src/prompt-composer-input/prompt-composer-input.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-input/prompt-composer-input.ts
@@ -1,11 +1,6 @@
-import { Directive, HostListener } from '@angular/core';
-import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
-import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
-import { fromEvent } from 'rxjs';
-import { injectPromptComposerState } from '../prompt-composer/prompt-composer-state';
-import { injectThreadState } from '../thread/thread-state';
+import { Directive } from '@angular/core';
 import {
-  promptComposerInputState,
+  ngpPromptComposerInput,
   providePromptComposerInputState,
 } from './prompt-composer-input-state';
 
@@ -15,56 +10,6 @@ import {
   providers: [providePromptComposerInputState()],
 })
 export class NgpPromptComposerInput {
-  protected readonly thread = injectThreadState();
-  private readonly composer = injectPromptComposerState();
-  private readonly element = injectElementRef<HTMLInputElement | HTMLTextAreaElement>();
-
   /** The state of the prompt composer input. */
-  protected readonly state = promptComposerInputState<NgpPromptComposerInput>(this);
-
-  constructor() {
-    // set the initial state
-    this.composer().prompt.set(this.element.nativeElement.value);
-
-    // listen for requests to set the prompt
-    this.thread()
-      .requestPrompt.pipe(safeTakeUntilDestroyed())
-      .subscribe(value => {
-        // set the cursor to the end
-        this.composer().prompt.set(value);
-        this.element.nativeElement.setSelectionRange(value.length, value.length);
-        this.element.nativeElement.focus();
-      });
-
-    // listen for changes to the text content
-    fromEvent(this.element.nativeElement, 'input')
-      .pipe(safeTakeUntilDestroyed())
-      .subscribe(() => this.composer().prompt.set(this.element.nativeElement.value));
-
-    // any time the prompt changes, update the input value if needed
-    explicitEffect(
-      [this.composer().prompt],
-      ([prompt]) => (this.element.nativeElement.value = prompt),
-    );
-  }
-
-  /**
-   * If the user presses Enter, the form will be submitted, unless they are holding Shift.
-   * This directive automatically handles that behavior.
-   */
-  @HostListener('keydown.enter', ['$event'])
-  protected onEnterKey(event: Event): void {
-    if (event instanceof KeyboardEvent === false || event.shiftKey) {
-      return;
-    }
-
-    event.preventDefault();
-
-    // if there is no text content, do nothing
-    if (this.element.nativeElement.value.trim().length === 0) {
-      return;
-    }
-
-    this.composer().submitPrompt();
-  }
+  protected readonly state = ngpPromptComposerInput();
 }

--- a/packages/ng-primitives/ai/src/prompt-composer-submit/prompt-composer-submit-state.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-submit/prompt-composer-submit-state.ts
@@ -1,32 +1,48 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpPromptComposerSubmit } from './prompt-composer-submit';
+import { computed, signal, Signal } from '@angular/core';
+import { ngpButton } from 'ng-primitives/button';
+import { injectElementRef } from 'ng-primitives/internal';
+import { attrBinding, createPrimitive, dataBinding, listener } from 'ng-primitives/state';
+import { injectPromptComposerState } from '../prompt-composer/prompt-composer-state';
 
-/**
- * The state token  for the PromptComposerSubmit primitive.
- */
-export const NgpPromptComposerSubmitStateToken =
-  createStateToken<NgpPromptComposerSubmit>('PromptComposerSubmit');
+export interface NgpPromptComposerSubmitState {
+  /**
+   * Whether dictation is currently active.
+   */
+  readonly isDictating: Signal<boolean>;
+}
 
-/**
- * Provides the PromptComposerSubmit state.
- */
-export const providePromptComposerSubmitState = createStateProvider(
+export interface NgpPromptComposerSubmitProps {
+  /**
+   * Whether the submit button should be disabled.
+   */
+  readonly disabled?: Signal<boolean>;
+}
+
+export const [
   NgpPromptComposerSubmitStateToken,
-);
+  ngpPromptComposerSubmit,
+  injectPromptComposerSubmitState,
+  providePromptComposerSubmitState,
+] = createPrimitive(
+  'NgpPromptComposerSubmit',
+  ({ disabled = signal(false) }: NgpPromptComposerSubmitProps): NgpPromptComposerSubmitState => {
+    const element = injectElementRef<HTMLElement>();
+    const composer = injectPromptComposerState();
 
-/**
- * Injects the PromptComposerSubmit state.
- */
-export const injectPromptComposerSubmitState = createStateInjector<NgpPromptComposerSubmit>(
-  NgpPromptComposerSubmitStateToken,
-);
+    const isDictating = computed(() => composer().isDictating());
 
-/**
- * The PromptComposerSubmit state registration function.
- */
-export const promptComposerSubmitState = createState(NgpPromptComposerSubmitStateToken);
+    // the button is disabled explicitly or whenever there is nothing to submit
+    ngpButton({ disabled: computed(() => disabled() || composer().hasPrompt() === false) });
+
+    // Host bindings
+    attrBinding(element, 'type', 'button');
+    dataBinding(element, 'data-prompt', () => composer().hasPrompt());
+    dataBinding(element, 'data-dictating', isDictating);
+    dataBinding(element, 'data-dictation-supported', () => composer().dictationSupported);
+
+    // Listener
+    listener(element, 'click', () => composer().submitPrompt());
+
+    return { isDictating } satisfies NgpPromptComposerSubmitState;
+  },
+);

--- a/packages/ng-primitives/ai/src/prompt-composer-submit/prompt-composer-submit.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-submit/prompt-composer-submit.ts
@@ -1,9 +1,7 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, computed, Directive, HostListener, input } from '@angular/core';
-import { ngpButton } from 'ng-primitives/button';
-import { injectPromptComposerState } from '../prompt-composer/prompt-composer-state';
+import { booleanAttribute, Directive, input } from '@angular/core';
 import {
-  promptComposerSubmitState,
+  ngpPromptComposerSubmit,
   providePromptComposerSubmitState,
 } from './prompt-composer-submit-state';
 
@@ -11,35 +9,16 @@ import {
   selector: 'button[ngpPromptComposerSubmit]',
   exportAs: 'ngpPromptComposerSubmit',
   providers: [providePromptComposerSubmitState()],
-  host: {
-    type: 'button',
-    '[attr.data-prompt]': 'composer().hasPrompt() ? "" : null',
-    '[attr.data-dictating]': 'isDictating() ? "" : null',
-    '[attr.data-dictation-supported]': 'composer().dictationSupported ? "" : null',
-  },
 })
 export class NgpPromptComposerSubmit {
-  protected readonly composer = injectPromptComposerState();
-
   /** Whether the submit button should be disabled */
   readonly disabled = input<boolean, BooleanInput>(false, {
     transform: booleanAttribute,
   });
 
-  /** Whether dictation is currently active */
-  readonly isDictating = computed(() => this.composer().isDictating());
-
   /** The state of the prompt composer submit. */
-  protected readonly state = promptComposerSubmitState<NgpPromptComposerSubmit>(this);
+  protected readonly state = ngpPromptComposerSubmit({ disabled: this.disabled });
 
-  constructor() {
-    ngpButton({
-      disabled: computed(() => this.state.disabled() || this.composer().hasPrompt() === false),
-    });
-  }
-
-  @HostListener('click')
-  protected onClick(): void {
-    this.composer().submitPrompt();
-  }
+  /** Whether dictation is currently active */
+  readonly isDictating = this.state.isDictating;
 }

--- a/packages/ng-primitives/ai/src/prompt-composer/prompt-composer-state.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer/prompt-composer-state.ts
@@ -1,29 +1,105 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpPromptComposer } from './prompt-composer';
+import { computed, signal, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { createPrimitive, dataBinding } from 'ng-primitives/state';
+import { injectThreadState } from '../thread/thread-state';
 
-/**
- * The state token  for the PromptComposer primitive.
- */
-export const NgpPromptComposerStateToken = createStateToken<NgpPromptComposer>('PromptComposer');
+export interface NgpPromptComposerState {
+  /**
+   * The current prompt text.
+   */
+  readonly prompt: Signal<string>;
+  /**
+   * Whether the prompt input has content.
+   */
+  readonly hasPrompt: Signal<boolean>;
+  /**
+   * Whether the prompt is currently being dictated.
+   */
+  readonly isDictating: Signal<boolean>;
+  /**
+   * Whether dictation is supported by the browser.
+   */
+  readonly dictationSupported: boolean;
+  /**
+   * @internal
+   * Set the current prompt text.
+   */
+  setPrompt(value: string): void;
+  /**
+   * @internal
+   * Set whether the prompt is currently being dictated.
+   */
+  setDictating(value: boolean): void;
+  /**
+   * @internal
+   * Submit the current prompt if there is content, and clear the input.
+   */
+  submitPrompt(): void;
+}
 
-/**
- * Provides the PromptComposer state.
- */
-export const providePromptComposerState = createStateProvider(NgpPromptComposerStateToken);
+export interface NgpPromptComposerProps {
+  /**
+   * Emits whenever the user submits the prompt.
+   */
+  readonly onSubmit?: (prompt: string) => void;
+}
 
-/**
- * Injects the PromptComposer state.
- */
-export const injectPromptComposerState = createStateInjector<NgpPromptComposer>(
+export const [
   NgpPromptComposerStateToken,
-);
+  ngpPromptComposer,
+  injectPromptComposerState,
+  providePromptComposerState,
+] = createPrimitive(
+  'NgpPromptComposer',
+  ({ onSubmit }: NgpPromptComposerProps): NgpPromptComposerState => {
+    const element = injectElementRef<HTMLElement>();
+    const thread = injectThreadState();
 
-/**
- * The PromptComposer state registration function.
- */
-export const promptComposerState = createState(NgpPromptComposerStateToken);
+    /** Store the current prompt text. */
+    const prompt = signal<string>('');
+
+    /** Track whether the prompt is currently being dictated. */
+    const isDictating = signal<boolean>(false);
+
+    /** Determine whether the prompt input has content. */
+    const hasPrompt = computed(() => prompt().trim().length > 0);
+
+    /** Whether dictation is supported by the browser. This is resolved once and never changes. */
+    const dictationSupported = !!(
+      (globalThis as any).SpeechRecognition || (globalThis as any).webkitSpeechRecognition
+    );
+
+    // Host bindings
+    dataBinding(element, 'data-prompt', hasPrompt);
+    dataBinding(element, 'data-dictating', isDictating);
+    dataBinding(element, 'data-dictation-supported', dictationSupported);
+
+    function setPrompt(value: string): void {
+      prompt.set(value);
+    }
+
+    function setDictating(value: boolean): void {
+      isDictating.set(value);
+    }
+
+    function submitPrompt(): void {
+      if (!hasPrompt()) {
+        return;
+      }
+
+      onSubmit?.(prompt());
+      prompt.set('');
+      thread().scrollToBottom('smooth');
+    }
+
+    return {
+      prompt: prompt.asReadonly(),
+      hasPrompt,
+      isDictating: isDictating.asReadonly(),
+      dictationSupported,
+      setPrompt,
+      setDictating,
+      submitPrompt,
+    } satisfies NgpPromptComposerState;
+  },
+);

--- a/packages/ng-primitives/ai/src/prompt-composer/prompt-composer.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer/prompt-composer.ts
@@ -1,49 +1,37 @@
-import { computed, Directive, output, signal } from '@angular/core';
-import { injectThreadState } from '../thread/thread-state';
-import { promptComposerState, providePromptComposerState } from './prompt-composer-state';
+import { Directive, output } from '@angular/core';
+import { ngpPromptComposer, providePromptComposerState } from './prompt-composer-state';
 
 @Directive({
   selector: '[ngpPromptComposer]',
   exportAs: 'ngpPromptComposer',
   providers: [providePromptComposerState()],
-  host: {
-    '[attr.data-prompt]': 'hasPrompt() ? "" : null',
-    '[attr.data-dictating]': 'isDictating() ? "" : null',
-    '[attr.data-dictation-supported]': 'dictationSupported ? "" : null',
-  },
 })
 export class NgpPromptComposer {
-  private readonly thread = injectThreadState();
-
   /** Emits whenever the user submits the prompt. */
   readonly submit = output<string>({ alias: 'ngpPromptComposerSubmit' });
 
-  /** @internal Store the current prompt text. */
-  readonly prompt = signal<string>('');
-
-  /** @internal Track whether the prompt is currently being dictated */
-  readonly isDictating = signal<boolean>(false);
-
-  /** @internal Determine whether the prompt input has content */
-  readonly hasPrompt = computed(() => this.prompt().trim().length > 0);
-
-  /** Whether dictation is supported by the browser */
-  readonly dictationSupported = !!(
-    (globalThis as any).SpeechRecognition || (globalThis as any).webkitSpeechRecognition
-  );
-
   /** The state of the prompt composer. */
-  protected readonly state = promptComposerState<NgpPromptComposer>(this);
+  protected readonly state = ngpPromptComposer({
+    onSubmit: prompt => this.submit.emit(prompt),
+  });
+
+  /** @internal The current prompt text. */
+  readonly prompt = this.state.prompt;
+
+  /** @internal Whether the prompt is currently being dictated. */
+  readonly isDictating = this.state.isDictating;
+
+  /** @internal Whether the prompt input has content. */
+  readonly hasPrompt = this.state.hasPrompt;
+
+  /** Whether dictation is supported by the browser. */
+  readonly dictationSupported = this.state.dictationSupported;
 
   /**
    * @internal
    * Submits the current prompt if there is content, and clears the input.
    */
   submitPrompt(): void {
-    if (this.hasPrompt()) {
-      this.submit.emit(this.prompt());
-      this.prompt.set('');
-      this.thread().scrollToBottom('smooth');
-    }
+    this.state.submitPrompt();
   }
 }

--- a/packages/ng-primitives/ai/src/thread-message/tests/thread-message-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/thread-message/tests/thread-message-primitive.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'vitest';
 describe('NgpThreadMessage', () => {
   it('should observe content changes and trigger scroll behavior', async () => {
     @Component({
+      imports: [NgpThread, NgpThreadMessage],
       template: `
         <div ngpThread data-testid="thread">
           <div ngpThreadMessage>
@@ -18,9 +19,7 @@ describe('NgpThreadMessage', () => {
       content = 'Initial content';
     }
 
-    const { fixture } = await render(TestComponent, {
-      imports: [NgpThread, NgpThreadMessage],
-    });
+    const { fixture } = await render(TestComponent);
 
     const component = fixture.componentInstance;
 
@@ -37,6 +36,7 @@ describe('NgpThreadMessage', () => {
 
   it('should detect text node changes (streaming simulation)', async () => {
     @Component({
+      imports: [NgpThread, NgpThreadMessage],
       template: `
         <div ngpThread>
           <div ngpThreadMessage>
@@ -49,9 +49,7 @@ describe('NgpThreadMessage', () => {
       content = 'Hello';
     }
 
-    const { fixture } = await render(TestComponent, {
-      imports: [NgpThread, NgpThreadMessage],
-    });
+    const { fixture } = await render(TestComponent);
 
     const component = fixture.componentInstance;
 
@@ -74,6 +72,7 @@ describe('NgpThreadMessage', () => {
 
   it('should detect child element additions', async () => {
     @Component({
+      imports: [NgpThread, NgpThreadMessage],
       template: `
         <div ngpThread>
           <div ngpThreadMessage>
@@ -89,9 +88,7 @@ describe('NgpThreadMessage', () => {
       showExtra = false;
     }
 
-    const { fixture } = await render(TestComponent, {
-      imports: [NgpThread, NgpThreadMessage],
-    });
+    const { fixture } = await render(TestComponent);
 
     const component = fixture.componentInstance;
 
@@ -108,6 +105,7 @@ describe('NgpThreadMessage', () => {
 
   it('should detect nested content changes', async () => {
     @Component({
+      imports: [NgpThread, NgpThreadMessage],
       template: `
         <div ngpThread>
           <div ngpThreadMessage>
@@ -124,9 +122,7 @@ describe('NgpThreadMessage', () => {
       nestedContent = 'Initial';
     }
 
-    const { fixture } = await render(TestComponent, {
-      imports: [NgpThread, NgpThreadMessage],
-    });
+    const { fixture } = await render(TestComponent);
 
     const component = fixture.componentInstance;
 
@@ -143,6 +139,7 @@ describe('NgpThreadMessage', () => {
 
   it('should handle component lifecycle correctly', async () => {
     @Component({
+      imports: [NgpThread, NgpThreadMessage],
       template: `
         <div ngpThread>
           @if (showMessage) {
@@ -155,9 +152,7 @@ describe('NgpThreadMessage', () => {
       showMessage = true;
     }
 
-    const { fixture } = await render(TestComponent, {
-      imports: [NgpThread, NgpThreadMessage],
-    });
+    const { fixture } = await render(TestComponent);
 
     const component = fixture.componentInstance;
 
@@ -177,6 +172,7 @@ describe('NgpThreadMessage', () => {
 
   it('should handle multiple simultaneous content changes', async () => {
     @Component({
+      imports: [NgpThread, NgpThreadMessage],
       template: `
         <div ngpThread>
           <div ngpThreadMessage>
@@ -193,9 +189,7 @@ describe('NgpThreadMessage', () => {
       content3 = 'C';
     }
 
-    const { fixture } = await render(TestComponent, {
-      imports: [NgpThread, NgpThreadMessage],
-    });
+    const { fixture } = await render(TestComponent);
 
     const component = fixture.componentInstance;
 
@@ -216,6 +210,7 @@ describe('NgpThreadMessage', () => {
 
   it('should not trigger on attribute-only changes', async () => {
     @Component({
+      imports: [NgpThread, NgpThreadMessage],
       template: `
         <div ngpThread>
           <div ngpThreadMessage>
@@ -228,9 +223,7 @@ describe('NgpThreadMessage', () => {
       cssClass = 'initial-class';
     }
 
-    const { fixture } = await render(TestComponent, {
-      imports: [NgpThread, NgpThreadMessage],
-    });
+    const { fixture } = await render(TestComponent);
 
     const component = fixture.componentInstance;
 

--- a/packages/ng-primitives/ai/src/thread-message/thread-message-state.ts
+++ b/packages/ng-primitives/ai/src/thread-message/thread-message-state.ts
@@ -1,29 +1,40 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpThreadMessage } from './thread-message';
+import { fromMutationObserver, injectElementRef } from 'ng-primitives/internal';
+import { createPrimitive, onDestroy } from 'ng-primitives/state';
+import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
+import { injectThreadState } from '../thread/thread-state';
 
-/**
- * The state token  for the ThreadMessage primitive.
- */
-export const NgpThreadMessageStateToken = createStateToken<NgpThreadMessage>('ThreadMessage');
+export interface NgpThreadMessageState {}
 
-/**
- * Provides the ThreadMessage state.
- */
-export const provideThreadMessageState = createStateProvider(NgpThreadMessageStateToken);
-
-/**
- * Injects the ThreadMessage state.
- */
-export const injectThreadMessageState = createStateInjector<NgpThreadMessage>(
+export const [
   NgpThreadMessageStateToken,
-);
+  ngpThreadMessage,
+  injectThreadMessageState,
+  provideThreadMessageState,
+] = createPrimitive('NgpThreadMessage', (): NgpThreadMessageState => {
+  const element = injectElementRef<HTMLElement>();
+  const thread = injectThreadState();
 
-/**
- * The ThreadMessage state registration function.
- */
-export const threadMessageState = createState(NgpThreadMessageStateToken);
+  // Identity token for this message. The thread orders messages by registration order,
+  // so a stable per-message reference is all it needs.
+  const state: NgpThreadMessageState = {};
+
+  // Watch for content changes (like streaming text) and maintain scroll position
+  fromMutationObserver(element.nativeElement, {
+    childList: true, // Watch for new/removed child nodes
+    subtree: true, // Watch changes in all descendants
+    characterData: true, // Watch for text content changes in text nodes
+    attributes: false, // We don't care about attribute changes for content streaming
+  })
+    .pipe(safeTakeUntilDestroyed())
+    .subscribe(() => {
+      // if this is the last message, scroll to bottom
+      if (thread().isLastMessage(state)) {
+        thread().scrollToBottom('smooth');
+      }
+    });
+
+  thread().registerMessage(state);
+  onDestroy(() => thread().unregisterMessage(state));
+
+  return state;
+});

--- a/packages/ng-primitives/ai/src/thread-message/thread-message.ts
+++ b/packages/ng-primitives/ai/src/thread-message/thread-message.ts
@@ -1,8 +1,5 @@
-import { DestroyRef, Directive, ElementRef, inject } from '@angular/core';
-import { fromMutationObserver } from 'ng-primitives/internal';
-import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
-import { injectThreadState } from '../thread/thread-state';
-import { provideThreadMessageState, threadMessageState } from './thread-message-state';
+import { Directive } from '@angular/core';
+import { ngpThreadMessage, provideThreadMessageState } from './thread-message-state';
 
 @Directive({
   selector: '[ngpThreadMessage]',
@@ -10,30 +7,6 @@ import { provideThreadMessageState, threadMessageState } from './thread-message-
   providers: [provideThreadMessageState()],
 })
 export class NgpThreadMessage {
-  private readonly elementRef = inject(ElementRef<HTMLElement>);
-  private readonly destroyRef = inject(DestroyRef);
-  private readonly thread = injectThreadState();
-
   /** The state of the thread message. */
-  protected readonly state = threadMessageState<NgpThreadMessage>(this);
-
-  constructor() {
-    // Watch for content changes (like streaming text) and maintain scroll position
-    fromMutationObserver(this.elementRef.nativeElement, {
-      childList: true, // Watch for new/removed child nodes
-      subtree: true, // Watch changes in all descendants
-      characterData: true, // Watch for text content changes in text nodes
-      attributes: false, // We don't care about attribute changes for content streaming
-    })
-      .pipe(safeTakeUntilDestroyed())
-      .subscribe(() => {
-        // if this is the last message, scroll to bottom
-        if (this.thread().isLastMessage(this)) {
-          this.thread().scrollToBottom('smooth');
-        }
-      });
-
-    this.thread().registerMessage(this);
-    this.destroyRef.onDestroy(() => this.thread().unregisterMessage(this));
-  }
+  protected readonly state = ngpThreadMessage();
 }

--- a/packages/ng-primitives/ai/src/thread-suggestion/tests/thread-suggestion-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/thread-suggestion/tests/thread-suggestion-primitive.test.ts
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
+import {
+  NgpPromptComposer,
+  NgpPromptComposerInput,
+  NgpThread,
+  NgpThreadSuggestion,
+} from 'ng-primitives/ai';
+import { describe, expect, it } from 'vitest';
+
+describe('NgpThreadSuggestion', () => {
+  it('should populate the prompt when clicked', async () => {
+    await render(
+      `<div ngpThread>
+        <button ngpThreadSuggestion="Explain Angular signals">Suggestion</button>
+        <div ngpPromptComposer>
+          <input ngpPromptComposerInput />
+        </div>
+      </div>`,
+      {
+        imports: [NgpThread, NgpThreadSuggestion, NgpPromptComposer, NgpPromptComposerInput],
+      },
+    );
+
+    const input = screen.getByRole('textbox');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Suggestion' }));
+
+    await waitFor(() => expect(input).toHaveValue('Explain Angular signals'));
+    expect(input).toHaveFocus();
+  });
+
+  it('should not populate the prompt when setPromptOnClick is false', async () => {
+    await render(
+      `<div ngpThread>
+        <button
+          ngpThreadSuggestion="Explain Angular signals"
+          ngpThreadSuggestionSetPromptOnClick="false"
+        >
+          Suggestion
+        </button>
+        <div ngpPromptComposer>
+          <input ngpPromptComposerInput />
+        </div>
+      </div>`,
+      {
+        imports: [NgpThread, NgpThreadSuggestion, NgpPromptComposer, NgpPromptComposerInput],
+      },
+    );
+
+    const input = screen.getByRole('textbox');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Suggestion' }));
+
+    expect(input).toHaveValue('');
+  });
+
+  it('should do nothing when the suggestion is empty', async () => {
+    await render(
+      `<div ngpThread>
+        <button ngpThreadSuggestion>Suggestion</button>
+        <div ngpPromptComposer>
+          <input ngpPromptComposerInput />
+        </div>
+      </div>`,
+      {
+        imports: [NgpThread, NgpThreadSuggestion, NgpPromptComposer, NgpPromptComposerInput],
+      },
+    );
+
+    const input = screen.getByRole('textbox');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Suggestion' }));
+
+    expect(input).toHaveValue('');
+  });
+});

--- a/packages/ng-primitives/ai/src/thread-suggestion/thread-suggestion-state.ts
+++ b/packages/ng-primitives/ai/src/thread-suggestion/thread-suggestion-state.ts
@@ -1,30 +1,49 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpThreadSuggestion } from './thread-suggestion';
+import { signal, Signal } from '@angular/core';
+import { injectElementRef } from 'ng-primitives/internal';
+import { createPrimitive, listener } from 'ng-primitives/state';
+import { injectThreadState } from '../thread/thread-state';
 
-/**
- * The state token  for the ThreadSuggestion primitive.
- */
-export const NgpThreadSuggestionStateToken =
-  createStateToken<NgpThreadSuggestion>('ThreadSuggestion');
+export interface NgpThreadSuggestionState {
+  /**
+   * Populate the prompt with this suggestion.
+   */
+  submitSuggestion(): void;
+}
 
-/**
- * Provides the ThreadSuggestion state.
- */
-export const provideThreadSuggestionState = createStateProvider(NgpThreadSuggestionStateToken);
+export interface NgpThreadSuggestionProps {
+  /**
+   * The suggested text to display in the input field.
+   */
+  readonly suggestion?: Signal<string>;
+  /**
+   * Whether the suggestion should populate the prompt when clicked.
+   */
+  readonly setPromptOnClick?: Signal<boolean>;
+}
 
-/**
- * Injects the ThreadSuggestion state.
- */
-export const injectThreadSuggestionState = createStateInjector<NgpThreadSuggestion>(
+export const [
   NgpThreadSuggestionStateToken,
-);
+  ngpThreadSuggestion,
+  injectThreadSuggestionState,
+  provideThreadSuggestionState,
+] = createPrimitive(
+  'NgpThreadSuggestion',
+  ({
+    suggestion = signal(''),
+    setPromptOnClick = signal(true),
+  }: NgpThreadSuggestionProps): NgpThreadSuggestionState => {
+    const element = injectElementRef<HTMLElement>();
+    const thread = injectThreadState();
 
-/**
- * The ThreadSuggestion state registration function.
- */
-export const threadSuggestionState = createState(NgpThreadSuggestionStateToken);
+    function submitSuggestion(): void {
+      if (setPromptOnClick() && suggestion().length > 0) {
+        thread().setPrompt(suggestion());
+      }
+    }
+
+    // Listener
+    listener(element, 'click', submitSuggestion);
+
+    return { submitSuggestion } satisfies NgpThreadSuggestionState;
+  },
+);

--- a/packages/ng-primitives/ai/src/thread-suggestion/thread-suggestion.ts
+++ b/packages/ng-primitives/ai/src/thread-suggestion/thread-suggestion.ts
@@ -1,7 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Directive, HostListener, input } from '@angular/core';
-import { injectThreadState } from '../thread/thread-state';
-import { provideThreadSuggestionState, threadSuggestionState } from './thread-suggestion-state';
+import { booleanAttribute, Directive, input } from '@angular/core';
+import { ngpThreadSuggestion, provideThreadSuggestionState } from './thread-suggestion-state';
 
 @Directive({
   selector: 'button[ngpThreadSuggestion]',
@@ -9,8 +8,6 @@ import { provideThreadSuggestionState, threadSuggestionState } from './thread-su
   providers: [provideThreadSuggestionState()],
 })
 export class NgpThreadSuggestion {
-  private readonly thread = injectThreadState();
-
   /** The suggested text to display in the input field. */
   readonly suggestion = input<string>('', { alias: 'ngpThreadSuggestion' });
 
@@ -21,12 +18,13 @@ export class NgpThreadSuggestion {
   });
 
   /** The state of the thread suggestion. */
-  protected readonly state = threadSuggestionState<NgpThreadSuggestion>(this);
+  protected readonly state = ngpThreadSuggestion({
+    suggestion: this.suggestion,
+    setPromptOnClick: this.setPromptOnClick,
+  });
 
-  @HostListener('click')
+  /** Populate the prompt with this suggestion. */
   submitSuggestion(): void {
-    if (this.state.setPromptOnClick() && this.state.suggestion().length > 0) {
-      this.thread().setPrompt(this.state.suggestion());
-    }
+    this.state.submitSuggestion();
   }
 }

--- a/packages/ng-primitives/ai/src/thread-viewport/tests/thread-viewport-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/thread-viewport/tests/thread-viewport-primitive.test.ts
@@ -1,0 +1,95 @@
+import { Component } from '@angular/core';
+import { render, screen, waitFor } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
+import {
+  NgpPromptComposer,
+  NgpPromptComposerInput,
+  NgpThread,
+  NgpThreadMessage,
+  NgpThreadViewport,
+} from 'ng-primitives/ai';
+import { describe, expect, it } from 'vitest';
+
+describe('NgpThreadViewport', () => {
+  it('should scroll to the bottom when a prompt is submitted', async () => {
+    await render(
+      `<div ngpThread>
+        <div ngpThreadViewport data-testid="viewport" style="height: 100px; overflow-y: auto;">
+          <div style="height: 500px;">Tall content</div>
+        </div>
+        <div ngpPromptComposer>
+          <input ngpPromptComposerInput />
+        </div>
+      </div>`,
+      {
+        imports: [NgpThread, NgpThreadViewport, NgpPromptComposer, NgpPromptComposerInput],
+      },
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    expect(viewport.scrollTop).toBe(0);
+
+    await userEvent.type(screen.getByRole('textbox'), 'Hello world');
+    await userEvent.keyboard('{Enter}');
+
+    await waitFor(() => expect(viewport.scrollTop).toBeGreaterThan(0));
+  });
+
+  it('should not scroll when auto scroll is disabled', async () => {
+    await render(
+      `<div ngpThread>
+        <div
+          ngpThreadViewport
+          ngpThreadViewportAutoScroll="false"
+          data-testid="viewport"
+          style="height: 100px; overflow-y: auto;"
+        >
+          <div style="height: 500px;">Tall content</div>
+        </div>
+        <div ngpPromptComposer>
+          <input ngpPromptComposerInput />
+        </div>
+      </div>`,
+      {
+        imports: [NgpThread, NgpThreadViewport, NgpPromptComposer, NgpPromptComposerInput],
+      },
+    );
+
+    const viewport = screen.getByTestId('viewport');
+
+    await userEvent.type(screen.getByRole('textbox'), 'Hello world');
+    await userEvent.keyboard('{Enter}');
+
+    // give the scroll a chance to happen before asserting that it did not
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(viewport.scrollTop).toBe(0);
+  });
+
+  it('should scroll when the last message streams new content', async () => {
+    @Component({
+      imports: [NgpThread, NgpThreadViewport, NgpThreadMessage],
+      template: `
+        <div ngpThread>
+          <div ngpThreadViewport data-testid="viewport" style="height: 100px; overflow-y: auto;">
+            <div ngpThreadMessage style="height: 300px;">First message</div>
+            <div ngpThreadMessage style="height: 300px;">{{ content }}</div>
+          </div>
+        </div>
+      `,
+    })
+    class TestComponent {
+      content = 'Second';
+    }
+
+    const { fixture } = await render(TestComponent);
+
+    const viewport = screen.getByTestId('viewport');
+    expect(viewport.scrollTop).toBe(0);
+
+    fixture.componentInstance.content = 'Second message, now streaming more content';
+    fixture.detectChanges();
+
+    await waitFor(() => expect(viewport.scrollTop).toBeGreaterThan(0));
+  });
+});

--- a/packages/ng-primitives/ai/src/thread-viewport/thread-viewport-state.ts
+++ b/packages/ng-primitives/ai/src/thread-viewport/thread-viewport-state.ts
@@ -1,29 +1,80 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpThreadViewport } from './thread-viewport';
+import { signal, Signal } from '@angular/core';
+import { fromResizeEvent, injectElementRef } from 'ng-primitives/internal';
+import { createPrimitive, listener, onDestroy } from 'ng-primitives/state';
+import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
+import { injectThreadState } from '../thread/thread-state';
 
-/**
- * The state token  for the ThreadViewport primitive.
- */
-export const NgpThreadViewportStateToken = createStateToken<NgpThreadViewport>('ThreadViewport');
+export interface NgpThreadViewportState {
+  /**
+   * @internal
+   * Scroll the viewport to the bottom.
+   */
+  scrollToBottom(behavior: ScrollBehavior): void;
+}
 
-/**
- * Provides the ThreadViewport state.
- */
-export const provideThreadViewportState = createStateProvider(NgpThreadViewportStateToken);
+export interface NgpThreadViewportProps {
+  /**
+   * Whether the thread should automatically scroll to the bottom when new content is added.
+   */
+  readonly autoScroll?: Signal<boolean>;
+}
 
-/**
- * Injects the ThreadViewport state.
- */
-export const injectThreadViewportState = createStateInjector<NgpThreadViewport>(
+export const [
   NgpThreadViewportStateToken,
-);
+  ngpThreadViewport,
+  injectThreadViewportState,
+  provideThreadViewportState,
+] = createPrimitive(
+  'NgpThreadViewport',
+  ({ autoScroll = signal(true) }: NgpThreadViewportProps): NgpThreadViewportState => {
+    const element = injectElementRef<HTMLElement>();
+    const thread = injectThreadState();
 
-/**
- * The ThreadViewport state registration function.
- */
-export const threadViewportState = createState(NgpThreadViewportStateToken);
+    /** Store the last known scroll position */
+    let lastScrollTop = 0;
+
+    /** Determine if we are at the bottom of the scrollable container (within the threshold) */
+    let isAtBottom = false;
+
+    function scrollToBottom(behavior: ScrollBehavior): void {
+      if (!autoScroll()) {
+        return;
+      }
+
+      element.nativeElement.scrollTo({
+        top: element.nativeElement.scrollHeight,
+        behavior,
+      });
+    }
+
+    function onScroll(): void {
+      const { scrollHeight, scrollTop, clientHeight } = element.nativeElement;
+      const atBottom = scrollHeight - scrollTop <= clientHeight;
+
+      if (atBottom || lastScrollTop >= scrollTop) {
+        isAtBottom = atBottom;
+      }
+
+      lastScrollTop = scrollTop;
+    }
+
+    // Listener
+    listener(element, 'scroll', onScroll);
+
+    fromResizeEvent(element.nativeElement)
+      .pipe(safeTakeUntilDestroyed())
+      .subscribe(() => {
+        if (isAtBottom) {
+          scrollToBottom('instant');
+        }
+        onScroll();
+      });
+
+    const state = { scrollToBottom } satisfies NgpThreadViewportState;
+
+    thread().setViewport(state);
+    onDestroy(() => thread().removeViewport(state));
+
+    return state;
+  },
+);

--- a/packages/ng-primitives/ai/src/thread-viewport/thread-viewport.ts
+++ b/packages/ng-primitives/ai/src/thread-viewport/thread-viewport.ts
@@ -1,17 +1,6 @@
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
-import {
-  booleanAttribute,
-  Directive,
-  ElementRef,
-  HostListener,
-  inject,
-  input,
-  numberAttribute,
-} from '@angular/core';
-import { fromResizeEvent } from 'ng-primitives/internal';
-import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
-import { injectThreadState } from '../thread/thread-state';
-import { provideThreadViewportState, threadViewportState } from './thread-viewport-state';
+import { booleanAttribute, Directive, input, numberAttribute } from '@angular/core';
+import { ngpThreadViewport, provideThreadViewportState } from './thread-viewport-state';
 
 @Directive({
   selector: '[ngpThreadViewport]',
@@ -19,9 +8,6 @@ import { provideThreadViewportState, threadViewportState } from './thread-viewpo
   providers: [provideThreadViewportState()],
 })
 export class NgpThreadViewport {
-  private readonly thread = injectThreadState();
-  private readonly elementRef = inject(ElementRef<HTMLElement>);
-
   /**
    * The distance in pixels from the bottom of the scrollable container that is considered "at the bottom".
    * When the user scrolls within this threshold, the thread is treated as being at the bottom.
@@ -43,55 +29,14 @@ export class NgpThreadViewport {
     transform: booleanAttribute,
   });
 
-  /** Store the last known scroll position */
-  private lastScrollTop = 0;
-
-  /** Determine if we are at the bottom of the scrollable container (within the threshold) */
-  protected isAtBottom = false;
-
   /** The state of the thread viewport. */
-  protected readonly state = threadViewportState<NgpThreadViewport>(this);
-
-  constructor() {
-    // listen for scroll requests from the thread
-    this.thread()
-      .scrollRequest.pipe(safeTakeUntilDestroyed())
-      .subscribe(behavior => this.scrollToBottom(behavior));
-
-    fromResizeEvent(this.elementRef.nativeElement)
-      .pipe(safeTakeUntilDestroyed())
-      .subscribe(() => {
-        if (this.isAtBottom) {
-          this.scrollToBottom('instant');
-        }
-        this.onScroll();
-      });
-  }
+  protected readonly state = ngpThreadViewport({ autoScroll: this.autoScroll });
 
   /**
    * Scroll the container to the bottom.
    * @internal
    */
   scrollToBottom(behavior: ScrollBehavior): void {
-    if (!this.state.autoScroll()) {
-      return;
-    }
-
-    this.elementRef.nativeElement.scrollTo({
-      top: this.elementRef.nativeElement.scrollHeight,
-      behavior,
-    });
-  }
-
-  @HostListener('scroll')
-  protected onScroll(): void {
-    const element = this.elementRef.nativeElement;
-    const isAtBottom = element.scrollHeight - element.scrollTop <= element.clientHeight;
-
-    if (isAtBottom || this.lastScrollTop >= element.scrollTop) {
-      this.isAtBottom = isAtBottom;
-    }
-
-    this.lastScrollTop = element.scrollTop;
+    this.state.scrollToBottom(behavior);
   }
 }

--- a/packages/ng-primitives/ai/src/thread/tests/thread-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/thread/tests/thread-primitive.test.ts
@@ -1,0 +1,94 @@
+import { Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { render, screen, waitFor } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
+import {
+  NgpPromptComposer,
+  NgpPromptComposerInput,
+  NgpThread,
+  NgpThreadViewport,
+} from 'ng-primitives/ai';
+import { describe, expect, it } from 'vitest';
+
+describe('NgpThread', () => {
+  it('should route the prompt to the registered composer input', async () => {
+    await render(
+      `<div ngpThread #thread="ngpThread">
+        <div ngpPromptComposer>
+          <input ngpPromptComposerInput />
+        </div>
+        <button (click)="thread.setPrompt('From the thread')">Set prompt</button>
+      </div>`,
+      {
+        imports: [NgpThread, NgpPromptComposer, NgpPromptComposerInput],
+      },
+    );
+
+    const input = screen.getByRole('textbox');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Set prompt' }));
+
+    await waitFor(() => expect(input).toHaveValue('From the thread'));
+    expect(input).toHaveFocus();
+  });
+
+  it('should scroll the registered viewport to the bottom', async () => {
+    await render(
+      `<div ngpThread #thread="ngpThread">
+        <div ngpThreadViewport data-testid="viewport" style="height: 100px; overflow-y: auto;">
+          <div style="height: 500px;">Tall content</div>
+        </div>
+        <button (click)="thread.scrollToBottom('instant')">Scroll</button>
+      </div>`,
+      {
+        imports: [NgpThread, NgpThreadViewport],
+      },
+    );
+
+    const viewport = screen.getByTestId('viewport');
+    expect(viewport.scrollTop).toBe(0);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Scroll' }));
+
+    await waitFor(() => expect(viewport.scrollTop).toBeGreaterThan(0));
+  });
+
+  it('should do nothing when no viewport or prompt input is registered', async () => {
+    const { fixture } = await render(`<div ngpThread></div>`, {
+      imports: [NgpThread],
+    });
+
+    const thread = fixture.debugElement.query(By.directive(NgpThread)).injector.get(NgpThread);
+
+    expect(() => thread.scrollToBottom('instant')).not.toThrow();
+    expect(() => thread.setPrompt('Hello world')).not.toThrow();
+  });
+
+  it('should deregister the viewport when it is destroyed', async () => {
+    @Component({
+      imports: [NgpThread, NgpThreadViewport],
+      template: `
+        <div ngpThread>
+          @if (showViewport) {
+            <div ngpThreadViewport data-testid="viewport" style="height: 100px; overflow-y: auto;">
+              <div style="height: 500px;">Tall content</div>
+            </div>
+          }
+        </div>
+      `,
+    })
+    class TestComponent {
+      showViewport = true;
+    }
+
+    const { fixture } = await render(TestComponent);
+
+    const thread = fixture.debugElement.query(By.directive(NgpThread)).injector.get(NgpThread);
+
+    fixture.componentInstance.showViewport = false;
+    fixture.detectChanges();
+
+    expect(screen.queryByTestId('viewport')).not.toBeInTheDocument();
+    expect(() => thread.scrollToBottom('instant')).not.toThrow();
+  });
+});

--- a/packages/ng-primitives/ai/src/thread/thread-state.ts
+++ b/packages/ng-primitives/ai/src/thread/thread-state.ts
@@ -1,27 +1,117 @@
-import {
-  createState,
-  createStateInjector,
-  createStateProvider,
-  createStateToken,
-} from 'ng-primitives/state';
-import type { NgpThread } from './thread';
+import { signal } from '@angular/core';
+import { createPrimitive } from 'ng-primitives/state';
+import type { NgpPromptComposerInputState } from '../prompt-composer-input/prompt-composer-input-state';
+import type { NgpThreadMessageState } from '../thread-message/thread-message-state';
+import type { NgpThreadViewportState } from '../thread-viewport/thread-viewport-state';
 
-/**
- * The state token  for the Thread primitive.
- */
-export const NgpThreadStateToken = createStateToken<NgpThread>('Thread');
+export interface NgpThreadState {
+  /**
+   * Scroll the thread viewport to the bottom.
+   * @param behavior The scroll behavior to use.
+   */
+  scrollToBottom(behavior: ScrollBehavior): void;
+  /**
+   * Set the prompt text in the associated prompt composer.
+   * @param value The prompt text.
+   */
+  setPrompt(value: string): void;
+  /**
+   * @internal
+   * Register the viewport that scrolls this thread.
+   */
+  setViewport(viewport: NgpThreadViewportState): void;
+  /**
+   * @internal
+   * Deregister the viewport that scrolls this thread.
+   */
+  removeViewport(viewport: NgpThreadViewportState): void;
+  /**
+   * @internal
+   * Register the prompt input that receives the prompt text.
+   */
+  setPromptInput(input: NgpPromptComposerInputState): void;
+  /**
+   * @internal
+   * Deregister the prompt input that receives the prompt text.
+   */
+  removePromptInput(input: NgpPromptComposerInputState): void;
+  /**
+   * @internal
+   * Register a message with the thread.
+   */
+  registerMessage(message: NgpThreadMessageState): void;
+  /**
+   * @internal
+   * Deregister a message from the thread.
+   */
+  unregisterMessage(message: NgpThreadMessageState): void;
+  /**
+   * @internal
+   * Determine if the given message is the last message in the thread.
+   */
+  isLastMessage(message: NgpThreadMessageState): boolean;
+}
 
-/**
- * Provides the Thread state.
- */
-export const provideThreadState = createStateProvider(NgpThreadStateToken);
+export const [NgpThreadStateToken, ngpThread, injectThreadState, provideThreadState] =
+  createPrimitive('NgpThread', (): NgpThreadState => {
+    // The parts that carry out the thread's imperative work register themselves here, so the
+    // thread can drive them directly rather than broadcasting requests they may not receive.
+    const viewport = signal<NgpThreadViewportState | null>(null);
+    const promptInput = signal<NgpPromptComposerInputState | null>(null);
+    const messages = signal<NgpThreadMessageState[]>([]);
 
-/**
- * Injects the Thread state.
- */
-export const injectThreadState = createStateInjector<NgpThread>(NgpThreadStateToken);
+    function scrollToBottom(behavior: ScrollBehavior): void {
+      viewport()?.scrollToBottom(behavior);
+    }
 
-/**
- * The Thread state registration function.
- */
-export const threadState = createState(NgpThreadStateToken);
+    function setPrompt(value: string): void {
+      promptInput()?.setPrompt(value);
+    }
+
+    function setViewport(value: NgpThreadViewportState): void {
+      viewport.set(value);
+    }
+
+    function removeViewport(value: NgpThreadViewportState): void {
+      // only clear if this viewport is still the active one, so a newer viewport that has
+      // taken over isn't clobbered when an old one is torn down
+      if (viewport() === value) {
+        viewport.set(null);
+      }
+    }
+
+    function setPromptInput(value: NgpPromptComposerInputState): void {
+      promptInput.set(value);
+    }
+
+    function removePromptInput(value: NgpPromptComposerInputState): void {
+      if (promptInput() === value) {
+        promptInput.set(null);
+      }
+    }
+
+    function registerMessage(message: NgpThreadMessageState): void {
+      messages.update(current => [...current, message]);
+    }
+
+    function unregisterMessage(message: NgpThreadMessageState): void {
+      messages.update(current => current.filter(m => m !== message));
+    }
+
+    function isLastMessage(message: NgpThreadMessageState): boolean {
+      const current = messages();
+      return current.length > 0 && current[current.length - 1] === message;
+    }
+
+    return {
+      scrollToBottom,
+      setPrompt,
+      setViewport,
+      removeViewport,
+      setPromptInput,
+      removePromptInput,
+      registerMessage,
+      unregisterMessage,
+      isLastMessage,
+    } satisfies NgpThreadState;
+  });

--- a/packages/ng-primitives/ai/src/thread/thread.ts
+++ b/packages/ng-primitives/ai/src/thread/thread.ts
@@ -1,7 +1,5 @@
 import { Directive } from '@angular/core';
-import { Subject } from 'rxjs';
-import { NgpThreadMessage } from '../thread-message/thread-message';
-import { provideThreadState, threadState } from './thread-state';
+import { ngpThread, provideThreadState } from './thread-state';
 
 @Directive({
   selector: '[ngpThread]',
@@ -9,38 +7,22 @@ import { provideThreadState, threadState } from './thread-state';
   providers: [provideThreadState()],
 })
 export class NgpThread {
-  private messages: NgpThreadMessage[] = [];
-
-  /** @internal emit event to trigger scrolling to bottom */
-  readonly scrollRequest = new Subject<ScrollBehavior>();
-
-  /** @internal emit event to trigger setting the prompt */
-  readonly requestPrompt = new Subject<string>();
-
   /** The state of the thread. */
-  protected readonly state = threadState<NgpThread>(this);
+  protected readonly state = ngpThread();
 
+  /**
+   * Scroll the thread viewport to the bottom.
+   * @param behavior The scroll behavior to use.
+   */
   scrollToBottom(behavior: ScrollBehavior): void {
-    this.scrollRequest.next(behavior);
+    this.state.scrollToBottom(behavior);
   }
 
-  /** @internal Register a message with the thread */
-  registerMessage(message: NgpThreadMessage): void {
-    this.messages.push(message);
-  }
-
-  /** @internal Unregister a message from the thread */
-  unregisterMessage(message: NgpThreadMessage): void {
-    this.messages = this.messages.filter(m => m !== message);
-  }
-
-  /** @internal Determine if the given message is the last message in the thread */
-  isLastMessage(message: NgpThreadMessage): boolean {
-    return this.messages.length > 0 && this.messages[this.messages.length - 1] === message;
-  }
-
-  /** @internal Set the prompt text in the associated prompt composer */
+  /**
+   * Set the prompt text in the associated prompt composer.
+   * @param value The prompt text.
+   */
   setPrompt(value: string): void {
-    this.requestPrompt.next(value);
+    this.state.setPrompt(value);
   }
 }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated — internal state-pattern migration with no consumer-facing API change, so no docs update is needed

## PR Type

- [x] Refactoring (no functional changes, no api changes)

## Issue

Closes #839

## What does this PR implement/fix?

Migrates the `ai` primitives (`prompt-composer` and `thread`, 8 parts) from the legacy createStateToken/createStateProvider/createStateInjector/createState quadruple to the current createPrimitive state pattern, in line with the recent listbox (#835), search (#838) and input-otp (#834) migrations. This leaves `combobox` (#759) and `date-picker` as the last legacy primitives.

### What moved
- thread: the two RxJS Subjects (`scrollRequest`, `requestPrompt`) are gone. The viewport and the prompt input now register with the thread (`setViewport`/`removeViewport`, `setPromptInput`/`removePromptInput`) and the thread drives them directly, the way roving-focus drives its items. The backing signals stay private to the factory; children deregister with `onDestroy`, and the remove functions only clear when the caller is still the active part.
- thread-message / thread-viewport / thread-suggestion: new `-state.ts` factories own the mutation observer, the resize/scroll listeners and the click listener. Messages register an identity token (as input-otp slots do) so the thread can tell which one is last.
- prompt-composer: `prompt`, `hasPrompt`, `isDictating` and `dictationSupported` live in the factory along with the three `data-*` bindings; the directive emits through an `onSubmit` callback rather than reading state.
- prompt-composer-input / -submit / -dictation: host bindings, listeners and the SpeechRecognition lifecycle move into their factories. `-submit` and `-dictation` compose `ngpButton({ disabled })` inside the factory. `@HostListener('keydown.enter')` becomes an explicit `keydown` listener that checks `event.key`, since `listener()` registers raw DOM events.

### Tests
Adds suites for `thread`, `thread-viewport` and `thread-suggestion`, which had no coverage: prompt routing to the registered input, viewport scrolling and deregistration, `ngpThreadViewportAutoScroll="false"`, streaming into the last message, and the three click paths of a suggestion.

Also fixes the existing `thread-message` suite: its `TestComponent`s declared no `imports`, so with standalone components the directives were never applied and the tests passed without exercising the primitive. Full `ai` suite green (55/55), plus lint and AOT build.

### Out of scope
Three pre-existing bugs were found while migrating and deliberately left untouched so the diff stays structural; I'll file them separately: `ngpThreadViewportThreshold` is documented but never read; `NgpPromptComposerDictation` reads `window.SpeechRecognition` at construction and so breaks under SSR; and `ngpPromptComposer` hard-requires an `ngpThread` ancestor.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the AI primitives to `createPrimitive`, replacing RxJS subjects with direct part registration and moving host bindings/listeners into state factories. Expands exports and tests; no consumer API changes.

- **Refactors**
  - Migrated `prompt-composer`, `thread`, and parts (`input`, `submit`, `dictation`, `message`, `viewport`, `suggestion`) to `createPrimitive`; export `ngp*` factories, `*StateToken`s, and state types/props from `ai/src/index.ts`.
  - Thread now directly drives parts via registration: `setViewport/removeViewport`, `setPromptInput/removePromptInput`; tracks messages to identify the last one for auto-scroll.
  - `prompt-composer-*` move bindings/listeners into factories; `submit`/`dictation` compose `ngpButton({ disabled })`; explicit `keydown` handling (Enter submit, Escape to stop dictation). Dictation streams interim/final transcripts into the prompt, preserving existing text.

- **Tests**
  - Added suites for `thread`, `thread-viewport`, and `thread-suggestion`: prompt routing to registered input, viewport scrolling and deregistration, `ngpThreadViewportAutoScroll="false"`, and suggestion click behavior.
  - Fixed `thread-message` test setup to import directives so content change observation triggers auto-scroll.

- **Migration**
  - No changes required for consumers; existing directives continue to work. New `ngp*` state factories are available for advanced use.

<sup>Written for commit bc483dbd2e2147fb781d9b1530dcb95de06d1a83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser speech dictation for prompt composers, including start/stop controls and live transcript updates.
  * Prompt inputs now synchronise automatically with the composer, submit on Enter, and receive focus when populated by suggestions.
  * Configurable thread suggestions can populate the prompt input.
  * Improved thread auto-scrolling for submissions, streamed messages, viewport resizing, and respect for auto-scroll settings.
  * Expanded public AI primitive exports and state information for easier integration.
* **Tests**
  * Added/updated coverage for dictation, suggestions, scrolling, and thread message/view-port registration behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->