### PR TITLE
fix(date-picker): bound disabled-date search to min/max in setFocusedDate

### DIFF
--- a/packages/ng-primitives/date-picker/src/date-picker/date-picker-state.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker/date-picker-state.ts
@@ -255,15 +255,25 @@ export const [
       if (dateDisabled()(date)) {
         let nextDate = dateAdapter.add(date, { days: direction === 'forward' ? 1 : -1 });
 
+        // advance in the travel direction over disabled dates, but stop at the bounds
+        // so we never overshoot min/max (which would loop forever).
         while (
-          dateDisabled()(nextDate) ||
-          (minValue && dateAdapter.isBefore(nextDate, minValue)) ||
-          (maxValue && dateAdapter.isAfter(nextDate, maxValue))
+          dateDisabled()(nextDate) &&
+          (!minValue || !dateAdapter.isBefore(nextDate, minValue)) &&
+          (!maxValue || !dateAdapter.isAfter(nextDate, maxValue))
         ) {
           nextDate = dateAdapter.add(nextDate, { days: direction === 'forward' ? 1 : -1 });
         }
 
-        date = nextDate;
+        // only move focus if we landed on an enabled, in-bounds date; otherwise keep
+        // the clamped date rather than focusing something out of range.
+        const outOfBounds =
+          (!!minValue && dateAdapter.isBefore(nextDate, minValue)) ||
+          (!!maxValue && dateAdapter.isAfter(nextDate, maxValue));
+
+        if (!dateDisabled()(nextDate) && !outOfBounds) {
+          date = nextDate;
+        }
       }
 
       setFocused(date);

--- a/packages/ng-primitives/date-picker/src/date-picker/tests/date-picker-primitive.test.ts
+++ b/packages/ng-primitives/date-picker/src/date-picker/tests/date-picker-primitive.test.ts
@@ -445,6 +445,32 @@ describe('NgpDatePicker', () => {
       dayButton(12)!.click();
       expect(dateChange).not.toHaveBeenCalled();
     });
+
+    it('should stop searching at max instead of looping forever when every remaining day is disabled', async () => {
+      const { tabbable, fixture } = await setup({
+        focusedDate: new Date(2025, 7, 18),
+        max: new Date(2025, 7, 20),
+        dateDisabled: (date: Date) => date.getDate() >= 19,
+      });
+      tabbable()!.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+      await fixture.whenStable();
+      // every day from 19 through max (20) is disabled, so the search must give up at the
+      // bound rather than overshoot it forever; focus stays clamped, not out of range.
+      expect(tabbable()?.textContent?.trim()).toBe('19');
+    });
+
+    it('should stop searching at min instead of looping forever when every remaining day is disabled', async () => {
+      const { tabbable, fixture } = await setup({
+        focusedDate: new Date(2025, 7, 15),
+        min: new Date(2025, 7, 12),
+        dateDisabled: (date: Date) => date.getDate() <= 14,
+      });
+      tabbable()!.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+      await fixture.whenStable();
+      // every day from 14 down through min (12) is disabled, so the search must give up at the
+      // bound rather than undershoot it forever; focus stays clamped, not out of range.
+      expect(tabbable()?.textContent?.trim()).toBe('14');
+    });
   });
 
   describe('preserve time on select', () => {

--- a/packages/ng-primitives/date-picker/src/date-range-picker/date-range-picker-state.ts
+++ b/packages/ng-primitives/date-picker/src/date-range-picker/date-range-picker-state.ts
@@ -206,15 +206,25 @@ export const [
       if (dateDisabled()(date)) {
         let nextDate = dateAdapter.add(date, { days: direction === 'forward' ? 1 : -1 });
 
+        // advance in the travel direction over disabled dates, but stop at the bounds
+        // so we never overshoot min/max (which would loop forever).
         while (
-          dateDisabled()(nextDate) ||
-          (minValue && dateAdapter.isBefore(nextDate, minValue)) ||
-          (maxValue && dateAdapter.isAfter(nextDate, maxValue))
+          dateDisabled()(nextDate) &&
+          (!minValue || !dateAdapter.isBefore(nextDate, minValue)) &&
+          (!maxValue || !dateAdapter.isAfter(nextDate, maxValue))
         ) {
           nextDate = dateAdapter.add(nextDate, { days: direction === 'forward' ? 1 : -1 });
         }
 
-        date = nextDate;
+        // only move focus if we landed on an enabled, in-bounds date; otherwise keep
+        // the clamped date rather than focusing something out of range.
+        const outOfBounds =
+          (!!minValue && dateAdapter.isBefore(nextDate, minValue)) ||
+          (!!maxValue && dateAdapter.isAfter(nextDate, maxValue));
+
+        if (!dateDisabled()(nextDate) && !outOfBounds) {
+          date = nextDate;
+        }
       }
 
       setFocused(date);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

`setFocusedDate` in `date-picker-state.ts` and `date-range-picker-state.ts` skips disabled dates
while moving focus in a given direction, but the search loop never checked `min`/`max`. If every
remaining date between the current focus and the bound is disabled, `nextDate` overshoots the
bound, `isAfter(nextDate, max)` (or `isBefore(nextDate, min)`) stays permanently true, and the loop
spins forever.

This fixes both files so the search stops as soon as it crosses `min`/`max`, and only moves focus
onto a date that is both enabled and in range - otherwise the clamped date is kept instead of
focusing something out of bounds.

This is a pre-existing bug (present before #849's state-management migration, which intentionally
left it untouched to keep that diff a pure structural migration) - not something introduced by
this change.

## Does this PR introduce a breaking change?

- [x] No
- [ ] Yes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the disabled-date navigation in `setFocusedDate` to `min`/`max` to prevent infinite loops when all remaining dates are disabled. Applies to both single and range pickers so focus stays within range.

- **Bug Fixes**
  - Stop searching past `min`/`max` when skipping disabled days in `setFocusedDate`.
  - Only move focus to enabled, in-range dates; otherwise keep the clamped date.
  - Added tests for both min and max scenarios to prevent regressions.

<sup>Written for commit 2a55ef7b93e212745d0d27cb7f79d66467997ac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date-picker keyboard navigation near minimum and maximum boundaries when intervening dates are disabled.
  * Prevented focus from moving outside the configured date range or becoming stuck while searching for an enabled date.
  * Applied the same boundary handling to date-range pickers, keeping focus on the nearest valid date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->