### PR TITLE
fix(ai): apply the thread viewport threshold and gate auto-scroll on it

### DIFF
--- a/packages/ng-primitives/ai/src/thread-message/thread-message-state.ts
+++ b/packages/ng-primitives/ai/src/thread-message/thread-message-state.ts
@@ -27,9 +27,10 @@ export const [
   })
     .pipe(safeTakeUntilDestroyed())
     .subscribe(() => {
-      // if this is the last message, scroll to bottom
+      // follow the stream only while the user is still at the bottom, so it does not pull
+      // them away from an earlier message they are reading
       if (thread().isLastMessage(state)) {
-        thread().scrollToBottom('smooth');
+        thread().autoScrollToBottom('smooth');
       }
     });
 

--- a/packages/ng-primitives/ai/src/thread-message/thread-message-state.ts
+++ b/packages/ng-primitives/ai/src/thread-message/thread-message-state.ts
@@ -30,7 +30,7 @@ export const [
       // follow the stream only while the user is still at the bottom, so it does not pull
       // them away from an earlier message they are reading
       if (thread().isLastMessage(state)) {
-        thread().autoScrollToBottom('smooth');
+        thread().scrollToBottomIfNeeded('smooth');
       }
     });
 

--- a/packages/ng-primitives/ai/src/thread-viewport/tests/thread-viewport-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/thread-viewport/tests/thread-viewport-primitive.test.ts
@@ -92,4 +92,103 @@ describe('NgpThreadViewport', () => {
 
     await waitFor(() => expect(viewport.scrollTop).toBeGreaterThan(0));
   });
+
+  describe('threshold', () => {
+    /**
+     * A viewport 100px tall holding two 300px messages, so the scrollable distance is 500px.
+     * Streaming grows the last message to 400px, taking the scrollable distance to 600px.
+     */
+    @Component({
+      imports: [NgpThread, NgpThreadViewport, NgpThreadMessage],
+      template: `
+        <div ngpThread>
+          <div
+            [ngpThreadViewportThreshold]="threshold"
+            ngpThreadViewport
+            data-testid="viewport"
+            style="height: 100px; overflow-y: auto;"
+          >
+            <div ngpThreadMessage style="height: 300px;">First message</div>
+            <div [style.height.px]="height" ngpThreadMessage>{{ content }}</div>
+          </div>
+        </div>
+      `,
+    })
+    class StreamingThread {
+      threshold = 70;
+      height = 300;
+      content = 'Second';
+    }
+
+    /** Scroll the viewport and give the scroll listener a chance to run. */
+    async function scrollTo(viewport: HTMLElement, top: number): Promise<void> {
+      viewport.scrollTop = top;
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+
+    /** Grow the last message, which streams new content into it. */
+    function stream(fixture: { componentInstance: StreamingThread; detectChanges(): void }): void {
+      fixture.componentInstance.height = 400;
+      fixture.componentInstance.content = 'Second message, now streaming more content';
+      fixture.detectChanges();
+    }
+
+    it('should not scroll when the last message streams and the user has scrolled up', async () => {
+      const { fixture } = await render(StreamingThread);
+      const viewport = screen.getByTestId('viewport');
+
+      // go to the bottom, then scroll back up to read an earlier message
+      await scrollTo(viewport, 500);
+      await scrollTo(viewport, 0);
+
+      stream(fixture);
+
+      // give the scroll a chance to happen before asserting that it did not
+      await new Promise(resolve => setTimeout(resolve, 150));
+
+      expect(viewport.scrollTop).toBe(0);
+    });
+
+    it('should scroll when the last message streams and the user is at the bottom', async () => {
+      const { fixture } = await render(StreamingThread);
+      const viewport = screen.getByTestId('viewport');
+
+      await scrollTo(viewport, 500);
+
+      stream(fixture);
+
+      await waitFor(() => expect(viewport.scrollTop).toBe(600));
+    });
+
+    it('should treat a position within the threshold as being at the bottom', async () => {
+      const { fixture } = await render(StreamingThread);
+      const viewport = screen.getByTestId('viewport');
+
+      // scroll up off the bottom, but only by 50px — inside the default 70px threshold
+      await scrollTo(viewport, 500);
+      await scrollTo(viewport, 450);
+
+      stream(fixture);
+
+      await waitFor(() => expect(viewport.scrollTop).toBe(600));
+    });
+
+    it('should honour a custom threshold', async () => {
+      const { fixture } = await render(StreamingThread, {
+        componentProperties: { threshold: 0 },
+      });
+      const viewport = screen.getByTestId('viewport');
+
+      // the same 50px off the bottom, now outside the configured 0px threshold
+      await scrollTo(viewport, 500);
+      await scrollTo(viewport, 450);
+
+      stream(fixture);
+
+      // give the scroll a chance to happen before asserting that it did not
+      await new Promise(resolve => setTimeout(resolve, 150));
+
+      expect(viewport.scrollTop).toBe(450);
+    });
+  });
 });

--- a/packages/ng-primitives/ai/src/thread-viewport/tests/thread-viewport-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/thread-viewport/tests/thread-viewport-primitive.test.ts
@@ -173,6 +173,27 @@ describe('NgpThreadViewport', () => {
       await waitFor(() => expect(viewport.scrollTop).toBe(600));
     });
 
+    it('should recompute the at-bottom state when the threshold changes', async () => {
+      const { fixture } = await render(StreamingThread);
+      const viewport = screen.getByTestId('viewport');
+
+      // 50px off the bottom, inside the initial 70px threshold
+      await scrollTo(viewport, 500);
+      await scrollTo(viewport, 450);
+
+      // narrow the threshold without scrolling again — the same position is now outside it
+      fixture.componentInstance.threshold = 0;
+      fixture.detectChanges();
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      stream(fixture);
+
+      // give the scroll a chance to happen before asserting that it did not
+      await new Promise(resolve => setTimeout(resolve, 150));
+
+      expect(viewport.scrollTop).toBe(450);
+    });
+
     it('should honour a custom threshold', async () => {
       const { fixture } = await render(StreamingThread, {
         componentProperties: { threshold: 0 },

--- a/packages/ng-primitives/ai/src/thread-viewport/thread-viewport-state.ts
+++ b/packages/ng-primitives/ai/src/thread-viewport/thread-viewport-state.ts
@@ -10,6 +10,12 @@ export interface NgpThreadViewportState {
    * Scroll the viewport to the bottom.
    */
   scrollToBottom(behavior: ScrollBehavior): void;
+  /**
+   * @internal
+   * Scroll the viewport to the bottom, but only if it is already at the bottom, so content
+   * arriving while the user is reading further up does not pull them away from it.
+   */
+  autoScrollToBottom(behavior: ScrollBehavior): void;
 }
 
 export interface NgpThreadViewportProps {
@@ -17,6 +23,10 @@ export interface NgpThreadViewportProps {
    * Whether the thread should automatically scroll to the bottom when new content is added.
    */
   readonly autoScroll?: Signal<boolean>;
+  /**
+   * The distance in pixels from the bottom that is still considered "at the bottom".
+   */
+  readonly threshold?: Signal<number>;
 }
 
 export const [
@@ -26,7 +36,10 @@ export const [
   provideThreadViewportState,
 ] = createPrimitive(
   'NgpThreadViewport',
-  ({ autoScroll = signal(true) }: NgpThreadViewportProps): NgpThreadViewportState => {
+  ({
+    autoScroll = signal(true),
+    threshold = signal(70),
+  }: NgpThreadViewportProps): NgpThreadViewportState => {
     const element = injectElementRef<HTMLElement>();
     const thread = injectThreadState();
 
@@ -47,9 +60,18 @@ export const [
       });
     }
 
+    function autoScrollToBottom(behavior: ScrollBehavior): void {
+      // the user has scrolled away from the bottom, so leave them where they are
+      if (!isAtBottom) {
+        return;
+      }
+
+      scrollToBottom(behavior);
+    }
+
     function onScroll(): void {
       const { scrollHeight, scrollTop, clientHeight } = element.nativeElement;
-      const atBottom = scrollHeight - scrollTop <= clientHeight;
+      const atBottom = scrollHeight - scrollTop - clientHeight <= threshold();
 
       if (atBottom || lastScrollTop >= scrollTop) {
         isAtBottom = atBottom;
@@ -64,13 +86,11 @@ export const [
     fromResizeEvent(element.nativeElement)
       .pipe(safeTakeUntilDestroyed())
       .subscribe(() => {
-        if (isAtBottom) {
-          scrollToBottom('instant');
-        }
+        autoScrollToBottom('instant');
         onScroll();
       });
 
-    const state = { scrollToBottom } satisfies NgpThreadViewportState;
+    const state = { scrollToBottom, autoScrollToBottom } satisfies NgpThreadViewportState;
 
     thread().setViewport(state);
     onDestroy(() => thread().removeViewport(state));

--- a/packages/ng-primitives/ai/src/thread-viewport/thread-viewport-state.ts
+++ b/packages/ng-primitives/ai/src/thread-viewport/thread-viewport-state.ts
@@ -1,5 +1,5 @@
 import { signal, Signal } from '@angular/core';
-import { fromResizeEvent, injectElementRef } from 'ng-primitives/internal';
+import { explicitEffect, fromResizeEvent, injectElementRef } from 'ng-primitives/internal';
 import { createPrimitive, listener, onDestroy } from 'ng-primitives/state';
 import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
 import { injectThreadState } from '../thread/thread-state';
@@ -15,7 +15,7 @@ export interface NgpThreadViewportState {
    * Scroll the viewport to the bottom, but only if it is already at the bottom, so content
    * arriving while the user is reading further up does not pull them away from it.
    */
-  autoScrollToBottom(behavior: ScrollBehavior): void;
+  scrollToBottomIfNeeded(behavior: ScrollBehavior): void;
 }
 
 export interface NgpThreadViewportProps {
@@ -60,7 +60,7 @@ export const [
       });
     }
 
-    function autoScrollToBottom(behavior: ScrollBehavior): void {
+    function scrollToBottomIfNeeded(behavior: ScrollBehavior): void {
       // the user has scrolled away from the bottom, so leave them where they are
       if (!isAtBottom) {
         return;
@@ -83,14 +83,17 @@ export const [
     // Listener
     listener(element, 'scroll', onScroll);
 
+    // no scroll event fires when the threshold itself changes, so recompute against the new value
+    explicitEffect([threshold], () => onScroll());
+
     fromResizeEvent(element.nativeElement)
       .pipe(safeTakeUntilDestroyed())
       .subscribe(() => {
-        autoScrollToBottom('instant');
+        scrollToBottomIfNeeded('instant');
         onScroll();
       });
 
-    const state = { scrollToBottom, autoScrollToBottom } satisfies NgpThreadViewportState;
+    const state = { scrollToBottom, scrollToBottomIfNeeded } satisfies NgpThreadViewportState;
 
     thread().setViewport(state);
     onDestroy(() => thread().removeViewport(state));

--- a/packages/ng-primitives/ai/src/thread-viewport/thread-viewport.ts
+++ b/packages/ng-primitives/ai/src/thread-viewport/thread-viewport.ts
@@ -30,7 +30,10 @@ export class NgpThreadViewport {
   });
 
   /** The state of the thread viewport. */
-  protected readonly state = ngpThreadViewport({ autoScroll: this.autoScroll });
+  protected readonly state = ngpThreadViewport({
+    autoScroll: this.autoScroll,
+    threshold: this.threshold,
+  });
 
   /**
    * Scroll the container to the bottom.

--- a/packages/ng-primitives/ai/src/thread/thread-state.ts
+++ b/packages/ng-primitives/ai/src/thread/thread-state.ts
@@ -11,6 +11,12 @@ export interface NgpThreadState {
    */
   scrollToBottom(behavior: ScrollBehavior): void;
   /**
+   * @internal
+   * Scroll the thread viewport to the bottom, but only if it is already at the bottom.
+   * @param behavior The scroll behavior to use.
+   */
+  autoScrollToBottom(behavior: ScrollBehavior): void;
+  /**
    * Set the prompt text in the associated prompt composer.
    * @param value The prompt text.
    */
@@ -64,6 +70,10 @@ export const [NgpThreadStateToken, ngpThread, injectThreadState, provideThreadSt
       viewport()?.scrollToBottom(behavior);
     }
 
+    function autoScrollToBottom(behavior: ScrollBehavior): void {
+      viewport()?.autoScrollToBottom(behavior);
+    }
+
     function setPrompt(value: string): void {
       promptInput()?.setPrompt(value);
     }
@@ -105,6 +115,7 @@ export const [NgpThreadStateToken, ngpThread, injectThreadState, provideThreadSt
 
     return {
       scrollToBottom,
+      autoScrollToBottom,
       setPrompt,
       setViewport,
       removeViewport,

--- a/packages/ng-primitives/ai/src/thread/thread-state.ts
+++ b/packages/ng-primitives/ai/src/thread/thread-state.ts
@@ -15,7 +15,7 @@ export interface NgpThreadState {
    * Scroll the thread viewport to the bottom, but only if it is already at the bottom.
    * @param behavior The scroll behavior to use.
    */
-  autoScrollToBottom(behavior: ScrollBehavior): void;
+  scrollToBottomIfNeeded(behavior: ScrollBehavior): void;
   /**
    * Set the prompt text in the associated prompt composer.
    * @param value The prompt text.
@@ -70,8 +70,8 @@ export const [NgpThreadStateToken, ngpThread, injectThreadState, provideThreadSt
       viewport()?.scrollToBottom(behavior);
     }
 
-    function autoScrollToBottom(behavior: ScrollBehavior): void {
-      viewport()?.autoScrollToBottom(behavior);
+    function scrollToBottomIfNeeded(behavior: ScrollBehavior): void {
+      viewport()?.scrollToBottomIfNeeded(behavior);
     }
 
     function setPrompt(value: string): void {
@@ -115,7 +115,7 @@ export const [NgpThreadStateToken, ngpThread, injectThreadState, provideThreadSt
 
     return {
       scrollToBottom,
-      autoScrollToBottom,
+      scrollToBottomIfNeeded,
       setPrompt,
       setViewport,
       removeViewport,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #870

## What does this PR implement/fix?

`ngpThreadViewportThreshold` is documented as the distance from the bottom within which the thread counts as being "at the bottom", governing "whether automatic scrolling to the bottom should occur". Neither half held.

**The input never reached the state.** `NgpThreadViewport` declared it, but only `autoScroll` was passed to `ngpThreadViewport(...)`, and `onScroll` compared `scrollHeight - scrollTop <= clientHeight` — a fixed 0px tolerance. Setting the input changed nothing, and sub-pixel scroll offsets (fractional device pixel ratios, zoom) could read as "not at the bottom" while the thread looked pinned to it.

**The at-bottom result was only consulted on resize.** The new-content path ignored it: `NgpThreadMessage`'s mutation observer called `thread.scrollToBottom('smooth')` whenever the last message changed, so a streaming reply pulled the viewport back down while the user was reading earlier messages.

This PR:

- adds `threshold` to `NgpThreadViewportProps`, passes the input through from the directive, and measures `scrollHeight - scrollTop - clientHeight <= threshold()`;
- adds `autoScrollToBottom(behavior)`, which scrolls only when the viewport is already at the bottom, and routes the thread-message path through it. The resize handler now shares it instead of repeating the check inline.

The explicit scroll on submit still goes through `scrollToBottom` and stays unconditional — someone who just sent a prompt should always be taken to the bottom.

Four tests cover it: streaming does not move a viewport the user scrolled up from, still follows one that is at the bottom, treats a position inside the threshold as at the bottom, and honours a custom threshold. The first and last fail on `next`.

No documentation change: the input's doc comment already describes this behaviour and is the source for the generated API reference — it was accurate, the implementation was not.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

No public API changes — the input already existed, it just did nothing. Runtime behaviour does change, in the direction the input documents: a thread the user has scrolled up from no longer jumps to the bottom as content streams in, and `ngpThreadViewportThreshold` now takes effect where it previously had none.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat auto-scroll so it only follows streaming replies when the viewport is already at the bottom. The `ngpThreadViewportThreshold` input now works, updates live, and prevents jumps while reading.

- **Bug Fixes**
  - Pass `ngpThreadViewportThreshold` to `ngpThreadViewport` state and use it in the at-bottom check (`scrollHeight - scrollTop - clientHeight <= threshold()`), defaulting to 70px.
  - Add `scrollToBottomIfNeeded(behavior)` and use it for streaming and resize; only scroll when already at the bottom. Submit still uses `scrollToBottom` unconditionally.
  - Recompute the at-bottom state when the threshold changes to avoid stale values; tests cover scrolled-up, at-bottom, threshold tolerance, custom threshold, and live threshold changes.

<sup>Written for commit 33b3b49ba1f4c804578c4ecf2d0878db870c7462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable “at bottom” threshold for thread viewport auto-scrolling, including the ability to disable thresholding.
* **Bug Fixes**
  * Improved streaming updates so the view follows new messages only when the user is at, or within the threshold of, the bottom (otherwise it won’t interrupt older content).
  * Ensured resize and threshold changes re-check “at bottom” and only scroll when appropriate.
* **Tests**
  * Added coverage for scrolling threshold behaviour during streaming, including edge cases like custom thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->