### PR TITLE
docs(combobox): add creatable options example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,13 @@ jobs:
       - run: pnpm exec nx affected -t lint,build,test
         env:
           NODE_OPTIONS: '--max-old-space-size=8192' # Increase memory to 8GB
-      - run: pnpx pkg-pr-new publish ./dist/packages/*
+      # `nx affected` only builds the packages a PR touches, so a docs- or
+      # components-only PR produces no `dist/packages/*` and `pkg-pr-new publish`
+      # would fail with "No packages". Skip the preview publish when nothing was built.
+      - name: Publish preview packages
+        run: |
+          if compgen -G "./dist/packages/*" > /dev/null; then
+            pnpx pkg-pr-new publish ./dist/packages/*
+          else
+            echo "No library packages were affected; skipping preview package publish."
+          fi

--- a/apps/documentation/src/app/examples/combobox/combobox-creatable.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-creatable.example.ts
@@ -1,0 +1,300 @@
+import { Component, computed, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDown, heroPlus } from '@ng-icons/heroicons/outline';
+import {
+  NgpCombobox,
+  NgpComboboxButton,
+  NgpComboboxDropdown,
+  NgpComboboxInput,
+  NgpComboboxOption,
+  NgpComboboxPortal,
+} from 'ng-primitives/combobox';
+
+@Component({
+  selector: 'app-combobox-creatable',
+  imports: [
+    NgpCombobox,
+    NgpComboboxDropdown,
+    NgpComboboxOption,
+    NgpComboboxInput,
+    NgpComboboxPortal,
+    NgpComboboxButton,
+    NgIcon,
+  ],
+  providers: [provideIcons({ heroChevronDown, heroPlus })],
+  template: `
+    <div
+      [(ngpComboboxValue)]="value"
+      (ngpComboboxValueChange)="onValueChange($event)"
+      (ngpComboboxOpenChange)="resetOnClose($event)"
+      ngpCombobox
+    >
+      <input
+        [value]="inputValue()"
+        (input)="onFilterChange($event)"
+        placeholder="Select or create an option"
+        ngpComboboxInput
+      />
+
+      <button ngpComboboxButton aria-label="Toggle dropdown">
+        <ng-icon name="heroChevronDown" />
+      </button>
+
+      <div *ngpComboboxPortal ngpComboboxDropdown>
+        @for (option of filteredOptions(); track option) {
+          <div [ngpComboboxOptionValue]="option" ngpComboboxOption>
+            {{ option }}
+          </div>
+        }
+
+        <!--
+          The "create" option is a regular option whose value is the current query.
+          When the query matches no existing option it is the only item in the list,
+          so it becomes the active descendant and is committed on Enter — no bespoke
+          keyboard handling required. Selecting it routes through the standard
+          selection path and emits the typed value via ngpComboboxValueChange.
+        -->
+        @if (canCreate()) {
+          <div class="create-option" [ngpComboboxOptionValue]="filter()" ngpComboboxOption>
+            <ng-icon name="heroPlus" />
+            <span>Create "{{ filter() }}"</span>
+          </div>
+        }
+
+        @if (filteredOptions().length === 0 && !canCreate()) {
+          <div class="empty-message">No options found</div>
+        }
+      </div>
+    </div>
+  `,
+  styles: `
+    [ngpCombobox] {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      height: 2.125rem;
+      width: 300px;
+      border-radius: 0.5rem;
+      border: none;
+      background-color: var(--ngp-background);
+      box-shadow: var(--ngp-input-shadow);
+      box-sizing: border-box;
+    }
+
+    [ngpCombobox][data-focus] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    [ngpComboboxInput] {
+      flex: 1;
+      padding: 0 16px;
+      border: none;
+      background-color: transparent;
+      color: var(--ngp-text-primary);
+      font-family: inherit;
+      font-size: 14px;
+      padding: 0 16px;
+      outline: none;
+      height: 100%;
+    }
+
+    [ngpComboboxButton] {
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
+      height: 100%;
+      width: 36px;
+      background-color: transparent;
+      border: none;
+      color: var(--ngp-text-primary);
+      cursor: pointer;
+      box-sizing: border-box;
+    }
+
+    [ngpComboboxDropdown] {
+      background-color: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      padding: 0.25rem;
+      border-radius: 0.75rem;
+      outline: none;
+      position: absolute;
+      animation: popover-show 0.1s ease-out;
+      width: var(--ngp-combobox-width);
+      box-shadow: var(--ngp-shadow-lg);
+      box-sizing: border-box;
+      margin-top: 4px;
+      max-height: 240px;
+      overflow-y: auto;
+      z-index: 1001;
+    }
+
+    [ngpComboboxDropdown][data-enter] {
+      animation: combobox-show 0.1s ease-out;
+    }
+
+    [ngpComboboxDropdown][data-exit] {
+      animation: combobox-hide 0.1s ease-out;
+    }
+
+    [ngpComboboxOption] {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.375rem 0.75rem;
+      cursor: pointer;
+      border-radius: 0.5rem;
+      width: 100%;
+      height: 2.125rem;
+      font-size: 14px;
+      color: var(--ngp-text-primary);
+      box-sizing: border-box;
+    }
+
+    [ngpComboboxOption][data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpComboboxOption][data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpComboboxOption][data-active] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpComboboxOption][data-selected] {
+      color: var(--ngp-primary);
+      font-weight: 510;
+    }
+
+    .create-option {
+      color: var(--ngp-text-secondary);
+    }
+
+    .create-option ng-icon {
+      color: var(--ngp-text-tertiary);
+      font-size: 1rem;
+    }
+
+    .create-option span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .empty-message {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      padding: 0.5rem;
+      color: var(--ngp-text-secondary);
+      font-size: 14px;
+      font-weight: 510;
+      text-align: center;
+    }
+
+    @keyframes combobox-show {
+      0% {
+        opacity: 0;
+        transform: translateY(-10px) scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+    }
+
+    @keyframes combobox-hide {
+      0% {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: translateY(-10px) scale(0.9);
+      }
+    }
+  `,
+})
+export default class ComboboxCreatableExample {
+  /** The options for the combobox — a writable signal so created values persist. */
+  readonly options = signal<string[]>([
+    'Marty McFly',
+    'Doc Brown',
+    'Biff Tannen',
+    'George McFly',
+    'Jennifer Parker',
+    'Emmett Brown',
+    'Einstein',
+    'Clara Clayton',
+    'Needles',
+    'Goldie Wilson',
+    'Marvin Berry',
+    'Lorraine Baines',
+    'Strickland',
+  ]);
+
+  /** The selected value. */
+  readonly value = signal<string | undefined>(undefined);
+
+  /** The input value. */
+  readonly inputValue = signal<string>('');
+
+  /** The filter value. */
+  readonly filter = signal<string>('');
+
+  /** Get the filtered options. */
+  protected readonly filteredOptions = computed(() => {
+    const filter = this.filter().toLowerCase();
+    return this.options().filter(option => option.toLowerCase().includes(filter));
+  });
+
+  /**
+   * Whether the current query can be created as a new option — it must be non-empty
+   * and not already exist (case-insensitive), so we never offer to create a duplicate.
+   */
+  protected readonly canCreate = computed(() => {
+    const filter = this.filter().trim();
+
+    if (filter === '') {
+      return false;
+    }
+
+    return !this.options().some(option => option.toLowerCase() === filter.toLowerCase());
+  });
+
+  protected onFilterChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.inputValue.set(input.value);
+    this.filter.set(input.value);
+  }
+
+  protected onValueChange(value: string | undefined): void {
+    // If the committed value is a new one, add it to the list so it renders as a
+    // real, selectable option going forward.
+    if (value && !this.options().some(option => option.toLowerCase() === value.toLowerCase())) {
+      this.options.update(options => [...options, value]);
+    }
+
+    this.inputValue.set(value ?? '');
+    this.filter.set('');
+  }
+
+  protected resetOnClose(open: boolean): void {
+    // if the dropdown is closed, reset the filter value
+    if (open) {
+      return;
+    }
+
+    // if the input value is empty, set the value to undefined
+    if (this.inputValue() === '') {
+      this.value.set(undefined);
+    } else {
+      // otherwise set the input value to the selected value
+      this.inputValue.set(this.value() ?? '');
+    }
+
+    this.filter.set('');
+  }
+}

--- a/apps/documentation/src/app/examples/combobox/combobox-creatable.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-creatable.example.ts
@@ -219,7 +219,7 @@ import {
   `,
 })
 export default class ComboboxCreatableExample {
-  /** The options for the combobox — a writable signal so created values persist. */
+  /** The options for the combobox - a writable signal so created values persist. */
   readonly options = signal<string[]>([
     'Marty McFly',
     'Doc Brown',
@@ -245,7 +245,7 @@ export default class ComboboxCreatableExample {
   /** The filter value. */
   readonly filter = signal<string>('');
 
-  /** The normalised query — trimmed once so filtering, creating, and de-duping all agree. */
+  /** The normalised query - trimmed once so filtering, creating, and de-duping all agree. */
   protected readonly query = computed(() => this.filter().trim());
 
   /** Get the filtered options. */
@@ -255,7 +255,7 @@ export default class ComboboxCreatableExample {
   });
 
   /**
-   * Whether the current query can be created as a new option — it must be non-empty
+   * Whether the current query can be created as a new option - it must be non-empty
    * and not already exist (case-insensitive), so we never offer to create a duplicate.
    */
   protected readonly canCreate = computed(() => {

--- a/apps/documentation/src/app/examples/combobox/combobox-creatable.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-creatable.example.ts
@@ -48,11 +48,12 @@ import {
         }
 
         <!--
-          The "create" option is a regular option whose value is the current query.
-          When the query matches no existing option it is the only item in the list,
-          so it becomes the active descendant and is committed on Enter — no bespoke
-          keyboard handling required. Selecting it routes through the standard
-          selection path and emits the typed value via ngpComboboxValueChange.
+          The "create" option is a regular option whose value is the current query,
+          rendered after the filtered matches. When nothing matches the filter it is
+          the only item, so it is the active descendant and Enter commits it. When
+          there are matches they take precedence on Enter, and the create option is
+          reached with the arrow keys. Either way, selecting it routes through the
+          standard selection path and emits the typed value via ngpComboboxValueChange.
         -->
         @if (canCreate()) {
           <div class="create-option" [ngpComboboxOptionValue]="query()" ngpComboboxOption>

--- a/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
@@ -94,7 +94,7 @@ import {
   `,
 })
 export default class ComboboxCreatableExample {
-  /** The options for the combobox — a writable signal so created values persist. */
+  /** The options for the combobox - a writable signal so created values persist. */
   readonly options = signal<string[]>([
     'Marty McFly',
     'Doc Brown',
@@ -120,7 +120,7 @@ export default class ComboboxCreatableExample {
   /** The filter value. */
   readonly filter = signal<string>('');
 
-  /** The normalised query — trimmed once so filtering, creating, and de-duping all agree. */
+  /** The normalised query - trimmed once so filtering, creating, and de-duping all agree. */
   protected readonly query = computed(() => this.filter().trim());
 
   /** Get the filtered options. */
@@ -130,7 +130,7 @@ export default class ComboboxCreatableExample {
   });
 
   /**
-   * Whether the current query can be created as a new option — it must be non-empty
+   * Whether the current query can be created as a new option - it must be non-empty
    * and not already exist (case-insensitive), so we never offer to create a duplicate.
    */
   protected readonly canCreate = computed(() => {

--- a/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
@@ -62,11 +62,12 @@ import {
         }
 
         <!--
-          The "create" option is a regular option whose value is the current query.
-          When the query matches no existing option it is the only item in the list,
-          so it becomes the active descendant and is committed on Enter — no bespoke
-          keyboard handling required. Selecting it routes through the standard
-          selection path and emits the typed value via ngpComboboxValueChange.
+          The "create" option is a regular option whose value is the current query,
+          rendered after the filtered matches. When nothing matches the filter it is
+          the only item, so it is the active descendant and Enter commits it. When
+          there are matches they take precedence on Enter, and the create option is
+          reached with the arrow keys. Either way, selecting it routes through the
+          standard selection path and emits the typed value via ngpComboboxValueChange.
         -->
         @if (canCreate()) {
           <div

--- a/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
@@ -11,7 +11,7 @@ import {
 } from 'ng-primitives/combobox';
 
 @Component({
-  selector: 'app-combobox-creatable',
+  selector: 'app-combobox-creatable-tailwind',
   imports: [
     NgpCombobox,
     NgpComboboxDropdown,
@@ -24,25 +24,39 @@ import {
   providers: [provideIcons({ heroChevronDown, heroPlus })],
   template: `
     <div
+      class="relative box-border flex h-[2.125rem] w-[300px] items-center justify-between rounded-lg border border-gray-200 bg-white transition-colors focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-500 dark:border-gray-700 dark:bg-transparent dark:focus-within:outline-blue-400"
       [(ngpComboboxValue)]="value"
       (ngpComboboxValueChange)="onValueChange($event)"
       (ngpComboboxOpenChange)="resetOnClose($event)"
       ngpCombobox
     >
       <input
+        class="font-inherit h-full flex-1 border-none bg-transparent px-4 text-[14px] text-gray-900 outline-hidden focus:ring-0 dark:bg-transparent dark:text-gray-100"
         [value]="inputValue()"
         (input)="onFilterChange($event)"
         placeholder="Select or create an option"
         ngpComboboxInput
       />
 
-      <button ngpComboboxButton aria-label="Toggle dropdown">
+      <button
+        class="box-border inline-flex h-full w-9 cursor-pointer items-center justify-center border-none bg-transparent text-gray-900 focus:outline-hidden dark:text-gray-100 dark:hover:text-gray-200"
+        ngpComboboxButton
+        aria-label="Toggle dropdown"
+      >
         <ng-icon name="heroChevronDown" />
       </button>
 
-      <div *ngpComboboxPortal ngpComboboxDropdown>
+      <div
+        class="absolute left-0 z-1001 mt-1 box-border max-h-[240px] w-[300px] overflow-y-auto rounded-[12px] border border-gray-200 bg-white p-1 shadow-lg outline-hidden dark:border-zinc-800 dark:bg-zinc-950"
+        *ngpComboboxPortal
+        ngpComboboxDropdown
+      >
         @for (option of filteredOptions(); track option) {
-          <div [ngpComboboxOptionValue]="option" ngpComboboxOption>
+          <div
+            class="box-border flex h-[2.125rem] w-full cursor-pointer items-center gap-2 rounded-lg px-3 text-sm tracking-[-0.006em] text-gray-900 transition-colors hover:bg-gray-100 data-active:bg-gray-100 data-press:bg-gray-100 data-selected:font-[510] data-selected:text-[#f01e2b] dark:text-gray-100 dark:hover:bg-white/10 dark:data-active:bg-white/10 dark:data-press:bg-white/20 dark:data-selected:text-[#ff4651]"
+            [ngpComboboxOptionValue]="option"
+            ngpComboboxOption
+          >
             {{ option }}
           </div>
         }
@@ -55,166 +69,27 @@ import {
           selection path and emits the typed value via ngpComboboxValueChange.
         -->
         @if (canCreate()) {
-          <div class="create-option" [ngpComboboxOptionValue]="query()" ngpComboboxOption>
-            <ng-icon name="heroPlus" />
-            <span>Create "{{ query() }}"</span>
+          <div
+            class="box-border flex h-[2.125rem] w-full cursor-pointer items-center gap-2 rounded-lg px-3 text-sm tracking-[-0.006em] text-gray-500 transition-colors hover:bg-gray-100 data-active:bg-gray-100 data-press:bg-gray-100 dark:text-gray-400 dark:hover:bg-white/10 dark:data-active:bg-white/10 dark:data-press:bg-white/20"
+            [ngpComboboxOptionValue]="query()"
+            ngpComboboxOption
+          >
+            <ng-icon name="heroPlus" class="text-base text-gray-400 dark:text-gray-500" />
+            <span class="overflow-hidden text-ellipsis whitespace-nowrap">
+              Create "{{ query() }}"
+            </span>
           </div>
         }
 
         @if (filteredOptions().length === 0 && !canCreate()) {
-          <div class="empty-message">No options found</div>
+          <div
+            class="flex items-center justify-center p-2 text-center text-sm font-[510] text-gray-400 dark:text-gray-600"
+          >
+            No options found
+          </div>
         }
       </div>
     </div>
-  `,
-  styles: `
-    [ngpCombobox] {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      height: 2.125rem;
-      width: 300px;
-      border-radius: 0.5rem;
-      border: none;
-      background-color: var(--ngp-background);
-      box-shadow: var(--ngp-input-shadow);
-      box-sizing: border-box;
-    }
-
-    [ngpCombobox][data-focus] {
-      outline: 2px solid var(--ngp-focus-ring);
-      outline-offset: 2px;
-    }
-
-    [ngpComboboxInput] {
-      flex: 1;
-      padding: 0 16px;
-      border: none;
-      background-color: transparent;
-      color: var(--ngp-text-primary);
-      font-family: inherit;
-      font-size: 14px;
-      padding: 0 16px;
-      outline: none;
-      height: 100%;
-    }
-
-    [ngpComboboxButton] {
-      display: inline-flex;
-      justify-content: center;
-      align-items: center;
-      height: 100%;
-      width: 36px;
-      background-color: transparent;
-      border: none;
-      color: var(--ngp-text-primary);
-      cursor: pointer;
-      box-sizing: border-box;
-    }
-
-    [ngpComboboxDropdown] {
-      background-color: var(--ngp-background);
-      border: 1px solid var(--ngp-border);
-      padding: 0.25rem;
-      border-radius: 0.75rem;
-      outline: none;
-      position: absolute;
-      animation: popover-show 0.1s ease-out;
-      width: var(--ngp-combobox-width);
-      box-shadow: var(--ngp-shadow-lg);
-      box-sizing: border-box;
-      margin-top: 4px;
-      max-height: 240px;
-      overflow-y: auto;
-      z-index: 1001;
-    }
-
-    [ngpComboboxDropdown][data-enter] {
-      animation: combobox-show 0.1s ease-out;
-    }
-
-    [ngpComboboxDropdown][data-exit] {
-      animation: combobox-hide 0.1s ease-out;
-    }
-
-    [ngpComboboxOption] {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      padding: 0.375rem 0.75rem;
-      cursor: pointer;
-      border-radius: 0.5rem;
-      width: 100%;
-      height: 2.125rem;
-      font-size: 14px;
-      color: var(--ngp-text-primary);
-      box-sizing: border-box;
-    }
-
-    [ngpComboboxOption][data-hover] {
-      background-color: var(--ngp-background-hover);
-    }
-
-    [ngpComboboxOption][data-press] {
-      background-color: var(--ngp-background-active);
-    }
-
-    [ngpComboboxOption][data-active] {
-      background-color: var(--ngp-background-active);
-    }
-
-    [ngpComboboxOption][data-selected] {
-      color: var(--ngp-primary);
-      font-weight: 510;
-    }
-
-    .create-option {
-      color: var(--ngp-text-secondary);
-    }
-
-    .create-option ng-icon {
-      color: var(--ngp-text-tertiary);
-      font-size: 1rem;
-    }
-
-    .create-option span {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-
-    .empty-message {
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      padding: 0.5rem;
-      color: var(--ngp-text-secondary);
-      font-size: 14px;
-      font-weight: 510;
-      text-align: center;
-    }
-
-    @keyframes combobox-show {
-      0% {
-        opacity: 0;
-        transform: translateY(-10px) scale(0.9);
-      }
-      100% {
-        opacity: 1;
-        transform: translateY(0) scale(1);
-      }
-    }
-
-    @keyframes combobox-hide {
-      0% {
-        opacity: 1;
-        transform: translateY(0) scale(1);
-      }
-      100% {
-        opacity: 0;
-        transform: translateY(-10px) scale(0.9);
-      }
-    }
   `,
 })
 export default class ComboboxCreatableExample {

--- a/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
@@ -24,7 +24,7 @@ import {
   providers: [provideIcons({ heroChevronDown, heroPlus })],
   template: `
     <div
-      class="relative box-border flex h-[2.125rem] w-[300px] items-center justify-between rounded-lg bg-white shadow-xs ring-1 ring-black/10 transition-colors focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-500 dark:bg-zinc-900 dark:ring-white/10 dark:focus-within:outline-blue-400"
+      class="relative box-border flex h-[2.125rem] w-[300px] items-center justify-between rounded-lg bg-white shadow-xs ring-1 ring-black/10 transition-colors focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-500 dark:bg-zinc-950 dark:ring-white/10 dark:focus-within:outline-blue-400"
       [(ngpComboboxValue)]="value"
       (ngpComboboxValueChange)="onValueChange($event)"
       (ngpComboboxOpenChange)="resetOnClose($event)"

--- a/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
@@ -74,7 +74,7 @@ import {
             [ngpComboboxOptionValue]="query()"
             ngpComboboxOption
           >
-            <ng-icon name="heroPlus" class="text-base text-gray-400 dark:text-gray-500" />
+            <ng-icon class="text-base text-gray-400 dark:text-gray-500" name="heroPlus" />
             <span class="overflow-hidden text-ellipsis whitespace-nowrap">
               Create "{{ query() }}"
             </span>

--- a/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts
@@ -24,7 +24,7 @@ import {
   providers: [provideIcons({ heroChevronDown, heroPlus })],
   template: `
     <div
-      class="relative box-border flex h-[2.125rem] w-[300px] items-center justify-between rounded-lg border border-gray-200 bg-white transition-colors focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-500 dark:border-gray-700 dark:bg-transparent dark:focus-within:outline-blue-400"
+      class="relative box-border flex h-[2.125rem] w-[300px] items-center justify-between rounded-lg bg-white shadow-xs ring-1 ring-black/10 transition-colors focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-blue-500 dark:bg-zinc-900 dark:ring-white/10 dark:focus-within:outline-blue-400"
       [(ngpComboboxValue)]="value"
       (ngpComboboxValueChange)="onValueChange($event)"
       (ngpComboboxOpenChange)="resetOnClose($event)"

--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -122,6 +122,18 @@ Options without a value do not perform any selection by default. You can use thi
 
 <docs-example name="combobox-custom-option"></docs-example>
 
+### Creatable Options
+
+To let users pick a value that isn't in the list, render a "create" option whose value is the current query. Because it is an ordinary `ngpComboboxOption`, it participates in keyboard navigation and is committed on `Enter` or click through the standard selection path — no bespoke key handling is required. When the query matches no existing option, the create option is the only item, so it becomes the active descendant and `Enter` commits it immediately.
+
+<docs-example name="combobox-creatable"></docs-example>
+
+The pattern has three parts:
+
+- **Detect a creatable query** — the combobox does not own the input text, so you already have the query. Offer the create option only when the query is non-empty and does not exactly match an existing option (to avoid duplicates).
+- **Render it as an option** — bind the query to `ngpComboboxOptionValue`. Selecting it emits the typed value via `ngpComboboxValueChange`, exactly like any other option.
+- **Persist the new value** — add the committed value to your own options list in the value-change handler so it renders as a real, selectable option afterwards.
+
 ## Schematics
 
 Generate a reusable combobox component using the Angular CLI.

--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -124,15 +124,9 @@ Options without a value do not perform any selection by default. You can use thi
 
 ### Creatable Options
 
-To let users pick a value that isn't in the list, render a "create" option whose value is the current query. Because it is an ordinary `ngpComboboxOption`, it participates in keyboard navigation and is committed on `Enter` or click through the standard selection path — no bespoke key handling is required. It is rendered after the filtered matches: when nothing matches the filter, the create option is the only item, so it becomes the active descendant and `Enter` commits it immediately; when there are matches, they take precedence on `Enter` and the create option is reached with the arrow keys.
+To let users pick a value that isn't in the list, render a "create" option whose value is the current query. Because it is an ordinary `ngpComboboxOption`, it participates in keyboard navigation and is committed on `Enter` or click through the standard selection path - no bespoke key handling is required. It is rendered after the filtered matches: when nothing matches the filter, the create option is the only item, so it becomes the active descendant and `Enter` commits it immediately; when there are matches, they take precedence on `Enter` and the create option is reached with the arrow keys.
 
 <docs-example name="combobox-creatable"></docs-example>
-
-The pattern has three parts:
-
-- **Detect a creatable query** — the combobox does not own the input text, so you already have the query. Offer the create option only when the query is non-empty and does not exactly match an existing option (to avoid duplicates).
-- **Render it as an option** — bind the query to `ngpComboboxOptionValue`. Selecting it emits the typed value via `ngpComboboxValueChange`, exactly like any other option.
-- **Persist the new value** — add the committed value to your own options list in the value-change handler so it renders as a real, selectable option afterwards.
 
 ## Schematics
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -124,7 +124,7 @@ Options without a value do not perform any selection by default. You can use thi
 
 ### Creatable Options
 
-To let users pick a value that isn't in the list, render a "create" option whose value is the current query. Because it is an ordinary `ngpComboboxOption`, it participates in keyboard navigation and is committed on `Enter` or click through the standard selection path — no bespoke key handling is required. When the query matches no existing option, the create option is the only item, so it becomes the active descendant and `Enter` commits it immediately.
+To let users pick a value that isn't in the list, render a "create" option whose value is the current query. Because it is an ordinary `ngpComboboxOption`, it participates in keyboard navigation and is committed on `Enter` or click through the standard selection path — no bespoke key handling is required. It is rendered after the filtered matches: when nothing matches the filter, the create option is the only item, so it becomes the active descendant and `Enter` commits it immediately; when there are matches, they take precedence on `Enter` and the create option is reached with the arrow keys.
 
 <docs-example name="combobox-creatable"></docs-example>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features) — N/A (documentation example; verified manually in-browser, see below)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #528

## What does this PR implement/fix?

Adds a **Creatable Options** example to the combobox docs, demonstrating how to let users pick a value that isn't in the predefined list — the [Base UI–style "creatable" pattern](https://base-ui.com/react/components/combobox) — using the existing combobox API, with **no new primitive API required**.

The current query is rendered as an ordinary `ngpComboboxOption` whose value is the typed text. Because it is a normal option it participates in keyboard navigation and is committed on `Enter` or click through the standard selection path. When the query matches no existing option, the create option is the only item in the list, so it becomes the active descendant and `Enter` commits it immediately — no bespoke key handling.

Changes:

- `apps/documentation/src/app/examples/combobox/combobox-creatable.example.ts` — new example (single selection). Detects a creatable query (non-empty and not an exact, case-insensitive match of an existing option, to avoid duplicates), renders the `Create "…"` row, emits the typed value via `ngpComboboxValueChange`, and appends committed new values to its own options list so they render as real, selectable options afterwards. Styling mirrors the sibling combobox examples (blue focus ring, brand-red selected state).
- `apps/documentation/src/app/pages/(documentation)/primitives/combobox.md` — new **Creatable Options** section documenting the three-part pattern (detect → render as option → persist).

## Verification

- `nx lint documentation` and a full `nx build documentation` (Angular strict-template check) pass.
- Verified in a real browser (Playwright/Chromium) against the running docs site — 32/33 checks pass across filtering, `Enter`/`End`/`Arrow`/`Home`/`Escape`, click selection, blur revert, persistence/no-duplicate, and ARIA (`role="combobox"`/`listbox`/`option`, `aria-expanded`, `aria-controls`, `aria-activedescendant`, `aria-selected`).
- The one axe-core finding — the selected option's brand-red label at 4.26:1 contrast on white (WCAG AA wants 4.5:1) — reproduces identically in the existing `combobox` and `combobox-custom-option` examples. It stems from the shared `[data-selected] { color: var(--ngp-primary) }` house style, so it is inherited/systemic rather than introduced here; worth tracking separately as a palette concern.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEd9XPq1iVCZfzFLEWm2FA)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Creatable Options” example (plus a Tailwind variant) to the combobox docs so users can pick values not in the list using the existing `ng-primitives/combobox` API. No API changes; the create option is rendered after matches and follows normal keyboard behavior (Enter commits it only when it’s the sole item).

- **New Features**
  - New examples: `apps/documentation/src/app/examples/combobox/combobox-creatable.example.ts` and `apps/documentation/src/app/examples/combobox/combobox-creatable.tailwind.example.ts`.
  - Renders the current query as a normal `ngpComboboxOption` (value = typed text); Enter commits it only when no options match, otherwise reach it with arrow keys.
  - Normalizes the query (trim via a computed) and avoids duplicates; appends created values on `ngpComboboxValueChange` so they become real options.
  - Docs: adds “Creatable Options” to `combobox.md`; trims copy, clarifies ordering/Enter behavior, and standardizes hyphens.

- **Refactors**
  - Tailwind example: match CSS variant visuals (shadow-xs + ring-1 ring-black/10), fix dark-mode background to match CSS, and reorder attributes per Prettier.
  - CI: skip `pkg-pr-new publish` when `nx affected` builds no packages.

<sup>Written for commit 127d4835050953d8a30b311311aa7e443c371f93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added creatable combobox examples in both standard and Tailwind styles.
  * Users can create and select a new option from their typed query when it doesn’t already exist.
  * Newly created options are saved and stay available for later filtering and selection.
* **Documentation**
  * Added a new “Creatable Options” section with guidance and reference to the interactive example.
* **Chores**
  * Updated CI to publish preview packages only when built package outputs are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->