### PR TITLE
fix(ai): only submit prompt on unmodified Enter

### DIFF
--- a/packages/ng-primitives/ai/src/prompt-composer-input/prompt-composer-input-state.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-input/prompt-composer-input-state.ts
@@ -32,7 +32,7 @@ export const [
    * This primitive automatically handles that behavior.
    */
   listener(element, 'keydown', (event: KeyboardEvent) => {
-    if (event.key !== 'Enter' || event.shiftKey) {
+    if (event.key !== 'Enter' || event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
       return;
     }
 

--- a/packages/ng-primitives/ai/src/prompt-composer-input/tests/prompt-composer-input-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-input/tests/prompt-composer-input-primitive.test.ts
@@ -128,6 +128,31 @@ describe('NgpPromptComposerInput', () => {
     expect(textarea).toHaveValue('First line\nSecond line');
   });
 
+  it('should not submit on Ctrl+Enter or Meta+Enter', async () => {
+    const submitSpy = vi.fn();
+
+    await render(
+      `<div ngpThread>
+        <div ngpPromptComposer (ngpPromptComposerSubmit)="onSubmit($event)">
+          <input ngpPromptComposerInput />
+        </div>
+      </div>`,
+      {
+        imports: [NgpThread, NgpPromptComposer, NgpPromptComposerInput],
+        componentProperties: { onSubmit: submitSpy },
+      },
+    );
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+
+    await userEvent.type(input, 'Test message');
+    await userEvent.keyboard('{Control>}{Enter}{/Control}');
+    await userEvent.keyboard('{Meta>}{Enter}{/Meta}');
+
+    expect(submitSpy).not.toHaveBeenCalled();
+    expect(input.value).toBe('Test message');
+  });
+
   it('should not submit when input is empty', async () => {
     const submitSpy = vi.fn();
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

No issue — follow-up to #846, which migrated `NgpPromptComposerInput` from `@HostListener` to the `createPrimitive` state pattern.

## What does this PR implement/fix?

`NgpPromptComposerInput`'s Enter-to-submit handling used to be `@HostListener('keydown.enter')`, which Angular only fires for **unmodified** Enter — a key event with `Ctrl`, `Alt`, or `Meta` held goes down a different key path and never matches. The #846 migration rewrote it as a raw `keydown` listener that checks `event.key !== 'Enter' || event.shiftKey`, which drops that implicit guard: `Ctrl+Enter`, `Alt+Enter`, and `Cmd/Meta+Enter` now also submit the prompt and call `preventDefault()`, swallowing browser/OS shortcuts bound to those combinations that previously reached them untouched.

This restores the original behaviour by excluding `ctrlKey` / `altKey` / `metaKey` alongside the existing `shiftKey` check, so only a bare Enter submits.

A test (`should not submit on Ctrl+Enter or Meta+Enter`) covers the regression.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

No public API changes. This restores the pre-#846 behaviour rather than changing it; any app that came to rely on the unintended `Ctrl+Enter`/`Cmd+Enter` submit introduced by #846 (which shipped less than a week ago and was never documented) will see those combinations stop submitting again.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore original behavior in `NgpPromptComposerInput`: submit only on bare Enter; modifier combos (Ctrl/Alt/Meta) no longer submit. This fixes a regression from the raw keydown migration and preserves browser/OS shortcuts.

- **Bug Fixes**
  - Guard Enter handler to ignore events with `ctrlKey`, `altKey`, or `metaKey` (in addition to `shiftKey`).
  - Added test to ensure Ctrl+Enter and Meta+Enter do not submit or clear the input.

<sup>Written for commit aea622a0a2f75cae1bc8e4a66157633e14e1d617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated prompt composer keyboard handling so Enter with Ctrl, Alt, Meta, or Shift no longer submits the prompt.
  * Preserves the entered text when these key combinations are used.

* **Tests**
  * Added coverage to verify that Ctrl+Enter and Meta+Enter do not trigger submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->