### PR TITLE
fix(portal): keep the positioning strategy on overlay position updates

### DIFF
--- a/.claude/rules/comments.md
+++ b/.claude/rules/comments.md
@@ -1,0 +1,35 @@
+# Code Comments
+
+Write the code so it explains itself, and add a comment where extra context
+genuinely helps. Comments are for what the code cannot say.
+
+## Prefer clearer code to a comment
+
+A comment that compensates for an unclear name or shape is a missed refactor.
+Rename the thing, extract the expression, and drop the comment.
+
+```ts
+// ❌ restates the code
+// Return 'fixed' if the computed position is fixed, otherwise the configured strategy.
+return getComputedStyle(el).position === 'fixed' ? 'fixed' : this.config.strategy;
+```
+
+## Comment the why
+
+Constraints, trade-offs, browser quirks, and the reason a non-obvious shape is
+the right one - these are worth a line.
+
+```ts
+// ✅ context the code cannot carry
+// Resolved per pass so every caller agrees: `updatePosition()` used to take the
+// `absolute` default, which offsets a `fixed` panel by the page scroll.
+```
+
+## Keep it concise
+
+- A line or two. A JSDoc block longer than the member it documents is too long.
+- If it needs paragraphs, the audience is a reviewer - put it in the commit
+  message or PR description.
+- Leave measurements, benchmarks, changelog notes and investigation write-ups out
+  of source files. `git blame` and the PR cover them.
+- Delete stale comments rather than let them drift.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ contain.
 See `.claude/rules/` for detailed coding standards:
 
 - `angular-patterns.md` - Signal-based APIs, readonly signals, computed/effects
+- `comments.md` - Let the code explain itself; comment the why, concisely
 - `naming-conventions.md` - Selector prefixes, class names, file names
 - `state-management.md` - The `createPrimitive` state pattern: one `-state.ts` per part, host bindings inside the factory, thin directives, controlled state, state composition
 - `docs-example-styling.md` - Styling the documentation examples: brand red reserved for state, blue for focus, typography/radii scale, CSS + Tailwind parity

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -863,12 +863,6 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    * Internal method to setup positioning of the overlay
    */
   private setupPositioning(overlayElement: HTMLElement): void {
-    // Determine positioning strategy based on overlay element's CSS
-    const strategy =
-      getComputedStyle(overlayElement).position === 'fixed'
-        ? 'fixed'
-        : this.config.strategy || 'absolute';
-
     // Get the reference for auto-update - use trigger element for resize/scroll tracking
     // even when using programmatic position (the virtual element is created dynamically in computePosition)
     const referenceElement = this.config.anchorElement || this.config.triggerElement;
@@ -877,18 +871,30 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     this.disposePositioning = autoUpdate(
       referenceElement,
       overlayElement,
-      () => this.computePosition(overlayElement, strategy),
+      () => this.computePosition(overlayElement),
       { animationFrame: this.config.trackPosition ?? false },
     );
   }
 
   /**
+   * Determine the positioning strategy from the overlay element's computed CSS.
+   *
+   * Resolved per pass so every caller agrees: `updatePosition()` used to reach
+   * `computePosition()` without one and take the `absolute` default, which offsets a
+   * `fixed` panel by the page scroll.
+   */
+  private resolveStrategy(overlayElement: HTMLElement): Strategy {
+    return getComputedStyle(overlayElement).position === 'fixed'
+      ? 'fixed'
+      : this.config.strategy || 'absolute';
+  }
+
+  /**
    * Compute the overlay position using floating-ui
    */
-  private async computePosition(
-    overlayElement: HTMLElement,
-    strategy: Strategy = 'absolute',
-  ): Promise<void> {
+  private async computePosition(overlayElement: HTMLElement): Promise<void> {
+    const strategy = this.resolveStrategy(overlayElement);
+
     // Create middleware array
     // Order matters: offset → flip → shift → size → arrow (per Floating UI docs)
     const middleware: Middleware[] = [offset(this.config.offset ?? 0)];

--- a/packages/ng-primitives/portal/src/tests/overlay-positioning.test.ts
+++ b/packages/ng-primitives/portal/src/tests/overlay-positioning.test.ts
@@ -1,0 +1,95 @@
+import { Component, signal } from '@angular/core';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpPopover, NgpPopoverPlacement, NgpPopoverTrigger } from 'ng-primitives/popover';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const OFFSET = 8;
+
+@Component({
+  template: `
+    <div class="spacer"></div>
+    <button
+      [ngpPopoverTrigger]="content"
+      [ngpPopoverTriggerPlacement]="placement()"
+      [ngpPopoverTriggerOffset]="offset"
+    >
+      Open Popover
+    </button>
+    <div class="spacer"></div>
+
+    <ng-template #content>
+      <div ngpPopover>Popover content</div>
+    </ng-template>
+  `,
+  // The strategy comes from the panel's computed `position`; the docs examples use `fixed`.
+  styles: `
+    /* Enough page to scroll while keeping the trigger and panel inside the viewport. */
+    .spacer {
+      height: 600px;
+    }
+
+    [ngpPopover] {
+      position: fixed;
+      width: 120px;
+      height: 60px;
+    }
+  `,
+  imports: [NgpPopoverTrigger, NgpPopover],
+})
+class FixedPopoverTestComponent {
+  readonly placement = signal<NgpPopoverPlacement>('bottom');
+  readonly offset = OFFSET;
+}
+
+describe('overlay positioning', () => {
+  afterEach(() => {
+    document.querySelectorAll('[ngpPopover]').forEach(el => el.remove());
+    window.scrollTo(0, 0);
+  });
+
+  describe('positioning strategy', () => {
+    /** A `fixed` panel sits against the viewport, so `absolute` displaces it by the scroll. */
+    async function expectAnchoredBelowTrigger(trigger: HTMLElement) {
+      await waitFor(() => {
+        const popover = document.querySelector('[ngpPopover]') as HTMLElement | null;
+        expect(popover?.style.top).toBeTruthy();
+        expect(popover!.getBoundingClientRect().top).toBeCloseTo(
+          trigger.getBoundingClientRect().bottom + OFFSET,
+          0,
+        );
+      });
+    }
+
+    it('should anchor a fixed overlay to its trigger on a scrolled page', async () => {
+      const { getByRole } = await render(FixedPopoverTestComponent);
+      window.scrollTo(0, 400);
+      expect(window.scrollY).toBeGreaterThan(0);
+
+      const trigger = getByRole('button');
+      fireEvent.click(trigger);
+
+      await expectAnchoredBelowTrigger(trigger);
+    });
+
+    it('should stay anchored when the position is updated', async () => {
+      const { fixture, getByRole } = await render(FixedPopoverTestComponent);
+      window.scrollTo(0, 400);
+
+      const trigger = getByRole('button');
+      fireEvent.click(trigger);
+      await expectAnchoredBelowTrigger(trigger);
+
+      // A placement change routes through `updatePosition()`, which lost the strategy.
+      fixture.componentInstance.placement.set('top');
+      fixture.detectChanges();
+
+      await waitFor(() => {
+        const popover = document.querySelector('[ngpPopover]') as HTMLElement;
+        expect(popover.getBoundingClientRect().bottom).toBeCloseTo(
+          trigger.getBoundingClientRect().top - OFFSET,
+          0,
+        );
+      });
+    });
+  });
+});

--- a/packages/ng-primitives/src/test-setup.vitest.ts
+++ b/packages/ng-primitives/src/test-setup.vitest.ts
@@ -8,6 +8,9 @@ import { installVitestDomPolyfills } from './test-dom-polyfills';
 
 setupTestBed({
   browserMode: true,
+  // `browserMode` alone sets `destroyAfterEach: false`, which keeps every test file's
+  // injector - and the CDK singletons it created - alive in the shared browser page.
+  teardown: { destroyAfterEach: true },
 });
 
 // In zoneless mode, plain TS property mutations don't mark views dirty, so


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — no public API change

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [x] Other... Please describe: a test-setup fix for a suite-wide slowdown

## Issue

Refs #758 — found while investigating that issue. It does not close it.

## What does this PR implement/fix?

Three independent changes, one commit each. No public API changes.

### 1. `updatePosition()` computed with the wrong strategy

`updatePosition()` called `computePosition()` without a strategy, so it took the `absolute` parameter default regardless of how the panel is actually positioned. This was not conditional on anything — every call took the default, every time.

Affected paths, all live:

| path | trigger |
| --- | --- |
| `overlay.ts:347` | `explicitEffect([config.placement], …)` — any placement change |
| `overlay.ts:353` | `explicitEffect([config.position], …)` — any programmatic position change |
| `context-menu-trigger-state.ts:199` | every context-menu reposition (right-click at a new point) |
| `dialog-ref.ts:92` | the public `NgpDialogRef.updatePosition()` API |

A `position: fixed` panel — how the menu and popover examples style it, and what the auto-detection in `setupPositioning()` had already picked — computed as `absolute` gets the page scroll offset added to the reference rect, and loses floating-ui's WebKit visual-viewport compensation, which only applies to the `fixed` strategy. The panel is left adrift from its trigger by however far the page is scrolled.

The strategy is now resolved from the panel's computed `position` on each positioning pass, so every entry point sees the same value rather than only the one that happened to be given it at setup.

Written test-first and verified to fail for the right reason — without the fix the panel lands 325px out, exactly the page scroll:

```
AssertionError: expected 592 to be close to 267
```

Resolving per pass rather than caching is deliberate but cheap: a `getComputedStyle().position` read measures 0.75µs warm, and 11.7µs in the worst case where layout was just dirtied — against a pass that already measures both element rects and does its own `getComputedStyle` calls internally.

### 2. Browser tests never destroyed their components

`setupTestBed({ browserMode: true })` sets `destroyAfterEach: false`, so no fixture is ever destroyed. Vitest browser mode reuses a single iframe for the whole run, so every test file's injector stays alive — and with it the CDK `FocusMonitor` and `ViewportRuler` singletons it created.

Those listeners accumulate on `document` and run on every subsequent interaction. Dispatching 300 mousedown/keydown pairs costs **1.3ms in a fresh page and 1096ms once 29 overlay test files have run**, which is why only `userEvent`-driven tests degrade while `fireEvent` ones stay flat:

| combobox test | alone | after 29 overlay files |
| --- | --- | --- |
| renders the input (no `userEvent`) | 37ms | 37ms |
| opens the dropdown | 42ms | 488ms |
| selects an option on click | 40ms | 1360ms |
| renders the placeholder (no `userEvent`) | 9ms | 9ms |

This is what had been failing CI on this branch as `combobox > selects an option on click and closes the dropdown` timing out at 15s. It was deterministic, not flaky — that test is simply the one that crosses the limit first, and it reproduced on commits touching nothing near combobox.

`browserMode` is deprecated in Analog (`@sunset 3.0.0`) and setting `destroyAfterEach: false` is its only effect, so `teardown: { destroyAfterEach: true }` is the supported way to opt back in rather than a workaround.

Result: that test runs in ~50ms in the full parallel suite, the suite drops from 72.6s to 31.2s, and CI on this branch is green.

### 3. A comment style rule

Comment style was the one convention not written down in `.claude/rules/`, and it drifted — verbose JSDoc blocks, benchmarks and history recorded in source files. Adds `.claude/rules/comments.md`: let the code explain itself, comment the why, keep it to a line or two.

## Verification

- Browser suite: 2369 tests / 155 files passing
- `nx lint ng-primitives`: 0 errors · `nx build ng-primitives` clean

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The positioning change is internal to the portal; overlays already computing with the correct strategy are unaffected. The test-setup and rules changes ship in no package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay positioning when using fixed CSS positioning, including after page scrolling and placement changes.
  * Ensured overlays recalculate their positioning strategy during updates for more accurate placement.

* **Tests**
  * Added coverage for fixed overlays and dynamic placement changes.
  * Improved test isolation by enabling automatic cleanup after each test.

* **Documentation**
  * Added guidance for writing concise, useful code comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->