### PR TITLE
fix(internal): harden exit-animation system and align with native animate.leave

### DIFF
--- a/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
@@ -43,9 +43,36 @@ export interface NgpExitAnimationRef {
   cancel: () => void;
 }
 
+/**
+ * Buffer (ms) added to the longest animation's own computed duration when arming
+ * the fallback timeout, so the timeout only fires once the animation should have
+ * finished but `finished` failed to settle. Matches the native `animate.leave`
+ * class runner's `longest.duration + 50`.
+ */
+const EXIT_ANIMATION_FALLBACK_BUFFER = 50;
+
 /** Whether an animation repeats forever, and so will never resolve `finished`. */
 function isInfinite(animation: Animation): boolean {
   return animation.effect?.getComputedTiming().iterations === Infinity;
+}
+
+/**
+ * The defensive fallback delay for a set of exit animations: the longest
+ * animation's own end time plus a small buffer. Used only as a safety net - if
+ * `finished` (the authoritative signal) never settles, teardown still proceeds
+ * shortly after the animation should have ended. Derived from each animation's
+ * declared timing, so a healthy long animation is never cut short. Mirrors
+ * native's CSS `animate.leave` fallback (`longest.duration + 50`, uncapped).
+ */
+function exitAnimationFallbackTimeout(animations: Animation[]): number {
+  let longest = 0;
+  for (const animation of animations) {
+    const endTime = animation.effect?.getComputedTiming().endTime;
+    if (typeof endTime === 'number' && Number.isFinite(endTime)) {
+      longest = Math.max(longest, endTime);
+    }
+  }
+  return longest + EXIT_ANIMATION_FALLBACK_BUFFER;
 }
 
 export function setupExitAnimation({
@@ -54,6 +81,12 @@ export function setupExitAnimation({
 }: NgpExitAnimationOptions): NgpExitAnimationRef {
   let state: 'enter' | 'exit' = 'enter';
   let exitResolve: (() => void) | null = null;
+  let exitTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  // Whether this environment can actually run and observe CSS animations. On the
+  // server (or any non-DOM environment) there is nothing to animate or wait for,
+  // so enter/exit collapse to synchronous attribute toggles.
+  const canAnimate = typeof element.getAnimations === 'function';
 
   function setState(newState: 'enter' | 'exit') {
     state = newState;
@@ -70,8 +103,18 @@ export function setupExitAnimation({
     }
   }
 
-  // Set the initial state to 'enter' - immediately if instant, otherwise next frame
-  if (immediate) {
+  function clearExitTimeout() {
+    if (exitTimeout !== null) {
+      clearTimeout(exitTimeout);
+      exitTimeout = null;
+    }
+  }
+
+  // Set the initial state to 'enter' - immediately if instant or if there is no
+  // `requestAnimationFrame` to defer to (e.g. server-side rendering), otherwise
+  // next frame so the browser registers the "from" state and plays the enter
+  // transition.
+  if (immediate || typeof requestAnimationFrame !== 'function') {
     setState('enter');
   } else {
     requestAnimationFrame(() => setState('enter'));
@@ -79,9 +122,21 @@ export function setupExitAnimation({
 
   return {
     exit: () => {
-      return new Promise((resolve, reject) => {
+      return new Promise<void>(resolve => {
         exitResolve = resolve;
         setState('exit');
+
+        const settle = () => {
+          clearExitTimeout();
+          exitResolve = null;
+          resolve();
+        };
+
+        // Nothing to wait for when the environment can't run animations.
+        if (!canAnimate) {
+          settle();
+          return;
+        }
 
         // Only wait for animations that will actually finish. Infinite
         // animations (e.g. a spinner or pulse on the element) never resolve
@@ -89,34 +144,29 @@ export function setupExitAnimation({
         // - and any overlay it belongs to - stuck on screen forever.
         const animations = element.getAnimations().filter(animation => !isInfinite(animation));
 
-        // Wait for the exit animations to finish
-        if (animations.length > 0) {
-          Promise.all(animations.map(anim => anim.finished))
-            .then(() => {
-              exitResolve = null;
-              resolve();
-            })
-            .catch(err => {
-              exitResolve = null;
-              // AbortError is expected when element is removed during animation
-              // e.g. when the user navigates away to another page
-              // Note: Animation.finished can reject with DOMException which may not pass instanceof Error
-              if ((err as { name?: string })?.name === 'AbortError') {
-                resolve();
-              } else {
-                reject(err);
-              }
-            });
-        } else {
-          exitResolve = null;
-          resolve();
+        // No finite exit animation - remove immediately.
+        if (animations.length === 0) {
+          settle();
+          return;
         }
+
+        // Defensive fallback: `finished` is the authoritative signal, but if it
+        // never settles (a paused/stuck animation, or a browser quirk) teardown
+        // must still proceed. Mirrors the native `animate.leave` fallback timeout.
+        exitTimeout = setTimeout(settle, exitAnimationFallbackTimeout(animations));
+
+        // Resolve - never reject - once every finite animation settles. A
+        // rejected exit would propagate through `detach()` and leave the overlay
+        // in the DOM forever, so errors (including the AbortError raised when the
+        // element is removed mid-animation) resolve exactly like success.
+        Promise.allSettled(animations.map(anim => anim.finished)).then(settle);
       });
     },
     cancel: () => {
       if (state === 'exit') {
+        clearExitTimeout();
         // Cancel any running animations
-        const animations = element.getAnimations();
+        const animations = canAnimate ? element.getAnimations() : [];
         for (const anim of animations) {
           anim.cancel();
         }

--- a/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
@@ -127,8 +127,16 @@ export function setupExitAnimation({
         setState('exit');
 
         const settle = () => {
-          clearExitTimeout();
-          exitResolve = null;
+          // Only the currently active cycle may clear the shared timeout/resolver.
+          // `cancel()` rejects the running animations' `finished` promises
+          // asynchronously (AbortError), so a superseded cycle's `settle()` can
+          // fire after a new exit() has started on the same ref (exit → cancel →
+          // exit, via the portal's cancelDetach). A stale settle() must not clear
+          // the new cycle's fallback timer or null its resolver.
+          if (exitResolve === resolve) {
+            clearExitTimeout();
+            exitResolve = null;
+          }
           resolve();
         };
 

--- a/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
@@ -149,6 +149,52 @@ describe('setupExitAnimation', () => {
     expect(element).toHaveAttribute('data-exit');
   });
 
+  /** An animation whose `finished` rejects with AbortError when cancelled, like real WAAPI. */
+  function abortableAnimation(): Animation {
+    let reject!: (reason: unknown) => void;
+    const finished = new Promise<void>((_, r) => (reject = r));
+    finished.catch(() => undefined);
+    return {
+      finished,
+      cancel: () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+      effect: { getComputedTiming: () => ({ iterations: 1, endTime: 100_000 }) },
+    } as unknown as Animation;
+  }
+
+  /** A finite animation whose `finished` never settles - only the fallback timer can resolve it. */
+  function neverSettlingAnimation(endTime: number): Animation {
+    return {
+      finished: new Promise<void>(() => undefined),
+      cancel: () => undefined,
+      effect: { getComputedTiming: () => ({ iterations: 1, endTime }) },
+    } as unknown as Animation;
+  }
+
+  it('a superseded cycle does not clobber the new cycle (exit → cancel → exit)', async () => {
+    const element = document.createElement('div');
+    const first = abortableAnimation();
+    element.getAnimations = () => [first];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+
+    // Cycle 1: exit then cancel. cancel() rejects `first.finished` asynchronously,
+    // so cycle 1's Promise.allSettled(...).then(settle) is still pending.
+    const exit1 = ref.exit();
+    ref.cancel();
+
+    // Cycle 2 starts synchronously (portal cancelDetach → detach → exit again on the
+    // same ref) BEFORE microtasks flush, so cycle 1's late settle() runs while cycle 2
+    // owns the shared state. Cycle 2's animation never settles, so it can only resolve
+    // via the fallback timer - which a stale settle() would wrongly clear.
+    const stuck = neverSettlingAnimation(10);
+    element.getAnimations = () => [stuck];
+    const exit2 = ref.exit();
+
+    // exit2 must still resolve (via its fallback timer), proving the timer survived.
+    await expect(exit2).resolves.toBeUndefined();
+    await exit1;
+  });
+
   it('cancel() returns to the enter state and resolves a pending exit', async () => {
     const element = document.createElement('div');
     const { animation } = finiteAnimation();

--- a/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
@@ -2,17 +2,37 @@ import { describe, expect, it } from 'vitest';
 import { setupExitAnimation } from '../exit-animation';
 
 describe('setupExitAnimation', () => {
-  /** A fake animation whose `finished` promise is controllable. */
-  function finiteAnimation(): { animation: Animation; finish: () => void } {
+  /**
+   * A fake animation whose `finished` promise is controllable. `endTime` feeds
+   * the defensive fallback timeout; it defaults to a large value so tests that
+   * exercise `finished` are never resolved early by the fallback.
+   */
+  function finiteAnimation(endTime = 100_000): {
+    animation: Animation;
+    finish: () => void;
+    fail: (reason: unknown) => void;
+  } {
     let finish!: () => void;
-    const finished = new Promise<void>(resolve => (finish = resolve));
-    return { animation: { finished } as unknown as Animation, finish };
+    let fail!: (reason: unknown) => void;
+    const finished = new Promise<void>((resolve, reject) => {
+      finish = resolve;
+      fail = reject;
+    });
+    // Prevent an unhandled rejection warning; the code under test observes it.
+    finished.catch(() => undefined);
+    const animation = {
+      finished,
+      cancel: () => undefined,
+      effect: { getComputedTiming: () => ({ iterations: 1, endTime }) },
+    } as unknown as Animation;
+    return { animation, finish, fail };
   }
 
   /** A fake animation that repeats forever, so `finished` never resolves. */
   function infiniteAnimation(): Animation {
     return {
       finished: new Promise<void>(() => undefined),
+      cancel: () => undefined,
       effect: { getComputedTiming: () => ({ iterations: Infinity }) },
     } as unknown as Animation;
   }
@@ -75,5 +95,73 @@ describe('setupExitAnimation', () => {
     finish();
     await exit;
     expect(settled).toBe(true);
+  });
+
+  it('resolves (never rejects) when an animation fails, so teardown still happens', async () => {
+    const element = document.createElement('div');
+    const { animation, fail } = finiteAnimation();
+    element.getAnimations = () => [animation];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+    const exit = ref.exit();
+
+    // A non-AbortError rejection must not propagate - it would otherwise trap the
+    // overlay in the DOM forever when `detach()` awaits this promise.
+    fail(new Error('boom'));
+
+    await expect(exit).resolves.toBeUndefined();
+  });
+
+  it('resolves on AbortError (element removed mid-animation)', async () => {
+    const element = document.createElement('div');
+    const { animation, fail } = finiteAnimation();
+    element.getAnimations = () => [animation];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+    const exit = ref.exit();
+
+    fail(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+
+    await expect(exit).resolves.toBeUndefined();
+  });
+
+  it('falls back to a timeout when `finished` never settles', async () => {
+    const element = document.createElement('div');
+    // A finite (non-infinite) animation whose `finished` never resolves - e.g. a
+    // paused animation. The short endTime keeps the fallback fast for the test.
+    const { animation } = finiteAnimation(10);
+    element.getAnimations = () => [animation];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+
+    // Should resolve via the fallback timeout (endTime + buffer) rather than hang.
+    await expect(ref.exit()).resolves.toBeUndefined();
+  });
+
+  it('resolves immediately when the environment cannot run animations (SSR)', async () => {
+    const element = document.createElement('div');
+    // Simulate a non-DOM environment where getAnimations is unavailable.
+    (element as unknown as { getAnimations?: unknown }).getAnimations = undefined;
+
+    const ref = setupExitAnimation({ element, immediate: true });
+
+    await expect(ref.exit()).resolves.toBeUndefined();
+    expect(element).toHaveAttribute('data-exit');
+  });
+
+  it('cancel() returns to the enter state and resolves a pending exit', async () => {
+    const element = document.createElement('div');
+    const { animation } = finiteAnimation();
+    element.getAnimations = () => [animation];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+    const exit = ref.exit();
+    expect(element).toHaveAttribute('data-exit');
+
+    ref.cancel();
+
+    await expect(exit).resolves.toBeUndefined();
+    expect(element).toHaveAttribute('data-enter');
+    expect(element).not.toHaveAttribute('data-exit');
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

## What does this PR implement/fix?

We evaluated replacing our custom `data-enter` / `data-exit` animation system with Angular's native `animate.enter` / `animate.leave`. Native can't replace it for our overlays yet — ComponentPortal-based overlays (reusable components, service-opened dialogs) remove their host element synchronously via CDK, so native `animate.leave` never gets a chance to defer removal, and collapsible/accordion never insert or remove their element. The custom system stays; this PR instead **hardens `setupExitAnimation()` to match native's robustness** where native is more careful.

- **Teardown never gets stuck.** `exit()` now resolves rather than rejects when an animation errors, mirroring native's `Promise.allSettled`. Previously a non-`AbortError` rejection propagated through `detach()` / `NgpExitAnimationManager.exit()` / `NgpDialogRef.close()` — none of which catch it — leaving the overlay in the DOM forever. This fixes a latent stuck-overlay bug across every portal-based overlay and the dialog.
- **Fallback timeout.** A paused or never-settling animation can no longer block removal indefinitely: `exit()` also races a fallback of the longest animation's own declared duration plus a small buffer, mirroring native's CSS `animate.leave` fallback (`longest.duration + 50`). Because the delay is derived from each animation's own timing, a healthy long animation is never cut short; `finished` stays the authoritative completion signal.
- **Non-browser / SSR safety.** The enter state is set synchronously when there is no `requestAnimationFrame`, and `exit()` resolves immediately when the element has no `getAnimations()` (no DOM animation support), instead of throwing.

Infinite animations (spinners, pulses) are still filtered out so they never block removal.

New unit tests cover: resolve-not-reject on animation error, resolve on `AbortError`, the fallback timeout when `finished` never settles, immediate resolution in a non-DOM environment, and `cancel()` returning to the enter state.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The `NgpExitAnimationRef` public shape is unchanged (`exit()` is still `() => Promise<void>`); it simply no longer rejects. All changes are internal hardening.


---
_Generated by [Claude Code](https://claude.ai/code/session_0169ow1bK5TGNjFdteFicPnn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exit animation reliability by ensuring teardown always resolves, even when animation completion fails or never settles (including proper handling of `AbortError`).
  * Added a defensive fallback timeout based on the longest finite animation to prevent stuck exits.
  * Made exit behaviour work correctly in non-DOM/SSR-like environments by falling back to synchronous attribute updates when animations can’t be inspected.
  * Ensured cancelling an exit restores the enter state and stops any pending fallback.
* **Tests**
  * Expanded coverage for fallback timing, rejection/abort scenarios, non-DOM behaviour, and exit→cancel→exit cycle safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the exit-animation system to match native animate.leave so overlays never get stuck, even when animations fail, pause, or reenter. Safer in SSR and portal-based overlays, with no API changes.

- **Bug Fixes**
  - exit() now resolves instead of rejecting on animation errors.
  - Added a fallback timeout: longest animation endTime + 50ms if `finished` never settles.
  - SSR/non-browser safety: resolves immediately when `getAnimations` is unavailable; sets enter state sync when no `requestAnimationFrame`.
  - Reentrancy guard: exit → cancel → exit can’t clear the new cycle’s fallback timer; infinite animations still don’t block, and cancel() restores enter state.

<sup>Written for commit 230c4d7ea7b9c5cdff206a2e306a60156fab8e42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

