### PR TITLE
fix(portal): block scroll against the layout viewport, and position overlays before first paint

### DIFF
--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -291,6 +291,9 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   /** Function to dispose the positioning auto-update */
   private disposePositioning?: () => void;
 
+  /** Whether the panel is hidden waiting on its first computed position */
+  private hiddenUntilPositioned = false;
+
   /** Timeout handle for showing the overlay */
   private openTimeout?: () => void;
 
@@ -913,8 +916,50 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       throw new Error('Overlay element is not available.');
     }
 
+    // Keep the panel out of sight until its first position lands
+    this.hideUntilPositioned(outletElement);
+
     // Set up positioning
     this.setupPositioning(outletElement);
+  }
+
+  /**
+   * Hide a freshly attached panel until its first position lands.
+   *
+   * The parts bind `left`/`top` with `styleBinding`, which runs in `afterRenderEffect` and
+   * so is not flushed by the portal's synchronous `detectChanges()`. Without this the panel
+   * spends its first painted frame at its *static* position - the end of the container's
+   * flow - which both shows it in the wrong place and, being in flow, grows the document's
+   * scrollable area by the panel's height. On iOS Safari that height change moves the
+   * dynamic viewport, so the whole page jumps and returns rather than just the panel.
+   */
+  private hideUntilPositioned(overlayElement: HTMLElement): void {
+    overlayElement.style.opacity = '0';
+    // An explicit origin, so the hidden panel is not laid out past the end of the container.
+    overlayElement.style.left = '0px';
+    overlayElement.style.top = '0px';
+    this.hiddenUntilPositioned = true;
+  }
+
+  /**
+   * Reveal the panel now that `position` describes it.
+   *
+   * The coordinates are written straight to the element rather than left to the parts'
+   * `styleBinding`s, which would not land until the next application tick - a frame after
+   * the panel became visible. `opacity` rather than `visibility` so the panel stays in the
+   * accessibility tree and hit-testable throughout; it resolves within the attaching task's
+   * microtasks, before the frame in which `setupExitAnimation` applies `data-enter`, so the
+   * first paint already carries the enter state.
+   */
+  private revealAtPosition(overlayElement: HTMLElement, x: number, y: number): void {
+    if (!this.hiddenUntilPositioned) {
+      return;
+    }
+
+    this.hiddenUntilPositioned = false;
+    overlayElement.style.left = `${x}px`;
+    overlayElement.style.top = `${y}px`;
+    overlayElement.style.removeProperty('opacity');
   }
 
   /**
@@ -1025,6 +1070,8 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
 
     // Update position signal
     this.position.set({ x: position.x, y: position.y });
+
+    this.revealAtPosition(overlayElement, position.x, position.y);
 
     // Update final placement signal
     this.finalPlacement.set(position.placement);

--- a/packages/ng-primitives/portal/src/scroll-strategy.ts
+++ b/packages/ng-primitives/portal/src/scroll-strategy.ts
@@ -73,7 +73,7 @@ export class BlockScrollStrategy implements ScrollStrategy {
     if (this.canBeEnabled()) {
       const root = this.document.documentElement!;
 
-      this.previousScrollPosition = this.viewportRuler.getViewportScrollPosition();
+      this.previousScrollPosition = this.getLayoutViewportScrollPosition();
 
       // Cache the previous inline styles in case the user had set them.
       this.previousHTMLStyles.left = root.style.left || '';
@@ -139,6 +139,26 @@ export class BlockScrollStrategy implements ScrollStrategy {
         bodyStyle.scrollBehavior = previousBodyScrollBehavior;
       }
     }
+  }
+
+  /**
+   * The scroll offset of the *layout* viewport, which is what a `position: fixed` `<html>`
+   * is offset against.
+   *
+   * Read from the document element's own rect rather than `ViewportRuler`, whose `||`
+   * fallthrough reaches `window.scrollX`/`scrollY` when an axis reports a zero document
+   * offset - and WebKit measures those against the *visual* viewport, so a pinch-zoomed,
+   * panned page reports the pan amount rather than 0. Compensating by that shifts the whole
+   * page the moment an overlay opens. `getBoundingClientRect()` is layout-viewport-relative
+   * in every browser, and unlike `visualViewport` it is a synchronous layout read rather
+   * than a value iOS Safari updates behind its URL bar and rubber-band overscroll.
+   * @see https://github.com/ng-primitives/ng-primitives/issues/758
+   */
+  private getLayoutViewportScrollPosition(): { top: number; left: number } {
+    const documentRect = this.document.documentElement!.getBoundingClientRect();
+
+    // `|| 0` normalises the `-0` an unscrolled axis would otherwise negate into.
+    return { top: -documentRect.top || 0, left: -documentRect.left || 0 };
   }
 
   private canBeEnabled(): boolean {

--- a/packages/ng-primitives/portal/src/tests/overlay-first-paint.test.ts
+++ b/packages/ng-primitives/portal/src/tests/overlay-first-paint.test.ts
@@ -1,0 +1,123 @@
+import { Component } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { NgpMenu, NgpMenuTrigger } from 'ng-primitives/menu';
+
+interface FirstPaint {
+  /** The document's scrollable height at the moment the panel entered the DOM. */
+  scrollHeightAtInsertion: number;
+  /** Whether the panel was still transparent when it entered the DOM. */
+  hiddenAtInsertion: boolean;
+  /** The panel's inline styles on the first frame the browser could paint it. */
+  opacity: string;
+  left: string;
+  top: string;
+}
+
+/** Component styles do not reach a portalled panel, so the panel is styled globally. */
+const panelStyles = `
+  [ngpMenu] {
+    position: absolute;
+    width: 200px;
+  }
+  [ngpMenu] > div {
+    height: 30px;
+  }
+`;
+
+@Component({
+  imports: [NgpMenu, NgpMenuTrigger],
+  template: `
+    <div class="spacer"></div>
+    <button [ngpMenuTrigger]="menu" ngpMenuTriggerScrollBehavior="reposition" data-testid="trigger">
+      Open
+    </button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="panel">
+        @for (item of items; track item) {
+          <div>{{ item }}</div>
+        }
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    .spacer {
+      height: 1500px;
+    }
+  `,
+})
+class Host {
+  readonly items = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+}
+
+/**
+ * The panel's `left`/`top` are bound with `styleBinding`, which runs in `afterRenderEffect`
+ * and is not flushed by the portal's synchronous `detectChanges()`. Before the overlay hid
+ * the panel until positioned, that left it painted at its static position - the end of the
+ * container's flow - for a frame, growing the document's scrollable area by its height.
+ */
+describe('overlay first paint', () => {
+  let styleElement: HTMLStyleElement;
+
+  beforeEach(() => {
+    styleElement = document.createElement('style');
+    styleElement.textContent = panelStyles;
+    document.head.appendChild(styleElement);
+  });
+
+  afterEach(() => styleElement.remove());
+
+  /** Open the menu and capture the panel's state on the first frame it could be painted. */
+  function openAndCaptureFirstPaint(trigger: HTMLElement): Promise<FirstPaint> {
+    return new Promise<FirstPaint>(resolve => {
+      const observer = new MutationObserver(records => {
+        for (const record of records) {
+          for (const node of Array.from(record.addedNodes)) {
+            if (!(node instanceof HTMLElement) || !node.matches('[data-testid="panel"]')) {
+              continue;
+            }
+
+            observer.disconnect();
+            const scrollHeightAtInsertion = document.documentElement.scrollHeight;
+            const hiddenAtInsertion = getComputedStyle(node).opacity === '0';
+
+            requestAnimationFrame(() =>
+              resolve({
+                scrollHeightAtInsertion,
+                hiddenAtInsertion,
+                opacity: node.style.opacity,
+                left: node.style.left,
+                top: node.style.top,
+              }),
+            );
+          }
+        }
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+      trigger.click();
+    });
+  }
+
+  it('should not grow the document while the panel waits to be positioned', async () => {
+    const { getByTestId } = await render(Host);
+    const scrollHeightBeforeOpen = document.documentElement.scrollHeight;
+
+    const firstPaint = await openAndCaptureFirstPaint(getByTestId('trigger'));
+
+    expect(firstPaint.scrollHeightAtInsertion).toBe(scrollHeightBeforeOpen);
+  });
+
+  it('should not show the panel until it has been positioned', async () => {
+    const { getByTestId } = await render(Host);
+
+    const firstPaint = await openAndCaptureFirstPaint(getByTestId('trigger'));
+
+    expect(firstPaint.hiddenAtInsertion).toBe(true);
+    // Revealed within the attaching task's microtasks, so the first frame is already correct.
+    expect(firstPaint.opacity).toBe('');
+    expect(firstPaint.left).not.toBe('');
+    expect(firstPaint.top).not.toBe('');
+    expect(firstPaint.top).not.toBe('0px');
+  });
+});

--- a/packages/ng-primitives/portal/src/tests/scroll-strategy.test.ts
+++ b/packages/ng-primitives/portal/src/tests/scroll-strategy.test.ts
@@ -1,4 +1,5 @@
-import { CloseScrollStrategy } from 'ng-primitives/portal';
+import { ViewportRuler } from '@angular/cdk/scrolling';
+import { BlockScrollStrategy, CloseScrollStrategy } from 'ng-primitives/portal';
 import { describe, expect, it, vi } from 'vitest';
 
 describe('CloseScrollStrategy', () => {
@@ -100,5 +101,113 @@ describe('CloseScrollStrategy', () => {
 
     scrollableContainer.dispatchEvent(new Event('scroll'));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('BlockScrollStrategy', () => {
+  let root: HTMLElement;
+  let body: HTMLElement;
+  let strategy: BlockScrollStrategy | undefined;
+  let scroll: ReturnType<typeof vi.spyOn>;
+
+  /**
+   * Build a strategy against stand-in `html`/`body` elements so a test can vary the
+   * scroll position without scrolling or restyling the real page.
+   *
+   * `documentRect` is the document element's viewport-relative rect - a page scrolled
+   * down 900px puts its top edge at -900.
+   */
+  function createStrategy(
+    rulerScrollPosition: { top: number; left: number },
+    documentRect: { top: number; left: number } = {
+      top: -rulerScrollPosition.top,
+      left: -rulerScrollPosition.left,
+    },
+  ): BlockScrollStrategy {
+    const viewportRuler = {
+      getViewportScrollPosition: () => rulerScrollPosition,
+      getViewportSize: () => ({ width: 400, height: 600 }),
+    } as unknown as ViewportRuler;
+
+    root.getBoundingClientRect = () => new DOMRect(documentRect.left, documentRect.top, 400, 4000);
+
+    const document = {
+      documentElement: root,
+      body,
+    } as unknown as Document;
+
+    return (strategy = new BlockScrollStrategy(viewportRuler, document));
+  }
+
+  beforeEach(() => {
+    root = window.document.createElement('div');
+    // The strategy only blocks scroll on a page that actually overflows.
+    Object.defineProperty(root, 'scrollHeight', { value: 4000 });
+    Object.defineProperty(root, 'scrollWidth', { value: 400 });
+
+    body = window.document.createElement('div');
+    scroll = vi.spyOn(window, 'scroll').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    strategy?.disable();
+    strategy = undefined;
+    scroll.mockRestore();
+  });
+
+  it('should offset the page by the document scroll position', () => {
+    createStrategy({ top: 900, left: 0 }).enable();
+
+    expect(root.style.position).toBe('fixed');
+    expect(root.style.top).toBe('-900px');
+    expect(root.style.left).toBe('0px');
+  });
+
+  // A pinch-zoomed WebKit page reports the visual viewport pan through `window.scrollX`,
+  // which the ruler falls back to. Offsetting by that shifts the whole page - and every
+  // `position: fixed` overlay with it - by the pan amount. The document element's rect is
+  // layout-viewport-relative, so it stays on the layout scroll.
+  // https://github.com/ng-primitives/ng-primitives/issues/758
+  it('should ignore the visual viewport pan of a pinch-zoomed page', () => {
+    createStrategy(
+      // What the ruler reports on WebKit: the layout scroll plus the pan.
+      { top: 940, left: 150 },
+      // The layout scroll the document rect reports regardless of the pan.
+      { top: -900, left: 0 },
+    ).enable();
+
+    expect(root.style.top).toBe('-900px');
+    expect(root.style.left).toBe('0px');
+  });
+
+  it('should restore the layout scroll position on disable', () => {
+    const blockScrollStrategy = createStrategy({ top: 940, left: 150 }, { top: -900, left: 0 });
+
+    blockScrollStrategy.enable();
+    blockScrollStrategy.disable();
+
+    expect(scroll).toHaveBeenCalledWith(0, 900);
+  });
+
+  it('should offset by a horizontal scroll position', () => {
+    createStrategy({ top: 500, left: 20 }).enable();
+
+    expect(root.style.top).toBe('-500px');
+    expect(root.style.left).toBe('-20px');
+  });
+
+  it('should restore the previous inline styles on disable', () => {
+    root.style.position = 'relative';
+    root.style.overflowY = 'hidden';
+
+    const blockScrollStrategy = createStrategy({ top: 900, left: 0 });
+
+    blockScrollStrategy.enable();
+    blockScrollStrategy.disable();
+
+    expect(root.style.position).toBe('relative');
+    expect(root.style.overflowY).toBe('hidden');
+    expect(root.style.top).toBe('');
+    expect(root.hasAttribute('data-scrollblock')).toBe(false);
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #758

## What does this PR implement/fix?

Rebased onto `next` and narrowed to two fixes. The overflow boundary options moved to #866 and the `Ngp*` positioning type aliases to #867 (merged), so this PR no longer carries either.

### Scroll blocking measured the wrong viewport (#758)

`BlockScrollStrategy` pins the root `html` element with `position: fixed` and offsets it by the current scroll position. That offset came from `ViewportRuler.getViewportScrollPosition()`, whose `||` chain falls through to `window.scrollX`/`scrollY` whenever an axis reports a zero document offset — which is every mobile page horizontally. Chrome 61 moved those onto the layout viewport, but WebKit still measures them against the visual viewport, so a pinch-zoomed, panned iOS page reports the pan amount instead of `0` and the whole page shifts the moment a menu opens.

It now reads the offset from the document element's own `getBoundingClientRect()` — layout-viewport-relative in every browser, and the measurement the ruler already prefers, just without the fallback that overrides it. It is also a synchronous layout read rather than a `visualViewport` value, which matters on iOS Safari, where `pageTop`/`offsetTop` are updated behind the URL bar transitions and rubber-band overscroll.

Note the issue's own root-cause analysis is inverted: Floating UI's `+visualViewport.offset` for the `fixed` strategy is the *correction* for WebKit's client rects, not a bug. Removing it, as the issue suggests, would introduce a pan-sized misalignment on iOS that is invisible on desktop.

### Overlay panels were painted before they were positioned

The parts bind the panel's `left`/`top` with `styleBinding`, which runs in `afterRenderEffect`. The portal's synchronous `detectChanges()` does not flush those, so the coordinates land on the next application tick — a frame after the panel is already in the DOM and paintable.

For that frame the panel sits at its static position, the end of its container's flow, and being in flow it grows the document's scrollable area by its own height before shrinking back. Measured in Chromium on a 1534px page with a 240px panel:

```
at insertion   left:(unset) top:(unset)  rect: 0,1534   scrollHeight: 1774
first paint    left:0px     top:1260px   rect: 0,1260   scrollHeight: 1534
```

On iOS Safari that height change moves the dynamic viewport, so the whole page jumps and returns; whether a paint lands in the window varies, which is why it presents as an intermittent flicker. It reproduces with `select`, which never blocks scroll — the two fixes here are independent.

The panel is now pinned to its container's origin and held transparent when it attaches, with the computed coordinates written straight to the element and the panel revealed inside `computePosition`. That settles within the attaching task's microtasks, before the frame in which `setupExitAnimation` applies `data-enter`, so the first paint already carries both the position and the enter state. `opacity` rather than `visibility` keeps the panel in the accessibility tree and hit-testable throughout — `visibility: hidden` removes it from the accessibility tree and breaks queries in existing tests, and would do the same to consumers' tests.

## Testing

Both fixes are regression-tested and each test was verified to fail without its change:

- scroll strategy — the pinch-zoom and disable-restore cases fail with the pan-inflated offset when `getLayoutViewportScrollPosition()` is reverted to the plain ruler call.
- first paint — `expected 1761 to be 1521` for the document growth, and `expected false to be true` for the panel being visible at insertion.

Full suite green: 2400 browser tests, `nx build ng-primitives` and `nx lint ng-primitives` clean.

The iOS behaviour itself is the one thing verified on hardware rather than in CI: dropping the first-paint commit reproduced the flicker and restoring it cleared it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWM2JuKvvtBwrVxXwoMhYu