### PR TITLE
fix(schematics): honour --prefix in camelCase selectors and aliases

### DIFF
--- a/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
@@ -79,6 +79,18 @@ describe('Component Schematic', () => {
     expect(content).toContain("selector: 'button[foo-button]'");
   });
 
+  it('should drop the separator with the prefix when it is empty', async () => {
+    const options: AngularPrimitivesComponentSchema = {
+      primitive: 'button',
+      path: 'projects/bar/src/app/button',
+      prefix: '',
+    };
+
+    const tree = await schematicRunner.runSchematic('primitive', options, appTree);
+    const content = tree.readContent('/projects/bar/src/app/button/button.component.ts');
+    expect(content).toContain("selector: 'button[button]'");
+  });
+
   describe('camelCase selectors and aliases', () => {
     // The trigger directives use an attribute selector in camelCase, and carry the prefix
     // in their input aliases too - none of which look like the dashed `app-` form.
@@ -113,8 +125,6 @@ describe('Component Schematic', () => {
       expect(content).toContain("selector: '[fooPopoverTrigger]'");
       expect(content).toContain("'ngpPopoverTriggerDisabled:fooPopoverTriggerDisabled'");
       expect(content).toContain("alias: 'fooPopoverTrigger'");
-      // the ngp side of a host directive input is the library's own, and must not move
-      expect(content).not.toContain('foongp');
     });
 
     it('should camelize a multi word prefix', async () => {
@@ -146,6 +156,11 @@ describe('Component Schematic', () => {
       expect(content).toContain("selector: '[popoverTrigger]'");
       expect(content).toContain("'ngpPopoverTriggerDisabled:popoverTriggerDisabled'");
       expect(content).toContain("alias: 'popoverTrigger'");
+
+      // the sibling part is generated in the same run, and its dashed selector has to come
+      // out just as clean - a leading `-popover` is not a name Angular would accept
+      const sibling = tree.readContent('/projects/bar/src/app/popover/popover.component.ts');
+      expect(sibling).toContain("selector: 'popover'");
     });
 
     it('should apply the prefix to the tooltip trigger too', async () => {

--- a/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
@@ -79,6 +79,93 @@ describe('Component Schematic', () => {
     expect(content).toContain("selector: 'button[foo-button]'");
   });
 
+  describe('camelCase selectors and aliases', () => {
+    // The trigger directives use an attribute selector in camelCase, and carry the prefix
+    // in their input aliases too - none of which look like the dashed `app-` form.
+    const triggerPath = '/projects/bar/src/app/popover/popover-trigger.component.ts';
+
+    it('should fall back to the app prefix when none is given', async () => {
+      // the default is the path almost every consumer takes, and a broken placeholder here
+      // still type-checks - only an assertion catches it
+      const options: AngularPrimitivesComponentSchema = {
+        primitive: 'popover',
+        path: 'projects/bar/src/app/popover',
+      };
+
+      const tree = await schematicRunner.runSchematic('primitive', options, appTree);
+      const content = tree.readContent(triggerPath);
+
+      expect(content).toContain("selector: '[appPopoverTrigger]'");
+      expect(content).toContain("'ngpPopoverTriggerDisabled:appPopoverTriggerDisabled'");
+      expect(content).toContain("alias: 'appPopoverTrigger'");
+    });
+
+    it('should apply the prefix to a camelCase selector and its aliases', async () => {
+      const options: AngularPrimitivesComponentSchema = {
+        primitive: 'popover',
+        path: 'projects/bar/src/app/popover',
+        prefix: 'foo',
+      };
+
+      const tree = await schematicRunner.runSchematic('primitive', options, appTree);
+      const content = tree.readContent(triggerPath);
+
+      expect(content).toContain("selector: '[fooPopoverTrigger]'");
+      expect(content).toContain("'ngpPopoverTriggerDisabled:fooPopoverTriggerDisabled'");
+      expect(content).toContain("alias: 'fooPopoverTrigger'");
+      // the ngp side of a host directive input is the library's own, and must not move
+      expect(content).not.toContain('foongp');
+    });
+
+    it('should camelize a multi word prefix', async () => {
+      const options: AngularPrimitivesComponentSchema = {
+        primitive: 'popover',
+        path: 'projects/bar/src/app/popover',
+        prefix: 'my-app',
+      };
+
+      const tree = await schematicRunner.runSchematic('primitive', options, appTree);
+      const content = tree.readContent(triggerPath);
+
+      expect(content).toContain("selector: '[myAppPopoverTrigger]'");
+      expect(content).toContain("'ngpPopoverTriggerDisabled:myAppPopoverTriggerDisabled'");
+      expect(content).toContain("alias: 'myAppPopoverTrigger'");
+    });
+
+    it('should drop the prefix entirely when it is empty, keeping the name camelCase', async () => {
+      const options: AngularPrimitivesComponentSchema = {
+        primitive: 'popover',
+        path: 'projects/bar/src/app/popover',
+        prefix: '',
+      };
+
+      const tree = await schematicRunner.runSchematic('primitive', options, appTree);
+      const content = tree.readContent(triggerPath);
+
+      // a leading capital (`[PopoverTrigger]`) would be a legal but bizarre selector
+      expect(content).toContain("selector: '[popoverTrigger]'");
+      expect(content).toContain("'ngpPopoverTriggerDisabled:popoverTriggerDisabled'");
+      expect(content).toContain("alias: 'popoverTrigger'");
+    });
+
+    it('should apply the prefix to the tooltip trigger too', async () => {
+      const options: AngularPrimitivesComponentSchema = {
+        primitive: 'tooltip',
+        path: 'projects/bar/src/app/tooltip',
+        prefix: 'foo',
+      };
+
+      const tree = await schematicRunner.runSchematic('primitive', options, appTree);
+      const content = tree.readContent(
+        '/projects/bar/src/app/tooltip/tooltip-trigger.component.ts',
+      );
+
+      expect(content).toContain("selector: '[fooTooltipTrigger]'");
+      expect(content).toContain("'ngpTooltipTriggerDisabled:fooTooltipTriggerDisabled'");
+      expect(content).toContain("alias: 'fooTooltipTrigger'");
+    });
+  });
+
   it('should create a primitive with the correct component suffix', async () => {
     const options: AngularPrimitivesComponentSchema = {
       primitive: 'button',

--- a/packages/ng-primitives/schematics/ng-generate/templates/accordion/accordion-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/accordion/accordion-item.__fileSuffix@dasherize__.ts.template
@@ -9,7 +9,7 @@ import {
 import { NgpButton } from 'ng-primitives/button';
 
 @Component({
-  selector: '<%= prefix %>-accordion-item',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>accordion-item',
   hostDirectives: [
     {
       directive: NgpAccordionItem,

--- a/packages/ng-primitives/schematics/ng-generate/templates/accordion/accordion.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/accordion/accordion.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpAccordion } from 'ng-primitives/accordion';
 
 @Component({
-  selector: '<%= prefix %>-accordion',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>accordion',
   hostDirectives: [
     {
       directive: NgpAccordion,

--- a/packages/ng-primitives/schematics/ng-generate/templates/avatar/avatar.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/avatar/avatar.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component, input } from '@angular/core';
 import { NgpAvatar, NgpAvatarFallback, NgpAvatarImage } from 'ng-primitives/avatar';
 
 @Component({
-  selector: '<%= prefix %>-avatar',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>avatar',
   hostDirectives: [NgpAvatar],
   imports: [NgpAvatarImage, NgpAvatarFallback],
   template: `

--- a/packages/ng-primitives/schematics/ng-generate/templates/button/button.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/button/button.__fileSuffix@dasherize__.ts.template
@@ -12,7 +12,7 @@ export type ButtonSize = 'sm' | 'md' | 'lg' | 'xl';
 export type ButtonVariant = 'primary' | 'secondary' | 'destructive' | 'outline' | 'ghost' | 'link';
 
 @Component({
-  selector: 'button[<%= prefix %>-button]',
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>button]',
   hostDirectives: [{ directive: NgpButton, inputs: ['disabled'] }],
   template: `
     <ng-content select="[slot=leading]" />

--- a/packages/ng-primitives/schematics/ng-generate/templates/checkbox/checkbox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/checkbox/checkbox.__fileSuffix@dasherize__.ts.template
@@ -7,7 +7,7 @@ import { injectCheckboxState, NgpCheckbox } from 'ng-primitives/checkbox';
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-checkbox',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>checkbox',
   hostDirectives: [
     {
       directive: NgpCheckbox,

--- a/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
@@ -14,7 +14,7 @@ import {
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-combobox',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>combobox',
   imports: [
     NgpCombobox,
     NgpComboboxDropdown,

--- a/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu-item.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpContextMenuItem } from 'ng-primitives/context-menu';
 
 @Component({
-  selector: 'button[<%= prefix %>-context-menu-item]',
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>context-menu-item]',
   hostDirectives: [NgpContextMenuItem],
   host: { type: 'button' },
   template: `

--- a/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/context-menu/context-menu.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpContextMenu } from 'ng-primitives/context-menu';
 
 @Component({
-  selector: '<%= prefix %>-context-menu',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>context-menu',
   hostDirectives: [NgpContextMenu],
   template: `
     <ng-content />

--- a/packages/ng-primitives/schematics/ng-generate/templates/date-picker/date-picker.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/date-picker/date-picker.__fileSuffix@dasherize__.ts.template
@@ -17,7 +17,7 @@ import {
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-date-picker',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>date-picker',
   hostDirectives: [
     {
       directive: NgpDatePicker,

--- a/packages/ng-primitives/schematics/ng-generate/templates/dialog/dialog.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/dialog/dialog.__fileSuffix@dasherize__.ts.template
@@ -8,7 +8,7 @@ import {
 } from 'ng-primitives/dialog';
 
 @Component({
-  selector: '<%= prefix %>-dialog',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>dialog',
   hostDirectives: [NgpDialogOverlay],
   imports: [NgpDialog, NgpDialogTitle, NgpDialogDescription],
   providers: [

--- a/packages/ng-primitives/schematics/ng-generate/templates/file-upload/file-upload.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/file-upload/file-upload.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpFileUpload } from 'ng-primitives/file-upload';
 
 @Component({
-  selector: '<%= prefix %>-file-upload',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>file-upload',
   hostDirectives: [
     {
       directive: NgpFileUpload,

--- a/packages/ng-primitives/schematics/ng-generate/templates/form-field/field.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/form-field/field.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpFormField } from 'ng-primitives/form-field';
 
 @Component({
-  selector: '<%= prefix %>-field',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>field',
   hostDirectives: [NgpFormField],
   template: `
     <ng-content />

--- a/packages/ng-primitives/schematics/ng-generate/templates/input-otp/input-otp.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/input-otp/input-otp.__fileSuffix@dasherize__.ts.template
@@ -14,7 +14,7 @@ import { NgpInputOtp, NgpInputOtpInput, NgpInputOtpSlot } from 'ng-primitives/in
 import { ChangeFn, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-input-otp',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>input-otp',
   imports: [NgpInputOtp, NgpInputOtpInput, NgpInputOtpSlot],
   providers: [
     {

--- a/packages/ng-primitives/schematics/ng-generate/templates/input/input.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/input/input.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpInput } from 'ng-primitives/input';
 
 @Component({
-  selector: 'input[<%= prefix %>-input]',
+  selector: 'input[<% if (prefix) { %><%= prefix %>-<% } %>input]',
   hostDirectives: [{ directive: NgpInput, inputs: ['disabled'] }],
   template: '',
   styles: `

--- a/packages/ng-primitives/schematics/ng-generate/templates/listbox/listbox-option.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/listbox/listbox-option.__fileSuffix@dasherize__.ts.template
@@ -4,7 +4,7 @@ import { heroCheckSolid } from '@ng-icons/heroicons/solid';
 import { NgpListboxOption } from 'ng-primitives/listbox';
 
 @Component({
-  selector: '<%= prefix %>-listbox-option',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>listbox-option',
   hostDirectives: [
     {
       directive: NgpListboxOption,

--- a/packages/ng-primitives/schematics/ng-generate/templates/listbox/listbox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/listbox/listbox.__fileSuffix@dasherize__.ts.template
@@ -8,7 +8,7 @@ import { injectListboxState, NgpListbox, provideListboxState } from 'ng-primitiv
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-listbox',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>listbox',
   providers: [
     provideIcons({ heroChevronDownSolid }),
     provideListboxState(),

--- a/packages/ng-primitives/schematics/ng-generate/templates/menu/menu-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/menu/menu-item.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpMenuItem } from 'ng-primitives/menu';
 
 @Component({
-  selector: 'button[<%= prefix %>-menu-item]',
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>menu-item]',
   hostDirectives: [NgpMenuItem],
   template: `
     <ng-content />

--- a/packages/ng-primitives/schematics/ng-generate/templates/menu/menu.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/menu/menu.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpMenu } from 'ng-primitives/menu';
 
 @Component({
-  selector: '<%= prefix %>-menu',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>menu',
   hostDirectives: [NgpMenu],
   template: `
     <ng-content />

--- a/packages/ng-primitives/schematics/ng-generate/templates/meter/meter.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/meter/meter.__fileSuffix@dasherize__.ts.template
@@ -9,7 +9,7 @@ import {
 } from 'ng-primitives/meter';
 
 @Component({
-  selector: '<%= prefix %>-meter',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>meter',
   hostDirectives: [
     { directive: NgpMeter, inputs: ['ngpMeterValue:value', 'ngpMeterMin:min', 'ngpMeterMax:max'] },
   ],

--- a/packages/ng-primitives/schematics/ng-generate/templates/native-select/native-select.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/native-select/native-select.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpNativeSelect } from 'ng-primitives/select';
 
 @Component({
-  selector: 'select[<%= prefix %>-select]',
+  selector: 'select[<% if (prefix) { %><%= prefix %>-<% } %>select]',
   hostDirectives: [{ directive: NgpNativeSelect, inputs: ['ngpNativeSelectDisabled:disabled'] }],
   template: `
     <ng-content />

--- a/packages/ng-primitives/schematics/ng-generate/templates/number-field/number-field.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/number-field/number-field.__fileSuffix@dasherize__.ts.template
@@ -7,7 +7,7 @@ import {
 } from 'ng-primitives/number-field';
 
 @Component({
-  selector: '<%= prefix %>-number-field',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>number-field',
   hostDirectives: [
     {
       directive: NgpNumberField,

--- a/packages/ng-primitives/schematics/ng-generate/templates/pagination/pagination.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/pagination/pagination.__fileSuffix@dasherize__.ts.template
@@ -19,7 +19,7 @@ import {
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-pagination',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>pagination',
   hostDirectives: [
     {
       directive: NgpPagination,

--- a/packages/ng-primitives/schematics/ng-generate/templates/password/password.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/password/password.__fileSuffix@dasherize__.ts.template
@@ -12,7 +12,7 @@ import {
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-password',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>password',
   hostDirectives: [NgpPassword],
   imports: [NgIcon, NgpPasswordInput, NgpPasswordToggle, NgpButton],
   providers: [provideValueAccessor(Password<%= componentSuffix %>), provideIcons({ lucideEye, lucideEyeOff })],

--- a/packages/ng-primitives/schematics/ng-generate/templates/popover/popover-trigger.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/popover/popover-trigger.__fileSuffix@dasherize__.ts.template
@@ -4,22 +4,22 @@ import { NgpPopoverTrigger } from 'ng-primitives/popover';
 import { Popover<%= componentSuffix %> } from './popover<% if (fileSuffix) { %>.<%= dasherize(fileSuffix) %><% } %>';
 
 @Directive({
-  selector: '[appPopoverTrigger]',
+  selector: '[<%= camelize(prefix + "PopoverTrigger") %>]',
   hostDirectives: [
     {
       directive: NgpPopoverTrigger,
       inputs: [
-        'ngpPopoverTriggerDisabled:appPopoverTriggerDisabled',
-        'ngpPopoverTriggerPlacement:appPopoverTriggerPlacement',
-        'ngpPopoverTriggerOffset:appPopoverTriggerOffset',
-        'ngpPopoverTriggerShowDelay:appPopoverTriggerShowDelay',
-        'ngpPopoverTriggerHideDelay:appPopoverTriggerHideDelay',
-        'ngpPopoverTriggerFlip:appPopoverTriggerFlip',
-        'ngpPopoverTriggerContainer:appPopoverTriggerContainer',
-        'ngpPopoverTriggerCloseOnOutsideClick:appPopoverTriggerCloseOnOutsideClick',
-        'ngpPopoverTriggerCloseOnEscape:appPopoverTriggerCloseOnEscape',
-        'ngpPopoverTriggerScrollBehavior:appPopoverTriggerScrollBehavior',
-        'ngpPopoverTriggerContext:appPopoverTrigger',
+        'ngpPopoverTriggerDisabled:<%= camelize(prefix + "PopoverTriggerDisabled") %>',
+        'ngpPopoverTriggerPlacement:<%= camelize(prefix + "PopoverTriggerPlacement") %>',
+        'ngpPopoverTriggerOffset:<%= camelize(prefix + "PopoverTriggerOffset") %>',
+        'ngpPopoverTriggerShowDelay:<%= camelize(prefix + "PopoverTriggerShowDelay") %>',
+        'ngpPopoverTriggerHideDelay:<%= camelize(prefix + "PopoverTriggerHideDelay") %>',
+        'ngpPopoverTriggerFlip:<%= camelize(prefix + "PopoverTriggerFlip") %>',
+        'ngpPopoverTriggerContainer:<%= camelize(prefix + "PopoverTriggerContainer") %>',
+        'ngpPopoverTriggerCloseOnOutsideClick:<%= camelize(prefix + "PopoverTriggerCloseOnOutsideClick") %>',
+        'ngpPopoverTriggerCloseOnEscape:<%= camelize(prefix + "PopoverTriggerCloseOnEscape") %>',
+        'ngpPopoverTriggerScrollBehavior:<%= camelize(prefix + "PopoverTriggerScrollBehavior") %>',
+        'ngpPopoverTriggerContext:<%= camelize(prefix + "PopoverTrigger") %>',
       ],
     },
   ],
@@ -30,7 +30,7 @@ export class PopoverTrigger {
 
   /** Define the content of the popover */
   readonly content = input.required<string>({
-    alias: 'appPopoverTrigger',
+    alias: '<%= camelize(prefix + "PopoverTrigger") %>',
   });
 
   constructor() {

--- a/packages/ng-primitives/schematics/ng-generate/templates/popover/popover.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/popover/popover.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { injectPopoverContext, NgpPopover } from 'ng-primitives/popover';
 
 @Component({
-  selector: '<%= prefix %>-popover',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>popover',
   hostDirectives: [NgpPopover],
   template: `
     {{ content() }}

--- a/packages/ng-primitives/schematics/ng-generate/templates/progress/progress.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/progress/progress.__fileSuffix@dasherize__.ts.template
@@ -9,7 +9,7 @@ import {
 } from 'ng-primitives/progress';
 
 @Component({
-  selector: '<%= prefix %>-progress',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>progress',
   hostDirectives: [
     {
       directive: NgpProgress,

--- a/packages/ng-primitives/schematics/ng-generate/templates/radio/radio-group.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/radio/radio-group.__fileSuffix@dasherize__.ts.template
@@ -9,7 +9,7 @@ import {
 } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-radio-group',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>radio-group',
   hostDirectives: [
     {
       directive: NgpRadioGroup,

--- a/packages/ng-primitives/schematics/ng-generate/templates/radio/radio-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/radio/radio-item.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpRadioItem } from 'ng-primitives/radio';
 
 @Component({
-  selector: '<%= prefix %>-radio-item',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>radio-item',
   hostDirectives: [
     {
       directive: NgpRadioItem,

--- a/packages/ng-primitives/schematics/ng-generate/templates/range-slider/range-slider.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/range-slider/range-slider.__fileSuffix@dasherize__.ts.template
@@ -13,7 +13,7 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 import { merge } from 'rxjs';
 
 @Component({
-  selector: '<%= prefix %>-range-slider',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>range-slider',
   hostDirectives: [
     {
       directive: NgpRangeSlider,

--- a/packages/ng-primitives/schematics/ng-generate/templates/rating/rating.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/rating/rating.__fileSuffix@dasherize__.ts.template
@@ -7,7 +7,7 @@ import { injectRatingState, NgpRating, NgpRatingItem } from 'ng-primitives/ratin
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-rating',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>rating',
   hostDirectives: [
     {
       directive: NgpRating,

--- a/packages/ng-primitives/schematics/ng-generate/templates/search/search.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/search/search.__fileSuffix@dasherize__.ts.template
@@ -8,7 +8,7 @@ import { NgpSearch, NgpSearchClear } from 'ng-primitives/search';
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-search',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>search',
   hostDirectives: [NgpSearch],
   imports: [NgIcon, NgpSearchClear, NgpInput, NgpButton],
   providers: [provideValueAccessor(Search<%= componentSuffix %>), provideIcons({ heroMagnifyingGlass })],

--- a/packages/ng-primitives/schematics/ng-generate/templates/select/select.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/select/select.__fileSuffix@dasherize__.ts.template
@@ -13,7 +13,7 @@ import {
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-select',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>select',
   hostDirectives: [
     {
       directive: NgpSelect,

--- a/packages/ng-primitives/schematics/ng-generate/templates/separator/separator.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/separator/separator.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpSeparator } from 'ng-primitives/separator';
 
 @Component({
-  selector: '[<%= prefix %>-separator]',
+  selector: '[<% if (prefix) { %><%= prefix %>-<% } %>separator]',
   hostDirectives: [{ directive: NgpSeparator, inputs: ['ngpSeparatorOrientation:orientation'] }],
   template: ``,
   styles: `

--- a/packages/ng-primitives/schematics/ng-generate/templates/slider/slider.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/slider/slider.__fileSuffix@dasherize__.ts.template
@@ -11,7 +11,7 @@ import {
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-slider',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>slider',
   hostDirectives: [
     {
       directive: NgpSlider,

--- a/packages/ng-primitives/schematics/ng-generate/templates/switch/switch.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/switch/switch.__fileSuffix@dasherize__.ts.template
@@ -5,7 +5,7 @@ import { injectSwitchState, NgpSwitch, NgpSwitchThumb } from 'ng-primitives/swit
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-switch',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>switch',
   hostDirectives: [
     {
       directive: NgpSwitch,

--- a/packages/ng-primitives/schematics/ng-generate/templates/tabs/tab.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/tabs/tab.__fileSuffix@dasherize__.ts.template
@@ -1,7 +1,7 @@
 import { Component, input, TemplateRef, viewChild } from '@angular/core';
 
 @Component({
-  selector: '<%= prefix %>-tab',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>tab',
   template: `
     <ng-template #content>
       <ng-content />

--- a/packages/ng-primitives/schematics/ng-generate/templates/tabs/tabs.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/tabs/tabs.__fileSuffix@dasherize__.ts.template
@@ -4,7 +4,7 @@ import { NgpTabButton, NgpTabList, NgpTabPanel, NgpTabset } from 'ng-primitives/
 import { Tab<%= componentSuffix %> } from './tab<% if (fileSuffix) { %>.<%= dasherize(fileSuffix) %><% } %>';
 
 @Component({
-  selector: '<%= prefix %>-tabs',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>tabs',
   imports: [NgpTabset, NgpTabButton, NgpTabList, NgpTabPanel, NgTemplateOutlet],
   template: `
     <div [(ngpTabsetValue)]="value" ngpTabset>

--- a/packages/ng-primitives/schematics/ng-generate/templates/textarea/textarea.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/textarea/textarea.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { NgpTextarea } from 'ng-primitives/textarea';
 
 @Component({
-  selector: 'textarea[<%= prefix %>-textarea]',
+  selector: 'textarea[<% if (prefix) { %><%= prefix %>-<% } %>textarea]',
   hostDirectives: [{ directive: NgpTextarea, inputs: ['disabled'] }],
   template: `
     <ng-content />

--- a/packages/ng-primitives/schematics/ng-generate/templates/toast/toast.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toast/toast.__fileSuffix@dasherize__.ts.template
@@ -3,7 +3,7 @@ import { NgpButton } from 'ng-primitives/button';
 import { injectToastContext, NgpToast, NgpToastManager } from 'ng-primitives/toast';
 
 @Component({
-  selector: '<%= prefix %>-toast',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>toast',
   imports: [NgpButton],
   hostDirectives: [NgpToast],
   host: {

--- a/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group-item.__fileSuffix@dasherize__.ts.template
@@ -3,7 +3,7 @@ import { NgpButton } from 'ng-primitives/button';
 import { NgpToggleGroupItem } from 'ng-primitives/toggle-group';
 
 @Component({
-  selector: 'button[<%= prefix %>-toggle-group-item]',
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>toggle-group-item]',
   hostDirectives: [
     {
       directive: NgpToggleGroupItem,

--- a/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toggle-group/toggle-group.__fileSuffix@dasherize__.ts.template
@@ -5,7 +5,7 @@ import { injectToggleGroupState, NgpToggleGroup } from 'ng-primitives/toggle-gro
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: '<%= prefix %>-toggle-group',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>toggle-group',
   hostDirectives: [
     {
       directive: NgpToggleGroup,

--- a/packages/ng-primitives/schematics/ng-generate/templates/toggle/toggle.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toggle/toggle.__fileSuffix@dasherize__.ts.template
@@ -6,7 +6,7 @@ import { injectToggleState, NgpToggle } from 'ng-primitives/toggle';
 import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
 
 @Component({
-  selector: 'button[<%= prefix %>-toggle]',
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>toggle]',
   hostDirectives: [
     {
       directive: NgpToggle,

--- a/packages/ng-primitives/schematics/ng-generate/templates/toolbar/toolbar-button.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toolbar/toolbar-button.__fileSuffix@dasherize__.ts.template
@@ -3,7 +3,7 @@ import { NgpButton } from 'ng-primitives/button';
 import { NgpRovingFocusItem } from 'ng-primitives/roving-focus';
 
 @Component({
-  selector: 'button[<%= prefix %>-toolbar-button]',
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>toolbar-button]',
   hostDirectives: [
     { directive: NgpButton, inputs: ['disabled'] },
     {

--- a/packages/ng-primitives/schematics/ng-generate/templates/toolbar/toolbar.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/toolbar/toolbar.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { injectToolbarState, NgpToolbar } from 'ng-primitives/toolbar';
 
 @Component({
-  selector: '<%= prefix %>-toolbar',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>toolbar',
   hostDirectives: [{ directive: NgpToolbar, inputs: ['ngpToolbarOrientation:orientation'] }],
   template: `
     <ng-content />

--- a/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip-trigger.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip-trigger.__fileSuffix@dasherize__.ts.template
@@ -3,21 +3,21 @@ import { injectTooltipTriggerState, NgpTooltipTrigger } from 'ng-primitives/tool
 import { Tooltip<%= componentSuffix %> } from './tooltip<% if (fileSuffix) { %>.<%= dasherize(fileSuffix) %><% } %>';
 
 @Directive({
-  selector: '[appTooltipTrigger]',
+  selector: '[<%= camelize(prefix + "TooltipTrigger") %>]',
   hostDirectives: [
     {
       directive: NgpTooltipTrigger,
       inputs: [
-        'ngpTooltipTriggerPlacement:appTooltipTriggerPlacement',
-        'ngpTooltipTriggerDisabled:appTooltipTriggerDisabled',
-        'ngpTooltipTriggerOffset:appTooltipTriggerOffset',
-        'ngpTooltipTriggerShowDelay:appTooltipTriggerShowDelay',
-        'ngpTooltipTriggerHideDelay:appTooltipTriggerHideDelay',
-        'ngpTooltipTriggerFlip:appTooltipTriggerFlip',
-        'ngpTooltipTriggerContainer:appTooltipTriggerContainer',
-        'ngpTooltipTriggerShowOnOverflow:appTooltipTriggerShowOnOverflow',
-        'ngpTooltipTriggerHoverableContent:appTooltipTriggerHoverableContent',
-        'ngpTooltipTriggerContext:appTooltipTrigger',
+        'ngpTooltipTriggerPlacement:<%= camelize(prefix + "TooltipTriggerPlacement") %>',
+        'ngpTooltipTriggerDisabled:<%= camelize(prefix + "TooltipTriggerDisabled") %>',
+        'ngpTooltipTriggerOffset:<%= camelize(prefix + "TooltipTriggerOffset") %>',
+        'ngpTooltipTriggerShowDelay:<%= camelize(prefix + "TooltipTriggerShowDelay") %>',
+        'ngpTooltipTriggerHideDelay:<%= camelize(prefix + "TooltipTriggerHideDelay") %>',
+        'ngpTooltipTriggerFlip:<%= camelize(prefix + "TooltipTriggerFlip") %>',
+        'ngpTooltipTriggerContainer:<%= camelize(prefix + "TooltipTriggerContainer") %>',
+        'ngpTooltipTriggerShowOnOverflow:<%= camelize(prefix + "TooltipTriggerShowOnOverflow") %>',
+        'ngpTooltipTriggerHoverableContent:<%= camelize(prefix + "TooltipTriggerHoverableContent") %>',
+        'ngpTooltipTriggerContext:<%= camelize(prefix + "TooltipTrigger") %>',
       ],
     },
   ],
@@ -28,7 +28,7 @@ export class TooltipTrigger {
 
   /** Define the content of the tooltip */
   readonly content = input.required<string>({
-    alias: 'appTooltipTrigger',
+    alias: '<%= camelize(prefix + "TooltipTrigger") %>',
   });
 
   constructor() {

--- a/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip.__fileSuffix@dasherize__.ts.template
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { injectTooltipContext, NgpTooltip } from 'ng-primitives/tooltip';
 
 @Component({
-  selector: '<%= prefix %>-tooltip',
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>tooltip',
   hostDirectives: [NgpTooltip],
   template: `
     {{ content() }}

--- a/packages/tools/project.json
+++ b/packages/tools/project.json
@@ -6,6 +6,14 @@
   "tags": [],
   "// targets": "to see all targets run: nx show project tools --web",
   "targets": {
+    "test": {
+      "executor": "@nx/vitest:test",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "configFile": "packages/tools/vitest.config.ts",
+        "passWithNoTests": true
+      }
+    },
     "llms": {
       "executor": "@ng-primitives/tools:llms",
       "options": {

--- a/packages/tools/src/generators/templates/templates.test.ts
+++ b/packages/tools/src/generators/templates/templates.test.ts
@@ -1,0 +1,112 @@
+import { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { templatesGenerator } from './templates';
+
+const SOURCES = 'apps/components/src/app/pages/reusable-components';
+const TEMPLATES = 'packages/ng-primitives/schematics/ng-generate/templates';
+
+describe('templates generator', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  /** Write a single file primitive to the source directory the generator reads. */
+  function writePrimitive(primitive: string, content: string): void {
+    tree.write(`${SOURCES}/${primitive}/${primitive}.ts`, content);
+  }
+
+  /** Read the template the generator produced for a single file primitive. */
+  function readTemplate(primitive: string): string {
+    return (
+      tree.read(
+        `${TEMPLATES}/${primitive}/${primitive}.__fileSuffix@dasherize__.ts.template`,
+        'utf-8',
+      ) ?? ''
+    );
+  }
+
+  it('should drop the separator with the prefix in a dashed selector', async () => {
+    writePrimitive(
+      'thing',
+      `import { Directive } from '@angular/core';
+
+@Directive({ selector: 'button[app-thing]' })
+export class Thing {}`,
+    );
+
+    await templatesGenerator(tree);
+
+    // the conditional is what keeps an empty prefix from leaving `[-thing]`
+    expect(readTemplate('thing')).toContain(
+      `selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>thing]'`,
+    );
+  });
+
+  it('should rewrite a camelCase selector, input alias and host directive inputs', async () => {
+    writePrimitive(
+      'thing',
+      `import { Directive, input } from '@angular/core';
+import { NgpThing } from 'ng-primitives/thing';
+
+@Directive({
+  selector: '[appThing]',
+  hostDirectives: [{ directive: NgpThing, inputs: ['ngpThingDisabled:appThingDisabled'] }],
+})
+export class Thing {
+  readonly content = input.required<string>({ alias: 'appThing' });
+}`,
+    );
+
+    await templatesGenerator(tree);
+
+    const template = readTemplate('thing');
+
+    expect(template).toContain(`selector: '[<%= camelize(prefix + "Thing") %>]'`);
+    expect(template).toContain(`'ngpThingDisabled:<%= camelize(prefix + "ThingDisabled") %>'`);
+    expect(template).toContain(`alias: '<%= camelize(prefix + "Thing") %>'`);
+  });
+
+  it('should rewrite model and output aliases and host directive outputs', async () => {
+    writePrimitive(
+      'thing',
+      `import { Directive, model, output } from '@angular/core';
+import { NgpThing } from 'ng-primitives/thing';
+
+@Directive({
+  selector: '[appThing]',
+  hostDirectives: [{ directive: NgpThing, outputs: ['ngpThingChange:appThingChange'] }],
+})
+export class Thing {
+  readonly value = model<string>('', { alias: 'appThingValue' });
+  readonly done = output<void>({ alias: 'appThingDone' });
+}`,
+    );
+
+    await templatesGenerator(tree);
+
+    const template = readTemplate('thing');
+
+    expect(template).toContain(`'ngpThingChange:<%= camelize(prefix + "ThingChange") %>'`);
+    expect(template).toContain(`alias: '<%= camelize(prefix + "ThingValue") %>'`);
+    expect(template).toContain(`alias: '<%= camelize(prefix + "ThingDone") %>'`);
+  });
+
+  it('should reject a prefix it does not know how to rewrite', async () => {
+    // `exportAs` is not one of the nodes the rewrite reaches, so the prefix would otherwise
+    // be baked into the template and quietly ignore --prefix
+    writePrimitive(
+      'thing',
+      `import { Directive } from '@angular/core';
+
+@Directive({ selector: '[appThing]', exportAs: 'appThing' })
+export class Thing {}`,
+    );
+
+    await expect(templatesGenerator(tree)).rejects.toThrow(
+      /thing\/thing\.ts: the "app" prefix survived in appThing/,
+    );
+  });
+});

--- a/packages/tools/src/generators/templates/templates.ts
+++ b/packages/tools/src/generators/templates/templates.ts
@@ -53,6 +53,8 @@ export async function templatesGenerator(tree: Tree) {
       // process the template
       const content = processTemplate(source, componentClasses);
 
+      assertPrefixReplaced(content, filePath);
+
       // write the new file to packages/ng-primitives/schematics/ng-generate/templates
       tree.write(
         `packages/ng-primitives/schematics/ng-generate/templates/${primitive}/${file.replace('.ts', '.__fileSuffix@dasherize__.ts')}.template`,
@@ -69,7 +71,8 @@ export default templatesGenerator;
 /**
  * Convert the template into Angular schematics format
  * This does the following:
- * - Replace the prefix in the component selector with the <%= prefix %> placeholder
+ * - Replace the prefix in the component selector, in the input/output aliases, and in the
+ *   host directive input/output mappings with the <%= prefix %> placeholder
  * - Append any component class names with the <%= componentSuffix %> placeholder
  * - Append the <%= fileSuffix %> placeholder to relative import paths, so a part still
  *   resolves its siblings once they are generated under the consumer's own suffixes
@@ -96,8 +99,32 @@ function processTemplate(content: string, componentClasses: ReadonlySet<string>)
     edits.push({
       start: selector.getStart(),
       end: selector.getEnd(),
-      text: selector.getText().replace('app-', '<%= prefix %>-'),
+      text: replacePrefix(selector.getText()),
     });
+  }
+
+  // The prefix is not confined to the selector: a trigger directive also carries it in its
+  // input aliases (`alias: 'appPopoverTrigger'`) and in the input/output mappings of its host
+  // directives (`'ngpPopoverTriggerDisabled:appPopoverTriggerDisabled'`). `model` takes the
+  // same `alias` option as `input`/`output`, so it is covered even though nothing uses it yet.
+  const aliases = query<ts.StringLiteral>(
+    content,
+    'CallExpression:has(Identifier[name=/^(input|output|model)$/]) ObjectLiteralExpression PropertyAssignment:has(Identifier[name="alias"]) > StringLiteral',
+  );
+
+  const hostDirectiveMappings = query<ts.StringLiteral>(
+    content,
+    'PropertyAssignment:has(Identifier[name="hostDirectives"]) PropertyAssignment:has(Identifier[name=/^(inputs|outputs)$/]) ArrayLiteralExpression > StringLiteral',
+  );
+
+  for (const literal of [...aliases, ...hostDirectiveMappings]) {
+    const text = literal.getText();
+    const replaced = replacePrefix(text);
+
+    // most parts alias nothing that carries the prefix - do not queue a no-op edit
+    if (replaced !== text) {
+      edits.push({ start: literal.getStart(), end: literal.getEnd(), text: replaced });
+    }
   }
 
   // point relative imports at the sibling file's generated name
@@ -151,6 +178,53 @@ function processTemplate(content: string, componentClasses: ReadonlySet<string>)
   }
 
   return applyEdits(content, edits);
+}
+
+/**
+ * Swap the `app` prefix the source components are written with for the `<%= prefix %>`
+ * placeholder, in both the forms it takes:
+ *
+ * - dashed - `app-popover`, `[app-separator]`, `button[app-button]`
+ * - camelCase - `[appPopoverTrigger]`, `alias: 'appPopoverTrigger'`
+ *
+ * The camelCase form runs the prefix and the rest of the name back through `camelize` so
+ * that a multi word prefix reads correctly (`my-app` gives `myAppPopoverTrigger`) and an
+ * empty prefix - which the schema explicitly permits - drops out cleanly as
+ * `popoverTrigger` rather than leaving the leading capital of `PopoverTrigger`.
+ *
+ * Both patterns are anchored on a word boundary, and the camelCase one requires an
+ * uppercase letter to follow, so ordinary words like `appearance` are left alone. Both
+ * replace globally: no selector here is a comma separated list today, but a
+ * `String.prototype.replace` with a string pattern would silently rewrite only the first
+ * entry of one.
+ */
+function replacePrefix(text: string): string {
+  return text
+    .replace(/\bapp-/g, '<%= prefix %>-')
+    .replace(/\bapp([A-Z]\w*)/g, '<%= camelize(prefix + "$1") %>');
+}
+
+/**
+ * Fail the build if any `app` prefix survived the rewrite.
+ *
+ * `replacePrefix` is only applied to the nodes the queries above reach - the selector, the
+ * `alias` of an `input`/`output`/`model`, and the input/output mappings of a host directive.
+ * Anything else that spells the prefix out (an `exportAs`, a decorator style `@Input('appX')`,
+ * an `<app-thing>` in an inline template, an `app-thing` selector in a `styles` block) would
+ * otherwise be baked into the template verbatim and quietly ignore `--prefix`, and the
+ * generated templates are build output that nothing else reviews. Better to stop here and
+ * teach `processTemplate` about the new shape.
+ */
+function assertPrefixReplaced(content: string, filePath: string): void {
+  const leftovers = content.match(/\bapp-[\w-]*|\bapp[A-Z]\w*/g);
+
+  if (leftovers) {
+    throw new Error(
+      `${filePath}: the "app" prefix survived in ${[...new Set(leftovers)].join(', ')}. ` +
+        'processTemplate only rewrites the selector, input/output/model aliases and host ' +
+        'directive input/output mappings - teach it about this location as well.',
+    );
+  }
 }
 
 /** The names of the classes in a file that Angular treats as components. */

--- a/packages/tools/src/generators/templates/templates.ts
+++ b/packages/tools/src/generators/templates/templates.ts
@@ -187,10 +187,13 @@ function processTemplate(content: string, componentClasses: ReadonlySet<string>)
  * - dashed - `app-popover`, `[app-separator]`, `button[app-button]`
  * - camelCase - `[appPopoverTrigger]`, `alias: 'appPopoverTrigger'`
  *
- * The camelCase form runs the prefix and the rest of the name back through `camelize` so
- * that a multi word prefix reads correctly (`my-app` gives `myAppPopoverTrigger`) and an
- * empty prefix - which the schema explicitly permits - drops out cleanly as
- * `popoverTrigger` rather than leaving the leading capital of `PopoverTrigger`.
+ * The schema explicitly permits an empty prefix, and both forms have to survive it. The
+ * dashed form drops the separator with it, so `app-popover` gives `popover` rather than a
+ * leading dash - `-popover` is not a name the schema's own `html-selector` format would
+ * accept. The camelCase form runs the prefix and the rest of the name back through
+ * `camelize`, which lowercases the leading character for the same reason (`popoverTrigger`,
+ * not `PopoverTrigger`) and as a bonus reads a multi word prefix correctly (`my-app` gives
+ * `myAppPopoverTrigger`).
  *
  * Both patterns are anchored on a word boundary, and the camelCase one requires an
  * uppercase letter to follow, so ordinary words like `appearance` are left alone. Both
@@ -200,7 +203,7 @@ function processTemplate(content: string, componentClasses: ReadonlySet<string>)
  */
 function replacePrefix(text: string): string {
   return text
-    .replace(/\bapp-/g, '<%= prefix %>-')
+    .replace(/\bapp-/g, '<% if (prefix) { %><%= prefix %>-<% } %>')
     .replace(/\bapp([A-Z]\w*)/g, '<%= camelize(prefix + "$1") %>');
 }
 

--- a/packages/tools/vitest.config.ts
+++ b/packages/tools/vitest.config.ts
@@ -1,0 +1,13 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/tools',
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    reporters: ['default'],
+  },
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Docs already state that `prefix` is "The prefix to apply to the generated component selector" on every primitive page. That is the behaviour this PR delivers, so there is nothing to update.

## PR Type

- [x] Bugfix

## Issue

Closes #

## What does this PR implement/fix?

`ng g ng-primitives:primitive --prefix foo` ignored the prefix for the trigger directives. `processTemplate` rewrote only the dashed `app-` form, and only in the component selector, so `popover` and `tooltip` still generated:

- `selector: '[appPopoverTrigger]'`
- `alias: 'appPopoverTrigger'`
- `'ngpPopoverTriggerDisabled:appPopoverTriggerDisabled'`

while the sibling component selector correctly became `foo-popover`.

The rewrite now covers both forms of the prefix — `app-` and `app` followed by an uppercase letter — and is applied to input/output/model aliases and to the input/output mappings of host directives as well as to the selector. The camelCase form goes through `camelize`, so a multi-word prefix reads correctly (`my-app` gives `myAppPopoverTrigger`).

Two related fixes fell out of it:

- **An empty prefix is no longer broken.** The schema permits `''`, but the placeholder always emitted its trailing dash, producing `selector: '-popover'` and `'button[-button]'` — names Angular rejects, and that the schema's own `html-selector` format would reject too. The separator is now emitted only when there is a prefix. This is why every dashed template is regenerated.
- **The generator fails loudly when it cannot rewrite a prefix.** The rewrite only reaches the nodes it queries for, so anything else that spells the prefix out (an `exportAs`, a decorator-style `@Input('appX')`, an `<app-thing>` in an inline template) would silently ignore `--prefix`. Since the templates are build output that nothing else reviews, `templatesGenerator` now throws instead.

`packages/tools` had no test target, no vitest config and no specs, so the generator was only ever exercised through the schematic tests that consume its output. Added one, plus specs driving the generator over a synthetic source tree — covering the guard and the `model`/`output` alias and host-directive `outputs` branches that no real source uses.

Templates under `schematics/ng-generate/templates` are regenerated with `nx run ng-primitives:build:templates`, not hand-edited.

`nx test tools` 4/4 · `nx test-node ng-primitives` 49/49 · `nx lint tools` and `nx lint ng-primitives` clean.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Generated output is byte-identical for the default prefix, so existing snapshots and any regeneration with no `--prefix` are unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PAuznsb3syT2TWg34tsXhP)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes schematics to honor `--prefix` in camelCase selectors and aliases (e.g. trigger directives), and handles empty prefixes without leaving stray dashes. Regenerates templates and adds tests so generated selectors and IO aliases always respect the chosen prefix.

- **Bug Fixes**
  - Apply the prefix to both dashed and camelCase forms in selectors, `input`/`output`/`model` aliases, and host directive `inputs`/`outputs`; camelizes multi-word prefixes (e.g. `my-app` → `myAppPopoverTrigger`).
  - Empty prefix drops the separator in dashed selectors (e.g. `button[button]`, `popover`), avoiding invalid names like `-popover`.
  - Generator now fails when an `app` prefix survives the rewrite (e.g. in `exportAs`), preventing silent ignore of `--prefix`.
  - Regenerated popover/tooltip trigger templates and all dashed selectors to use a conditional prefix; added vitest setup and tests for the templates generator and schematic cases using `@nx/vitest:test`.

<sup>Written for commit 55db2f8217e6ab57bc75789bd26ff90211f892a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated primitives now support optional, empty, and custom prefixes without malformed selectors.
  * Selector and input/output aliases are consistently generated for dashed and camelCase names, including tooltip and popover triggers.

* **Bug Fixes**
  * Prevented leftover default prefixes from appearing in generated templates.
  * Added validation to report incomplete prefix replacements.

* **Tests**
  * Added coverage for selector, alias, prefix, and error-handling scenarios.
  * Added a test target and Vitest configuration for tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->