### PR TITLE
refactor: adopt controlledState across two-way value primitives

### DIFF
--- a/.claude/rules/state-management.md
+++ b/.claude/rules/state-management.md
@@ -89,6 +89,89 @@ them (`this.selected()`), which the `prefer-state` lint rule forbids.
   only because it exposes deprecated `setValue`/`setMin`/`setMax` setters;
   `meter`, which has none, passes them through read-only.)
 
+### Two-way value inputs: `value` + `defaultValue`
+
+When a value input has a matching `*Change` output (a `[(ngpXValue)]` two-way
+binding), reach for `controlledState` rather than `controlled`, so
+controlled/uncontrolled mode **latches** correctly. `controlled` (a plain
+`linkedSignal`) does **not** latch - an internal `.set()` wins until the input
+next emits - so a value the consumer binds one-way and never writes back would
+drift on interaction. `controlledState` keeps a controlled value pinned to its
+binding and only mutates internal state in uncontrolled mode. `checkbox`,
+`toggle-group`, `switch`, `slider`, `listbox` and the `color` primitives follow
+this. Four rules make it work:
+
+**1. The value input defaults to `undefined`; add a sibling `default*` input.**
+`controlledState` decides controlled vs uncontrolled by whether `value()` is
+`undefined`, so the value input can't default to a concrete value - give the
+uncontrolled initial value its own input.
+
+```ts
+// directive — NOT `input<T>(SOME_DEFAULT, ...)`, or it is always controlled
+readonly value = input<T | undefined>(undefined, { alias: 'ngpXValue' });
+readonly defaultValue = input<T>(SOME_DEFAULT, { alias: 'ngpXDefaultValue' });
+```
+
+A coercion transform must **preserve `undefined`**, or it destroys the sentinel
+rule 1 depends on. `numberAttribute(undefined)` is `NaN` and
+`booleanAttribute(undefined)` is `false` - both are concrete values, so a
+runtime-undefined binding (`[ngpXValue]="maybeUndef()"`) would latch the part
+into controlled mode with a bogus value instead of staying uncontrolled. Never
+put a bare `transform: numberAttribute` / `transform: booleanAttribute` on a
+two-way value input; use the `coerceNumberOrUndefined` /
+`coerceBooleanOrUndefined` helpers from `ng-primitives/utils`, which pass
+`undefined` straight through and coerce everything else as usual. (This only
+applies to number/boolean inputs - a generic-typed value like `listbox`'s or
+`toggle-group`'s has no transform and already passes `undefined` through.)
+
+```ts
+import { coerceNumberOrUndefined } from 'ng-primitives/utils';
+
+readonly value = input<number | undefined, NumberInput>(undefined, {
+  alias: 'ngpXValue',
+  transform: coerceNumberOrUndefined, // preserve undefined (uncontrolled)
+});
+```
+
+**2. Feed the optional default through `controlled(_default, fallback)`.**
+`controlledState`'s `defaultValue` needs a `Signal<T>`, but the input is
+optional. `controlled(_defaultValue, <concrete default>)` converts
+optional → required-with-fallback. This is the one sanctioned case where
+`controlled` wraps a value the factory itself never `.set()`s (see the rule
+above) - it exists to supply the fallback, and is paired with a `setDefault*`
+(rule 3) so there is still a real mutation path.
+
+```ts
+const defaultValue = controlled(_defaultValue, SOME_DEFAULT);
+const [value, setValue, valueChange] = controlledState<T>({
+  value: _value,
+  defaultValue,
+  onChange: onValueChange,
+});
+```
+
+**3. Expose the value via `deprecatedSetter`, and expose `setDefault*` too.**
+Return `value: deprecatedSetter(value, 'setValue', setValue)` so a direct
+`.set()` warns and routes through the setter, plus `setValue` and
+`setDefaultValue: defaultValue.set`. Expose the `setDefault*` consistently -
+every primitive with a `default*` input also exposes its setter.
+
+**4. When the emit is bespoke, use `controlledState` for latching only.** If a
+part has its own emit choreography that `controlledState`'s change-gated emit
+can't express (e.g. `number-field`'s silent input-commit, or a `string`-typed
+output over a `string | null` value), keep a manual `emitter`, call the setter
+with `{ emit: false }`, and emit yourself.
+
+```ts
+const [value, setValueInternal] = controlledState<T>({ value: _value, defaultValue });
+const valueChange = emitter<T>();
+function setValue(next: T): void {
+  setValueInternal(next, { emit: false }); // controlledState only handles latching
+  onValueChange?.(next);
+  valueChange.emit(next);
+}
+```
+
 ## Return only what other parts read
 
 The object the factory returns is the part's inter-part / public API, exposed via

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox.ts
@@ -1,7 +1,7 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import { Directive, booleanAttribute, input, output } from '@angular/core';
 import { SetterOptions } from 'ng-primitives/state';
-import { uniqueId } from 'ng-primitives/utils';
+import { coerceBooleanOrUndefined, uniqueId } from 'ng-primitives/utils';
 import { ngpCheckbox, provideCheckboxState } from './checkbox-state';
 
 /**
@@ -23,7 +23,7 @@ export class NgpCheckbox {
    */
   readonly checked = input<boolean | undefined, BooleanInput>(undefined, {
     alias: 'ngpCheckboxChecked',
-    transform: booleanAttribute,
+    transform: coerceBooleanOrUndefined,
   });
 
   /**

--- a/packages/ng-primitives/checkbox/src/checkbox/tests/checkbox-primitive.test.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/tests/checkbox-primitive.test.ts
@@ -212,6 +212,22 @@ describe('NgpCheckbox', () => {
       expect(checkbox).toHaveAttribute('data-checked', '');
     });
 
+    it('should stay uncontrolled when the checked binding is explicitly undefined', async () => {
+      await render(
+        `<div ngpCheckbox [ngpCheckboxChecked]="checked" ngpCheckboxDefaultChecked></div>`,
+        {
+          imports: [NgpCheckbox],
+          componentProperties: { checked: undefined },
+        },
+      );
+      const checkbox = screen.getByRole('checkbox');
+      // an explicit `undefined` must not coerce to `false` — it stays uncontrolled at the default
+      expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(checkbox);
+      expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    });
+
     it('should toggle freely from a defaultChecked start', async () => {
       const spy = vi.fn();
       await render(

--- a/packages/ng-primitives/collapsible/src/collapsible/collapsible-state.ts
+++ b/packages/ng-primitives/collapsible/src/collapsible/collapsible-state.ts
@@ -55,6 +55,10 @@ export interface NgpCollapsibleState {
    */
   setDisabled(value: boolean): void;
   /**
+   * Set the default open state.
+   */
+  setDefaultOpen(value: boolean): void;
+  /**
    * Register the trigger id.
    * @internal
    */
@@ -159,6 +163,7 @@ export const [
       toggle,
       setOpen,
       setDisabled,
+      setDefaultOpen: defaultOpen.set,
       setTrigger,
       setContent,
     } satisfies NgpCollapsibleState;

--- a/packages/ng-primitives/collapsible/src/collapsible/collapsible.ts
+++ b/packages/ng-primitives/collapsible/src/collapsible/collapsible.ts
@@ -2,6 +2,7 @@ import { BooleanInput } from '@angular/cdk/coercion';
 import { booleanAttribute, Directive, input, output } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
 import { SetterOptions } from 'ng-primitives/state';
+import { coerceBooleanOrUndefined } from 'ng-primitives/utils';
 import { ngpCollapsible, provideCollapsibleState } from './collapsible-state';
 
 /**
@@ -20,7 +21,7 @@ export class NgpCollapsible {
    */
   readonly open = input<boolean | undefined, BooleanInput>(undefined, {
     alias: 'ngpCollapsibleOpen',
-    transform: booleanAttribute,
+    transform: coerceBooleanOrUndefined,
   });
 
   /**

--- a/packages/ng-primitives/collapsible/src/collapsible/tests/collapsible-primitive.test.ts
+++ b/packages/ng-primitives/collapsible/src/collapsible/tests/collapsible-primitive.test.ts
@@ -53,6 +53,21 @@ describe('NgpCollapsible', () => {
     expect(fixture.getByTestId('trigger')).toHaveAttribute('aria-expanded', 'true');
   });
 
+  it('should stay uncontrolled when the open binding is explicitly undefined', async () => {
+    const fixture = await render(
+      `<div data-testid="root" ngpCollapsible [ngpCollapsibleOpen]="open" ngpCollapsibleDefaultOpen>
+        <button data-testid="trigger" ngpCollapsibleTrigger>Toggle</button>
+        <div ngpCollapsibleContent>Content</div>
+      </div>`,
+      { imports, componentProperties: { open: undefined } },
+    );
+    // an explicit `undefined` must not coerce to `false` — it stays uncontrolled at the default
+    expect(fixture.getByTestId('root')).toHaveAttribute('data-open');
+
+    fireEvent.click(fixture.getByTestId('trigger'));
+    expect(fixture.getByTestId('root')).not.toHaveAttribute('data-open');
+  });
+
   describe('trigger', () => {
     it('should set type="button" on a button host', async () => {
       const fixture = await renderTemplate();

--- a/packages/ng-primitives/color/src/color-area/color-area-state.ts
+++ b/packages/ng-primitives/color/src/color-area/color-area-state.ts
@@ -14,6 +14,7 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   dataBinding,
   emitter,
@@ -73,6 +74,9 @@ export interface NgpColorAreaState {
   focusThumb(origin: FocusOrigin): void;
   /** Set the disabled state. */
   setDisabled(disabled: boolean): void;
+
+  /** Set the default value used in uncontrolled mode. */
+  setDefaultValue(value: Color): void;
 }
 
 /**
@@ -80,7 +84,9 @@ export interface NgpColorAreaState {
  */
 export interface NgpColorAreaProps {
   readonly id?: Signal<string>;
-  readonly value?: Signal<Color>;
+  readonly value?: Signal<Color | undefined>;
+  /** The default color value for uncontrolled usage. */
+  readonly defaultValue?: Signal<Color>;
   readonly xChannel?: Signal<ColorChannel>;
   readonly yChannel?: Signal<ColorChannel>;
   readonly colorSpace?: Signal<ColorSpace | undefined>;
@@ -125,7 +131,8 @@ export const [NgpColorAreaStateToken, ngpColorArea, injectColorAreaState, provid
     'NgpColorArea',
     ({
       id = signal(uniqueId('ngp-color-area')),
-      value: _value = signal(Color.parse('hsb(0, 100%, 100%)')),
+      value: _value = signal<Color | undefined>(undefined),
+      defaultValue: _defaultValue,
       xChannel = signal<ColorChannel>('saturation'),
       yChannel = signal<ColorChannel>('brightness'),
       colorSpace: _colorSpace = signal<ColorSpace | undefined>(undefined),
@@ -138,7 +145,8 @@ export const [NgpColorAreaStateToken, ngpColorArea, injectColorAreaState, provid
       const document = inject(DOCUMENT);
       // Bind to a parent color picker when present, otherwise own the value locally.
       const picker = injectColorPickerState({ optional: true });
-      const local = controlled(_value);
+      const defaultValue = controlled(_defaultValue, Color.parse('hsb(0, 100%, 100%)'));
+      const [local, setLocal] = controlledState<Color>({ value: _value, defaultValue });
       const value = computed(() => picker()?.value() ?? local());
       const disabled = controlled(_disabled);
       const valueChange = emitter<Color>();
@@ -221,7 +229,7 @@ export const [NgpColorAreaStateToken, ngpColorArea, injectColorAreaState, provid
         if (parent) {
           parent.setValue(newValue, options);
         } else {
-          local.set(newValue);
+          setLocal(newValue, { emit: false });
         }
         if (options?.emit !== false) {
           onValueChange?.(newValue);
@@ -274,6 +282,7 @@ export const [NgpColorAreaStateToken, ngpColorArea, injectColorAreaState, provid
         thumb,
         valueChange: valueChange.asObservable(),
         setValue,
+        setDefaultValue: defaultValue.set,
         setChannels,
         adjustChannel,
         setThumb,

--- a/packages/ng-primitives/color/src/color-area/color-area.ts
+++ b/packages/ng-primitives/color/src/color-area/color-area.ts
@@ -19,8 +19,13 @@ export class NgpColorArea {
   readonly id = input<string>(uniqueId('ngp-color-area'));
 
   /** The color value. */
-  readonly value = input<Color>(Color.parse('hsb(0, 100%, 100%)'), {
+  readonly value = input<Color | undefined>(undefined, {
     alias: 'ngpColorAreaValue',
+  });
+
+  /** The default color value for uncontrolled usage. */
+  readonly defaultValue = input<Color>(Color.parse('hsb(0, 100%, 100%)'), {
+    alias: 'ngpColorAreaDefaultValue',
   });
 
   /** Emits when the value changes. */
@@ -52,6 +57,7 @@ export class NgpColorArea {
   protected readonly state = ngpColorArea({
     id: this.id,
     value: this.value,
+    defaultValue: this.defaultValue,
     xChannel: this.xChannel,
     yChannel: this.yChannel,
     colorSpace: this.colorSpace,

--- a/packages/ng-primitives/color/src/color-area/tests/color-area.test.ts
+++ b/packages/ng-primitives/color/src/color-area/tests/color-area.test.ts
@@ -9,7 +9,7 @@ function template(extra = ''): string {
     <div
       ngpColorArea
       data-testid="area"
-      [ngpColorAreaValue]="value"
+      [ngpColorAreaDefaultValue]="value"
       ${extra}
       (ngpColorAreaValueChange)="onChange($event)">
       <div ngpColorAreaThumb data-testid="thumb"></div>
@@ -109,5 +109,38 @@ describe('NgpColorArea', () => {
     fireEvent.keyDown(thumb, { key: 'ArrowUp' });
     fireEvent.pointerDown(getByTestId('area'), { clientX: 10, clientY: 10 });
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  describe('value binding (standalone)', () => {
+    it('one-way controlled: emits but does not move the thumb without a round-trip', async () => {
+      const onChange = vi.fn<(c: Color) => void>();
+      const { getByTestId } = await render(
+        `<div ngpColorArea [ngpColorAreaValue]="value" (ngpColorAreaValueChange)="onChange($event)" data-testid="area">
+           <div ngpColorAreaThumb data-testid="thumb"></div>
+         </div>`,
+        { imports, componentProperties: { value: Color.parse('hsb(0, 50%, 50%)'), onChange } },
+      );
+      const thumb = getByTestId('thumb');
+      expect(thumb).toHaveAttribute('aria-valuenow', '50');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(thumb).toHaveAttribute('aria-valuenow', '50');
+    });
+
+    it('two-way: round-trips and moves the thumb', async () => {
+      const { getByTestId } = await render(
+        `<div ngpColorArea [(ngpColorAreaValue)]="value" data-testid="area">
+           <div ngpColorAreaThumb data-testid="thumb"></div>
+         </div>`,
+        { imports, componentProperties: { value: Color.parse('hsb(0, 50%, 50%)') } },
+      );
+      const thumb = getByTestId('thumb');
+      expect(thumb).toHaveAttribute('aria-valuenow', '50');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+      expect(thumb).toHaveAttribute('aria-valuenow', '51');
+    });
   });
 });

--- a/packages/ng-primitives/color/src/color-field/color-field-state.ts
+++ b/packages/ng-primitives/color/src/color-field/color-field-state.ts
@@ -4,6 +4,7 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   emitter,
   listener,
@@ -37,6 +38,9 @@ export interface NgpColorFieldState {
   setValue(value: Color, options?: SetterOptions): void;
   /** Set the disabled state. */
   setDisabled(disabled: boolean): void;
+
+  /** Set the default value used in uncontrolled mode. */
+  setDefaultValue(value: Color): void;
 }
 
 /**
@@ -44,7 +48,9 @@ export interface NgpColorFieldState {
  */
 export interface NgpColorFieldProps {
   readonly id?: Signal<string>;
-  readonly value?: Signal<Color>;
+  readonly value?: Signal<Color | undefined>;
+  /** The default color value for uncontrolled usage. */
+  readonly defaultValue?: Signal<Color>;
   readonly channel?: Signal<ColorChannel | undefined>;
   readonly colorSpace?: Signal<ColorSpace | undefined>;
   readonly disabled?: Signal<boolean>;
@@ -84,7 +90,8 @@ export const [
   'NgpColorField',
   ({
     id = signal(uniqueId('ngp-color-field')),
-    value: _value = signal(Color.parse('#ff0000')),
+    value: _value = signal<Color | undefined>(undefined),
+    defaultValue: _defaultValue,
     channel = signal<ColorChannel | undefined>(undefined),
     colorSpace: _colorSpace = signal<ColorSpace | undefined>(undefined),
     disabled = signal(false),
@@ -93,7 +100,8 @@ export const [
     const element = injectElementRef<HTMLInputElement>();
     // Bind to a parent color picker when present, otherwise own the value locally.
     const picker = injectColorPickerState({ optional: true });
-    const local = controlled(_value);
+    const defaultValue = controlled(_defaultValue, Color.parse('#ff0000'));
+    const [local, setLocal] = controlledState<Color>({ value: _value, defaultValue });
     const value = computed(() => picker()?.value() ?? local());
     const valueChange = emitter<Color>();
 
@@ -145,7 +153,7 @@ export const [
       if (parent) {
         parent.setValue(newValue, options);
       } else {
-        local.set(newValue);
+        setLocal(newValue, { emit: false });
       }
       if (options?.emit !== false) {
         onValueChange?.(newValue);
@@ -232,6 +240,7 @@ export const [
       disabled: input.disabled,
       valueChange: valueChange.asObservable(),
       setValue,
+      setDefaultValue: defaultValue.set,
       setDisabled,
     } satisfies NgpColorFieldState;
   },

--- a/packages/ng-primitives/color/src/color-field/color-field.ts
+++ b/packages/ng-primitives/color/src/color-field/color-field.ts
@@ -21,8 +21,13 @@ export class NgpColorField {
   readonly id = input<string>(uniqueId('ngp-color-field'));
 
   /** The color value. */
-  readonly value = input<Color>(Color.parse('#ff0000'), {
+  readonly value = input<Color | undefined>(undefined, {
     alias: 'ngpColorFieldValue',
+  });
+
+  /** The default color value for uncontrolled usage. */
+  readonly defaultValue = input<Color>(Color.parse('#ff0000'), {
+    alias: 'ngpColorFieldDefaultValue',
   });
 
   /** Emits when the value changes. */
@@ -49,6 +54,7 @@ export class NgpColorField {
   protected readonly state = ngpColorField({
     id: this.id,
     value: this.value,
+    defaultValue: this.defaultValue,
     channel: this.channel,
     colorSpace: this.colorSpace,
     disabled: this.disabled,

--- a/packages/ng-primitives/color/src/color-field/tests/color-field.test.ts
+++ b/packages/ng-primitives/color/src/color-field/tests/color-field.test.ts
@@ -8,7 +8,7 @@ async function setup(props: { value?: Color; channel?: string; extra?: string } 
     `<input
         ngpColorField
         data-testid="field"
-        [ngpColorFieldValue]="value"
+        [ngpColorFieldDefaultValue]="value"
         ${props.channel ? `ngpColorFieldChannel="${props.channel}"` : ''}
         ${props.extra ?? ''}
         (ngpColorFieldValueChange)="onChange($event)" />`,
@@ -102,5 +102,44 @@ describe('NgpColorField', () => {
     expect(input).toHaveAttribute('disabled');
     fireEvent.keyDown(input, { key: 'ArrowUp' });
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  describe('value binding (standalone)', () => {
+    it('one-way controlled: emits on blur but reverts the input without a round-trip', async () => {
+      const onChange = vi.fn<(c: Color) => void>();
+      const view = await render(
+        `<input ngpColorField data-testid="field" [ngpColorFieldValue]="value"
+                (ngpColorFieldValueChange)="onChange($event)" />`,
+        {
+          imports: [NgpColorField],
+          componentProperties: { value: Color.parse('#ff0000'), onChange },
+        },
+      );
+      const input = view.getByTestId('field') as HTMLInputElement;
+      expect(input.value).toBe('#ff0000');
+
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: '#00ff00' } });
+      fireEvent.blur(input);
+
+      // emitted, but controlled value is not written back, so the field reverts
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(input.value).toBe('#ff0000');
+    });
+
+    it('two-way: round-trips the committed value', async () => {
+      const view = await render(
+        `<input ngpColorField data-testid="field" [(ngpColorFieldValue)]="value" />`,
+        { imports: [NgpColorField], componentProperties: { value: Color.parse('#ff0000') } },
+      );
+      const input = view.getByTestId('field') as HTMLInputElement;
+      expect(input.value).toBe('#ff0000');
+
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: '#00ff00' } });
+      fireEvent.blur(input);
+
+      expect(input.value).toBe('#00ff00');
+    });
   });
 });

--- a/packages/ng-primitives/color/src/color-picker/color-picker-state.ts
+++ b/packages/ng-primitives/color/src/color-picker/color-picker-state.ts
@@ -3,8 +3,9 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
-  emitter,
+  deprecatedSetter,
   SetterOptions,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
@@ -24,6 +25,8 @@ export interface NgpColorPickerState {
   readonly valueChange: Observable<Color>;
   /** Set the shared color value. */
   setValue(value: Color, options?: SetterOptions): void;
+  /** Set the default color value used in uncontrolled mode. */
+  setDefaultValue(value: Color): void;
 }
 
 /**
@@ -31,7 +34,10 @@ export interface NgpColorPickerState {
  */
 export interface NgpColorPickerProps {
   readonly id?: Signal<string>;
-  readonly value?: Signal<Color>;
+  /** The shared color value. When defined the picker is controlled. */
+  readonly value?: Signal<Color | undefined>;
+  /** The default color value for uncontrolled usage. */
+  readonly defaultValue?: Signal<Color>;
   readonly onValueChange?: (value: Color) => void;
 }
 
@@ -44,28 +50,30 @@ export const [
   'NgpColorPicker',
   ({
     id = signal(uniqueId('ngp-color-picker')),
-    value: _value = signal(Color.parse('#ff0000')),
+    value: _value = signal<Color | undefined>(undefined),
+    defaultValue: _defaultValue,
     onValueChange,
   }: NgpColorPickerProps): NgpColorPickerState => {
     const element = injectElementRef();
-    const value = controlled(_value);
-    const valueChange = emitter<Color>();
+    const defaultValue = controlled(_defaultValue, Color.parse('#ff0000'));
+    const [value, setValueInternal, valueChange] = controlledState<Color>({
+      value: _value,
+      defaultValue,
+      onChange: onValueChange,
+    });
 
     attrBinding(element, 'id', id);
 
     function setValue(newValue: Color, options?: SetterOptions): void {
-      value.set(newValue);
-      if (options?.emit !== false) {
-        onValueChange?.(newValue);
-        valueChange.emit(newValue);
-      }
+      setValueInternal(newValue, options);
     }
 
     return {
       id,
-      value,
-      valueChange: valueChange.asObservable(),
+      value: deprecatedSetter(value, 'setValue', setValue),
+      valueChange,
       setValue,
+      setDefaultValue: defaultValue.set,
     } satisfies NgpColorPickerState;
   },
 );

--- a/packages/ng-primitives/color/src/color-picker/color-picker.ts
+++ b/packages/ng-primitives/color/src/color-picker/color-picker.ts
@@ -17,9 +17,14 @@ export class NgpColorPicker {
   /** The id of the picker. */
   readonly id = input<string>(uniqueId('ngp-color-picker'));
 
-  /** The color value. */
-  readonly value = input<Color>(Color.parse('#ff0000'), {
+  /** The color value. When defined the picker is controlled. */
+  readonly value = input<Color | undefined>(undefined, {
     alias: 'ngpColorPickerValue',
+  });
+
+  /** The default color value for uncontrolled usage. */
+  readonly defaultValue = input<Color>(Color.parse('#ff0000'), {
+    alias: 'ngpColorPickerDefaultValue',
   });
 
   /** Emits when the value changes. */
@@ -30,6 +35,7 @@ export class NgpColorPicker {
   protected readonly state = ngpColorPicker({
     id: this.id,
     value: this.value,
+    defaultValue: this.defaultValue,
     onValueChange: value => this.valueChange.emit(value),
   });
 

--- a/packages/ng-primitives/color/src/color-picker/tests/color-picker.test.ts
+++ b/packages/ng-primitives/color/src/color-picker/tests/color-picker.test.ts
@@ -20,7 +20,7 @@ const imports = [
 async function setup(value: Color = Color.parse('#ff0000')) {
   const onChange = vi.fn<(c: Color) => void>();
   const view = await render(
-    `<div ngpColorPicker [ngpColorPickerValue]="value" (ngpColorPickerValueChange)="onChange($event)">
+    `<div ngpColorPicker [ngpColorPickerDefaultValue]="value" (ngpColorPickerValueChange)="onChange($event)">
        <div ngpColorSlider ngpColorSliderChannel="hue">
          <div ngpColorSliderTrack></div>
          <div ngpColorSliderThumb data-testid="thumb"></div>
@@ -67,5 +67,53 @@ describe('NgpColorPicker coordination', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     // green -> hue 120, so the sibling slider thumb moved
     expect(thumb).toHaveAttribute('aria-valuenow', '120');
+  });
+
+  it('round-trips a two-way binding across children', async () => {
+    const { getByTestId, fixture } = await render(
+      `<div ngpColorPicker [(ngpColorPickerValue)]="value">
+         <div ngpColorSlider ngpColorSliderChannel="hue">
+           <div ngpColorSliderTrack></div>
+           <div ngpColorSliderThumb data-testid="thumb"></div>
+         </div>
+         <input ngpColorField data-testid="field" />
+       </div>`,
+      { imports, componentProperties: { value: Color.parse('#ff0000') } },
+    );
+    const thumb = getByTestId('thumb');
+    const field = getByTestId('field') as HTMLInputElement;
+    expect(thumb).toHaveAttribute('aria-valuenow', '0');
+
+    fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+
+    // two-way binding writes the value back, so the shared value advances and the
+    // sibling field re-renders from it.
+    expect(thumb).toHaveAttribute('aria-valuenow', '1');
+    expect(field.value).not.toBe('#ff0000');
+    expect(fixture.componentInstance.value.getChannelValue('hue')).toBe(1);
+  });
+
+  it('stays put when controlled and the parent does not write the value back', async () => {
+    const onChange = vi.fn<(c: Color) => void>();
+    const view = await render(
+      `<div ngpColorPicker [ngpColorPickerValue]="value" (ngpColorPickerValueChange)="onChange($event)">
+         <div ngpColorSlider ngpColorSliderChannel="hue">
+           <div ngpColorSliderTrack></div>
+           <div ngpColorSliderThumb data-testid="thumb"></div>
+         </div>
+         <input ngpColorField data-testid="field" />
+       </div>`,
+      { imports, componentProperties: { value: Color.parse('#ff0000'), onChange } },
+    );
+    const thumb = view.getByTestId('thumb');
+    const field = view.getByTestId('field') as HTMLInputElement;
+
+    fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+
+    // the picker notifies via valueChange, but because it is controlled and the
+    // parent never writes the new value back, the shared value must not drift.
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(thumb).toHaveAttribute('aria-valuenow', '0');
+    expect(field.value).toBe('#ff0000');
   });
 });

--- a/packages/ng-primitives/color/src/color-slider/color-slider-state.ts
+++ b/packages/ng-primitives/color/src/color-slider/color-slider-state.ts
@@ -5,6 +5,7 @@ import { injectElementRef } from 'ng-primitives/internal';
 import { ngpSlider } from 'ng-primitives/slider';
 import {
   controlled,
+  controlledState,
   createPrimitive,
   emitter,
   SetterOptions,
@@ -51,6 +52,9 @@ export interface NgpColorSliderState {
   focusThumb(origin: FocusOrigin): void;
   /** Set the disabled state. */
   setDisabled(disabled: boolean): void;
+
+  /** Set the default value used in uncontrolled mode. */
+  setDefaultValue(value: Color): void;
   /** Set the orientation. */
   setOrientation(orientation: NgpOrientation): void;
 }
@@ -60,7 +64,9 @@ export interface NgpColorSliderState {
  */
 export interface NgpColorSliderProps {
   readonly id?: Signal<string>;
-  readonly value?: Signal<Color>;
+  readonly value?: Signal<Color | undefined>;
+  /** The default color value for uncontrolled usage. */
+  readonly defaultValue?: Signal<Color>;
   readonly channel?: Signal<ColorChannel>;
   readonly colorSpace?: Signal<ColorSpace | undefined>;
   readonly orientation?: Signal<NgpOrientation>;
@@ -103,7 +109,8 @@ export const [
   'NgpColorSlider',
   ({
     id = signal(uniqueId('ngp-color-slider')),
-    value: _value = signal(Color.parse('#ff0000')),
+    value: _value = signal<Color | undefined>(undefined),
+    defaultValue: _defaultValue,
     channel = signal<ColorChannel>('hue'),
     colorSpace: _colorSpace = signal<ColorSpace | undefined>(undefined),
     orientation = signal<NgpOrientation>('horizontal'),
@@ -113,7 +120,8 @@ export const [
     const element = injectElementRef();
     // Bind to a parent color picker when present, otherwise own the value locally.
     const picker = injectColorPickerState({ optional: true });
-    const local = controlled(_value);
+    const defaultValue = controlled(_defaultValue, Color.parse('#ff0000'));
+    const [local, setLocal] = controlledState<Color>({ value: _value, defaultValue });
     const value = computed(() => picker()?.value() ?? local());
     const valueChange = emitter<Color>();
 
@@ -152,7 +160,7 @@ export const [
       if (parent) {
         parent.setValue(newValue, options);
       } else {
-        local.set(newValue);
+        setLocal(newValue, { emit: false });
       }
       if (options?.emit !== false) {
         onValueChange?.(newValue);
@@ -173,6 +181,7 @@ export const [
       disabled: slider.disabled,
       valueChange: valueChange.asObservable(),
       setValue,
+      setDefaultValue: defaultValue.set,
       focusThumb: slider.focusThumb,
       setDisabled: slider.setDisabled,
       setOrientation: slider.setOrientation,

--- a/packages/ng-primitives/color/src/color-slider/color-slider.ts
+++ b/packages/ng-primitives/color/src/color-slider/color-slider.ts
@@ -22,8 +22,13 @@ export class NgpColorSlider {
   readonly id = input<string>(uniqueId('ngp-color-slider'));
 
   /** The color value. */
-  readonly value = input<Color>(Color.parse('#ff0000'), {
+  readonly value = input<Color | undefined>(undefined, {
     alias: 'ngpColorSliderValue',
+  });
+
+  /** The default color value for uncontrolled usage. */
+  readonly defaultValue = input<Color>(Color.parse('#ff0000'), {
+    alias: 'ngpColorSliderDefaultValue',
   });
 
   /** Emits when the value changes. */
@@ -55,6 +60,7 @@ export class NgpColorSlider {
   protected readonly state = ngpColorSlider({
     id: this.id,
     value: this.value,
+    defaultValue: this.defaultValue,
     channel: this.channel,
     colorSpace: this.colorSpace,
     orientation: this.orientation,

--- a/packages/ng-primitives/color/src/color-slider/tests/color-slider.test.ts
+++ b/packages/ng-primitives/color/src/color-slider/tests/color-slider.test.ts
@@ -10,7 +10,7 @@ function template(extra = ''): string {
     <div
       ngpColorSlider
       data-testid="slider"
-      [ngpColorSliderValue]="value"
+      [ngpColorSliderDefaultValue]="value"
       [ngpColorSliderChannel]="channel"
       ${extra}
       (ngpColorSliderValueChange)="onChange($event)">
@@ -118,5 +118,41 @@ describe('NgpColorSlider', () => {
     expect(thumb).toHaveAttribute('data-disabled', '');
     fireEvent.keyDown(thumb, { key: 'ArrowUp' });
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  describe('value binding (standalone)', () => {
+    it('one-way controlled: emits but does not move the thumb without a round-trip', async () => {
+      const onChange = vi.fn<(c: Color) => void>();
+      const { getByTestId } = await render(
+        `<div ngpColorSlider [ngpColorSliderValue]="value" ngpColorSliderChannel="hue"
+              (ngpColorSliderValueChange)="onChange($event)" data-testid="slider">
+           <div ngpColorSliderTrack></div>
+           <div ngpColorSliderThumb data-testid="thumb"></div>
+         </div>`,
+        { imports, componentProperties: { value: Color.parse('#ff0000'), onChange } },
+      );
+      const thumb = getByTestId('thumb');
+      expect(thumb).toHaveAttribute('aria-valuenow', '0');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(thumb).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('two-way: round-trips and moves the thumb', async () => {
+      const { getByTestId } = await render(
+        `<div ngpColorSlider [(ngpColorSliderValue)]="value" ngpColorSliderChannel="hue" data-testid="slider">
+           <div ngpColorSliderTrack></div>
+           <div ngpColorSliderThumb data-testid="thumb"></div>
+         </div>`,
+        { imports, componentProperties: { value: Color.parse('#ff0000') } },
+      );
+      const thumb = getByTestId('thumb');
+      expect(thumb).toHaveAttribute('aria-valuenow', '0');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+      expect(thumb).toHaveAttribute('aria-valuenow', '1');
+    });
   });
 });

--- a/packages/ng-primitives/color/src/color-swatch-picker/color-swatch-picker-state.ts
+++ b/packages/ng-primitives/color/src/color-swatch-picker/color-swatch-picker-state.ts
@@ -5,6 +5,7 @@ import { ngpRovingFocusGroup } from 'ng-primitives/roving-focus';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   dataBinding,
   emitter,
@@ -31,6 +32,8 @@ export interface NgpColorSwatchPickerState {
   isSelected(color: Color): boolean;
   /** Select a color. */
   select(color: Color, options?: SetterOptions): void;
+  /** Set the default selected color used in uncontrolled mode. */
+  setDefaultValue(value: Color | undefined): void;
 }
 
 /**
@@ -38,7 +41,10 @@ export interface NgpColorSwatchPickerState {
  */
 export interface NgpColorSwatchPickerProps {
   readonly id?: Signal<string>;
+  /** The selected color. When defined the swatch picker is controlled. */
   readonly value?: Signal<Color | undefined>;
+  /** The default selected color for uncontrolled usage (undefined = no selection). */
+  readonly defaultValue?: Signal<Color | undefined>;
   readonly orientation?: Signal<NgpOrientation>;
   readonly disabled?: Signal<boolean>;
   readonly onValueChange?: (value: Color) => void;
@@ -59,13 +65,19 @@ export const [
   ({
     id = signal(uniqueId('ngp-color-swatch-picker')),
     value: _value = signal<Color | undefined>(undefined),
+    defaultValue: _defaultValue,
     orientation = signal<NgpOrientation>('horizontal'),
     disabled = signal(false),
     onValueChange,
   }: NgpColorSwatchPickerProps): NgpColorSwatchPickerState => {
     const element = injectElementRef<HTMLElement>();
     const picker = injectColorPickerState({ optional: true });
-    const local = controlled(_value);
+    // `undefined` local means "no selection", so the default is undefined too.
+    const defaultValue = controlled<Color | undefined>(_defaultValue, undefined);
+    const [local, setLocal] = controlledState<Color | undefined>({
+      value: _value,
+      defaultValue,
+    });
     const value = computed(() => picker()?.value() ?? local() ?? Color.parse('#000000'));
     const hasSelection = computed(() => !!(picker() || local()));
     const valueChange = emitter<Color>();
@@ -94,7 +106,7 @@ export const [
       if (parent) {
         parent.setValue(color, options);
       } else {
-        local.set(color);
+        setLocal(color, { emit: false });
       }
       if (options?.emit !== false) {
         onValueChange?.(color);
@@ -109,6 +121,7 @@ export const [
       valueChange: valueChange.asObservable(),
       isSelected,
       select,
+      setDefaultValue: defaultValue.set,
     } satisfies NgpColorSwatchPickerState;
   },
 );

--- a/packages/ng-primitives/color/src/color-swatch-picker/color-swatch-picker.ts
+++ b/packages/ng-primitives/color/src/color-swatch-picker/color-swatch-picker.ts
@@ -20,9 +20,14 @@ export class NgpColorSwatchPicker {
   /** The id of the swatch picker. */
   readonly id = input<string>(uniqueId('ngp-color-swatch-picker'));
 
-  /** The selected color. */
+  /** The selected color. When defined the swatch picker is controlled. */
   readonly value = input<Color | undefined>(undefined, {
     alias: 'ngpColorSwatchPickerValue',
+  });
+
+  /** The default selected color for uncontrolled usage (undefined = no selection). */
+  readonly defaultValue = input<Color | undefined>(undefined, {
+    alias: 'ngpColorSwatchPickerDefaultValue',
   });
 
   /** Emits when the selected color changes. */
@@ -44,6 +49,7 @@ export class NgpColorSwatchPicker {
   protected readonly state = ngpColorSwatchPicker({
     id: this.id,
     value: this.value,
+    defaultValue: this.defaultValue,
     orientation: this.orientation,
     disabled: this.disabled,
     onValueChange: value => this.valueChange.emit(value),

--- a/packages/ng-primitives/color/src/color-swatch-picker/tests/color-swatch-picker.test.ts
+++ b/packages/ng-primitives/color/src/color-swatch-picker/tests/color-swatch-picker.test.ts
@@ -10,7 +10,7 @@ async function setup(selected = '#ff0000') {
     `<div
         ngpColorSwatchPicker
         data-testid="picker"
-        [ngpColorSwatchPickerValue]="value"
+        [ngpColorSwatchPickerDefaultValue]="value"
         (ngpColorSwatchPickerValueChange)="onChange($event)">
        <button [ngpColorSwatchPickerItem]="red" data-testid="red"></button>
        <button [ngpColorSwatchPickerItem]="green" data-testid="green"></button>
@@ -74,5 +74,50 @@ describe('NgpColorSwatchPicker', () => {
     const { red, green, blue } = await setup();
     const stops = [red, green, blue].filter(el => el.getAttribute('tabindex') === '0');
     expect(stops).toHaveLength(1);
+  });
+
+  describe('value binding (standalone)', () => {
+    const template = (binding: string) => `
+      <div ngpColorSwatchPicker ${binding} (ngpColorSwatchPickerValueChange)="onChange($event)">
+        <button [ngpColorSwatchPickerItem]="red" data-testid="red"></button>
+        <button [ngpColorSwatchPickerItem]="green" data-testid="green"></button>
+      </div>`;
+    const props = (onChange: unknown) => ({
+      value: Color.parse('#ff0000'),
+      red: Color.parse('#ff0000'),
+      green: Color.parse('#00ff00'),
+      onChange,
+    });
+
+    it('one-way controlled: emits but keeps the selection without a round-trip', async () => {
+      const onChange = vi.fn<(c: Color) => void>();
+      const view = await render(template('[ngpColorSwatchPickerValue]="value"'), {
+        imports,
+        componentProperties: props(onChange),
+      });
+      const red = view.getByTestId('red');
+      const green = view.getByTestId('green');
+      expect(red).toHaveAttribute('data-selected', '');
+
+      fireEvent.click(green);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(red).toHaveAttribute('data-selected', '');
+      expect(green).not.toHaveAttribute('data-selected');
+    });
+
+    it('two-way: round-trips and moves the selection', async () => {
+      const view = await render(template('[(ngpColorSwatchPickerValue)]="value"'), {
+        imports,
+        componentProperties: props(vi.fn()),
+      });
+      const red = view.getByTestId('red');
+      const green = view.getByTestId('green');
+
+      fireEvent.click(green);
+
+      expect(green).toHaveAttribute('data-selected', '');
+      expect(red).not.toHaveAttribute('data-selected');
+    });
   });
 });

--- a/packages/ng-primitives/color/src/color-wheel/color-wheel-state.ts
+++ b/packages/ng-primitives/color/src/color-wheel/color-wheel-state.ts
@@ -14,6 +14,7 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   dataBinding,
   emitter,
@@ -56,6 +57,9 @@ export interface NgpColorWheelState {
   focusThumb(origin: FocusOrigin): void;
   /** Set the disabled state. */
   setDisabled(disabled: boolean): void;
+
+  /** Set the default value used in uncontrolled mode. */
+  setDefaultValue(value: Color): void;
 }
 
 /**
@@ -63,7 +67,9 @@ export interface NgpColorWheelState {
  */
 export interface NgpColorWheelProps {
   readonly id?: Signal<string>;
-  readonly value?: Signal<Color>;
+  readonly value?: Signal<Color | undefined>;
+  /** The default color value for uncontrolled usage. */
+  readonly defaultValue?: Signal<Color>;
   readonly colorSpace?: Signal<ColorSpace>;
   readonly disabled?: Signal<boolean>;
   readonly onValueChange?: (value: Color) => void;
@@ -84,7 +90,8 @@ export const [
   'NgpColorWheel',
   ({
     id = signal(uniqueId('ngp-color-wheel')),
-    value: _value = signal(Color.parse('hsl(0, 100%, 50%)')),
+    value: _value = signal<Color | undefined>(undefined),
+    defaultValue: _defaultValue,
     colorSpace = signal<ColorSpace>('hsl'),
     disabled: _disabled = signal(false),
     onValueChange,
@@ -94,7 +101,8 @@ export const [
     const injector = inject(Injector);
     const document = inject(DOCUMENT);
     const picker = injectColorPickerState({ optional: true });
-    const local = controlled(_value);
+    const defaultValue = controlled(_defaultValue, Color.parse('hsl(0, 100%, 50%)'));
+    const [local, setLocal] = controlledState<Color>({ value: _value, defaultValue });
     const value = computed(() => picker()?.value() ?? local());
     const disabled = controlled(_disabled);
     const valueChange = emitter<Color>();
@@ -165,7 +173,7 @@ export const [
       if (parent) {
         parent.setValue(newValue, options);
       } else {
-        local.set(newValue);
+        setLocal(newValue, { emit: false });
       }
       if (options?.emit !== false) {
         onValueChange?.(newValue);
@@ -203,6 +211,7 @@ export const [
       thumb,
       valueChange: valueChange.asObservable(),
       setValue,
+      setDefaultValue: defaultValue.set,
       setHue,
       setThumb,
       focusThumb,

--- a/packages/ng-primitives/color/src/color-wheel/color-wheel.ts
+++ b/packages/ng-primitives/color/src/color-wheel/color-wheel.ts
@@ -19,8 +19,13 @@ export class NgpColorWheel {
   readonly id = input<string>(uniqueId('ngp-color-wheel'));
 
   /** The color value. */
-  readonly value = input<Color>(Color.parse('hsl(0, 100%, 50%)'), {
+  readonly value = input<Color | undefined>(undefined, {
     alias: 'ngpColorWheelValue',
+  });
+
+  /** The default color value for uncontrolled usage. */
+  readonly defaultValue = input<Color>(Color.parse('hsl(0, 100%, 50%)'), {
+    alias: 'ngpColorWheelDefaultValue',
   });
 
   /** Emits when the value changes. */
@@ -42,6 +47,7 @@ export class NgpColorWheel {
   protected readonly state = ngpColorWheel({
     id: this.id,
     value: this.value,
+    defaultValue: this.defaultValue,
     colorSpace: this.colorSpace,
     disabled: this.disabled,
     onValueChange: value => this.valueChange.emit(value),

--- a/packages/ng-primitives/color/src/color-wheel/tests/color-wheel.test.ts
+++ b/packages/ng-primitives/color/src/color-wheel/tests/color-wheel.test.ts
@@ -8,7 +8,7 @@ async function setup(props: { value?: Color; extra?: string } = {}) {
     `<div
         ngpColorWheel
         data-testid="wheel"
-        [ngpColorWheelValue]="value"
+        [ngpColorWheelDefaultValue]="value"
         ${props.extra ?? ''}
         (ngpColorWheelValueChange)="onChange($event)">
        <div ngpColorWheelThumb data-testid="thumb"></div>
@@ -85,5 +85,44 @@ describe('NgpColorWheel', () => {
     fireEvent.keyDown(thumb, { key: 'ArrowRight' });
     fireEvent.pointerDown(wheel, { clientX: 200, clientY: 100 });
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  describe('value binding (standalone)', () => {
+    it('one-way controlled: emits but does not move the thumb without a round-trip', async () => {
+      const onChange = vi.fn<(c: Color) => void>();
+      const { getByTestId } = await render(
+        `<div ngpColorWheel [ngpColorWheelValue]="value" (ngpColorWheelValueChange)="onChange($event)" data-testid="wheel">
+           <div ngpColorWheelThumb data-testid="thumb"></div>
+         </div>`,
+        {
+          imports: [NgpColorWheel, NgpColorWheelThumb],
+          componentProperties: { value: Color.parse('hsl(120, 100%, 50%)'), onChange },
+        },
+      );
+      const thumb = getByTestId('thumb');
+      expect(thumb).toHaveAttribute('aria-valuenow', '120');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(thumb).toHaveAttribute('aria-valuenow', '120');
+    });
+
+    it('two-way: round-trips and moves the thumb', async () => {
+      const { getByTestId } = await render(
+        `<div ngpColorWheel [(ngpColorWheelValue)]="value" data-testid="wheel">
+           <div ngpColorWheelThumb data-testid="thumb"></div>
+         </div>`,
+        {
+          imports: [NgpColorWheel, NgpColorWheelThumb],
+          componentProperties: { value: Color.parse('hsl(120, 100%, 50%)') },
+        },
+      );
+      const thumb = getByTestId('thumb');
+      expect(thumb).toHaveAttribute('aria-valuenow', '120');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+      expect(thumb).toHaveAttribute('aria-valuenow', '121');
+    });
   });
 });

--- a/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox-state.ts
@@ -8,9 +8,9 @@ import { injectPopoverTriggerState } from 'ng-primitives/popover';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   deprecatedSetter,
-  emitter,
   listener,
   SetterOptions,
   StateInjectionOptions,
@@ -71,6 +71,10 @@ export interface NgpListboxState<T> {
    * Sets the listbox selection.
    */
   setValue: (value: T[], options?: SetterOptions) => void;
+  /**
+   * Sets the default listbox selection used in uncontrolled mode.
+   */
+  setDefaultValue: (value: T[]) => void;
   setDisabled: (value: boolean) => void;
 }
 
@@ -84,9 +88,13 @@ export interface NgpListboxProps<T> {
    */
   readonly mode?: Signal<NgpSelectionMode>;
   /**
-   * The listbox selection.
+   * The listbox selection. When defined the listbox is controlled.
    */
-  readonly value?: Signal<T[]>;
+  readonly value?: Signal<T[] | undefined>;
+  /**
+   * The default listbox selection for uncontrolled usage.
+   */
+  readonly defaultValue?: Signal<T[]>;
   /**
    * The listbox disabled state.
    */
@@ -108,7 +116,8 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
     <T>({
       id = signal(uniqueId('ngp-listbox')),
       mode = signal<NgpSelectionMode>('single'),
-      value: _value = signal<T[]>([]),
+      value: _value = signal<T[] | undefined>(undefined),
+      defaultValue: _defaultValue,
       disabled: _disabled = signal<boolean>(false),
       compareWith = signal<(a: T, b: T) => boolean>((a, b) => a === b),
       onValueChange,
@@ -120,8 +129,12 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       const options = signal<NgpListboxOptionState<T>[]>([]);
       const isFocused = signal<boolean>(false);
 
-      const value = controlled(_value);
-      const valueChange = emitter<T[]>();
+      const defaultValue = controlled(_defaultValue, []);
+      const [value, setValueInternal, valueChange] = controlledState<T[]>({
+        value: _value,
+        defaultValue,
+        onChange: onValueChange,
+      });
 
       const disabled = controlled(_disabled);
       const tabIndex = computed(() => (disabled() ? -1 : 0));
@@ -222,12 +235,11 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
       }
 
       function setValue(newValue: T[], options?: SetterOptions): void {
-        value.set(newValue);
+        setValueInternal(newValue, options);
+      }
 
-        if (options?.emit !== false) {
-          valueChange.emit(newValue);
-          onValueChange?.(newValue);
-        }
+      function setDefaultValue(newValue: T[]): void {
+        defaultValue.set(newValue);
       }
 
       function selectOption(val: T, origin: FocusOrigin): void {
@@ -282,13 +294,14 @@ export const [NgpListboxStateToken, ngpListbox, _injectListboxState, provideList
         disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
         isFocused,
         activeDescendantManager: activeDescendant,
-        valueChange: valueChange.asObservable(),
+        valueChange,
         selectOption,
         isSelected,
         activateOption,
         addOption,
         removeOption,
         setValue,
+        setDefaultValue,
         setDisabled,
       } satisfies NgpListboxState<T>;
     },

--- a/packages/ng-primitives/listbox/src/listbox/listbox.ts
+++ b/packages/ng-primitives/listbox/src/listbox/listbox.ts
@@ -23,10 +23,17 @@ export class NgpListbox<T> {
   });
 
   /**
-   * The listbox selection.
+   * The listbox selection. When defined the listbox is controlled.
    */
-  readonly value = input<T[]>([], {
+  readonly value = input<T[] | undefined>(undefined, {
     alias: 'ngpListboxValue',
+  });
+
+  /**
+   * The default listbox selection for uncontrolled usage.
+   */
+  readonly defaultValue = input<T[]>([], {
+    alias: 'ngpListboxDefaultValue',
   });
 
   /**
@@ -57,6 +64,7 @@ export class NgpListbox<T> {
       id: this.id,
       mode: this.mode,
       value: this.value,
+      defaultValue: this.defaultValue,
       disabled: this.disabled,
       compareWith: this.compareWith,
       onValueChange: (value: T[]) => this.valueChange.emit(value),

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-primitive.test.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-primitive.test.ts
@@ -691,4 +691,112 @@ describe('NgpListbox', () => {
       expect(container.getByTestId('opt-a')).not.toHaveAttribute('data-selected');
     });
   });
+
+  describe('controlled mode', () => {
+    it('should reflect a controlled value binding', async () => {
+      const container = await render(
+        `<div ngpListbox [ngpListboxValue]="['b']" data-testid="listbox">
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">A</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">B</div>
+        </div>`,
+        { imports },
+      );
+
+      expect(container.getByTestId('opt-b')).toHaveAttribute('data-selected');
+      expect(container.getByTestId('opt-a')).not.toHaveAttribute('data-selected');
+    });
+
+    it('should update the DOM when a controlled value changes via two-way binding on click', async () => {
+      const container = await render(
+        `<div ngpListbox [(ngpListboxValue)]="value" data-testid="listbox">
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">A</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">B</div>
+        </div>`,
+        { imports, componentProperties: { value: [] as string[] } },
+      );
+
+      fireEvent.click(container.getByTestId('opt-a'));
+      expect(container.getByTestId('opt-a')).toHaveAttribute('data-selected');
+
+      fireEvent.click(container.getByTestId('opt-b'));
+      expect(container.getByTestId('opt-b')).toHaveAttribute('data-selected');
+      expect(container.getByTestId('opt-a')).not.toHaveAttribute('data-selected');
+    });
+
+    it('should emit valueChange on click but not update the DOM when the parent does not update the binding', async () => {
+      const valueChange = vi.fn();
+      const container = await render(
+        `<div
+          ngpListbox
+          [ngpListboxValue]="value"
+          (ngpListboxValueChange)="valueChange($event)"
+          data-testid="listbox"
+        >
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">A</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">B</div>
+        </div>`,
+        { imports, componentProperties: { value: ['a'] as string[], valueChange } },
+      );
+
+      // "a" is the controlled selection.
+      expect(container.getByTestId('opt-a')).toHaveAttribute('data-selected');
+
+      // Clicking another option notifies the consumer through valueChange, but
+      // because the parent never writes the new value back, the controlled
+      // selection must stay put — the internal value must not drift.
+      fireEvent.click(container.getByTestId('opt-b'));
+
+      expect(valueChange).toHaveBeenCalledWith(['b']);
+      expect(container.getByTestId('opt-a')).toHaveAttribute('data-selected');
+      expect(container.getByTestId('opt-b')).not.toHaveAttribute('data-selected');
+    });
+  });
+
+  describe('defaultValue (uncontrolled)', () => {
+    it('should select the default value on init', async () => {
+      const container = await render(
+        `<div ngpListbox [ngpListboxDefaultValue]="['b']" data-testid="listbox">
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">A</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">B</div>
+        </div>`,
+        { imports },
+      );
+
+      expect(container.getByTestId('opt-b')).toHaveAttribute('data-selected');
+      expect(container.getByTestId('opt-a')).not.toHaveAttribute('data-selected');
+    });
+
+    it('should let a click override the default value (uncontrolled)', async () => {
+      const container = await render(
+        `<div ngpListbox [ngpListboxDefaultValue]="['b']" data-testid="listbox">
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">A</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">B</div>
+        </div>`,
+        { imports },
+      );
+
+      fireEvent.click(container.getByTestId('opt-a'));
+
+      expect(container.getByTestId('opt-a')).toHaveAttribute('data-selected');
+      expect(container.getByTestId('opt-b')).not.toHaveAttribute('data-selected');
+    });
+
+    it('should prefer a controlled value over the default value when both are provided', async () => {
+      const container = await render(
+        `<div
+          ngpListbox
+          [ngpListboxValue]="['a']"
+          [ngpListboxDefaultValue]="['b']"
+          data-testid="listbox"
+        >
+          <div ngpListboxOption ngpListboxOptionValue="a" data-testid="opt-a">A</div>
+          <div ngpListboxOption ngpListboxOptionValue="b" data-testid="opt-b">B</div>
+        </div>`,
+        { imports },
+      );
+
+      expect(container.getByTestId('opt-a')).toHaveAttribute('data-selected');
+      expect(container.getByTestId('opt-b')).not.toHaveAttribute('data-selected');
+    });
+  });
 });

--- a/packages/ng-primitives/menu/src/menu-item-checkbox/menu-item-checkbox-state.ts
+++ b/packages/ng-primitives/menu/src/menu-item-checkbox/menu-item-checkbox-state.ts
@@ -3,9 +3,9 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   dataBinding,
-  emitter,
   listener,
 } from 'ng-primitives/state';
 import { Observable } from 'rxjs';
@@ -26,13 +26,23 @@ export interface NgpMenuItemCheckboxState {
    * Toggle the checkbox value.
    */
   toggle(): void;
+
+  /**
+   * Set the default checked state used in uncontrolled mode.
+   */
+  setDefaultChecked(value: boolean): void;
 }
 
 export interface NgpMenuItemCheckboxProps {
   /**
-   * Whether the checkbox is checked.
+   * Whether the checkbox is checked. When defined the checkbox is controlled.
    */
-  readonly checked?: Signal<boolean>;
+  readonly checked?: Signal<boolean | undefined>;
+
+  /**
+   * The default checked state for uncontrolled usage.
+   */
+  readonly defaultChecked?: Signal<boolean>;
 
   /**
    * Whether the checkbox is disabled.
@@ -53,13 +63,18 @@ export const [
 ] = createPrimitive(
   'NgpMenuItemCheckbox',
   ({
-    checked: _checked = signal(false),
+    checked: _checked = signal<boolean | undefined>(undefined),
+    defaultChecked: _defaultChecked,
     disabled = signal(false),
     onCheckedChange,
   }: NgpMenuItemCheckboxProps): NgpMenuItemCheckboxState => {
     const element = injectElementRef();
-    const checked = controlled(_checked);
-    const checkedChange = emitter<boolean>();
+    const defaultChecked = controlled(_defaultChecked, false);
+    const [checked, setChecked, checkedChange] = controlledState({
+      value: _checked,
+      defaultValue: defaultChecked,
+      onChange: onCheckedChange,
+    });
 
     // Use base menu item behavior but don't close on select
     ngpMenuItem({ disabled, closeOnSelect: signal(false), role: 'menuitemcheckbox' });
@@ -76,16 +91,14 @@ export const [
         return;
       }
 
-      const nextChecked = !checked();
-      checked.set(nextChecked);
-      onCheckedChange?.(nextChecked);
-      checkedChange.emit(nextChecked);
+      setChecked(!checked());
     }
 
     return {
       checked,
-      checkedChange: checkedChange.asObservable(),
+      checkedChange,
       toggle,
+      setDefaultChecked: defaultChecked.set,
     } satisfies NgpMenuItemCheckboxState;
   },
 );

--- a/packages/ng-primitives/menu/src/menu-item-checkbox/menu-item-checkbox.ts
+++ b/packages/ng-primitives/menu/src/menu-item-checkbox/menu-item-checkbox.ts
@@ -1,6 +1,7 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import { booleanAttribute, Directive, input, output } from '@angular/core';
 import { ngpRovingFocusItem, provideRovingFocusItemState } from 'ng-primitives/roving-focus';
+import { coerceBooleanOrUndefined } from 'ng-primitives/utils';
 import { ngpMenuItemCheckbox, provideMenuItemCheckboxState } from './menu-item-checkbox-state';
 
 /**
@@ -12,9 +13,15 @@ import { ngpMenuItemCheckbox, provideMenuItemCheckboxState } from './menu-item-c
   providers: [provideMenuItemCheckboxState(), provideRovingFocusItemState()],
 })
 export class NgpMenuItemCheckbox {
-  /** Whether the checkbox is checked */
-  readonly checked = input<boolean, BooleanInput>(false, {
+  /** Whether the checkbox is checked. When defined the checkbox is controlled. */
+  readonly checked = input<boolean | undefined, BooleanInput>(undefined, {
     alias: 'ngpMenuItemCheckboxChecked',
+    transform: coerceBooleanOrUndefined,
+  });
+
+  /** The default checked state for uncontrolled usage */
+  readonly defaultChecked = input<boolean, BooleanInput>(false, {
+    alias: 'ngpMenuItemCheckboxDefaultChecked',
     transform: booleanAttribute,
   });
 
@@ -32,6 +39,7 @@ export class NgpMenuItemCheckbox {
   constructor() {
     ngpMenuItemCheckbox({
       checked: this.checked,
+      defaultChecked: this.defaultChecked,
       disabled: this.disabled,
       onCheckedChange: value => this.checkedChange.emit(value),
     });

--- a/packages/ng-primitives/menu/src/menu-item-radio-group/menu-item-radio-group-state.ts
+++ b/packages/ng-primitives/menu/src/menu-item-radio-group/menu-item-radio-group-state.ts
@@ -1,6 +1,12 @@
 import { Signal, signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, controlled, createPrimitive, emitter } from 'ng-primitives/state';
+import {
+  attrBinding,
+  controlled,
+  controlledState,
+  createPrimitive,
+  emitter,
+} from 'ng-primitives/state';
 import { Observable } from 'rxjs';
 
 export interface NgpMenuItemRadioGroupState {
@@ -18,13 +24,23 @@ export interface NgpMenuItemRadioGroupState {
    * Select a radio item by value.
    */
   select(value: string): void;
+
+  /**
+   * Set the default value used in uncontrolled mode.
+   */
+  setDefaultValue(value: string | null): void;
 }
 
 export interface NgpMenuItemRadioGroupProps {
   /**
-   * The current value of the radio group.
+   * The current value of the radio group. When defined the group is controlled.
    */
-  readonly value?: Signal<string | null>;
+  readonly value?: Signal<string | null | undefined>;
+
+  /**
+   * The default value for uncontrolled usage.
+   */
+  readonly defaultValue?: Signal<string | null>;
 
   /**
    * Callback fired when the value changes.
@@ -40,11 +56,19 @@ export const [
 ] = createPrimitive(
   'NgpMenuItemRadioGroup',
   ({
-    value: _value = signal(null),
+    value: _value = signal<string | null | undefined>(undefined),
+    defaultValue: _defaultValue,
     onValueChange,
   }: NgpMenuItemRadioGroupProps): NgpMenuItemRadioGroupState => {
     const element = injectElementRef();
-    const value = controlled(_value);
+    // `controlledState` provides controlled/uncontrolled latching; the group
+    // only ever selects string values, so we keep a string-typed emitter and
+    // drive it manually (calling the setter with emit:false).
+    const defaultValue = controlled<string | null>(_defaultValue, null);
+    const [value, setValue] = controlledState<string | null>({
+      value: _value,
+      defaultValue,
+    });
     const valueChange = emitter<string>();
 
     // Host bindings
@@ -55,7 +79,7 @@ export const [
         return;
       }
 
-      value.set(newValue);
+      setValue(newValue, { emit: false });
       onValueChange?.(newValue);
       valueChange.emit(newValue);
     }
@@ -64,6 +88,7 @@ export const [
       value,
       valueChange: valueChange.asObservable(),
       select,
+      setDefaultValue: defaultValue.set,
     } satisfies NgpMenuItemRadioGroupState;
   },
 );

--- a/packages/ng-primitives/menu/src/menu-item-radio-group/menu-item-radio-group.ts
+++ b/packages/ng-primitives/menu/src/menu-item-radio-group/menu-item-radio-group.ts
@@ -13,9 +13,14 @@ import {
   providers: [provideMenuItemRadioGroupState()],
 })
 export class NgpMenuItemRadioGroup {
-  /** The current value of the radio group */
-  readonly value = input<string | null>(null, {
+  /** The current value of the radio group. When defined the group is controlled. */
+  readonly value = input<string | null | undefined>(undefined, {
     alias: 'ngpMenuItemRadioGroupValue',
+  });
+
+  /** The default value for uncontrolled usage */
+  readonly defaultValue = input<string | null>(null, {
+    alias: 'ngpMenuItemRadioGroupDefaultValue',
   });
 
   /** Event emitted when the value changes */
@@ -26,6 +31,7 @@ export class NgpMenuItemRadioGroup {
   constructor() {
     ngpMenuItemRadioGroup({
       value: this.value,
+      defaultValue: this.defaultValue,
       onValueChange: value => this.valueChange.emit(value),
     });
   }

--- a/packages/ng-primitives/menu/src/menu/tests/menu-item-checkbox.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-item-checkbox.test.ts
@@ -56,6 +56,51 @@ class TestMenuCheckboxComponent {
 })
 class TestMenuCheckboxDisabledComponent {}
 
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu">
+        <button
+          [ngpMenuItemCheckboxChecked]="checked"
+          (ngpMenuItemCheckboxCheckedChange)="lastChange = $event"
+          ngpMenuItemCheckbox
+          data-testid="checkbox-item"
+        >
+          Show Toolbar
+        </button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItemCheckbox],
+})
+class TestMenuCheckboxControlledComponent {
+  // controlled but never updated in response to the change event
+  readonly checked = false;
+  lastChange: boolean | undefined;
+}
+
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu">
+        <button
+          [ngpMenuItemCheckboxDefaultChecked]="true"
+          ngpMenuItemCheckbox
+          data-testid="checkbox-item"
+        >
+          Show Toolbar
+        </button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItemCheckbox],
+})
+class TestMenuCheckboxDefaultComponent {}
+
 async function openMenu(fixture: any) {
   const trigger = fixture.debugElement.nativeElement.querySelector('[data-testid="trigger"]');
   fireEvent.click(trigger);
@@ -362,5 +407,33 @@ describe('NgpMenuItemCheckbox in submenu', () => {
 
     // Root menu should still be open
     expect(rootTrigger).toHaveAttribute('data-open');
+  });
+
+  it('should emit checkedChange on click but not update the DOM when controlled without round-trip', async () => {
+    const { fixture } = await render(TestMenuCheckboxControlledComponent);
+    await openMenu(fixture);
+
+    const checkbox = document.querySelector('[data-testid="checkbox-item"]')!;
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(checkbox);
+    TestBed.flushEffects();
+
+    // notified, but the controlled value is never written back so it stays put
+    expect(fixture.componentInstance.lastChange).toBe(true);
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    expect(checkbox).not.toHaveAttribute('data-checked');
+  });
+
+  it('should start checked from ngpMenuItemCheckboxDefaultChecked and toggle uncontrolled', async () => {
+    const { fixture } = await render(TestMenuCheckboxDefaultComponent);
+    await openMenu(fixture);
+
+    const checkbox = document.querySelector('[data-testid="checkbox-item"]')!;
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(checkbox);
+    TestBed.flushEffects();
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
   });
 });

--- a/packages/ng-primitives/menu/src/menu/tests/menu-item-radio.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-item-radio.test.ts
@@ -77,6 +77,56 @@ class TestMenuRadioComponent {
 })
 class TestMenuRadioDisabledComponent {}
 
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu">
+        <div
+          [ngpMenuItemRadioGroupValue]="theme"
+          (ngpMenuItemRadioGroupValueChange)="lastChange = $event"
+          ngpMenuItemRadioGroup
+        >
+          <button ngpMenuItemRadio ngpMenuItemRadioValue="light" data-testid="radio-light">
+            Light
+          </button>
+          <button ngpMenuItemRadio ngpMenuItemRadioValue="dark" data-testid="radio-dark">
+            Dark
+          </button>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItemRadioGroup, NgpMenuItemRadio],
+})
+class TestMenuRadioControlledComponent {
+  // controlled but never updated in response to the change event
+  readonly theme = 'light';
+  lastChange: string | undefined;
+}
+
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu">
+        <div ngpMenuItemRadioGroupDefaultValue="light" ngpMenuItemRadioGroup>
+          <button ngpMenuItemRadio ngpMenuItemRadioValue="light" data-testid="radio-light">
+            Light
+          </button>
+          <button ngpMenuItemRadio ngpMenuItemRadioValue="dark" data-testid="radio-dark">
+            Dark
+          </button>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItemRadioGroup, NgpMenuItemRadio],
+})
+class TestMenuRadioDefaultComponent {}
+
 async function openMenu(fixture: any) {
   const trigger = fixture.debugElement.nativeElement.querySelector('[data-testid="trigger"]');
   fireEvent.click(trigger);
@@ -215,5 +265,36 @@ describe('NgpMenuItemRadioGroup', () => {
 
     // Theme should not have changed
     expect(fixture.componentInstance.theme).toBe(originalTheme);
+  });
+
+  it('should emit valueChange on select but not update the DOM when controlled without round-trip', async () => {
+    const { fixture } = await render(TestMenuRadioControlledComponent);
+    await openMenu(fixture);
+
+    const light = document.querySelector('[data-testid="radio-light"]')!;
+    const dark = document.querySelector('[data-testid="radio-dark"]')!;
+    expect(light).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(dark);
+    TestBed.flushEffects();
+
+    // notified, but the controlled value is never written back so it stays put
+    expect(fixture.componentInstance.lastChange).toBe('dark');
+    expect(light).toHaveAttribute('aria-checked', 'true');
+    expect(dark).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('should start from ngpMenuItemRadioGroupDefaultValue and select uncontrolled', async () => {
+    const { fixture } = await render(TestMenuRadioDefaultComponent);
+    await openMenu(fixture);
+
+    const light = document.querySelector('[data-testid="radio-light"]')!;
+    const dark = document.querySelector('[data-testid="radio-dark"]')!;
+    expect(light).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(dark);
+    TestBed.flushEffects();
+    expect(dark).toHaveAttribute('aria-checked', 'true');
+    expect(light).toHaveAttribute('aria-checked', 'false');
   });
 });

--- a/packages/ng-primitives/number-field/src/number-field/number-field-state.ts
+++ b/packages/ng-primitives/number-field/src/number-field/number-field-state.ts
@@ -3,6 +3,7 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   dataBinding,
   deprecatedSetter,
@@ -64,6 +65,10 @@ export interface NgpNumberFieldState {
    */
   setValue(value: number | null): void;
   /**
+   * Set the default value used in uncontrolled mode.
+   */
+  setDefaultValue(value: number | null): void;
+  /**
    * Increment the value by one step.
    */
   increment(multiplier?: number): void;
@@ -92,9 +97,13 @@ export interface NgpNumberFieldProps {
    */
   readonly id?: Signal<string>;
   /**
-   * The current value.
+   * The current value. When defined the number field is controlled.
    */
-  readonly value?: Signal<number | null>;
+  readonly value?: Signal<number | null | undefined>;
+  /**
+   * The default value for uncontrolled usage.
+   */
+  readonly defaultValue?: Signal<number | null>;
   /**
    * The minimum value.
    */
@@ -134,7 +143,8 @@ export const [
   'NgpNumberField',
   ({
     id = signal(uniqueId('ngp-number-field')),
-    value: _value = signal<number | null>(null),
+    value: _value = signal<number | null | undefined>(undefined),
+    defaultValue: _defaultValue,
     min = signal(-Infinity),
     max = signal(Infinity),
     step = signal(1),
@@ -144,7 +154,16 @@ export const [
     onValueChange,
   }: NgpNumberFieldProps): NgpNumberFieldState => {
     const element = injectElementRef();
-    const value = controlled(_value);
+    // `controlledState` provides controlled/uncontrolled latching. The number
+    // field's emit choreography (silent input commit + manual-emit fallback in
+    // increment/decrement) is bespoke, so we drive emits through our own
+    // emitter rather than controlledState's change observable, and always call
+    // its setter with `emit: false`.
+    const defaultValue = controlled(_defaultValue, null);
+    const [value, setValueInternal] = controlledState<number | null>({
+      value: _value,
+      defaultValue,
+    });
     const disabled = controlled(_disabled);
     const readonly = controlled(_readonly);
 
@@ -208,7 +227,9 @@ export const [
       const finalValue = newValue !== null ? clampAndStep(newValue) : null;
       // Skip emit when value is unchanged
       if (finalValue === value()) return;
-      value.set(finalValue);
+      // `emit: false` keeps controlledState from firing its own change; we emit
+      // manually below to preserve the number field's emit choreography.
+      setValueInternal(finalValue, { emit: false });
       if (!suppressEmit) {
         onValueChange?.(finalValue);
         valueChange.emit(finalValue);
@@ -285,7 +306,7 @@ export const [
 
     return {
       id,
-      value,
+      value: deprecatedSetter(value, 'setValue', setValue),
       min,
       max,
       step,
@@ -296,6 +317,7 @@ export const [
       canDecrement,
       valueChange: valueChange.asObservable(),
       setValue,
+      setDefaultValue: defaultValue.set,
       increment,
       decrement,
       setDisabled,

--- a/packages/ng-primitives/number-field/src/number-field/number-field.ts
+++ b/packages/ng-primitives/number-field/src/number-field/number-field.ts
@@ -19,10 +19,20 @@ export class NgpNumberField {
   readonly id = input<string>(uniqueId('ngp-number-field'));
 
   /**
-   * The value of the number field.
+   * The value of the number field. When defined the number field is controlled.
    */
-  readonly value = input<number | null, NumberInput>(null, {
+  readonly value = input<number | null | undefined, NumberInput>(undefined, {
     alias: 'ngpNumberFieldValue',
+    transform: (v: NumberInput) =>
+      v === undefined ? undefined : v === null || v === '' ? null : numberAttribute(v),
+  });
+
+  /**
+   * The default value of the number field for uncontrolled usage.
+   * @default null
+   */
+  readonly defaultValue = input<number | null, NumberInput>(null, {
+    alias: 'ngpNumberFieldDefaultValue',
     transform: (v: NumberInput) =>
       v === null || v === undefined || v === '' ? null : numberAttribute(v),
   });
@@ -88,6 +98,7 @@ export class NgpNumberField {
   protected readonly state = ngpNumberField({
     id: this.id,
     value: this.value,
+    defaultValue: this.defaultValue,
     min: this.min,
     max: this.max,
     step: this.step,

--- a/packages/ng-primitives/number-field/src/number-field/tests/number-field-component.test.ts
+++ b/packages/ng-primitives/number-field/src/number-field/tests/number-field-component.test.ts
@@ -60,8 +60,10 @@ describe('NumberField (reusable component) — standalone', () => {
   });
 
   it('increments the value when the increment button is clicked', async () => {
-    const { fixture } = await render(`<app-number-field value="5"></app-number-field>`, {
+    // `value` is the controlled input, so a two-way binding round-trips the change.
+    const { fixture } = await render(`<app-number-field [(value)]="value"></app-number-field>`, {
       imports: [NumberFieldFixture],
+      componentProperties: { value: 5 },
     });
 
     fireEvent.pointerDown(screen.getByTestId('increment'));
@@ -71,8 +73,9 @@ describe('NumberField (reusable component) — standalone', () => {
   });
 
   it('decrements the value when the decrement button is clicked', async () => {
-    const { fixture } = await render(`<app-number-field value="5"></app-number-field>`, {
+    const { fixture } = await render(`<app-number-field [(value)]="value"></app-number-field>`, {
       imports: [NumberFieldFixture],
+      componentProperties: { value: 5 },
     });
 
     fireEvent.pointerDown(screen.getByTestId('decrement'));
@@ -83,8 +86,8 @@ describe('NumberField (reusable component) — standalone', () => {
 
   it('increments the value with the ArrowUp key', async () => {
     const { fixture } = await render(
-      `<app-number-field value="5" min="0" max="10"></app-number-field>`,
-      { imports: [NumberFieldFixture] },
+      `<app-number-field [(value)]="value" min="0" max="10"></app-number-field>`,
+      { imports: [NumberFieldFixture], componentProperties: { value: 5 } },
     );
 
     const input = screen.getByRole('spinbutton');

--- a/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
+++ b/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
@@ -106,10 +106,68 @@ describe('NgpNumberField', () => {
     });
 
     it('should update aria-valuenow after incrementing', async () => {
-      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="5"');
+      const { fixture } = await renderNumberField('[ngpNumberFieldDefaultValue]="5"');
       fireEvent.pointerDown(screen.getByTestId('increment'));
       await fixture.whenStable();
       expect(screen.getByTestId('input')).toHaveAttribute('aria-valuenow', '6');
+    });
+  });
+
+  describe('controlled mode (no round-trip)', () => {
+    it('should emit valueChange on increment but not update the DOM when the parent does not update the binding', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="5"', valueChange);
+      fireEvent.pointerDown(screen.getByTestId('increment'));
+      await fixture.whenStable();
+
+      // notifies via valueChange, but the controlled value must stay put because
+      // the parent never writes the new value back.
+      expect(valueChange).toHaveBeenCalledWith(6);
+      expect(screen.getByTestId('input')).toHaveAttribute('aria-valuenow', '5');
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('5');
+    });
+  });
+
+  describe('two-way binding', () => {
+    it('should round-trip a two-way binding and update the value on increment', async () => {
+      const { fixture } = await render(
+        `<div ngpNumberField [(ngpNumberFieldValue)]="value" data-testid="number-field">
+          <button ngpNumberFieldDecrement data-testid="decrement">-</button>
+          <input ngpNumberFieldInput data-testid="input" />
+          <button ngpNumberFieldIncrement data-testid="increment">+</button>
+        </div>`,
+        { imports, componentProperties: { value: 5 } },
+      );
+      expect(screen.getByTestId('input')).toHaveAttribute('aria-valuenow', '5');
+
+      fireEvent.pointerDown(screen.getByTestId('increment'));
+      await fixture.whenStable();
+
+      expect(screen.getByTestId('input')).toHaveAttribute('aria-valuenow', '6');
+      expect(fixture.componentInstance.value).toBe(6);
+    });
+  });
+
+  describe('defaultValue (uncontrolled)', () => {
+    it('should display the default value on init', async () => {
+      const { fixture } = await renderNumberField('[ngpNumberFieldDefaultValue]="5"');
+      await fixture.whenStable();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('5');
+    });
+
+    it('should let interaction override the default value (uncontrolled)', async () => {
+      const { fixture } = await renderNumberField('[ngpNumberFieldDefaultValue]="5"');
+      fireEvent.pointerDown(screen.getByTestId('increment'));
+      await fixture.whenStable();
+      expect(screen.getByTestId('input')).toHaveAttribute('aria-valuenow', '6');
+    });
+
+    it('should prefer a controlled value over the default value', async () => {
+      const { fixture } = await renderNumberField(
+        '[ngpNumberFieldValue]="3" [ngpNumberFieldDefaultValue]="8"',
+      );
+      await fixture.whenStable();
+      expect(screen.getByTestId('input')).toHaveAttribute('aria-valuenow', '3');
     });
   });
 
@@ -129,7 +187,10 @@ describe('NgpNumberField', () => {
 
     it('should handle floating point precision with step=0.1', async () => {
       const valueChange = vi.fn();
-      await renderNumberField('[ngpNumberFieldValue]="0" [ngpNumberFieldStep]="0.1"', valueChange);
+      await renderNumberField(
+        '[ngpNumberFieldDefaultValue]="0" [ngpNumberFieldStep]="0.1"',
+        valueChange,
+      );
 
       const input = screen.getByTestId('input');
       fireEvent.keyDown(input, { key: 'ArrowUp' });
@@ -258,7 +319,7 @@ describe('NgpNumberField', () => {
 
     it('should use the typed value when the increment button is clicked while focused', async () => {
       const valueChange = vi.fn();
-      await renderNumberField('[ngpNumberFieldValue]="10"', valueChange);
+      await renderNumberField('[ngpNumberFieldDefaultValue]="10"', valueChange);
 
       const input = screen.getByTestId('input') as HTMLInputElement;
       fireEvent.focus(input);
@@ -273,7 +334,7 @@ describe('NgpNumberField', () => {
 
     it('should use the typed value when the decrement button is clicked while focused', async () => {
       const valueChange = vi.fn();
-      await renderNumberField('[ngpNumberFieldValue]="10"', valueChange);
+      await renderNumberField('[ngpNumberFieldDefaultValue]="10"', valueChange);
 
       const input = screen.getByTestId('input') as HTMLInputElement;
       fireEvent.focus(input);
@@ -286,7 +347,7 @@ describe('NgpNumberField', () => {
     });
 
     it('should update the display after a button increment while focused', async () => {
-      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="10"');
+      const { fixture } = await renderNumberField('[ngpNumberFieldDefaultValue]="10"');
 
       const input = screen.getByTestId('input') as HTMLInputElement;
       fireEvent.focus(input);
@@ -300,7 +361,7 @@ describe('NgpNumberField', () => {
 
     it('should allow multiple consecutive button clicks while focused', async () => {
       const valueChange = vi.fn();
-      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="10"', valueChange);
+      const { fixture } = await renderNumberField('[ngpNumberFieldDefaultValue]="10"', valueChange);
 
       const input = screen.getByTestId('input') as HTMLInputElement;
       fireEvent.focus(input);
@@ -336,7 +397,7 @@ describe('NgpNumberField', () => {
     it('should use the large step with Shift+ArrowUp', async () => {
       const valueChange = vi.fn();
       await renderNumberField(
-        '[ngpNumberFieldValue]="5" [ngpNumberFieldLargeStep]="10"',
+        '[ngpNumberFieldDefaultValue]="5" [ngpNumberFieldLargeStep]="10"',
         valueChange,
       );
       fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp', shiftKey: true });
@@ -346,7 +407,7 @@ describe('NgpNumberField', () => {
     it('should use the large step with Shift+ArrowDown', async () => {
       const valueChange = vi.fn();
       await renderNumberField(
-        '[ngpNumberFieldValue]="50" [ngpNumberFieldLargeStep]="10"',
+        '[ngpNumberFieldDefaultValue]="50" [ngpNumberFieldLargeStep]="10"',
         valueChange,
       );
       fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowDown', shiftKey: true });
@@ -375,7 +436,7 @@ describe('NgpNumberField', () => {
 
     it('should increment from the typed value rather than the stale signal value', async () => {
       const valueChange = vi.fn();
-      await renderNumberField('[ngpNumberFieldValue]="10"', valueChange);
+      await renderNumberField('[ngpNumberFieldDefaultValue]="10"', valueChange);
 
       const input = screen.getByTestId('input') as HTMLInputElement;
       fireEvent.focus(input);
@@ -389,7 +450,7 @@ describe('NgpNumberField', () => {
 
     it('should decrement from the typed value rather than the stale signal value', async () => {
       const valueChange = vi.fn();
-      await renderNumberField('[ngpNumberFieldValue]="10"', valueChange);
+      await renderNumberField('[ngpNumberFieldDefaultValue]="10"', valueChange);
 
       const input = screen.getByTestId('input') as HTMLInputElement;
       fireEvent.focus(input);
@@ -405,7 +466,7 @@ describe('NgpNumberField', () => {
     it('should increment by the large step on PageUp', async () => {
       const valueChange = vi.fn();
       await renderNumberField(
-        '[ngpNumberFieldValue]="5" [ngpNumberFieldLargeStep]="10"',
+        '[ngpNumberFieldDefaultValue]="5" [ngpNumberFieldLargeStep]="10"',
         valueChange,
       );
       const input = screen.getByTestId('input') as HTMLInputElement;
@@ -417,7 +478,7 @@ describe('NgpNumberField', () => {
     it('should decrement by the large step on PageDown', async () => {
       const valueChange = vi.fn();
       await renderNumberField(
-        '[ngpNumberFieldValue]="50" [ngpNumberFieldLargeStep]="10"',
+        '[ngpNumberFieldDefaultValue]="50" [ngpNumberFieldLargeStep]="10"',
         valueChange,
       );
       const input = screen.getByTestId('input') as HTMLInputElement;
@@ -755,7 +816,10 @@ describe('NgpNumberField', () => {
 
     it('should stop auto-repeat when hitting the max boundary', async () => {
       const valueChange = vi.fn();
-      await renderNumberField('[ngpNumberFieldValue]="8" [ngpNumberFieldMax]="10"', valueChange);
+      await renderNumberField(
+        '[ngpNumberFieldDefaultValue]="8" [ngpNumberFieldMax]="10"',
+        valueChange,
+      );
 
       fireEvent.pointerDown(screen.getByTestId('increment'));
       expect(valueChange).toHaveBeenCalledWith(9);

--- a/packages/ng-primitives/pagination/src/pagination/pagination-state.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination-state.ts
@@ -50,6 +50,11 @@ export interface NgpPaginationState {
    */
   setPage: (page: number, options?: SetterOptions) => void;
   /**
+   * Set the default page for uncontrolled usage.
+   * @param page The default page to set.
+   */
+  setDefaultPage: (page: number) => void;
+  /**
    * Go to the specified page.
    * @param page The page to go to.
    */
@@ -87,7 +92,7 @@ export const [
   'NgpPagination',
   ({
     page: _page = signal<number | undefined>(undefined),
-    defaultPage: _defaultPage = signal<number>(1),
+    defaultPage: _defaultPage,
     pageCount: _pageCount = signal<number>(0),
     disabled: _disabled = signal<boolean>(false),
     onPageChange,
@@ -97,10 +102,11 @@ export const [
     // controlled so a form control can set the disabled state via setDisabled,
     // while still following the `disabled` input when it is bound
     const disabled = controlled(_disabled);
+    const defaultPage = controlled(_defaultPage, 1);
 
     const [page, setPage, pageChange] = controlledState({
       value: _page,
-      defaultValue: _defaultPage,
+      defaultValue: defaultPage,
       onChange: onPageChange,
     });
 
@@ -139,6 +145,7 @@ export const [
       firstPage,
       lastPage,
       setPage,
+      setDefaultPage: defaultPage.set,
       goToPage,
     } satisfies NgpPaginationState;
   },

--- a/packages/ng-primitives/pagination/src/pagination/pagination.ts
+++ b/packages/ng-primitives/pagination/src/pagination/pagination.ts
@@ -1,5 +1,6 @@
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
 import { booleanAttribute, Directive, input, numberAttribute, output } from '@angular/core';
+import { coerceNumberOrUndefined } from 'ng-primitives/utils';
 import { ngpPagination, providePaginationState } from './pagination-state';
 
 /**
@@ -17,7 +18,7 @@ export class NgpPagination {
    */
   readonly page = input<number | undefined, NumberInput>(undefined, {
     alias: 'ngpPaginationPage',
-    transform: numberAttribute,
+    transform: coerceNumberOrUndefined,
   });
 
   /**
@@ -26,7 +27,7 @@ export class NgpPagination {
    */
   readonly defaultPage = input<number, NumberInput>(1, {
     alias: 'ngpPaginationDefaultPage',
-    transform: numberAttribute,
+    transform: (value: NumberInput) => numberAttribute(value, 1),
   });
 
   /**

--- a/packages/ng-primitives/pagination/src/pagination/tests/pagination-primitive.test.ts
+++ b/packages/ng-primitives/pagination/src/pagination/tests/pagination-primitive.test.ts
@@ -120,6 +120,36 @@ describe('NgpPagination', () => {
       expect(pagination).not.toHaveAttribute('data-last-page');
     });
 
+    it('should stay uncontrolled when the page binding is explicitly undefined', async () => {
+      const { getByRole } = await render(
+        `<div ngpPagination [ngpPaginationPage]="page" [ngpPaginationDefaultPage]="3" [ngpPaginationPageCount]="5">
+          <button data-testid="page-2" ngpPaginationButton ngpPaginationButtonPage="2">2</button>
+        </div>`,
+        {
+          imports: [NgpPagination, NgpPaginationButton],
+          componentProperties: { page: undefined },
+        },
+      );
+
+      // an explicit `undefined` must not coerce to NaN — it stays uncontrolled at the default page
+      expect(getByRole('navigation')).toHaveAttribute('data-page', '3');
+    });
+
+    it('should fall back to the declared default page when defaultPage is explicitly undefined', async () => {
+      const { getByRole } = await render(
+        `<div ngpPagination [ngpPaginationDefaultPage]="page" [ngpPaginationPageCount]="5">
+          <button data-testid="page-2" ngpPaginationButton ngpPaginationButtonPage="2">2</button>
+        </div>`,
+        {
+          imports: [NgpPagination, NgpPaginationButton],
+          componentProperties: { page: undefined },
+        },
+      );
+
+      // a bound-undefined default must resolve to the declared default (1), not NaN
+      expect(getByRole('navigation')).toHaveAttribute('data-page', '1');
+    });
+
     it('should mark the active page button with data-selected and aria-current', async () => {
       const { getByTestId, fixture } = await render(
         `<div ngpPagination [ngpPaginationPage]="2" [ngpPaginationPageCount]="3">

--- a/packages/ng-primitives/password/src/password/password.ts
+++ b/packages/ng-primitives/password/src/password/password.ts
@@ -1,6 +1,7 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import { booleanAttribute, computed, Directive, input, output, Signal } from '@angular/core';
 import { SetterOptions } from 'ng-primitives/state';
+import { coerceBooleanOrUndefined } from 'ng-primitives/utils';
 import { ngpPassword, providePasswordState } from './password-state';
 
 /**
@@ -17,7 +18,7 @@ export class NgpPassword {
    */
   readonly visible = input<boolean | undefined, BooleanInput>(undefined, {
     alias: 'ngpPasswordVisible',
-    transform: booleanAttribute,
+    transform: coerceBooleanOrUndefined,
   });
 
   /**

--- a/packages/ng-primitives/password/src/password/tests/password-primitive.test.ts
+++ b/packages/ng-primitives/password/src/password/tests/password-primitive.test.ts
@@ -56,6 +56,25 @@ describe('NgpPassword', () => {
 
       expect(getByTestId('input')).toHaveAttribute('type', 'text');
     });
+
+    it('should stay uncontrolled when ngpPasswordVisible is explicitly undefined', async () => {
+      const { getByTestId, fixture } = await render(
+        `
+        <div ngpPassword [ngpPasswordVisible]="visible" ngpPasswordDefaultVisible>
+          <input data-testid="input" ngpPasswordInput />
+          <button data-testid="toggle" ngpPasswordToggle></button>
+        </div>
+        `,
+        { imports, componentProperties: { visible: undefined } },
+      );
+
+      // an explicit `undefined` must not coerce to `false` — it stays uncontrolled at the default
+      expect(getByTestId('input')).toHaveAttribute('type', 'text');
+
+      fireEvent.click(getByTestId('toggle'));
+      await fixture.whenStable();
+      expect(getByTestId('input')).toHaveAttribute('type', 'password');
+    });
   });
 
   describe('data-visible attribute', () => {

--- a/packages/ng-primitives/rating/src/rating/rating-state.ts
+++ b/packages/ng-primitives/rating/src/rating/rating-state.ts
@@ -5,9 +5,10 @@ import {
   SetterOptions,
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   dataBinding,
-  emitter,
+  deprecatedSetter,
   listener,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
@@ -49,6 +50,8 @@ export interface NgpRatingState {
   readonly valueChange: Observable<number>;
   /** Set the committed value (clamped to `[0, count]`). */
   setValue(value: number, options?: SetterOptions): void;
+  /** Set the default value used in uncontrolled mode. */
+  setDefaultValue(value: number): void;
   /** Set the disabled state (merged with any form control disabled state). */
   setDisabled(disabled: boolean): void;
   /**
@@ -72,8 +75,10 @@ export interface NgpRatingState {
 export interface NgpRatingProps {
   /** The id of the rating. */
   readonly id?: Signal<string>;
-  /** The committed rating value. */
-  readonly value?: Signal<number>;
+  /** The committed rating value. When defined the rating is controlled. */
+  readonly value?: Signal<number | undefined>;
+  /** The default rating value for uncontrolled usage. */
+  readonly defaultValue?: Signal<number>;
   /** The number of items. */
   readonly count?: Signal<number>;
   /** Whether half values are allowed. */
@@ -95,7 +100,8 @@ export const [NgpRatingStateToken, ngpRating, injectRatingState, provideRatingSt
     'NgpRating',
     ({
       id = signal(uniqueId('ngp-rating')),
-      value: _value = signal(0),
+      value: _value = signal<number | undefined>(undefined),
+      defaultValue: _defaultValue,
       count = signal(5),
       allowHalf = signal(false),
       disabled: _disabled = signal(false),
@@ -107,10 +113,14 @@ export const [NgpRatingStateToken, ngpRating, injectRatingState, provideRatingSt
       onValueChange,
     }: NgpRatingProps): NgpRatingState => {
       const element = injectElementRef<HTMLElement>();
-      const value = controlled(_value);
+      const defaultValue = controlled(_defaultValue, 0);
+      const [value, setValueInternal, valueChange] = controlledState<number>({
+        value: _value,
+        defaultValue,
+        onChange: onValueChange,
+      });
       const disabledInput = controlled(_disabled);
       const hovered = signal<number | null>(null);
-      const valueChange = emitter<number>();
 
       // Merge the input disabled state with the form control (NgControl) state.
       const status = ngpFormControl({ id, disabled: disabledInput });
@@ -134,11 +144,7 @@ export const [NgpRatingStateToken, ngpRating, injectRatingState, provideRatingSt
 
       function setValue(newValue: number, options?: SetterOptions): void {
         const clamped = Math.min(count(), Math.max(0, newValue));
-        value.set(clamped);
-        if (options?.emit !== false) {
-          onValueChange?.(clamped);
-          valueChange.emit(clamped);
-        }
+        setValueInternal(clamped, options);
       }
 
       function setDisabled(isDisabled: boolean): void {
@@ -235,13 +241,14 @@ export const [NgpRatingStateToken, ngpRating, injectRatingState, provideRatingSt
 
       return {
         id,
-        value,
+        value: deprecatedSetter(value, 'setValue', setValue),
         count,
         allowHalf,
         disabled,
         readonly,
-        valueChange: valueChange.asObservable(),
+        valueChange,
         setValue,
+        setDefaultValue: defaultValue.set,
         setDisabled,
         commit,
         preview,

--- a/packages/ng-primitives/rating/src/rating/rating.ts
+++ b/packages/ng-primitives/rating/src/rating/rating.ts
@@ -1,7 +1,7 @@
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
 import { Directive, booleanAttribute, input, numberAttribute, output } from '@angular/core';
 import { SetterOptions } from 'ng-primitives/state';
-import { uniqueId } from 'ng-primitives/utils';
+import { coerceNumberOrUndefined, uniqueId } from 'ng-primitives/utils';
 import { injectRatingConfig } from '../config/rating-config';
 import { ngpRating, provideRatingState } from './rating-state';
 
@@ -24,11 +24,20 @@ export class NgpRating {
   readonly id = input<string>(uniqueId('ngp-rating'));
 
   /**
-   * The value of the rating.
+   * The value of the rating. When defined the rating is controlled.
    */
-  readonly value = input<number, NumberInput>(0, {
+  readonly value = input<number | undefined, NumberInput>(undefined, {
     alias: 'ngpRatingValue',
-    transform: numberAttribute,
+    transform: coerceNumberOrUndefined,
+  });
+
+  /**
+   * The default value of the rating for uncontrolled usage.
+   * @default 0
+   */
+  readonly defaultValue = input<number, NumberInput>(0, {
+    alias: 'ngpRatingDefaultValue',
+    transform: (value: NumberInput) => numberAttribute(value, 0),
   });
 
   /**
@@ -91,6 +100,7 @@ export class NgpRating {
   protected readonly state = ngpRating({
     id: this.id,
     value: this.value,
+    defaultValue: this.defaultValue,
     count: this.count,
     allowHalf: this.allowHalf,
     disabled: this.disabled,

--- a/packages/ng-primitives/rating/src/rating/tests/rating-primitive.test.ts
+++ b/packages/ng-primitives/rating/src/rating/tests/rating-primitive.test.ts
@@ -157,7 +157,7 @@ describe('NgpRating', () => {
   describe('pointer', () => {
     it('sets the value when a star is clicked', async () => {
       const { stars, valueChange, rating } = await renderRating(
-        `[ngpRatingValue]="0" [ngpRatingCount]="5"`,
+        `[ngpRatingDefaultValue]="0" [ngpRatingCount]="5"`,
       );
       fireEvent.click(stars()[2]);
       expect(valueChange).toHaveBeenCalledWith(3);
@@ -231,7 +231,7 @@ describe('NgpRating', () => {
   describe('keyboard', () => {
     it('increments on ArrowRight/ArrowUp and decrements on ArrowLeft/ArrowDown', async () => {
       const { rating, valueChange } = await renderRating(
-        `[ngpRatingValue]="2" [ngpRatingCount]="5"`,
+        `[ngpRatingDefaultValue]="2" [ngpRatingCount]="5"`,
       );
       fireEvent.keyDown(rating, { key: 'ArrowRight' });
       expect(valueChange).toHaveBeenLastCalledWith(3);
@@ -271,7 +271,7 @@ describe('NgpRating', () => {
 
     it('inverts arrow direction in RTL', async () => {
       const { rating, valueChange } = await renderRating(
-        `dir="rtl" [ngpRatingValue]="2" [ngpRatingCount]="5"`,
+        `dir="rtl" [ngpRatingDefaultValue]="2" [ngpRatingCount]="5"`,
       );
       fireEvent.keyDown(rating, { key: 'ArrowLeft' });
       expect(valueChange).toHaveBeenLastCalledWith(3);
@@ -309,7 +309,7 @@ describe('NgpRating', () => {
 
     it('moves to 1 (not 0) on Home when not clearable', async () => {
       const { rating, valueChange } = await renderRating(
-        `[ngpRatingValue]="3" [ngpRatingCount]="5" [ngpRatingClearable]="false"`,
+        `[ngpRatingDefaultValue]="3" [ngpRatingCount]="5" [ngpRatingClearable]="false"`,
       );
       fireEvent.keyDown(rating, { key: 'Home' });
       expect(valueChange).toHaveBeenLastCalledWith(1);
@@ -318,7 +318,7 @@ describe('NgpRating', () => {
 
     it('clears on re-select and Home when clearable is enabled', async () => {
       const { stars, rating, valueChange } = await renderRating(
-        `[ngpRatingValue]="3" [ngpRatingCount]="5" [ngpRatingClearable]="true"`,
+        `[ngpRatingDefaultValue]="3" [ngpRatingCount]="5" [ngpRatingClearable]="true"`,
       );
       fireEvent.click(stars()[2]);
       expect(valueChange).toHaveBeenLastCalledWith(0);
@@ -352,6 +352,53 @@ describe('NgpRating', () => {
       fireEvent.click(stars()[4]);
       fireEvent.keyDown(rating, { key: 'ArrowRight' });
       expect(valueChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('controlled mode', () => {
+    it('should emit valueChange but not update the DOM when the parent does not update the binding', async () => {
+      const { rating, valueChange } = await renderRating('[ngpRatingValue]="value"', { value: 2 });
+      expect(rating).toHaveAttribute('aria-valuenow', '2');
+
+      // Keyboard interaction notifies via valueChange, but because the parent
+      // never writes the value back, the controlled value must stay put.
+      fireEvent.keyDown(rating, { key: 'ArrowUp' });
+
+      expect(valueChange).toHaveBeenCalledWith(3);
+      expect(rating).toHaveAttribute('aria-valuenow', '2');
+    });
+
+    it('should update the DOM when a controlled value changes via two-way binding', async () => {
+      const { rating } = await renderRating('[(ngpRatingValue)]="value"', { value: 2 });
+
+      fireEvent.keyDown(rating, { key: 'ArrowUp' });
+      expect(rating).toHaveAttribute('aria-valuenow', '3');
+    });
+  });
+
+  describe('defaultValue (uncontrolled)', () => {
+    it('should start from the default value', async () => {
+      const { rating } = await renderRating('[ngpRatingDefaultValue]="2"');
+      expect(rating).toHaveAttribute('aria-valuenow', '2');
+    });
+
+    it('should let keyboard interaction override the default value (uncontrolled)', async () => {
+      const { rating } = await renderRating('[ngpRatingDefaultValue]="2"');
+      fireEvent.keyDown(rating, { key: 'ArrowUp' });
+      expect(rating).toHaveAttribute('aria-valuenow', '3');
+    });
+
+    it('should prefer a controlled value over the default value when both are provided', async () => {
+      const { rating } = await renderRating('[ngpRatingValue]="1" [ngpRatingDefaultValue]="4"');
+      expect(rating).toHaveAttribute('aria-valuenow', '1');
+    });
+
+    it('should fall back to the declared default when defaultValue is explicitly undefined', async () => {
+      const { rating } = await renderRating('[ngpRatingDefaultValue]="value"', {
+        value: undefined,
+      });
+      // a bound-undefined default must resolve to the declared default (0), not NaN
+      expect(rating).toHaveAttribute('aria-valuenow', '0');
     });
   });
 });

--- a/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider-state.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider-state.ts
@@ -6,10 +6,10 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   dataBinding,
   deprecatedSetter,
-  emitter,
   SetterOptions,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
@@ -24,13 +24,21 @@ export interface NgpRangeSliderProps {
    */
   readonly id?: Signal<string>;
   /**
-   * The low value of the range slider.
+   * The low value of the range slider. When defined the low thumb is controlled.
    */
-  readonly low?: Signal<number>;
+  readonly low?: Signal<number | undefined>;
   /**
-   * The high value of the range slider.
+   * The default low value for uncontrolled usage.
    */
-  readonly high?: Signal<number>;
+  readonly defaultLow?: Signal<number>;
+  /**
+   * The high value of the range slider. When defined the high thumb is controlled.
+   */
+  readonly high?: Signal<number | undefined>;
+  /**
+   * The default high value for uncontrolled usage.
+   */
+  readonly defaultHigh?: Signal<number>;
   /**
    * The minimum value.
    */
@@ -137,6 +145,14 @@ export interface NgpRangeSliderState {
    */
   setHighValue(value: number, options?: SetterOptions): void;
   /**
+   * Set the default low value used in uncontrolled mode.
+   */
+  setDefaultLow(value: number): void;
+  /**
+   * Set the default high value used in uncontrolled mode.
+   */
+  setDefaultHigh(value: number): void;
+  /**
    * Determines which thumb should be moved based on the position clicked.
    */
   getClosestThumb(percentage: number): 'low' | 'high';
@@ -175,8 +191,10 @@ export const [
   'NgpRangeSlider',
   ({
     id = signal(uniqueId('ngp-range-slider')),
-    low: _low = signal(0),
-    high: _high = signal(100),
+    low: _low = signal<number | undefined>(undefined),
+    defaultLow: _defaultLow,
+    high: _high = signal<number | undefined>(undefined),
+    defaultHigh: _defaultHigh,
     min = signal(0),
     max = signal(100),
     step = signal(1),
@@ -187,13 +205,21 @@ export const [
   }: NgpRangeSliderProps): NgpRangeSliderState => {
     const element = injectElementRef();
     const focusMonitor = inject(FocusMonitor);
-    const low = controlled(_low);
-    const high = controlled(_high);
+    const defaultLow = controlled(_defaultLow, 0);
+    const defaultHigh = controlled(_defaultHigh, 100);
+    const [low, setLowInternal, lowChange] = controlledState<number>({
+      value: _low,
+      defaultValue: defaultLow,
+      onChange: onLowChange,
+    });
+    const [high, setHighInternal, highChange] = controlledState<number>({
+      value: _high,
+      defaultValue: defaultHigh,
+      onChange: onHighChange,
+    });
     const disabled = controlled(_disabled);
     const orientation = controlled(_orientation);
 
-    const lowChange = emitter<number>();
-    const highChange = emitter<number>();
     const track = signal<ElementRef<HTMLElement> | undefined>(undefined);
     const thumbs = signal<ElementRef<HTMLElement>[]>([]);
 
@@ -222,21 +248,13 @@ export const [
     function setLowValue(value: number, options?: SetterOptions): void {
       const clampedValue = Math.max(min(), Math.min(value, high()));
       const steppedValue = Math.round((clampedValue - min()) / step()) * step() + min();
-      low.set(steppedValue);
-      if (options?.emit !== false) {
-        onLowChange?.(steppedValue);
-        lowChange.emit(steppedValue);
-      }
+      setLowInternal(steppedValue, options);
     }
 
     function setHighValue(value: number, options?: SetterOptions): void {
       const clampedValue = Math.min(max(), Math.max(value, low()));
       const steppedValue = Math.round((clampedValue - min()) / step()) * step() + min();
-      high.set(steppedValue);
-      if (options?.emit !== false) {
-        onHighChange?.(steppedValue);
-        highChange.emit(steppedValue);
-      }
+      setHighInternal(steppedValue, options);
     }
 
     function getClosestThumb(percentage: number): 'low' | 'high' {
@@ -276,8 +294,8 @@ export const [
 
     return {
       id,
-      low,
-      high,
+      low: deprecatedSetter(low, 'setLowValue', setLowValue),
+      high: deprecatedSetter(high, 'setHighValue', setHighValue),
       min,
       max,
       step,
@@ -288,10 +306,12 @@ export const [
       rangePercentage,
       track,
       thumbs,
-      lowChange: lowChange.asObservable(),
-      highChange: highChange.asObservable(),
+      lowChange,
+      highChange,
       setLowValue,
       setHighValue,
+      setDefaultLow: defaultLow.set,
+      setDefaultHigh: defaultHigh.set,
       getClosestThumb,
       addThumb,
       removeThumb,

--- a/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider.ts
@@ -1,7 +1,7 @@
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
 import { Directive, booleanAttribute, input, numberAttribute, output } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
-import { uniqueId } from 'ng-primitives/utils';
+import { coerceNumberOrUndefined, uniqueId } from 'ng-primitives/utils';
 import { ngpRangeSlider, provideRangeSliderState } from './range-slider-state';
 
 /**
@@ -19,11 +19,20 @@ export class NgpRangeSlider {
   readonly id = input<string>(uniqueId('ngp-range-slider'));
 
   /**
-   * The low value of the range slider.
+   * The low value of the range slider. When defined the low thumb is controlled.
    */
-  readonly low = input<number, NumberInput>(0, {
+  readonly low = input<number | undefined, NumberInput>(undefined, {
     alias: 'ngpRangeSliderLow',
-    transform: numberAttribute,
+    transform: coerceNumberOrUndefined,
+  });
+
+  /**
+   * The default low value for uncontrolled usage.
+   * @default 0
+   */
+  readonly defaultLow = input<number, NumberInput>(0, {
+    alias: 'ngpRangeSliderDefaultLow',
+    transform: (value: NumberInput) => numberAttribute(value, 0),
   });
 
   /**
@@ -34,11 +43,20 @@ export class NgpRangeSlider {
   });
 
   /**
-   * The high value of the range slider.
+   * The high value of the range slider. When defined the high thumb is controlled.
    */
-  readonly high = input<number, NumberInput>(100, {
+  readonly high = input<number | undefined, NumberInput>(undefined, {
     alias: 'ngpRangeSliderHigh',
-    transform: numberAttribute,
+    transform: coerceNumberOrUndefined,
+  });
+
+  /**
+   * The default high value for uncontrolled usage.
+   * @default 100
+   */
+  readonly defaultHigh = input<number, NumberInput>(100, {
+    alias: 'ngpRangeSliderDefaultHigh',
+    transform: (value: NumberInput) => numberAttribute(value, 100),
   });
 
   /**
@@ -93,7 +111,9 @@ export class NgpRangeSlider {
   private readonly state = ngpRangeSlider({
     id: this.id,
     low: this.low,
+    defaultLow: this.defaultLow,
     high: this.high,
+    defaultHigh: this.defaultHigh,
     min: this.min,
     max: this.max,
     step: this.step,

--- a/packages/ng-primitives/slider/src/range-slider/range-slider/tests/range-slider-component.test.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/tests/range-slider-component.test.ts
@@ -34,9 +34,10 @@ describe('RangeSlider (reusable component) — standalone', () => {
   });
 
   it('updates the low thumb value with the keyboard', async () => {
+    // low/high are controlled inputs, so two-way bindings round-trip the change.
     const { fixture } = await render(
-      `<app-range-slider [low]="20" [high]="80" [min]="0" [max]="100" [step]="1"></app-range-slider>`,
-      { imports: [RangeSlider] },
+      `<app-range-slider [(low)]="low" [(high)]="high" [min]="0" [max]="100" [step]="1"></app-range-slider>`,
+      { imports: [RangeSlider], componentProperties: { low: 20, high: 80 } },
     );
     await fixture.whenStable();
 
@@ -50,8 +51,8 @@ describe('RangeSlider (reusable component) — standalone', () => {
 
   it('clamps the low thumb so it cannot cross the high thumb', async () => {
     const { fixture } = await render(
-      `<app-range-slider [low]="20" [high]="80" [min]="0" [max]="100" [step]="1"></app-range-slider>`,
-      { imports: [RangeSlider] },
+      `<app-range-slider [(low)]="low" [(high)]="high" [min]="0" [max]="100" [step]="1"></app-range-slider>`,
+      { imports: [RangeSlider], componentProperties: { low: 20, high: 80 } },
     );
     await fixture.whenStable();
 

--- a/packages/ng-primitives/slider/src/range-slider/range-slider/tests/range-slider-primitive.test.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/tests/range-slider-primitive.test.ts
@@ -1099,4 +1099,87 @@ describe('NgpRangeSlider', () => {
       expect(focusViaSpy).not.toHaveBeenCalled();
     });
   });
+
+  describe('controlled mode (no round-trip)', () => {
+    const imports = [NgpRangeSlider, NgpRangeSliderThumb, NgpRangeSliderTrack, NgpRangeSliderRange];
+
+    it('should emit lowChange but not move the thumb when the parent does not update the binding', async () => {
+      const onLowChange = vi.fn();
+      const { fixture } = await render(
+        `<div
+          [ngpRangeSliderLow]="20"
+          [ngpRangeSliderHigh]="80"
+          [ngpRangeSliderMin]="0"
+          [ngpRangeSliderMax]="100"
+          (ngpRangeSliderLowChange)="onLowChange($event)"
+          ngpRangeSlider
+        >
+          <div ngpRangeSliderTrack>
+            <div ngpRangeSliderThumb data-testid="low-thumb"></div>
+            <div ngpRangeSliderThumb data-testid="high-thumb"></div>
+          </div>
+        </div>`,
+        { imports, componentProperties: { onLowChange } },
+      );
+      const lowThumb = screen.getByTestId('low-thumb');
+
+      lowThumb.focus();
+      await userEvent.keyboard('{arrowright}');
+      await fixture.whenStable();
+
+      expect(onLowChange).toHaveBeenCalledWith(21);
+      expect(lowThumb).toHaveAttribute('aria-valuenow', '20');
+    });
+  });
+
+  describe('defaultValue (uncontrolled)', () => {
+    const imports = [NgpRangeSlider, NgpRangeSliderThumb, NgpRangeSliderTrack, NgpRangeSliderRange];
+
+    it('should start from the default low/high and let interaction move a thumb', async () => {
+      const { fixture } = await render(
+        `<div
+          [ngpRangeSliderDefaultLow]="20"
+          [ngpRangeSliderDefaultHigh]="80"
+          [ngpRangeSliderMin]="0"
+          [ngpRangeSliderMax]="100"
+          ngpRangeSlider
+        >
+          <div ngpRangeSliderTrack>
+            <div ngpRangeSliderThumb data-testid="low-thumb"></div>
+            <div ngpRangeSliderThumb data-testid="high-thumb"></div>
+          </div>
+        </div>`,
+        { imports },
+      );
+      const lowThumb = screen.getByTestId('low-thumb');
+      expect(lowThumb).toHaveAttribute('aria-valuenow', '20');
+
+      lowThumb.focus();
+      await userEvent.keyboard('{arrowright}');
+      await fixture.whenStable();
+
+      expect(lowThumb).toHaveAttribute('aria-valuenow', '21');
+    });
+
+    it('should fall back to the declared defaults when the default bindings are explicitly undefined', async () => {
+      await render(
+        `<div
+          [ngpRangeSliderDefaultLow]="low"
+          [ngpRangeSliderDefaultHigh]="high"
+          [ngpRangeSliderMin]="0"
+          [ngpRangeSliderMax]="100"
+          ngpRangeSlider
+        >
+          <div ngpRangeSliderTrack>
+            <div ngpRangeSliderThumb data-testid="low-thumb"></div>
+            <div ngpRangeSliderThumb data-testid="high-thumb"></div>
+          </div>
+        </div>`,
+        { imports, componentProperties: { low: undefined, high: undefined } },
+      );
+      // bound-undefined defaults must resolve to the declared defaults (0 / 100), not NaN
+      expect(screen.getByTestId('low-thumb')).toHaveAttribute('aria-valuenow', '0');
+      expect(screen.getByTestId('high-thumb')).toHaveAttribute('aria-valuenow', '100');
+    });
+  });
 });

--- a/packages/ng-primitives/slider/src/slider/slider-state.ts
+++ b/packages/ng-primitives/slider/src/slider/slider-state.ts
@@ -6,10 +6,10 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   dataBinding,
   deprecatedSetter,
-  emitter,
   SetterOptions,
 } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
@@ -68,6 +68,10 @@ export interface NgpSliderState {
    */
   setValue(value: number, options?: SetterOptions): void;
   /**
+   * Set the default value used in uncontrolled mode.
+   */
+  setDefaultValue(value: number): void;
+  /**
    * Register the track element.
    */
   setTrack(track: ElementRef<HTMLElement> | undefined): void;
@@ -98,9 +102,13 @@ export interface NgpSliderProps {
    */
   readonly id?: Signal<string>;
   /**
-   * The slider value.
+   * The slider value. When defined the slider is controlled.
    */
-  readonly value?: Signal<number>;
+  readonly value?: Signal<number | undefined>;
+  /**
+   * The default value for uncontrolled usage.
+   */
+  readonly defaultValue?: Signal<number>;
   /**
    * The minimum value.
    */
@@ -132,7 +140,8 @@ export const [NgpSliderStateToken, ngpSlider, injectSliderState, provideSliderSt
     'NgpSlider',
     ({
       id = signal(uniqueId('ngp-slider')),
-      value: _value = signal(0),
+      value: _value = signal<number | undefined>(undefined),
+      defaultValue: _defaultValue,
       min = signal(0),
       max = signal(100),
       step = signal(1),
@@ -142,11 +151,15 @@ export const [NgpSliderStateToken, ngpSlider, injectSliderState, provideSliderSt
     }: NgpSliderProps): NgpSliderState => {
       const element = injectElementRef();
       const focusMonitor = inject(FocusMonitor);
-      const value = controlled(_value);
+      const defaultValue = controlled(_defaultValue, 0);
+      const [value, setValueInternal, valueChange] = controlledState<number>({
+        value: _value,
+        defaultValue,
+        onChange: onValueChange,
+      });
       const disabled = controlled(_disabled);
       const orientation = controlled(_orientation);
 
-      const valueChange = emitter<number>();
       const track = signal<ElementRef<HTMLElement> | undefined>(undefined);
       const thumb = signal<ElementRef<HTMLElement> | undefined>(undefined);
 
@@ -186,11 +199,7 @@ export const [NgpSliderStateToken, ngpSlider, injectSliderState, provideSliderSt
         const clamped = Math.min(max(), Math.max(min(), newValue));
         const stepped = Math.round((clamped - min()) / step()) * step() + min();
         const finalValue = Math.min(max(), Math.max(min(), stepped));
-        value.set(finalValue);
-        if (options?.emit !== false) {
-          onValueChange?.(finalValue);
-          valueChange.emit(finalValue);
-        }
+        setValueInternal(finalValue, options);
       }
 
       function setDisabled(isDisabled: boolean): void {
@@ -203,17 +212,18 @@ export const [NgpSliderStateToken, ngpSlider, injectSliderState, provideSliderSt
 
       return {
         id,
-        value,
+        value: deprecatedSetter(value, 'setValue', setValue),
         min,
         max,
         step,
         orientation: deprecatedSetter(orientation, 'setOrientation'),
         disabled: deprecatedSetter(disabled, 'setDisabled'),
-        valueChange: valueChange.asObservable(),
+        valueChange,
         percentage,
         track,
         thumb,
         setValue,
+        setDefaultValue: defaultValue.set,
         setTrack,
         setThumb,
         focusThumb,

--- a/packages/ng-primitives/slider/src/slider/slider.ts
+++ b/packages/ng-primitives/slider/src/slider/slider.ts
@@ -2,7 +2,7 @@ import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
 import { Directive, booleanAttribute, input, numberAttribute, output } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
 import { SetterOptions } from 'ng-primitives/state';
-import { uniqueId } from 'ng-primitives/utils';
+import { coerceNumberOrUndefined, uniqueId } from 'ng-primitives/utils';
 import { ngpSlider, provideSliderState } from './slider-state';
 
 /**
@@ -22,9 +22,18 @@ export class NgpSlider {
   /**
    * The value of the slider.
    */
-  readonly value = input<number, NumberInput>(0, {
+  readonly value = input<number | undefined, NumberInput>(undefined, {
     alias: 'ngpSliderValue',
-    transform: numberAttribute,
+    transform: coerceNumberOrUndefined,
+  });
+
+  /**
+   * The default value of the slider for uncontrolled usage.
+   * @default 0
+   */
+  readonly defaultValue = input<number, NumberInput>(0, {
+    alias: 'ngpSliderDefaultValue',
+    transform: (value: NumberInput) => numberAttribute(value, 0),
   });
 
   /**
@@ -80,6 +89,7 @@ export class NgpSlider {
   protected readonly state = ngpSlider({
     id: this.id,
     value: this.value,
+    defaultValue: this.defaultValue,
     min: this.min,
     max: this.max,
     step: this.step,

--- a/packages/ng-primitives/slider/src/slider/tests/slider-component.test.ts
+++ b/packages/ng-primitives/slider/src/slider/tests/slider-component.test.ts
@@ -22,9 +22,10 @@ describe('Slider (reusable component) — standalone', () => {
   });
 
   it('increments the value with the ArrowRight key', async () => {
+    // `value` is the controlled input, so a two-way binding round-trips the change.
     const { getByRole, fixture } = await render(
-      `<app-slider value="40" min="0" max="100" step="5"></app-slider>`,
-      { imports: [Slider] },
+      `<app-slider [(value)]="value" min="0" max="100" step="5"></app-slider>`,
+      { imports: [Slider], componentProperties: { value: 40 } },
     );
     const thumb = getByRole('slider');
 

--- a/packages/ng-primitives/slider/src/slider/tests/slider-primitive.test.ts
+++ b/packages/ng-primitives/slider/src/slider/tests/slider-primitive.test.ts
@@ -58,7 +58,7 @@ describe('NgpSlider', () => {
   it('should adjust value with keyboard on thumb', async () => {
     const valueChange = vi.fn();
     const { getByTestId } = await render(
-      createTemplate(`[ngpSliderValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="10"`),
+      createTemplate(`[ngpSliderDefaultValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="10"`),
       {
         imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
         componentProperties: { value: 5, valueChange },
@@ -299,7 +299,7 @@ describe('NgpSlider', () => {
     const valueChange = vi.fn();
     const { getByTestId } = await render(
       createTemplate(
-        `[ngpSliderValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="10" [ngpSliderStep]="2"`,
+        `[ngpSliderDefaultValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="10" [ngpSliderStep]="2"`,
       ),
       {
         imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
@@ -417,7 +417,7 @@ describe('NgpSlider', () => {
     const valueChange = vi.fn();
     const { getByTestId, fixture } = await render(
       createTemplate(
-        `[ngpSliderValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="100" [ngpSliderStep]="1"`,
+        `[ngpSliderDefaultValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="100" [ngpSliderStep]="1"`,
       ),
       {
         imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
@@ -577,5 +577,107 @@ describe('NgpSlider', () => {
     track.dispatchEvent(pointerEvent);
 
     expect(valueChange).toHaveBeenCalledWith(70);
+  });
+
+  describe('controlled mode (no round-trip)', () => {
+    it('should emit valueChange but not update the DOM when the parent does not update the binding', async () => {
+      const valueChange = vi.fn();
+      const { getByTestId } = await render(
+        createTemplate(`[ngpSliderValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="10"`),
+        {
+          imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+          componentProperties: { value: 5, valueChange },
+        },
+      );
+      const thumb = getByTestId('thumb');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+
+      expect(valueChange).toHaveBeenCalledWith(6);
+      expect(thumb).toHaveAttribute('aria-valuenow', '5');
+    });
+  });
+
+  describe('two-way binding', () => {
+    it('should round-trip a two-way binding and move the thumb on interaction', async () => {
+      const { getByTestId } = await render(
+        `<div ngpSlider [(ngpSliderValue)]="value" [ngpSliderMin]="0" [ngpSliderMax]="10" data-testid="slider">
+          <div ngpSliderTrack></div>
+          <div ngpSliderThumb data-testid="thumb"></div>
+        </div>`,
+        {
+          imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+          componentProperties: { value: 5 },
+        },
+      );
+      const thumb = getByTestId('thumb');
+      expect(thumb).toHaveAttribute('aria-valuenow', '5');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+      expect(thumb).toHaveAttribute('aria-valuenow', '6');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowLeft' });
+      expect(thumb).toHaveAttribute('aria-valuenow', '5');
+    });
+  });
+
+  describe('defaultValue (uncontrolled)', () => {
+    it('should start from the default value and let interaction override it', async () => {
+      const { getByTestId } = await render(
+        createTemplate(`[ngpSliderDefaultValue]="5" [ngpSliderMin]="0" [ngpSliderMax]="10"`),
+        {
+          imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+          componentProperties: { valueChange: vi.fn() },
+        },
+      );
+      const thumb = getByTestId('thumb');
+      expect(thumb).toHaveAttribute('aria-valuenow', '5');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+      expect(thumb).toHaveAttribute('aria-valuenow', '6');
+    });
+
+    it('should prefer a controlled value over the default value', async () => {
+      const { getByTestId } = await render(
+        createTemplate(
+          `[ngpSliderValue]="3" [ngpSliderDefaultValue]="8" [ngpSliderMin]="0" [ngpSliderMax]="10"`,
+        ),
+        {
+          imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+          componentProperties: { valueChange: vi.fn() },
+        },
+      );
+      expect(getByTestId('thumb')).toHaveAttribute('aria-valuenow', '3');
+    });
+
+    it('should stay uncontrolled when the value binding is explicitly undefined', async () => {
+      const { getByTestId } = await render(
+        createTemplate(
+          `[ngpSliderValue]="value" [ngpSliderDefaultValue]="5" [ngpSliderMin]="0" [ngpSliderMax]="10"`,
+        ),
+        {
+          imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+          componentProperties: { value: undefined, valueChange: vi.fn() },
+        },
+      );
+      const thumb = getByTestId('thumb');
+      // an explicit `undefined` must not coerce to NaN — it stays uncontrolled at the default
+      expect(thumb).toHaveAttribute('aria-valuenow', '5');
+
+      fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+      expect(thumb).toHaveAttribute('aria-valuenow', '6');
+    });
+
+    it('should fall back to the declared default when defaultValue is explicitly undefined', async () => {
+      const { getByTestId } = await render(
+        createTemplate(`[ngpSliderDefaultValue]="value" [ngpSliderMin]="0" [ngpSliderMax]="10"`),
+        {
+          imports: [NgpSlider, NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+          componentProperties: { value: undefined, valueChange: vi.fn() },
+        },
+      );
+      // a bound-undefined default must resolve to the declared default (0), not NaN
+      expect(getByTestId('thumb')).toHaveAttribute('aria-valuenow', '0');
+    });
   });
 });

--- a/packages/ng-primitives/switch/src/switch/switch-state.ts
+++ b/packages/ng-primitives/switch/src/switch/switch-state.ts
@@ -5,10 +5,10 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   controlled,
+  controlledState,
   createPrimitive,
   dataBinding,
   deprecatedSetter,
-  emitter,
   listener,
   SetterOptions,
 } from 'ng-primitives/state';
@@ -44,6 +44,10 @@ export interface NgpSwitchState {
    */
   setChecked(value: boolean, options?: SetterOptions): void;
   /**
+   * Set the default checked state used in uncontrolled mode.
+   */
+  setDefaultChecked(value: boolean): void;
+  /**
    * Update the disabled value.
    */
   setDisabled(value: boolean): void;
@@ -58,9 +62,13 @@ export interface NgpSwitchProps {
    */
   readonly id?: Signal<string>;
   /**
-   * Whether the switch is checked.
+   * Whether the switch is checked. When defined the switch is controlled.
    */
-  readonly checked?: Signal<boolean>;
+  readonly checked?: Signal<boolean | undefined>;
+  /**
+   * The default checked state for uncontrolled usage.
+   */
+  readonly defaultChecked?: Signal<boolean>;
   /**
    * Whether the switch is disabled.
    */
@@ -80,14 +88,20 @@ export const [NgpSwitchStateToken, ngpSwitch, injectSwitchState, provideSwitchSt
     'NgpSwitch',
     ({
       id = signal(uniqueId('ngp-switch')),
-      checked: _checked = signal(false),
+      checked: _checked = signal<boolean | undefined>(undefined),
+      defaultChecked: _defaultChecked,
       disabled: _disabled = signal(false),
       required: _required = signal(false),
       onCheckedChange,
     }: NgpSwitchProps): NgpSwitchState => {
       const element = injectElementRef<HTMLElement>();
       const isButton = element.nativeElement.tagName.toLowerCase() === 'button';
-      const checked = controlled(_checked);
+      const defaultChecked = controlled(_defaultChecked, false);
+      const [checked, setChecked, checkedChange] = controlledState({
+        value: _checked,
+        defaultValue: defaultChecked,
+        onChange: onCheckedChange,
+      });
       const disabledInput = controlled(_disabled);
 
       // Form control and interactions
@@ -95,7 +109,6 @@ export const [NgpSwitchStateToken, ngpSwitch, injectSwitchState, provideSwitchSt
       const disabled = computed(() => status().disabled ?? disabledInput());
       ngpInteractions({ hover: true, press: true, focusVisible: true, disabled });
 
-      const checkedChange = emitter<boolean>();
       const tabindex = computed(() => (disabled() ? -1 : 0));
 
       // Host bindings
@@ -130,25 +143,18 @@ export const [NgpSwitchStateToken, ngpSwitch, injectSwitchState, provideSwitchSt
         setChecked(!checked());
       }
 
-      function setChecked(value: boolean, options?: SetterOptions): void {
-        checked.set(value);
-        if (options?.emit !== false) {
-          onCheckedChange?.(value);
-          checkedChange.emit(value);
-        }
-      }
-
       function setDisabled(value: boolean): void {
         disabledInput.set(value);
       }
 
       return {
         id,
-        checked: deprecatedSetter(checked, 'setChecked'),
+        checked: deprecatedSetter(checked, 'setChecked', setChecked),
         disabled: deprecatedSetter(disabledInput, 'setDisabled'),
-        checkedChange: checkedChange.asObservable(),
+        checkedChange,
         toggle,
         setChecked,
+        setDefaultChecked: defaultChecked.set,
         setDisabled,
       } satisfies NgpSwitchState;
     },

--- a/packages/ng-primitives/switch/src/switch/switch.ts
+++ b/packages/ng-primitives/switch/src/switch/switch.ts
@@ -1,7 +1,7 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import { booleanAttribute, Directive, input, output } from '@angular/core';
 import { SetterOptions } from 'ng-primitives/state';
-import { uniqueId } from 'ng-primitives/utils';
+import { coerceBooleanOrUndefined, uniqueId } from 'ng-primitives/utils';
 import { ngpSwitch, provideSwitchState } from './switch-state';
 
 /**
@@ -19,11 +19,19 @@ export class NgpSwitch {
   readonly id = input<string>(uniqueId('ngp-switch'));
 
   /**
-   * Determine if the switch is checked.
+   * Determine if the switch is checked. When defined the switch is controlled.
+   */
+  readonly checked = input<boolean | undefined, BooleanInput>(undefined, {
+    alias: 'ngpSwitchChecked',
+    transform: coerceBooleanOrUndefined,
+  });
+
+  /**
+   * The default checked state for uncontrolled usage.
    * @default false
    */
-  readonly checked = input<boolean, BooleanInput>(false, {
-    alias: 'ngpSwitchChecked',
+  readonly defaultChecked = input<boolean, BooleanInput>(false, {
+    alias: 'ngpSwitchDefaultChecked',
     transform: booleanAttribute,
   });
 
@@ -59,6 +67,7 @@ export class NgpSwitch {
   readonly state = ngpSwitch({
     id: this.id,
     checked: this.checked,
+    defaultChecked: this.defaultChecked,
     disabled: this.disabled,
     required: this.required,
     onCheckedChange: value => this.checkedChange.emit(value),

--- a/packages/ng-primitives/switch/src/switch/tests/switch-primitive.test.ts
+++ b/packages/ng-primitives/switch/src/switch/tests/switch-primitive.test.ts
@@ -166,4 +166,69 @@ describe('NgpSwitch', () => {
       expect(checkedChange).not.toHaveBeenCalled();
     });
   });
+
+  describe('controlled mode (no round-trip)', () => {
+    it('should emit checkedChange on click but not update the DOM when the parent does not update the binding', async () => {
+      const checkedChange = vi.fn();
+      const { getByRole } = await render(
+        `<button ngpSwitch [ngpSwitchChecked]="checked" (ngpSwitchCheckedChange)="checkedChange($event)"></button>`,
+        { imports: [NgpSwitch], componentProperties: { checked: false, checkedChange } },
+      );
+      const button = getByRole('switch');
+
+      // controlled to unchecked; clicking notifies via checkedChange but the
+      // parent never writes the value back, so the DOM must stay unchecked.
+      fireEvent.click(button);
+
+      expect(checkedChange).toHaveBeenCalledWith(true);
+      expect(button).toHaveAttribute('aria-checked', 'false');
+      expect(button).not.toHaveAttribute('data-checked');
+    });
+  });
+
+  describe('defaultChecked (uncontrolled)', () => {
+    it('should start checked from the default value', async () => {
+      const { getByRole } = await render(
+        `<button ngpSwitch [ngpSwitchDefaultChecked]="true"></button>`,
+        {
+          imports: [NgpSwitch],
+        },
+      );
+      expect(getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('should let a click override the default value (uncontrolled)', async () => {
+      const { getByRole } = await render(
+        `<button ngpSwitch [ngpSwitchDefaultChecked]="true"></button>`,
+        {
+          imports: [NgpSwitch],
+        },
+      );
+      const button = getByRole('switch');
+
+      fireEvent.click(button);
+      expect(button).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('should prefer a controlled value over the default value when both are provided', async () => {
+      const { getByRole } = await render(
+        `<button ngpSwitch [ngpSwitchChecked]="false" [ngpSwitchDefaultChecked]="true"></button>`,
+        { imports: [NgpSwitch] },
+      );
+      expect(getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('should stay uncontrolled when the checked binding is explicitly undefined', async () => {
+      const { getByRole } = await render(
+        `<button ngpSwitch [ngpSwitchChecked]="checked" [ngpSwitchDefaultChecked]="true"></button>`,
+        { imports: [NgpSwitch], componentProperties: { checked: undefined } },
+      );
+      const button = getByRole('switch');
+      // an explicit `undefined` must not coerce to `false` — it stays uncontrolled at the default
+      expect(button).toHaveAttribute('aria-checked', 'true');
+
+      fireEvent.click(button);
+      expect(button).toHaveAttribute('aria-checked', 'false');
+    });
+  });
 });

--- a/packages/ng-primitives/toggle/src/toggle/tests/toggle-primitive.test.ts
+++ b/packages/ng-primitives/toggle/src/toggle/tests/toggle-primitive.test.ts
@@ -103,6 +103,20 @@ describe('NgpToggle', () => {
       expect(button).toHaveAttribute('data-selected', '');
     });
 
+    it('should stay uncontrolled when the selected binding is explicitly undefined', async () => {
+      await render(
+        `<button ngpToggle [ngpToggleSelected]="selected" ngpToggleDefaultSelected>Toggle</button>`,
+        { imports: [NgpToggle], componentProperties: { selected: undefined } },
+      );
+
+      const button = screen.getByRole('button');
+      // an explicit `undefined` must not coerce to `false` — it stays uncontrolled at the default
+      expect(button).toHaveAttribute('aria-pressed', 'true');
+
+      fireEvent.click(button);
+      expect(button).toHaveAttribute('aria-pressed', 'false');
+    });
+
     it('should toggle from defaultSelected state on click', async () => {
       const spy = vi.fn();
 

--- a/packages/ng-primitives/toggle/src/toggle/toggle.ts
+++ b/packages/ng-primitives/toggle/src/toggle/toggle.ts
@@ -1,6 +1,7 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import { booleanAttribute, Directive, input, output } from '@angular/core';
 import { SetterOptions } from 'ng-primitives/state';
+import { coerceBooleanOrUndefined } from 'ng-primitives/utils';
 import { ngpToggle, provideToggleState } from './toggle-state';
 
 /**
@@ -17,7 +18,7 @@ export class NgpToggle {
    */
   readonly selected = input<boolean | undefined, BooleanInput>(undefined, {
     alias: 'ngpToggleSelected',
-    transform: booleanAttribute,
+    transform: coerceBooleanOrUndefined,
   });
 
   /**

--- a/packages/ng-primitives/utils/src/helpers/coercion.ts
+++ b/packages/ng-primitives/utils/src/helpers/coercion.ts
@@ -1,0 +1,26 @@
+import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
+import { booleanAttribute, numberAttribute } from '@angular/core';
+
+/**
+ * A number input `transform` for a two-way value that may be uncontrolled.
+ *
+ * `numberAttribute` coerces `undefined` to `NaN`, which `controlledState` reads
+ * as a defined (controlled) value and latches the primitive into controlled
+ * mode with a bogus number. This preserves `undefined` so an absent binding
+ * stays uncontrolled, while coercing every other value as usual.
+ */
+export function coerceNumberOrUndefined(value: NumberInput): number | undefined {
+  return value === undefined ? undefined : numberAttribute(value);
+}
+
+/**
+ * A boolean input `transform` for a two-way value that may be uncontrolled.
+ *
+ * `booleanAttribute` coerces `undefined` to `false`, which `controlledState`
+ * reads as a defined (controlled) value and latches the primitive into
+ * controlled mode. This preserves `undefined` so an absent binding stays
+ * uncontrolled, while coercing every other value as usual.
+ */
+export function coerceBooleanOrUndefined(value: BooleanInput): boolean | undefined {
+  return value === undefined ? undefined : booleanAttribute(value);
+}

--- a/packages/ng-primitives/utils/src/helpers/tests/coercion.test.ts
+++ b/packages/ng-primitives/utils/src/helpers/tests/coercion.test.ts
@@ -1,0 +1,39 @@
+import { coerceBooleanOrUndefined, coerceNumberOrUndefined } from 'ng-primitives/utils';
+import { describe, expect, it } from 'vitest';
+
+describe('coerceNumberOrUndefined', () => {
+  it('should preserve undefined instead of coercing to NaN', () => {
+    expect(coerceNumberOrUndefined(undefined)).toBeUndefined();
+  });
+
+  it('should coerce numeric strings and numbers', () => {
+    expect(coerceNumberOrUndefined('42')).toBe(42);
+    expect(coerceNumberOrUndefined(42)).toBe(42);
+    expect(coerceNumberOrUndefined(0)).toBe(0);
+  });
+
+  it('should coerce non-numeric values to NaN (matching numberAttribute)', () => {
+    expect(coerceNumberOrUndefined(null)).toBeNaN();
+    expect(coerceNumberOrUndefined('abc')).toBeNaN();
+  });
+});
+
+describe('coerceBooleanOrUndefined', () => {
+  it('should preserve undefined instead of coercing to false', () => {
+    expect(coerceBooleanOrUndefined(undefined)).toBeUndefined();
+  });
+
+  it('should coerce any present value except the string "false" to true (matching booleanAttribute)', () => {
+    expect(coerceBooleanOrUndefined(true)).toBe(true);
+    // an empty string is the attribute-present form and coerces to true
+    expect(coerceBooleanOrUndefined('')).toBe(true);
+    expect(coerceBooleanOrUndefined('anything')).toBe(true);
+  });
+
+  it('should coerce false, null, and the string "false" to false (matching booleanAttribute)', () => {
+    expect(coerceBooleanOrUndefined(false)).toBe(false);
+    expect(coerceBooleanOrUndefined(null)).toBe(false);
+    // the literal string "false" coerces to false even though it is JS-truthy
+    expect(coerceBooleanOrUndefined('false')).toBe(false);
+  });
+});

--- a/packages/ng-primitives/utils/src/index.ts
+++ b/packages/ng-primitives/utils/src/index.ts
@@ -2,6 +2,7 @@ export { provideValueAccessor } from './forms/providers';
 export { controlStatus, NgpControlStatus } from './forms/status';
 export { ChangeFn, TouchedFn } from './forms/types';
 export { booleanAttributeBinding } from './helpers/attributes';
+export { coerceBooleanOrUndefined, coerceNumberOrUndefined } from './helpers/coercion';
 export { injectDisposables } from './helpers/disposables';
 export { uniqueId } from './helpers/unique-id';
 export {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated — the internal state-pattern rule (`.claude/rules/state-management.md`) is updated; consumer-facing docs are intentionally **not** updated yet (see note below)

## PR Type

- [x] Refactoring (no functional changes, no api changes) — but see the breaking-change note

## Issue

_No linked issue — follow-up to the `controlledState` standardization discussed alongside the date-picker state migration (#849)._

## What does this PR implement/fix?

Migrates every two-way–bindable value primitive that was still on the `controlled` + manual `emitter` approach to the `controlledState` helper, so controlled/uncontrolled mode **latches** correctly. A value bound one-way and never written back no longer self-mutates on interaction — it emits its change and waits for the parent to write it back. This brings these primitives in line with `checkbox`/`toggle-group`, which already use `controlledState`.

### Migrated

`listbox`, `switch`, `rating`, `slider`, `number-field`, `range-slider`, `menu-item-checkbox`, `menu-item-radio-group`, and the `color` set (`color-picker` + `color-field` / `-area` / `-slider` / `-wheel` / `-swatch-picker`). `select` was deliberately left as-is.

### What changed per primitive

- The two-way value moves from `controlled` (a non-latching `linkedSignal`) to `controlledState`.
- Each value input now defaults to `undefined`, with a new sibling `Default*` input for the uncontrolled initial value (`ngpSwitchDefaultChecked`, `ngpRatingDefaultValue`, `ngpSliderDefaultValue`, `ngpNumberFieldDefaultValue`, `ngpRangeSliderDefaultLow/High`, `ngpMenuItemCheckboxDefaultChecked`, `ngpMenuItemRadioGroupDefaultValue`, `ngpColor*DefaultValue`).
- Each state exposes a matching `setDefault*`.
- Bespoke emit choreography is preserved where `controlledState`'s change-gated emit can't express it (`number-field`'s silent input-commit; the `null`/`undefined` "empty" semantics of `menu-item-radio-group` and `color-swatch-picker`) by keeping a manual `emitter` and using `controlledState` for latching only.
- The reusable `number-field` / `slider` / `range-slider` example components keep their `value` / `low` / `high` inputs mapped to the **controlled** `ngpX*` inputs alongside their change outputs — i.e. two-way `[(value)]` — so their public API is unchanged.
- `.claude/rules/state-management.md` gains a "Two-way value inputs" subsection documenting the pattern.

### Tests

Every migrated primitive has explicit **one-way (controlled)**, **two-way**, and **default-value** tests. Full `ng-primitives` suite is green (2300+ browser tests, 43 node), lint is clean (0 errors), and the library AOT build + components app build pass.

## Does this PR introduce a breaking change?

- [x] Yes

Controlled-mode semantics now **latch**. A consumer who binds a value one-way (`[ngpXValue]="v"`) and does not write it back on `(...Change)` will see the control stop self-updating on interaction — it emits but no longer drifts. Two-way (`[(ngpXValue)]`) and `ngModel` / reactive-forms usage are **unaffected**. Additionally, each value input's type widens to include `undefined`.

**Migration path:** use two-way binding (`[(ngpXValue)]`) or move the initial value to the new `Default*` input (`[ngpXDefaultValue]`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `defaultValue`/`defaultChecked` inputs for uncontrolled usage across colour, menu, number field, rating, slider(s), switch, wheel, and selection primitives.
  * Added `setDefaultValue`/`setDefaultChecked` runtime APIs for updating uncontrolled defaults.
* **Bug Fixes**
  * Prevented visual and ARIA drift when a controlled parent doesn’t write values back (no round-trip).
* **Documentation**
  * Documented two-way value latching rules and controlled vs uncontrolled guidance.
* **Tests**
  * Expanded coverage for controlled, uncontrolled, and two-way binding scenarios, including standalone behaviour.
* **Chores**
  * Added new `coerceNumberOrUndefined`/`coerceBooleanOrUndefined` helpers and re-exported them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->