### PR TITLE
fix(menu): give the menu ownership of initial focus

### DIFF
--- a/packages/ng-primitives/context-menu/src/context-menu-trigger/tests/context-menu-primitive.test.ts
+++ b/packages/ng-primitives/context-menu/src/context-menu-trigger/tests/context-menu-primitive.test.ts
@@ -529,7 +529,7 @@ describe('NgpContextMenuTrigger', () => {
       await render(ContextMenuDisabledItemsComponent);
       await openContextMenu();
 
-      // Focus should already be on first item from focus trap
+      // Focus should already be on the first item from the menu's initial focus
       const item1 = document.querySelector('[data-testid="item-1"]') as HTMLElement;
       expect(document.activeElement).toBe(item1);
 

--- a/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap-state.ts
+++ b/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap-state.ts
@@ -105,12 +105,18 @@ export interface NgpFocusTrapProps {
    * If not provided, falls back to the FocusMonitor's last known origin.
    */
   readonly focusOrigin?: Signal<FocusOrigin>;
+
+  /**
+   * Whether focus should be moved into the trap when it is set up. Turn this off
+   * when the consumer places initial focus itself - the trap still traps.
+   */
+  readonly autoFocus?: Signal<boolean>;
 }
 
 export const [NgpFocusTrapStateToken, ngpFocusTrap, injectFocusTrapState, provideFocusTrapState] =
   createPrimitive(
     'NgpFocusTrap',
-    ({ disabled = signal(false), focusOrigin }: NgpFocusTrapProps) => {
+    ({ disabled = signal(false), focusOrigin, autoFocus = signal(true) }: NgpFocusTrapProps) => {
       const element = injectElementRef();
       const overlay = inject(NgpOverlay, { optional: true });
       const injector = inject(Injector);
@@ -151,24 +157,31 @@ export const [NgpFocusTrapStateToken, ngpFocusTrap, injectFocusTrapState, provid
         const previouslyFocusedElement = document.activeElement as HTMLElement | null;
         const hasFocusedCandidate = element.nativeElement.contains(previouslyFocusedElement);
 
-        // Only perform initial focusing if the focus trap is not disabled
-        if (!hasFocusedCandidate && !disabled?.()) {
-          // we do this to ensure the content is rendered before we try to find the first focusable element
-          // and focus it
-          afterNextRender(
-            {
-              write: () => {
-                focusFirst();
-
-                // if the focus didn't change, focus the container
-                if (document.activeElement === previouslyFocusedElement) {
-                  focus(element.nativeElement);
-                }
-              },
-            },
-            { injector },
-          );
+        if (hasFocusedCandidate) {
+          return;
         }
+
+        // we do this to ensure the content is rendered before we try to find the first focusable element
+        // and focus it
+        afterNextRender(
+          {
+            write: () => {
+              // Read the inputs here rather than during setup: this factory runs while
+              // the directive is constructed, before Angular has bound them.
+              if (disabled?.() || !autoFocus()) {
+                return;
+              }
+
+              focusFirst();
+
+              // if the focus didn't change, focus the container
+              if (document.activeElement === previouslyFocusedElement) {
+                focus(element.nativeElement);
+              }
+            },
+          },
+          { injector },
+        );
       }
 
       function teardownFocusTrap(): void {

--- a/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap-state.ts
+++ b/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap-state.ts
@@ -107,8 +107,7 @@ export interface NgpFocusTrapProps {
   readonly focusOrigin?: Signal<FocusOrigin>;
 
   /**
-   * Whether focus should be moved into the trap when it is set up. Turn this off
-   * when the consumer places initial focus itself - the trap still traps.
+   * Whether to move focus into the trap when it is set up. When off, focus is still trapped.
    */
   readonly autoFocus?: Signal<boolean>;
 }
@@ -166,8 +165,7 @@ export const [NgpFocusTrapStateToken, ngpFocusTrap, injectFocusTrapState, provid
         afterNextRender(
           {
             write: () => {
-              // Read the inputs here rather than during setup: this factory runs while
-              // the directive is constructed, before Angular has bound them.
+              // Read here, not during setup - the factory runs before Angular binds inputs.
               if (disabled?.() || !autoFocus()) {
                 return;
               }

--- a/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap.ts
+++ b/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap.ts
@@ -25,8 +25,7 @@ export class NgpFocusTrap {
   });
 
   /**
-   * Whether focus should be moved into the trap when it is set up. Turn this off
-   * to place initial focus yourself - focus is still trapped.
+   * Whether to move focus into the trap when it is set up. When off, focus is still trapped.
    * @default true
    */
   readonly autoFocus = input<boolean, BooleanInput>(true, {

--- a/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap.ts
+++ b/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap.ts
@@ -25,9 +25,19 @@ export class NgpFocusTrap {
   });
 
   /**
+   * Whether focus should be moved into the trap when it is set up. Turn this off
+   * to place initial focus yourself - focus is still trapped.
+   * @default true
+   */
+  readonly autoFocus = input<boolean, BooleanInput>(true, {
+    alias: 'ngpFocusTrapAutoFocus',
+    transform: booleanAttribute,
+  });
+
+  /**
    * The focus trap state.
    */
   constructor() {
-    ngpFocusTrap({ disabled: this.disabled });
+    ngpFocusTrap({ disabled: this.disabled, autoFocus: this.autoFocus });
   }
 }

--- a/packages/ng-primitives/focus-trap/src/focus-trap/tests/focus-trap.test.ts
+++ b/packages/ng-primitives/focus-trap/src/focus-trap/tests/focus-trap.test.ts
@@ -1,7 +1,7 @@
 import { FocusMonitor, InteractivityChecker } from '@angular/cdk/a11y';
 import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { fireEvent, render } from '@testing-library/angular';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
 import { NgpFocusTrap } from 'ng-primitives/focus-trap';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -63,6 +63,21 @@ class TestNestedFocusTrapsComponent {
   showFirst = signal(true);
   showSecond = signal(false);
   showThird = signal(false);
+}
+
+@Component({
+  selector: 'test-focus-trap-auto-focus',
+  imports: [NgpFocusTrap],
+  template: `
+    <button data-testid="outside-element" tabindex="0">Outside</button>
+    <div [ngpFocusTrapAutoFocus]="autoFocus()" ngpFocusTrap data-testid="focus-trap">
+      <button data-testid="button1" tabindex="0">Button 1</button>
+      <button data-testid="button2" tabindex="0">Button 2</button>
+    </div>
+  `,
+})
+class TestFocusTrapAutoFocusComponent {
+  autoFocus = signal(true);
 }
 
 @Component({
@@ -224,6 +239,37 @@ describe('NgpFocusTrap', () => {
 
       // Should not have data-focus-trap attribute when disabled
       expect(focusTrap).not.toHaveAttribute('data-focus-trap');
+    });
+  });
+
+  describe('Initial Focus', () => {
+    it('should focus the first tabbable element by default', async () => {
+      const container = await render(TestFocusTrapAutoFocusComponent);
+
+      await waitFor(() => expect(container.getByTestId('button1')).toHaveFocus());
+    });
+
+    it('should not move focus when autoFocus is disabled', async () => {
+      const container = await render(TestFocusTrapAutoFocusComponent, {
+        componentProperties: { autoFocus: signal(false) },
+      });
+
+      expect(container.getByTestId('button1')).not.toHaveFocus();
+      expect(container.getByTestId('focus-trap')).not.toHaveFocus();
+    });
+
+    it('should still trap focus when autoFocus is disabled', async () => {
+      const container = await render(TestFocusTrapAutoFocusComponent, {
+        componentProperties: { autoFocus: signal(false) },
+      });
+
+      const button1 = container.getByTestId('button1');
+      const outsideElement = container.getByTestId('outside-element');
+
+      button1.focus();
+      outsideElement.focus();
+
+      expect(button1).toHaveFocus();
     });
   });
 

--- a/packages/ng-primitives/menu/src/menu/menu-state.ts
+++ b/packages/ng-primitives/menu/src/menu/menu-state.ts
@@ -37,19 +37,15 @@ export const [NgpMenuStateToken, ngpMenu, injectMenuState, provideMenuState] = c
     const rovingFocusGroup = injectRovingFocusGroupState();
 
     // Always trap focus in menus per WAI-ARIA guidelines (Tab should not navigate within menus)
-    // Pass the open origin so focus trap uses the correct origin for :focus-visible styling.
-    // The menu owns initial focus (see below), so the trap only traps.
+    // Pass the open origin so focus trap uses the correct origin for :focus-visible styling
     const openOrigin = computed(() => menuTrigger()?.openOrigin() ?? 'program');
     ngpFocusTrap({
       focusOrigin: openOrigin,
       autoFocus: signal(false),
     });
 
-    // The focus trap can only find items that are already tabbable, and roving focus
-    // applies each item's tabindex in a later render phase than the trap's initial
-    // focus - so a menu item on a non-native element (e.g. a div) would be missed and
-    // focus would land on the container. Placing focus in the read phase runs after
-    // every item has its tabindex, so native and non-native items behave the same.
+    // Read phase, so it runs after roving focus has applied each item's tabindex - an item
+    // on a non-native element isn't focusable before that.
     afterNextRender({ read: () => focusInitialItem() }, { injector });
 
     // Register this element as the overlay outlet so floating-ui positions it correctly,
@@ -79,7 +75,7 @@ export const [NgpMenuStateToken, ngpMenu, injectMenuState, provideMenuState] = c
     function focusInitialItem(): void {
       const origin = openOrigin();
 
-      // Fall back to the container so focus is never left outside the trapped menu.
+      // Fall back to the container so focus is never left outside the trap.
       if (!rovingFocusGroup()?.activateFirst(origin)) {
         focusMonitor.focusVia(element.nativeElement, origin, { preventScroll: true });
       }

--- a/packages/ng-primitives/menu/src/menu/menu-state.ts
+++ b/packages/ng-primitives/menu/src/menu/menu-state.ts
@@ -1,9 +1,10 @@
-import { FocusOrigin } from '@angular/cdk/a11y';
+import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
 import { Directionality } from '@angular/cdk/bidi';
-import { computed, inject } from '@angular/core';
+import { afterNextRender, computed, inject, Injector, signal } from '@angular/core';
 import { ngpFocusTrap } from 'ng-primitives/focus-trap';
 import { injectElementRef } from 'ng-primitives/internal';
 import { injectOverlay } from 'ng-primitives/portal';
+import { injectRovingFocusGroupState } from 'ng-primitives/roving-focus';
 import { attrBinding, createPrimitive, listener, styleBinding } from 'ng-primitives/state';
 import { Subject } from 'rxjs';
 import { injectMenuTriggerState } from '../menu-trigger/menu-trigger-state';
@@ -29,15 +30,27 @@ export const [NgpMenuStateToken, ngpMenu, injectMenuState, provideMenuState] = c
     const element = injectElementRef();
     const overlay = injectOverlay();
     const directionality = inject(Directionality, { optional: true });
+    const injector = inject(Injector);
+    const focusMonitor = inject(FocusMonitor);
     const menuTrigger = injectMenuTriggerState();
     const parentMenu = injectMenuState({ optional: true, skipSelf: true });
+    const rovingFocusGroup = injectRovingFocusGroupState();
 
     // Always trap focus in menus per WAI-ARIA guidelines (Tab should not navigate within menus)
-    // Pass the open origin so focus trap uses the correct origin for :focus-visible styling
+    // Pass the open origin so focus trap uses the correct origin for :focus-visible styling.
+    // The menu owns initial focus (see below), so the trap only traps.
     const openOrigin = computed(() => menuTrigger()?.openOrigin() ?? 'program');
     ngpFocusTrap({
       focusOrigin: openOrigin,
+      autoFocus: signal(false),
     });
+
+    // The focus trap can only find items that are already tabbable, and roving focus
+    // applies each item's tabindex in a later render phase than the trap's initial
+    // focus - so a menu item on a non-native element (e.g. a div) would be missed and
+    // focus would land on the container. Placing focus in the read phase runs after
+    // every item has its tabindex, so native and non-native items behave the same.
+    afterNextRender({ read: () => focusInitialItem() }, { injector });
 
     // Register this element as the overlay outlet so floating-ui positions it correctly,
     // even when this directive is on a nested child component rather than the portal root.
@@ -63,6 +76,15 @@ export const [NgpMenuStateToken, ngpMenu, injectMenuState, provideMenuState] = c
     const closeSubmenus = new Subject<HTMLElement>();
 
     // Methods
+    function focusInitialItem(): void {
+      const origin = openOrigin();
+
+      // Fall back to the container so focus is never left outside the trapped menu.
+      if (!rovingFocusGroup()?.activateFirst(origin)) {
+        focusMonitor.focusVia(element.nativeElement, origin, { preventScroll: true });
+      }
+    }
+
     function onPointerEnter(): void {
       menuTrigger()?.setPointerOverContent(true);
     }

--- a/packages/ng-primitives/menu/src/menu/tests/menu-initial-focus.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-initial-focus.test.ts
@@ -1,0 +1,175 @@
+import { Component } from '@angular/core';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpSubmenuTrigger } from 'ng-primitives/menu';
+import { describe, expect, it } from 'vitest';
+
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu">
+        <div ngpMenuItem data-testid="item-1">Item 1</div>
+        <div ngpMenuItem data-testid="item-2">Item 2</div>
+        <div ngpMenuItem data-testid="item-3">Item 3</div>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem],
+})
+class TestMenuWithDivItemsComponent {}
+
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu">
+        <button ngpMenuItem data-testid="item-1">Item 1</button>
+        <button ngpMenuItem data-testid="item-2">Item 2</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem],
+})
+class TestMenuWithButtonItemsComponent {}
+
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu">
+        <div [ngpMenuItemDisabled]="true" ngpMenuItem data-testid="item-disabled">Disabled</div>
+        <div ngpMenuItem data-testid="item-2">Item 2</div>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem],
+})
+class TestMenuWithDisabledFirstItemComponent {}
+
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu">Nothing to see here</div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu],
+})
+class TestMenuWithoutItemsComponent {}
+
+@Component({
+  template: `
+    <button [ngpMenuTrigger]="menu" data-testid="root-trigger">Open Menu</button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="root-menu">
+        <div [ngpSubmenuTrigger]="submenu" ngpMenuItem data-testid="submenu-trigger">
+          Open Submenu
+        </div>
+      </div>
+    </ng-template>
+
+    <ng-template #submenu>
+      <div ngpMenu data-testid="submenu">
+        <div ngpMenuItem data-testid="submenu-item-1">Submenu Item 1</div>
+        <div ngpMenuItem data-testid="submenu-item-2">Submenu Item 2</div>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem, NgpSubmenuTrigger],
+})
+class TestSubmenuWithDivItemsComponent {}
+
+describe('NgpMenu initial focus', () => {
+  it('should focus the first item when the items are not natively focusable', async () => {
+    const { fixture } = await render(TestMenuWithDivItemsComponent);
+    const trigger = fixture.debugElement.nativeElement.querySelector('[data-testid="trigger"]');
+
+    fireEvent.click(trigger);
+    fixture.detectChanges();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="item-1"]')).toBe(document.activeElement),
+    );
+  });
+
+  it('should focus the first item when the items are natively focusable', async () => {
+    const { fixture } = await render(TestMenuWithButtonItemsComponent);
+    const trigger = fixture.debugElement.nativeElement.querySelector('[data-testid="trigger"]');
+
+    fireEvent.click(trigger);
+    fixture.detectChanges();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="item-1"]')).toBe(document.activeElement),
+    );
+  });
+
+  it('should support roving focus navigation once the first item is focused', async () => {
+    const { fixture } = await render(TestMenuWithDivItemsComponent);
+    const trigger = fixture.debugElement.nativeElement.querySelector('[data-testid="trigger"]');
+
+    fireEvent.click(trigger);
+    fixture.detectChanges();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="item-1"]')).toBe(document.activeElement),
+    );
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' });
+    fixture.detectChanges();
+
+    expect(document.querySelector('[data-testid="item-2"]')).toBe(document.activeElement);
+  });
+
+  it('should skip a disabled first item', async () => {
+    const { fixture } = await render(TestMenuWithDisabledFirstItemComponent);
+    const trigger = fixture.debugElement.nativeElement.querySelector('[data-testid="trigger"]');
+
+    fireEvent.click(trigger);
+    fixture.detectChanges();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="item-2"]')).toBe(document.activeElement),
+    );
+  });
+
+  it('should focus the menu container when there are no items to focus', async () => {
+    const { fixture } = await render(TestMenuWithoutItemsComponent);
+    const trigger = fixture.debugElement.nativeElement.querySelector('[data-testid="trigger"]');
+
+    fireEvent.click(trigger);
+    fixture.detectChanges();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="menu"]')).toBe(document.activeElement),
+    );
+  });
+
+  it('should focus the first submenu item when a submenu opens', async () => {
+    const { fixture } = await render(TestSubmenuWithDivItemsComponent);
+    const trigger = fixture.debugElement.nativeElement.querySelector(
+      '[data-testid="root-trigger"]',
+    );
+
+    fireEvent.click(trigger);
+    fixture.detectChanges();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="submenu-trigger"]')).toBe(
+        document.activeElement,
+      ),
+    );
+
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowRight' });
+    fixture.detectChanges();
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="submenu-item-1"]')).toBe(document.activeElement),
+    );
+  });
+});

--- a/packages/ng-primitives/roving-focus/src/roving-focus-group/roving-focus-group-state.ts
+++ b/packages/ng-primitives/roving-focus/src/roving-focus-group/roving-focus-group-state.ts
@@ -63,13 +63,15 @@ export interface NgpRovingFocusGroupState {
   /**
    * Activate the first item in the roving focus group.
    * @param origin The origin of the focus change
+   * @returns Whether an item was activated.
    */
-  activateFirst(origin?: FocusOrigin): void;
+  activateFirst(origin?: FocusOrigin): boolean;
   /**
    * Activate the last item in the roving focus group.
    * @param origin The origin of the focus change
+   * @returns Whether an item was activated.
    */
-  activateLast(origin?: FocusOrigin): void;
+  activateLast(origin?: FocusOrigin): boolean;
 }
 
 export interface NgpRovingFocusGroupProps {
@@ -164,7 +166,7 @@ export const [
      * Activate the first item in the roving focus group.
      * @param origin The origin of the focus change
      */
-    function activateFirstItem(origin: FocusOrigin): void {
+    function activateFirstItem(origin: FocusOrigin): boolean {
       // find the first item that is not disabled
       const item = getSortedItems().find(i => !i.disabled()) ?? null;
 
@@ -172,13 +174,15 @@ export const [
       if (item) {
         setActiveItem(item.id(), origin);
       }
+
+      return item !== null;
     }
 
     /**
      * Activate the last item in the roving focus group.
      * @param origin The origin of the focus change
      */
-    function activateLastItem(origin: FocusOrigin): void {
+    function activateLastItem(origin: FocusOrigin): boolean {
       // find the last item that is not disabled
       const item = [...getSortedItems()].reverse().find(i => !i.disabled()) ?? null;
 
@@ -186,6 +190,8 @@ export const [
       if (item) {
         setActiveItem(item.id(), origin);
       }
+
+      return item !== null;
     }
 
     /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) — the new `NgpFocusTrap` input is picked up automatically by `<api-docs name="NgpFocusTrap">` on the Focus Trap page

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #800

Follows up on #808, which fixed the symptom by re-focusing after `afterNextRender` + `requestAnimationFrame`. This addresses the underlying phase-ordering race instead.

## What does this PR implement/fix?

### The root cause

A menu item on a non-native element (e.g. a `div`) did not receive focus when the menu opened, so keyboard navigation had nothing to move from.

The focus trap both *trapped* focus and *placed* it, and the menu leaned on that. Two things collide:

- the trap's initial-focus scan only accepts elements `InteractivityChecker.isTabbable()` already reports as tabbable, and it runs in the **write** render phase;
- roving focus applies each item's `tabindex` through `attrBinding` → `afterRenderEffect`, which lands in the later **mixedReadWrite** phase.

A `<button>` qualifies whenever the attribute arrives. A `<div>` only qualifies once `tabindex="0"` has landed — which is after the scan — so the scan found no candidate and fell back to focusing the menu container. That fallback is exactly what #808's `activeElement === container` guard was catching, one frame later.

This was verified rather than assumed: with the new code in place but the callback moved from the `read` phase back to `write`, the four `div`-item tests fail again; on `read` they pass.

### The fix

Sort out who owns initial focus — the trap traps, the menu places.

- **`focus-trap`**: new `autoFocus` prop and matching `ngpFocusTrapAutoFocus` input, defaulting to `true`, so every other consumer (dialog, popover, standalone `ngpFocusTrap`) is unchanged. When off, the trap still traps; it just doesn't place initial focus.
- **`menu`**: passes `autoFocus: false` and calls `rovingFocusGroup().activateFirst(openOrigin())` itself in the **read** phase, after every item has its `tabindex`. Native and non-native items now take the same deterministic path — no `requestAnimationFrame`, no active-element guard. `ngpContextMenu` shares the same `ngpMenu` state and inherits the fix.
- **`roving-focus`**: `activateFirst` / `activateLast` return whether an item was activated, so the menu can fall back to focusing its container when a menu has no enabled items — preserving what the trap used to do there.

### One extra bug found on the way

The trap read `disabled()` while the directive was still constructing, before Angular binds inputs, so `[ngpFocusTrapDisabled]="true"` never actually suppressed initial focus. Both input reads now happen inside the render callback. The same would have applied to the new `autoFocus` input, which is how it surfaced.

### Tests

Written first, and the baseline was recorded before implementing: 4 failures in the new `menu-initial-focus.test.ts` and 1 in the new focus-trap `Initial Focus` block. The button-item and empty-menu-container cases passed from the start, pinning down existing behaviour that had to survive.

- `menu/src/menu/tests/menu-initial-focus.test.ts` (new): first item focused for `div` items and for `button` items, roving navigation after open, disabled first item skipped, container fallback when there are no items, and first submenu item on submenu open.
- `focus-trap/tests/focus-trap.test.ts`: focuses the first tabbable element by default, does not move focus when `autoFocus` is disabled, and still traps focus when `autoFocus` is disabled.

Full library suite green (2430 tests, 158 files); build and lint clean.

One thing worth flagging: on one of three full-suite runs, two hover/timeout tests failed — `menu-primitive.test.ts > should reset pointer tracking state when menu closes via item click` and a tooltip `mouseleave` test. Both hang off 50 ms grace periods, the tooltip one is not reachable from this diff, the menu suite passed 3/3 in isolation, and the other two full runs were clean. Reads as load-related flakiness in the sandbox rather than a regression, but calling it out rather than burying it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`NgpFocusTrapProps.autoFocus` and the `ngpFocusTrapAutoFocus` input are additive and default to the previous behaviour. `activateFirst` / `activateLast` change their return type from `void` to `boolean`, which is source-compatible for callers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwSXWakChbU1WDYJpKPbgi)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes menu initial focus so the first enabled item is focused on open (including non-native items like divs). Moves initial focus from `NgpFocusTrap` to the menu to avoid a render-phase race and remove the rAF workaround.

- **Bug Fixes**
  - `ng-primitives/menu`: menu owns initial focus; focuses first enabled item via roving focus in the read phase; falls back to the container when no items; applies to `ngpContextMenu` and submenus.
  - `ng-primitives/focus-trap`: adds `autoFocus` (`ngpFocusTrapAutoFocus`, default `true`); when `false`, the trap still traps but doesn’t move focus; input reads moved into render so `[ngpFocusTrapDisabled]` is honored.
  - `ng-primitives/roving-focus`: `activateFirst`/`activateLast` return a boolean to indicate if an item was activated.
  - Tests: add coverage for menu initial focus and focus-trap `autoFocus`.

- **Refactors**
  - Trimmed initial-focus comments in `ng-primitives/menu`.

<sup>Written for commit 3cf685c74599f33de04c405e745252c81140f9e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional control over whether focus automatically moves into a focus trap.
  * Improved menu initial focus, including disabled items, non-focusable items and empty menus.
  * Enhanced nested menu navigation and focus restoration.

* **Bug Fixes**
  * Improved coordination between focus trapping and roving focus, keeping focus reliably within menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->