### PR TITLE
docs: align section order across documentation pages

### DIFF
--- a/.claude/rules/documentation-pages.md
+++ b/.claude/rules/documentation-pages.md
@@ -1,0 +1,70 @@
+# Documentation Page Structure
+
+Applies to the docs pages under
+`apps/documentation/src/app/pages/(documentation)/**`. Readers move between
+primitives constantly, so every page must put the same section in the same
+place. The `documentation` generator emits this skeleton already - keep it when
+you add sections by hand.
+
+## Canonical section order
+
+Top-level (`##`) sections appear in this order:
+
+1. `Import`
+2. `Usage`
+3. `Reusable Component`
+4. `Schematics`
+5. `Examples`
+6. `API Reference`
+7. `Styling`
+8. `Animations`
+9. `Global Configuration`
+10. `Accessibility`
+
+Every section is optional - a primitive with no config provider has no
+`Global Configuration`. Omitting one is fine; reordering the ones you do have is
+not. `Accessibility` is always last.
+
+```md
+<!-- ✅ -->
+
+## Schematics
+
+## Examples
+
+## API Reference
+
+## Global Configuration
+
+## Accessibility
+
+<!-- ❌ Examples below API Reference, Accessibility not last -->
+
+## API Reference
+
+## Examples
+
+## Accessibility
+
+## Global Configuration
+```
+
+## Page-specific sections
+
+Sections outside the canonical list (`Features`, `Color values`, `Grouping
+Collapsibles`) are fine. Place them by what they are:
+
+- Explanatory or example-style content goes **before** `API Reference`, in the
+  `Examples` slot.
+- Never split `API Reference` from the reference tail that follows it -
+  `API Reference` → `Styling` → `Animations` → `Global Configuration` →
+  `Accessibility` stays contiguous.
+
+Prefer an `###` subsection under `Examples` to a new `##` when the content is
+just another example.
+
+## One heading per section
+
+A page gets at most one `## Examples` (and one of every other section). Add
+examples as `###` subsections of the existing block rather than opening a second
+one further down the page.

--- a/.claude/skills/ngp-code-review/SKILL.md
+++ b/.claude/skills/ngp-code-review/SKILL.md
@@ -118,6 +118,12 @@ PR template requires docs updates for features and bug fixes. For new public beh
 - Look for a docs page under `apps/documentation/src/app/pages/primitives/<primitive>/`.
 - Generators: `nx g @ng-primitives/tools:example <name> --primitive <primitive>` and `nx g @ng-primitives/tools:documentation`.
 
+If the diff adds or moves a `##` section in a page under `apps/documentation/src/app/pages/(documentation)/`, check it against `.claude/rules/documentation-pages.md`. Flag by `file:line`:
+
+- **Section out of order.** The canonical order is `Import` → `Usage` → `Reusable Component` → `Schematics` → `Examples` → `API Reference` → `Styling` → `Animations` → `Global Configuration` → `Accessibility`. Sections may be omitted, never reordered, and `Accessibility` is always last.
+- **A second `## Examples`** (or any duplicated section) on one page - add an `###` subsection to the existing block instead.
+- **A page-specific `##` section wedged between `API Reference` and `Accessibility`**, splitting the reference tail. Example-style content belongs before `API Reference`.
+
 If the diff touches files under `apps/documentation/src/app/examples/`, check them against `.claude/rules/docs-example-styling.md`. Common violations to flag by `file:line`:
 
 - **Off-brand colour.** Brand red (`--ngp-primary` / `#f01e2b` / `#ff4651`) on a focus ring (`:focus`, `[data-focus]`, `[data-focus-visible]`, `:focus-within`) - focus must be blue (`--ngp-focus-ring` / `blue-500` / `blue-400`). Conversely, blue / `--ngp-background-inverse` / off-palette tokens (`--ngp-text-blue`, `--ngp-background-blue`, `--ngp-background-success`) used for a _state_ (checked, selected, active, fill, primary button) - those must be brand red.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ See `.claude/rules/` for detailed coding standards:
 - `naming-conventions.md` - Selector prefixes, class names, file names
 - `state-management.md` - The `createPrimitive` state pattern: one `-state.ts` per part, host bindings inside the factory, thin directives, controlled state, state composition
 - `docs-example-styling.md` - Styling the documentation examples: brand red reserved for state, blue for focus, typography/radii scale, CSS + Tailwind parity
+- `documentation-pages.md` - The canonical `##` section order for docs pages, where page-specific sections go, one heading per section
 
 For code review, use the `ngp-code-review` skill — it consolidates these rules with the custom workspace lint rules, test conventions, and PR checklist.
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -64,6 +64,23 @@ Create a reusable component that uses the `NgpCombobox` directive.
 
 <docs-snippet name="combobox"></docs-snippet>
 
+## Schematics
+
+Generate a reusable combobox component using the Angular CLI.
+
+```bash npm
+ng g ng-primitives:primitive combobox
+```
+
+### Options
+
+- `path`: The path at which to create the component file.
+- `prefix`: The prefix to apply to the generated component selector.
+- `component-suffix`: The suffix to apply to the generated component class name.
+- `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
+
 ## Examples
 
 ### Custom Offset
@@ -127,23 +144,6 @@ Options without a value do not perform any selection by default. You can use thi
 To let users pick a value that isn't in the list, render a "create" option whose value is the current query. Because it is an ordinary `ngpComboboxOption`, it participates in keyboard navigation and is committed on `Enter` or click through the standard selection path - no bespoke key handling is required. It is rendered after the filtered matches: when nothing matches the filter, the create option is the only item, so it becomes the active descendant and `Enter` commits it immediately; when there are matches, they take precedence on `Enter` and the create option is reached with the arrow keys.
 
 <docs-example name="combobox-creatable"></docs-example>
-
-## Schematics
-
-Generate a reusable combobox component using the Angular CLI.
-
-```bash npm
-ng g ng-primitives:primitive combobox
-```
-
-### Options
-
-- `path`: The path at which to create the component file.
-- `prefix`: The prefix to apply to the generated component selector.
-- `component-suffix`: The suffix to apply to the generated component class name.
-- `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
-- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
@@ -212,23 +212,6 @@ The following context fields are available on the `ngpDatePickerCellRender` dire
   <api-attribute name="data-range-between" description="Applied when the button is between the start and end of a date range." />
 </api-reference-attributes>
 
-## Accessibility
-
-Adheres to the [WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/).
-
-### Keyboard Interactions
-
-- <kbd>Space</kbd> - Selects the focused date.
-- <kbd>Enter</kbd> - Selects the focused date.
-- <kbd>ArrowUp</kbd> - Moves focus to the same day of the previous week.
-- <kbd>ArrowDown</kbd> - Moves focus to the same day of the next week.
-- <kbd>ArrowLeft</kbd> - Moves focus to the previous day.
-- <kbd>ArrowRight</kbd> - Moves focus to the next day.
-- <kbd>Home</kbd> - Moves focus to the first day of the month.
-- <kbd>End</kbd> - Moves focus to the last day of the month.
-- <kbd>PageUp</kbd> - Moves focus to the same date in the previous month.
-- <kbd>PageDown</kbd> - Moves focus to the same date in the next month.
-
 ## Global Configuration
 
 You can configure the default options for all `NgpDatePicker` and `NgpDateRangePicker` calendars in your application by using the `provideDatePickerConfig` function in a providers array.
@@ -248,3 +231,20 @@ bootstrapApplication(AppComponent, {
 ### NgpDatePickerConfig
 
 <api-reference-config name="NgpDatePickerConfig"></api-reference-config>
+
+## Accessibility
+
+Adheres to the [WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/).
+
+### Keyboard Interactions
+
+- <kbd>Space</kbd> - Selects the focused date.
+- <kbd>Enter</kbd> - Selects the focused date.
+- <kbd>ArrowUp</kbd> - Moves focus to the same day of the previous week.
+- <kbd>ArrowDown</kbd> - Moves focus to the same day of the next week.
+- <kbd>ArrowLeft</kbd> - Moves focus to the previous day.
+- <kbd>ArrowRight</kbd> - Moves focus to the next day.
+- <kbd>Home</kbd> - Moves focus to the first day of the month.
+- <kbd>End</kbd> - Moves focus to the last day of the month.
+- <kbd>PageUp</kbd> - Moves focus to the same date in the previous month.
+- <kbd>PageDown</kbd> - Moves focus to the same date in the next month.

--- a/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
@@ -70,6 +70,26 @@ ng g ng-primitives:primitive dialog
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
+## Examples
+
+### Dismiss Guard
+
+Use dismiss guards to prevent a dialog from closing when there are unsaved changes. The `closeOnEscape` and `closeOnOutsideClick` options accept a guard function that returns a boolean or a `Promise<boolean>`.
+
+<docs-example name="dialog-dismiss-guard"></docs-example>
+
+### Dialog with external data
+
+Data can be passed to the dialog using the `NgpDialogManager`.
+
+<docs-example name="dialog-data"></docs-example>
+
+### Drawer
+
+A drawer is a type of dialog that slides in from the side of the screen.
+
+<docs-example name="dialog-drawer"></docs-example>
+
 ## API Reference
 
 The following directives are available to import from the `ng-primitives/dialog` package:
@@ -181,26 +201,6 @@ Reference returned by `NgpDialogManager.open()`. Provides methods to interact wi
 <prop-details name="updatePosition" type="() => NgpDialogRef">
   Updates the position of the dialog. Currently a no-op as dialogs are CSS-centered.
 </prop-details>
-
-## Examples
-
-### Dismiss Guard
-
-Use dismiss guards to prevent a dialog from closing when there are unsaved changes. The `closeOnEscape` and `closeOnOutsideClick` options accept a guard function that returns a boolean or a `Promise<boolean>`.
-
-<docs-example name="dialog-dismiss-guard"></docs-example>
-
-### Dialog with external data
-
-Data can be passed to the dialog using the `NgpDialogManager`.
-
-<docs-example name="dialog-data"></docs-example>
-
-### Drawer
-
-A drawer is a type of dialog that slides in from the side of the screen.
-
-<docs-example name="dialog-drawer"></docs-example>
 
 ## Accessibility
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
@@ -30,14 +30,6 @@ Assemble the file-upload directives in your template.
 ></button>
 ```
 
-## Examples
-
-### File Dropzone
-
-The file dropzone primitive allows you to create a dropzone for files. This functionality is built into the file upload primitive, but can also be used separately if you don't want to show the file upload dialog on click.
-
-<docs-example name="file-dropzone"></docs-example>
-
 ## Reusable Component
 
 Create a file upload component that uses the `NgpFileUpload` directive.
@@ -60,6 +52,14 @@ ng g ng-primitives:primitive file-upload
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
+
+## Examples
+
+### File Dropzone
+
+The file dropzone primitive allows you to create a dropzone for files. This functionality is built into the file upload primitive, but can also be used separately if you don't want to show the file upload dialog on click.
+
+<docs-example name="file-dropzone"></docs-example>
 
 ## API Reference
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/navigation-menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/navigation-menu.md
@@ -140,23 +140,6 @@ A standalone navigation link within the menu list.
   <api-attribute name="data-disabled" description="Applied when the link is disabled" />
 </api-reference-attributes>
 
-## Accessibility
-
-The navigation menu uses `role="navigation"` on the container, `aria-haspopup="menu"` and `aria-expanded` on triggers, and `role="menu"` with `aria-labelledby` on content panels. This follows the [WAI-ARIA Navigation Menu pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/).
-
-### Keyboard Interactions
-
-| Key                        | Action                                              |
-| -------------------------- | --------------------------------------------------- |
-| `ArrowRight` / `ArrowLeft` | Navigate between triggers (horizontal orientation)  |
-| `ArrowUp` / `ArrowDown`    | Navigate between triggers (vertical orientation)    |
-| `ArrowDown` (horizontal)   | Open content and focus first item                   |
-| `ArrowRight` (vertical)    | Open content and focus first item                   |
-| `Enter` / `Space`          | Open content and focus first item, or activate link |
-| `Escape`                   | Close content and return focus to trigger           |
-| `Home` / `End`             | Navigate to first/last trigger                      |
-| `Tab`                      | Move focus out of the navigation menu               |
-
 ## Styling
 
 The navigation menu content uses a portal and should be positioned using `position: fixed` or `position: absolute`.
@@ -233,3 +216,20 @@ bootstrapApplication(AppComponent, {
 ### NgpNavigationMenuConfig
 
 <api-reference-config name="NgpNavigationMenuConfig"></api-reference-config>
+
+## Accessibility
+
+The navigation menu uses `role="navigation"` on the container, `aria-haspopup="menu"` and `aria-expanded` on triggers, and `role="menu"` with `aria-labelledby` on content panels. This follows the [WAI-ARIA Navigation Menu pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/).
+
+### Keyboard Interactions
+
+| Key                        | Action                                              |
+| -------------------------- | --------------------------------------------------- |
+| `ArrowRight` / `ArrowLeft` | Navigate between triggers (horizontal orientation)  |
+| `ArrowUp` / `ArrowDown`    | Navigate between triggers (vertical orientation)    |
+| `ArrowDown` (horizontal)   | Open content and focus first item                   |
+| `ArrowRight` (vertical)    | Open content and focus first item                   |
+| `Enter` / `Space`          | Open content and focus first item, or activate link |
+| `Escape`                   | Close content and return focus to trigger           |
+| `Home` / `End`             | Navigate to first/last trigger                      |
+| `Tab`                      | Move focus out of the navigation menu               |

--- a/apps/documentation/src/app/pages/(documentation)/primitives/password.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/password.md
@@ -57,26 +57,6 @@ ng g ng-primitives:primitive password
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
-## Global Configuration
-
-You can configure the default labels and announcements for all password primitives in your application by using the `providePasswordConfig` function in a providers array.
-
-```ts
-import { providePasswordConfig } from 'ng-primitives/password';
-
-bootstrapApplication(AppComponent, {
-  providers: [
-    providePasswordConfig({
-      showLabel: 'Show password',
-      hideLabel: 'Hide password',
-      shownAnnouncement: 'Your password is shown',
-      hiddenAnnouncement: 'Your password is hidden',
-      ignorePasswordManagers: false,
-    }),
-  ],
-});
-```
-
 ## API Reference
 
 The following directives are available to import from the `ng-primitives/password` package:
@@ -110,6 +90,26 @@ The following directives are available to import from the `ng-primitives/passwor
 <api-reference-attributes>
   <api-attribute name="data-visible" description="Applied when the password is visible." />
 </api-reference-attributes>
+
+## Global Configuration
+
+You can configure the default labels and announcements for all password primitives in your application by using the `providePasswordConfig` function in a providers array.
+
+```ts
+import { providePasswordConfig } from 'ng-primitives/password';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    providePasswordConfig({
+      showLabel: 'Show password',
+      hideLabel: 'Hide password',
+      shownAnnouncement: 'Your password is shown',
+      hiddenAnnouncement: 'Your password is hidden',
+      ignorePasswordManagers: false,
+    }),
+  ],
+});
+```
 
 ## Accessibility
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -42,7 +42,7 @@ Create a popover component that uses the `NgpPopover` directive.
 
 ## Schematics
 
-Generate a reusable tooltip component using the Angular CLI.
+Generate a reusable popover component using the Angular CLI.
 
 ```bash npm
 ng g ng-primitives:primitive popover

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -34,6 +34,29 @@ Assemble the popover directives in your template.
 
 You can listen to the `ngpPopoverTriggerOpenChange` event to perform actions when the popover state changes. The event emits a boolean value indicating whether the popover is open or closed:
 
+## Reusable Component
+
+Create a popover component that uses the `NgpPopover` directive.
+
+<docs-snippet name="popover"></docs-snippet>
+
+## Schematics
+
+Generate a reusable tooltip component using the Angular CLI.
+
+```bash npm
+ng g ng-primitives:primitive popover
+```
+
+### Options
+
+- `path`: The path at which to create the component file.
+- `prefix`: The prefix to apply to the generated component selector.
+- `component-suffix`: The suffix to apply to the generated component class name.
+- `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
+- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
+
 ## Examples
 
 ### Custom Offset
@@ -68,31 +91,6 @@ You can customize the shift behavior to control how the popover stays within the
   Popover with custom shift padding
 </button>
 ```
-
-## Reusable Component
-
-Create a popover component that uses the `NgpPopover` directive.
-
-<docs-snippet name="popover"></docs-snippet>
-
-## Schematics
-
-Generate a reusable tooltip component using the Angular CLI.
-
-```bash npm
-ng g ng-primitives:primitive popover
-```
-
-### Options
-
-- `path`: The path at which to create the component file.
-- `prefix`: The prefix to apply to the generated component selector.
-- `component-suffix`: The suffix to apply to the generated component class name.
-- `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
-- `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
-
-## Examples
 
 ### Popover with anchor
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -106,64 +106,6 @@ You can customize the shift behavior to control how the tooltip stays within the
 </button>
 ```
 
-## API Reference
-
-The following directives are available to import from the `ng-primitives/tooltip` package:
-
-### NgpTooltip
-
-<api-docs name="NgpTooltip"></api-docs>
-
-<api-reference-props name="NgpTooltip"></api-reference-props>
-
-<api-reference-attributes>
-  <api-attribute name="data-enter" description="Applied when the tooltip is being added to the DOM. This can be used to trigger animations." />
-  <api-attribute name="data-exit" description="Applied when the tooltip is being removed from the DOM. This can be used to trigger animations." />
-  <api-attribute name="data-placement" description="The final rendered placement of the tooltip." />
-</api-reference-attributes>
-
-<api-reference-css-vars>
-  <api-css-var name="--ngp-tooltip-transform-origin" description="The transform origin of the tooltip for animations." />
-  <api-css-var name="--ngp-tooltip-trigger-width" description="The width of the trigger element." />
-  <api-css-var name="--ngp-tooltip-available-width" description="The available width of the tooltip before it overflows the viewport." />
-  <api-css-var name="--ngp-tooltip-available-height" description="The available height of the tooltip before it overflows the viewport." />
-</api-reference-css-vars>
-
-### NgpTooltipTrigger
-
-<api-docs name="NgpTooltipTrigger"></api-docs>
-
-<api-reference-props name="NgpTooltipTrigger"></api-reference-props>
-
-<api-reference-attributes>
-  <api-attribute name="data-open" description="Applied when the tooltip is open." />
-  <api-attribute name="data-disabled" description="Applied when the tooltip is disabled." />
-</api-reference-attributes>
-
-### NgpTooltipArrow
-
-The `NgpTooltipArrow` directive is used to add an arrow to the tooltip. It should be placed inside the tooltip content. It will receive `inset-inline-start` or `inset-block-start` styles to position the arrow based on the tooltip's placement. As a result it should be positioned absolutely within the tooltip content.
-
-The arrow can be styled conditionally based on the tooltip's final placement using the `data-placement` attribute:
-
-```css
-[ngpTooltipArrow][data-placement='top'] {
-  /* Arrow styles when tooltip is positioned on top */
-}
-
-[ngpTooltipArrow][data-placement='bottom'] {
-  /* Arrow styles when tooltip is positioned on bottom */
-}
-```
-
-<api-docs name="NgpTooltipArrow"></api-docs>
-
-<api-reference-props name="NgpTooltipArrow"></api-reference-props>
-
-<api-reference-attributes>
-  <api-attribute name="data-placement" description="The final rendered placement of the tooltip." />
-</api-reference-attributes>
-
 ## Using Text Content as Tooltip
 
 The `useTextContent` input (enabled by default) allows the tooltip to automatically use the text content of the trigger element as the tooltip content. This is particularly useful for displaying full text when content is truncated with ellipsis.
@@ -234,6 +176,64 @@ Use `ngpTooltipTriggerHoverableContent` to control whether hovering tooltip cont
 ```
 
 If tooltip content needs to be interactive or focusable, use [`Popover`](/primitives/popover) instead.
+
+## API Reference
+
+The following directives are available to import from the `ng-primitives/tooltip` package:
+
+### NgpTooltip
+
+<api-docs name="NgpTooltip"></api-docs>
+
+<api-reference-props name="NgpTooltip"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-enter" description="Applied when the tooltip is being added to the DOM. This can be used to trigger animations." />
+  <api-attribute name="data-exit" description="Applied when the tooltip is being removed from the DOM. This can be used to trigger animations." />
+  <api-attribute name="data-placement" description="The final rendered placement of the tooltip." />
+</api-reference-attributes>
+
+<api-reference-css-vars>
+  <api-css-var name="--ngp-tooltip-transform-origin" description="The transform origin of the tooltip for animations." />
+  <api-css-var name="--ngp-tooltip-trigger-width" description="The width of the trigger element." />
+  <api-css-var name="--ngp-tooltip-available-width" description="The available width of the tooltip before it overflows the viewport." />
+  <api-css-var name="--ngp-tooltip-available-height" description="The available height of the tooltip before it overflows the viewport." />
+</api-reference-css-vars>
+
+### NgpTooltipTrigger
+
+<api-docs name="NgpTooltipTrigger"></api-docs>
+
+<api-reference-props name="NgpTooltipTrigger"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-open" description="Applied when the tooltip is open." />
+  <api-attribute name="data-disabled" description="Applied when the tooltip is disabled." />
+</api-reference-attributes>
+
+### NgpTooltipArrow
+
+The `NgpTooltipArrow` directive is used to add an arrow to the tooltip. It should be placed inside the tooltip content. It will receive `inset-inline-start` or `inset-block-start` styles to position the arrow based on the tooltip's placement. As a result it should be positioned absolutely within the tooltip content.
+
+The arrow can be styled conditionally based on the tooltip's final placement using the `data-placement` attribute:
+
+```css
+[ngpTooltipArrow][data-placement='top'] {
+  /* Arrow styles when tooltip is positioned on top */
+}
+
+[ngpTooltipArrow][data-placement='bottom'] {
+  /* Arrow styles when tooltip is positioned on bottom */
+}
+```
+
+<api-docs name="NgpTooltipArrow"></api-docs>
+
+<api-reference-props name="NgpTooltipArrow"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-placement" description="The final rendered placement of the tooltip." />
+</api-reference-attributes>
 
 ## Styling
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features) — n/a, markdown and agent-rule files only, no runnable code changed
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

## Issue

No linked issue — this came out of noticing that documentation pages had drifted into several different section orders.

## What does this PR implement/fix?

Documentation pages had drifted into several different section orders, so readers moving between primitives found the same section in a different place each time.

**Consensus order.** Derived two ways, which agree. The docs generator template (`packages/tools/src/generators/documentation/files/__name__.md.template`) emits Import → Usage → Reusable Component → Schematics → API Reference → Global Configuration, and the majority of hand-written pages slot the remaining sections around that:

> `Import` → `Usage` → `Reusable Component` → `Schematics` → `Examples` → `API Reference` → `Styling` → `Animations` → `Global Configuration` → `Accessibility`

Placing `Examples` after `Schematics` held 14 pages to 4; the trailing `Styling`/`Animations`/`Global Configuration`/`Accessibility` block held on every page but two. Sections stay optional — plenty of pages legitimately omit several — but the ones a page does have now appear in this order, with `Accessibility` always last.

**Outliers reordered** (8 of 59 pages):

| Page | Was | Fix |
| --- | --- | --- |
| `combobox` | Examples before Schematics | swapped |
| `date-picker` | Accessibility before Global Configuration | swapped |
| `dialog` | Examples after API Reference | moved up |
| `file-upload` | Examples before Reusable Component | moved below Schematics |
| `navigation-menu` | Accessibility mid-page | moved to end |
| `password` | Global Configuration before API Reference | swapped |
| `popover` | **two separate `## Examples` sections** | merged into one, after Schematics |
| `tooltip` | 3 example-style `##` sections between API Reference and Styling | moved above API Reference |

Two judgment calls worth a reviewer's eye:

- **`popover`** is the only genuine content change. It had a duplicate `## Examples` heading, so both bodies were merged under one heading rather than leaving two. This is the sole reason its diff is not a pure reorder (−10 chars, exactly the removed heading and its blank line).
- **`tooltip`**'s "Using Text Content as Tooltip" / "Conditional Tooltips" / "Hoverable Tooltip Content" are not canonical section names, but they are example content that split `API Reference` from `Styling` — an adjacency every other page keeps. They moved above `API Reference`. Easy to revert independently if you'd rather they stayed put.

Left alone deliberately: `number-field`'s "Features", `collapsible`'s "Grouping Collapsibles", and `color-picker`'s "Color values" / "Gradients" are page-specific sections already sitting in sensible slots, with no cross-page consensus to violate.

**Keeping it aligned.** The second commit adds `.claude/rules/documentation-pages.md` recording the canonical order, where page-specific sections go without splitting the `API Reference` → `Accessibility` tail, and the one-heading-per-section rule. It is indexed from the Coding Conventions list in `CLAUDE.md` and from section 7 of the `ngp-code-review` skill, so reviews flag ordering drift by `file:line` rather than relying on it being spotted by eye.

**Verification.** Each reordered file's line multiset was compared against its previous version: all eight are identical apart from popover's duplicate heading, so no prose was lost or reflowed. `prettier --check` passes on the docs pages and the new rule files, and a validator over all 59 pages reports zero remaining outliers.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Markdown content and agent-facing rule files only. No library code, public API, or build output is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_016thnW2ZrsCEbJJ8PMa6dpX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the section order across docs pages and codified a canonical order to keep pages consistent. This makes sections predictable and easier to scan.

- **Refactors**
  - Set and applied canonical order: Import → Usage → Reusable Component → Schematics → Examples → API Reference → Styling → Animations → Global Configuration → Accessibility.
  - Adjusted outliers: combobox, date-picker, dialog, file-upload, navigation-menu, password; popover (merged duplicate “Examples” into one after Schematics); tooltip (moved example sections above API Reference).
  - Added `.claude/rules/documentation-pages.md`, referenced from `CLAUDE.md`, and review checks in `ngp-code-review` to flag future drift.
  - Docs-only changes; content unchanged except removing a duplicate heading in popover and fixing Schematics wording in popover (tooltip → popover).

<sup>Written for commit 8bab04a449caa5f8d98b79ec2ea8731d732519a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardised the recommended section order for documentation pages.
  * Updated review guidance to check documentation section ordering and duplicate headings.
  * Reorganised several primitive documentation pages for consistent navigation, including Schematics, Examples, API Reference, Global Configuration and Accessibility sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->