### PR TITLE
fix(ai): read speech recognition from globalThis so dictation survives SSR

### DIFF
--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
@@ -11,13 +11,6 @@ import {
 } from 'ng-primitives/state';
 import { injectPromptComposerState } from '../prompt-composer/prompt-composer-state';
 
-declare global {
-  interface Window {
-    SpeechRecognition: any;
-    webkitSpeechRecognition: any;
-  }
-}
-
 export interface NgpPromptComposerDictationState {
   /**
    * Whether dictation is currently active.
@@ -93,7 +86,10 @@ export const [
     }
 
     function initializeSpeechRecognition(): void {
-      const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+      // read through globalThis, not window: this runs during construction, which is the one
+      // phase the server executes, and referencing an undeclared `window` there is a ReferenceError
+      const SpeechRecognition =
+        (globalThis as any).SpeechRecognition || (globalThis as any).webkitSpeechRecognition;
 
       if (!SpeechRecognition) {
         return;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #872

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

`initializeSpeechRecognition()` is called from the factory body, so it runs during construction —
the one phase the server executes. Its first line read the bare `window` global, and referencing
an undeclared identifier is a `ReferenceError`, not `undefined`, so it threw before the `||` could
short-circuit. Server-rendering or prerendering any page containing `button[ngpPromptComposerDictation]`
failed with `window is not defined`, and a consumer had no way around it other than not rendering
the button on the server.

Reading through `globalThis` fixes it and matches what `NgpPromptComposer` already does for
`dictationSupported`. On the server both properties are simply `undefined`, so the existing
`if (!SpeechRecognition) return;` guard takes over: no recognition object is created, `recognition`
stays `null`, and the three functions that use it (`onClick`, `startDictation`, `stopDictation`)
already guard against that. The button degrades to "dictation not supported", which is the state
the composer reports on the server anyway.

I did not add an `isPlatformBrowser(inject(PLATFORM_ID))` guard as the issue suggests as an
alternative — with `globalThis` it would be redundant, and it would leave the two files reading the
same API two different ways.

The change also drops the `declare global` block. It existed only to type that one read, and it was
emitted into the published `.d.ts`, so it was leaking `SpeechRecognition` and `webkitSpeechRecognition`
into the global scope of every consumer. Verified on a clean build that no `declare global` remains in
`dist/packages/ng-primitives/**/*.d.ts`, and that the shipped `fesm2022` bundle now contains only
`globalThis.*` reads and no `window.*` ones.

**On tests:** the existing 12 dictation tests pass unchanged — they already install their mocks on
`globalThis`, so they cover the browser path. I have not added an SSR regression test: `test-node`
currently only includes `schematics/**/*.node.test.ts` and does not wire the Angular plugin, so
rendering a primitive with `@angular/platform-server` would mean standing up a new vitest project.
That felt like repo infrastructure worth agreeing separately rather than folding into a one-line
bugfix — happy to add it here or in a follow-up, whichever you prefer.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

No public API changes and no behaviour change in the browser. The removed `declare global` was never
intended as public API; an application that was (knowingly or not) relying on the leaked ambient
`SpeechRecognition` / `webkitSpeechRecognition` types would now need to declare them itself.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSR crashes in the dictation feature by reading speech recognition from `globalThis` instead of `window`. Pages with the dictation button now prerender without "window is not defined" errors.

- **Bug Fixes**
  - Read `SpeechRecognition` via `globalThis` to avoid SSR `ReferenceError` and let dictation survive SSR/prerender.
  - Removed `declare global` typings to stop leaking `SpeechRecognition` types into consumer `.d.ts`.
  - No browser behavior changes; on the server it cleanly degrades to unsupported.

<sup>Written for commit da80d93105b626251065bc92c95b2941ab9d9b9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side compatibility for dictation speech recognition.
  * Prevented errors when initialising the prompt composer outside a browser environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->