### PR TITLE
feat(schematics): add a styles option to the primitive schematic

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/accordion.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/accordion.md
@@ -66,6 +66,7 @@ ng g ng-primitives:primitive accordion
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/accordion.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/accordion.md
@@ -65,7 +65,7 @@ ng g ng-primitives:primitive accordion
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/avatar.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/avatar.md
@@ -49,7 +49,7 @@ ng g ng-primitives:primitive avatar
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/avatar.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/avatar.md
@@ -50,6 +50,7 @@ ng g ng-primitives:primitive avatar
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/button.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/button.md
@@ -47,6 +47,7 @@ ng g ng-primitives:primitive button
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/button.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/button.md
@@ -46,7 +46,7 @@ ng g ng-primitives:primitive button
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
@@ -49,6 +49,7 @@ ng g ng-primitives:primitive checkbox
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
@@ -48,7 +48,7 @@ ng g ng-primitives:primitive checkbox
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -142,7 +142,7 @@ ng g ng-primitives:primitive combobox
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -143,6 +143,7 @@ ng g ng-primitives:primitive combobox
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
@@ -79,6 +79,7 @@ ng g ng-primitives:primitive date-picker
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
@@ -78,7 +78,7 @@ ng g ng-primitives:primitive date-picker
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
@@ -67,7 +67,7 @@ ng g ng-primitives:primitive dialog
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
@@ -68,6 +68,7 @@ ng g ng-primitives:primitive dialog
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
@@ -58,7 +58,7 @@ ng g ng-primitives:primitive file-upload
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
@@ -59,6 +59,7 @@ ng g ng-primitives:primitive file-upload
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
@@ -56,7 +56,7 @@ ng g ng-primitives:primitive form-field
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
@@ -57,6 +57,7 @@ ng g ng-primitives:primitive form-field
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/input-otp.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/input-otp.md
@@ -55,6 +55,7 @@ ng g ng-primitives:primitive input-otp
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/input-otp.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/input-otp.md
@@ -54,7 +54,7 @@ ng g ng-primitives:primitive input-otp
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/input.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/input.md
@@ -47,6 +47,7 @@ ng g ng-primitives:primitive input
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/input.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/input.md
@@ -46,7 +46,7 @@ ng g ng-primitives:primitive input
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/listbox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/listbox.md
@@ -51,6 +51,7 @@ ng g ng-primitives:primitive listbox
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/listbox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/listbox.md
@@ -50,7 +50,7 @@ ng g ng-primitives:primitive listbox
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -64,6 +64,7 @@ ng g ng-primitives:primitive menu
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -63,7 +63,7 @@ ng g ng-primitives:primitive menu
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/meter.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/meter.md
@@ -59,6 +59,7 @@ ng g ng-primitives:primitive meter
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/meter.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/meter.md
@@ -58,7 +58,7 @@ ng g ng-primitives:primitive meter
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/number-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/number-field.md
@@ -53,7 +53,7 @@ ng g ng-primitives:primitive number-field
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/number-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/number-field.md
@@ -54,6 +54,7 @@ ng g ng-primitives:primitive number-field
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/pagination.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/pagination.md
@@ -101,6 +101,7 @@ ng g ng-primitives:primitive pagination
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/pagination.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/pagination.md
@@ -100,7 +100,7 @@ ng g ng-primitives:primitive pagination
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/password.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/password.md
@@ -54,7 +54,7 @@ ng g ng-primitives:primitive password
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Global Configuration
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/password.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/password.md
@@ -55,6 +55,7 @@ ng g ng-primitives:primitive password
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Global Configuration
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -89,7 +89,7 @@ ng g ng-primitives:primitive popover
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -90,6 +90,7 @@ ng g ng-primitives:primitive popover
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/progress.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/progress.md
@@ -59,7 +59,7 @@ ng g ng-primitives:primitive progress
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/progress.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/progress.md
@@ -60,6 +60,7 @@ ng g ng-primitives:primitive progress
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/radio.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/radio.md
@@ -62,6 +62,7 @@ ng g ng-primitives:primitive radio
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/radio.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/radio.md
@@ -61,7 +61,7 @@ ng g ng-primitives:primitive radio
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/rating.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/rating.md
@@ -57,7 +57,7 @@ ng g ng-primitives:primitive rating
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/rating.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/rating.md
@@ -58,6 +58,7 @@ ng g ng-primitives:primitive rating
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/search.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/search.md
@@ -52,7 +52,7 @@ ng g ng-primitives:primitive search
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/search.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/search.md
@@ -53,6 +53,7 @@ ng g ng-primitives:primitive search
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -57,7 +57,7 @@ ng g ng-primitives:primitive select
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -58,6 +58,7 @@ ng g ng-primitives:primitive select
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/separator.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/separator.md
@@ -47,6 +47,7 @@ ng g ng-primitives:primitive separator
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/separator.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/separator.md
@@ -46,7 +46,7 @@ ng g ng-primitives:primitive separator
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/slider.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/slider.md
@@ -51,7 +51,7 @@ ng g ng-primitives:primitive slider
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/slider.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/slider.md
@@ -52,6 +52,7 @@ ng g ng-primitives:primitive slider
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/switch.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/switch.md
@@ -48,7 +48,7 @@ ng g ng-primitives:primitive switch
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/switch.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/switch.md
@@ -49,6 +49,7 @@ ng g ng-primitives:primitive switch
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tabs.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tabs.md
@@ -56,6 +56,7 @@ ng g ng-primitives:primitive tabs
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tabs.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tabs.md
@@ -55,7 +55,7 @@ ng g ng-primitives:primitive tabs
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/textarea.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/textarea.md
@@ -46,7 +46,7 @@ ng g ng-primitives:primitive textarea
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/textarea.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/textarea.md
@@ -47,6 +47,7 @@ ng g ng-primitives:primitive textarea
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
@@ -65,7 +65,7 @@ ng g ng-primitives:primitive toast
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
@@ -66,6 +66,7 @@ ng g ng-primitives:primitive toast
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toggle-group.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toggle-group.md
@@ -50,7 +50,7 @@ ng g ng-primitives:primitive toggle-group
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toggle-group.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toggle-group.md
@@ -51,6 +51,7 @@ ng g ng-primitives:primitive toggle-group
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toggle.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toggle.md
@@ -47,6 +47,7 @@ ng g ng-primitives:primitive toggle
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toggle.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toggle.md
@@ -46,7 +46,7 @@ ng g ng-primitives:primitive toggle
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toolbar.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toolbar.md
@@ -49,6 +49,7 @@ ng g ng-primitives:primitive toolbar
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toolbar.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toolbar.md
@@ -48,7 +48,7 @@ ng g ng-primitives:primitive toolbar
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -51,6 +51,7 @@ ng g ng-primitives:primitive tooltip
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -50,7 +50,7 @@ ng g ng-primitives:primitive tooltip
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 
 ## Examples
 

--- a/packages/ng-primitives/schematics/ng-generate/compiles.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/compiles.node.test.ts
@@ -150,6 +150,42 @@ describe('generated primitives compile', () => {
     expect(failures).toEqual([]);
   }, 60_000);
 
+  /**
+   * `--styles unstyled` removes the `styles` property from the decorator — a structural edit
+   * that must leave every primitive syntactically valid, whatever shape its decorator has.
+   */
+  it('produces files that parse when unstyled', async () => {
+    const failures: string[] = [];
+
+    for (const primitive of primitives) {
+      // a dedicated path per primitive, so this never collides with the default-styled
+      // components the beforeAll already generated into `app/<primitive>`
+      const dir = `projects/bar/src/app/unstyled-${primitive}`;
+      const tree = await schematicRunner.runSchematic(
+        'primitive',
+        { primitive, path: dir, styles: 'unstyled' },
+        appTree,
+      );
+
+      for (const file of tree.files.filter(file => file.includes(`/unstyled-${primitive}/`))) {
+        const content = tree.readContent(file);
+        expect(content, `${file.split('/').pop()} should have no styles block`).not.toContain(
+          'styles:',
+        );
+
+        const source = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true);
+        const diagnostics = (source as unknown as { parseDiagnostics?: ts.Diagnostic[] })
+          .parseDiagnostics;
+
+        if (diagnostics?.length) {
+          failures.push(...diagnostics.map(describeDiagnostic));
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  }, 60_000);
+
   function describeDiagnostic(diagnostic: ts.Diagnostic): string {
     const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
 

--- a/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
@@ -354,4 +354,57 @@ describe('Component Schematic', () => {
     expect(content).toContain('implements ControlValueAccessor');
     expect(content).toContain('provideValueAccessor(RatingComponent)');
   });
+
+  describe('styles option', () => {
+    // accordion-item is the busiest decorator (hostDirectives, providers, template) and its
+    // styles block — carrying @keyframes and @media — sits last, so removing it exercises the
+    // trailing-comma case.
+    const itemPath = '/projects/bar/src/app/accordion/accordion-item.component.ts';
+
+    it('keeps the full styles by default', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'primitive',
+        { primitive: 'accordion', path: 'projects/bar/src/app/accordion' },
+        appTree,
+      );
+
+      const content = tree.readContent(itemPath);
+      expect(content).toContain('styles:');
+      expect(content).toContain('var(--ngp');
+    });
+
+    it('removes the styles block entirely when unstyled', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'primitive',
+        { primitive: 'accordion', path: 'projects/bar/src/app/accordion', styles: 'unstyled' },
+        appTree,
+      );
+
+      const content = tree.readContent(itemPath);
+
+      // the whole styles property and its contents are gone
+      expect(content).not.toContain('styles:');
+      expect(content).not.toContain('var(--ngp');
+      expect(content).not.toContain('@keyframes');
+      // the rest of the component is untouched
+      expect(content).toContain('@Component({');
+      expect(content).toContain('template:');
+      expect(content).toContain('export class AccordionItemComponent');
+    });
+
+    it('treats the deprecated exampleStyles: false as unstyled', async () => {
+      const unstyled = await schematicRunner.runSchematic(
+        'primitive',
+        { primitive: 'accordion', path: 'projects/bar/src/app/accordion', styles: 'unstyled' },
+        appTree,
+      );
+      const deprecated = await schematicRunner.runSchematic(
+        'primitive',
+        { primitive: 'accordion', path: 'projects/bar/src/app/accordion', exampleStyles: false },
+        appTree,
+      );
+
+      expect(deprecated.readContent(itemPath)).toEqual(unstyled.readContent(itemPath));
+    });
+  });
 });

--- a/packages/ng-primitives/schematics/ng-generate/index.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.ts
@@ -126,7 +126,9 @@ function processChangeDetection(
   return Buffer.from(contentStr);
 }
 function processStyles(content: Buffer, options: AngularPrimitivesComponentSchema): Buffer {
-  if (options.exampleStyles) {
+  // `css` keeps the example styles verbatim; `unstyled` drops the `styles` property entirely
+  // so the consumer can bring their own, matching the docs' "Unstyled" example variant.
+  if (resolveStylesOption(options) !== 'unstyled') {
     return content;
   }
 
@@ -141,16 +143,29 @@ function processStyles(content: Buffer, options: AngularPrimitivesComponentSchem
     return content;
   }
 
-  const stylesNode = styles[0];
-  const stylesText = stylesNode.getText();
-  const stylesValue = stylesText.slice(1, stylesText.length - 1);
+  // Remove each `styles: `...`` property — its leading whitespace and any trailing comma
+  // included — from last to first so the earlier node offsets stay valid.
+  let result = contentStr;
+  for (const literal of [...styles].sort((a, b) => b.getStart() - a.getStart())) {
+    const property = literal.parent;
+    const start = property.getFullStart();
+    let end = property.getEnd();
+    if (result[end] === ',') {
+      end++;
+    }
+    result = result.slice(0, start) + result.slice(end);
+  }
 
-  // we want to preserve all the selectors, we just want to remove all the rules inside the selectors
-  const stylesWithoutRules = stylesValue.replace(/(?<=\{)[^}]+(?=\})/g, '');
+  return Buffer.from(result);
+}
 
-  // replace the styles value with the new value
-  const contentStrWithoutRules = contentStr.replace(stylesValue, stylesWithoutRules);
-
-  // convert back to a buffer
-  return Buffer.from(contentStrWithoutRules);
+/**
+ * Resolve the effective styles option, honouring the deprecated `exampleStyles` boolean:
+ * `styles` wins when set, otherwise `exampleStyles: false` maps to `unstyled`.
+ */
+function resolveStylesOption(options: AngularPrimitivesComponentSchema): 'css' | 'unstyled' {
+  if (options.styles === 'css' || options.styles === 'unstyled') {
+    return options.styles;
+  }
+  return options.exampleStyles === false ? 'unstyled' : 'css';
 }

--- a/packages/ng-primitives/schematics/ng-generate/schema.d.ts
+++ b/packages/ng-primitives/schematics/ng-generate/schema.d.ts
@@ -63,7 +63,16 @@ export interface AngularPrimitivesComponentSchema {
   fileSuffix?: string;
 
   /**
+   * How component styles should be generated.
+   * `css` includes the full example styles; `unstyled` omits them entirely so you
+   * can style the component yourself.
+   */
+  styles?: 'css' | 'unstyled';
+
+  /**
    * Whether example styles should be included.
+   *
+   * @deprecated Use `styles` instead: `true` maps to `--styles css`, `false` to `--styles unstyled`.
    */
   exampleStyles?: boolean;
   /**

--- a/packages/ng-primitives/schematics/ng-generate/schema.json
+++ b/packages/ng-primitives/schematics/ng-generate/schema.json
@@ -79,10 +79,15 @@
       "default": "component",
       "description": "Generate component template files with the specified suffix."
     },
+    "styles": {
+      "type": "string",
+      "description": "How component styles should be generated. `css` includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.",
+      "enum": ["css", "unstyled"]
+    },
     "exampleStyles": {
       "type": "boolean",
       "description": "Whether example styles should be generated.",
-      "default": true
+      "x-deprecated": "Use `styles` instead: `true` maps to `--styles css`, `false` to `--styles unstyled`."
     },
     "changeDetection": {
       "description": "The change detection strategy to use in the new component. Defaults to OnPush.",

--- a/packages/tools/src/generators/documentation/files/__name__.md.template
+++ b/packages/tools/src/generators/documentation/files/__name__.md.template
@@ -49,6 +49,7 @@ ng g ng-primitives:primitive <%= fileName %>
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 <% } %>
 
 ## API Reference

--- a/packages/tools/src/generators/documentation/files/__name__.md.template
+++ b/packages/tools/src/generators/documentation/files/__name__.md.template
@@ -48,7 +48,7 @@ ng g ng-primitives:primitive <%= fileName %>
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `example-styles`: Whether to include example styles in the generated component file. Defaults to `true`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 <% } %>
 
 ## API Reference


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — see follow-ups

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

No linked issue — this follows up our Discord conversation where you invited a draft PR for a
styles option on the primitive schematic.

## What does this PR implement/fix?

Adds a `--styles` option to the primitive schematic so consumers can choose how the generated
component is styled.

**Shipped here:**

- **`--styles css`** (the default) — the full example styles, exactly as today.
- **`--styles unstyled`** — omits the styles entirely, so you can style the component yourself.
  This matches what "Unstyled" already means in the docs, where the example loader strips the whole `styles` property.

`exampleStyles` is kept and deprecated (`x-deprecated` + `@deprecated`), mapping `true → css` and `false → unstyled`, so nothing breaks for existing callers.

**A latent bug goes away with it.** The old `--example-styles false` path rewrote the CSS in place with a regex (`/(?<=\{)[^}]+(?=\})/g`) that can't span nested braces, so it emitted **invalid CSS** for the ten primitives using `@keyframes`/`@media` (accordion, popover, toast, tooltip, select, input-otp, menu, combobox, dialog, context-menu). Removing the whole property sidesteps it — there is no in-place CSS rewriting left.

The `compiles.node.test.ts` gate from #841 now also generates **every** primitive `unstyled` and asserts it still parses; unit tests cover the removal and the deprecated-flag mapping.

### The `tailwind` value — a proposal I'd like your read on

I deliberately left `tailwind` out of this PR, because the obvious implementations all reintroduce the thing you didn't want. Sourcing it from the reusable components means a second hand-authored `*.tailwind.ts` per component, and that copy is invisible: `docs-snippet` renders source text and never instantiates, so nothing would catch it going stale. That risk isn't hypothetical — the docs example twins have already drifted despite being rendered side by side (the popover arrow is `:before`/`:after` in the CSS variant but two child `<span>`s in the Tailwind one, panel padding is `0.75rem 1rem` vs `p-3`, `font-weight: 500` vs `font-[510]`).

So instead of a second file, here's a shape where there is only ever **one** authored component and every variant is produced by **subtraction**. The component carries both representations side by side, and the generator removes what the chosen mode doesn't need:

```ts
@Component({
  selector: 'app-accordion-item',
  template: `
    <button ngpAccordionTrigger ngpButton tw="flex w-full items-center px-4 py-3">
      {{ heading() }}
    </button>
    <div
      ngpAccordionContent
      tw="overflow-hidden data-open:animate-[slideDown_200ms] data-closed:animate-[slideUp_200ms] motion-reduce:[animation-duration:0s]"
    >
      <ng-content />
    </div>
  `,
  styles: `
    [ngpAccordionTrigger] { display: flex; width: 100%; padding: 0.75rem 1rem; }

    /* @keep */
    @keyframes slideDown { ... }
    @keyframes slideUp { ... }
    /* @endkeep */
  `,
})
```

`data-open:`/`data-closed:` (no brackets) is the same bare data-attribute variant already used in `radio.tailwind.example.ts` (`data-checked:ring-[1.5px]`) for the same kind of boolean attribute `dataBinding` sets. The reduced-motion piece follows the real technique from #844 (`accordion-item.ts`): the fix there is `animation-duration: 0s`, not `animation: none` — the commit message explains why, `forwards` fill-mode has to survive so the collapsed/expanded height still lands, only the duration collapses to instant. Tailwind has no dedicated `animation-duration` utility (`duration-*` targets `transition-duration`), so the equivalent is an arbitrary property: `motion-reduce:[animation-duration:0s]`. `data-open`/`data-closed` are mutually exclusive, so one unconditional rule covers both, matching the `@media` block that targets both selectors together in the source.

Confidence differs between the two pieces, worth being upfront about: the `data-*` variant has
direct precedent in this repo; `motion-reduce:[animation-duration:0s]` composes two documented
Tailwind mechanisms (arbitrary properties + stackable variants) that I haven't seen combined in any
`.tailwind.example.ts` here, so I'd want to confirm it in a real pilot rather than assume it.

| mode       | what the generator does                                                     | result                            |
| ---------- | --------------------------------------------------------------------------- | --------------------------------- |
| `css`      | drop every `tw="…"`, keep the styles block                                  | byte-identical to today's output  |
| `tailwind` | promote `tw="…"` to `class="…"`, drop the CSS **except** the `@keep` region | utilities plus working animations |
| `unstyled` | drop every `tw="…"` and the whole styles block                              | what this PR already ships        |

Why this shape rather than the others:

- **One authored file.** The two representations sit next to each other, so a mismatch is visible in review rather than hidden in a file nobody opens. That's the part I think actually addresses your concern — it doesn't make drift impossible, it makes it non-silent.
- **`tw` as a separate attribute, not `class`.** The reusable components already ship 16 real `class="…"` attributes that their own CSS targets (`.slots`/`.slot` in input-otp, `.toast-title` in toast, …), so "strip the classes" would break them. A dedicated attribute is unambiguous, and promoting or dropping it is a string operation — no Angular template parsing on the publish-critical path.
- **`@keep` markers instead of guessing.** The animation trigger itself moves into `tw=` as a `data-*`-variant utility (`data-open:animate-[slideDown_200ms]`), so `@keep` only has to preserve the raw `@keyframes` rules — deciding which rule "is" the animation isn't mechanically decidable, but an explicit marker sidesteps needing to decide at all, and keeps the whole thing free of a CSS parser. The residual-keyframes pattern itself is already proven in `popover.tailwind.example.ts`.
- **Nothing changes visually in `apps/components`.** It doesn't load Tailwind (no plugin in its vite config), so the `tw` attributes are inert there and the components render from their CSS exactly as they do now. `prettier-plugin-tailwindcss` can be pointed at the attribute (`tailwindAttributes: ["tw"]`) so the classes still get sorted.

Honest about the cost: it's still two hand-written expressions of one design, so it reduces drift rather than eliminating it, and it means annotating ~46 components once. The Tailwind variant also wouldn't be visually verifiable in `nx serve components` unless Tailwind is added there or the generated variant is rendered in the docs app.

If the shape looks right to you I'm happy to wire it end-to-end on a single primitive as a follow-up PR — `accordion-item` is the honest worst case (keyframes, an `@media` block, semantic classes and a descendant rule), so it would show the weak seams rather than hide them.

### Follow-ups (not in this PR)

- Docs sweep: ~33 primitive pages document `--example-styles`; they keep working via the deprecated alias, but should move to `--styles` once the vocabulary is settled.
- The primitive enum is missing four generated primitives (`context-menu`, `number-field`, `password`, `range-slider`), so the `ng g` commands published on their docs pages fail validation today. Happy to fold that in here or send it separately.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`exampleStyles` still works; it's deprecated with a mapping to `--styles`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--styles` option to the primitive schematic (`css` or `unstyled`) and updates docs/templates to use it. Also fixes a date picker navigation loop at `min/max` when all dates are disabled.

- **New Features**
  - `--styles css|unstyled` (default `css`); `unstyled` removes the `styles` property for DIY styling.
  - Deprecates `exampleStyles`; maps to `--styles` (`true → css`, `false → unstyled`). Tests cover unstyled parsing and the mapping.
  - Documentation across primitive pages and the docs generator template now shows `--styles` and notes the deprecated `example-styles` mapping.

- **Bug Fixes**
  - Replaces the fragile CSS rewrite by deleting the `styles` block, fixing invalid CSS in primitives using `@keyframes`/`@media`.
  - Date picker and date range picker: stop the disabled-date search at `min`/`max` to avoid infinite loops; focus stays clamped when no enabled date remains.

<sup>Written for commit b1369f2ac426b97bd782e77c2c5939620d6db686. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `styles` option for primitive generation with `css` (default) and `unstyled` modes.
  * Unstyled mode omits component example styles entirely.
  * Kept the legacy `exampleStyles` / `example-styles` option as deprecated, mapping `true`→`css` and `false`→`unstyled`.
* **Documentation**
  * Updated all relevant primitive schematics pages to document `styles` and the deprecated compatibility option.
* **Tests**
  * Added tests to verify `unstyled` output contains no style definitions and that generated files remain valid TypeScript.
  * Added tests for correct `styles` handling on the accordion-item primitive, including deprecated-option parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->