### PR TITLE
feat(popover,tooltip): expose a setter for every trigger input

### DIFF
--- a/apps/components/src/app/pages/reusable-components/popover/popover-trigger.ts
+++ b/apps/components/src/app/pages/reusable-components/popover/popover-trigger.ts
@@ -34,6 +34,6 @@ export class PopoverTrigger {
   });
 
   constructor() {
-    this.popoverTrigger().popover.set(Popover);
+    this.popoverTrigger().setPopover(Popover);
   }
 }

--- a/apps/components/src/app/pages/reusable-components/tooltip/tooltip-trigger.ts
+++ b/apps/components/src/app/pages/reusable-components/tooltip/tooltip-trigger.ts
@@ -32,6 +32,6 @@ export class TooltipTrigger {
   });
 
   constructor() {
-    this.tooltipTrigger().tooltip.set(Tooltip);
+    this.tooltipTrigger().setTooltip(Tooltip);
   }
 }

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -28,6 +28,7 @@ import {
   dataBinding,
   deprecatedSetter,
   listener,
+  onDestroy,
   StateInjectionOptions,
 } from 'ng-primitives/state';
 
@@ -40,40 +41,40 @@ export interface NgpPopoverTriggerState<T> {
    * Define if the trigger should be disabled.
    * @default false
    */
-  readonly disabled: Signal<boolean>;
+  readonly disabled: WritableSignal<boolean>;
   /**
    * Define the placement of the popover relative to the trigger.
    * @default 'top'
    */
-  readonly placement: Signal<NgpPlacement>;
+  readonly placement: WritableSignal<NgpPlacement>;
   /**
    * Define the offset of the popover relative to the trigger.
    * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
    * @default 0
    */
-  readonly offset: Signal<NgpOffset>;
+  readonly offset: WritableSignal<NgpOffset>;
   /**
    * Define the delay before the popover is displayed.
    * @default 0
    */
-  readonly showDelay: Signal<number>;
+  readonly showDelay: WritableSignal<number>;
   /**
    * Define the delay before the popover is hidden.
    * @default 0
    */
-  readonly hideDelay: Signal<number>;
+  readonly hideDelay: WritableSignal<number>;
   /**
    * Define whether the popover should flip when there is not enough space for the popover.
    * Can be a boolean to enable/disable, or an object with padding and fallbackPlacements options.
    * @default true
    */
-  readonly flip: Signal<NgpFlip>;
+  readonly flip: WritableSignal<NgpFlip>;
   /**
    * Configure shift behavior to keep the popover in view.
    * Can be a boolean to enable/disable, or an object with padding and limiter options.
    * @default undefined (enabled by default in overlay)
    */
-  readonly shift: Signal<NgpShift>;
+  readonly shift: WritableSignal<NgpShift>;
   /**
    * Define the container in which the popover should be attached.
    * @default document.body
@@ -83,39 +84,39 @@ export interface NgpPopoverTriggerState<T> {
    * Define whether the popover should close when clicking outside of it, or a guard function.
    * @default true
    */
-  readonly closeOnOutsideClick: Signal<NgpDismissGuard<Element>>;
+  readonly closeOnOutsideClick: WritableSignal<NgpDismissGuard<Element>>;
   /**
    * Define whether the popover should close when the escape key is pressed, or a guard function.
    * @default true
    */
-  readonly closeOnEscape: Signal<NgpDismissGuard<KeyboardEvent>>;
+  readonly closeOnEscape: WritableSignal<NgpDismissGuard<KeyboardEvent>>;
   /**
    * Defines how the popover behaves when the window is scrolled.
    * @default 'reposition'
    */
-  readonly scrollBehavior: Signal<'reposition' | 'block' | 'close'>;
+  readonly scrollBehavior: WritableSignal<'reposition' | 'block' | 'close'>;
   /**
    * Provide context to the popover. This can be used to pass data to the popover content.
    */
-  readonly context: Signal<T | undefined>;
+  readonly context: WritableSignal<T | undefined>;
   /**
    * Define an anchor element for positioning the popover.
    * If provided, the popover will be positioned relative to this element instead of the trigger.
    */
-  readonly anchor: Signal<HTMLElement | null>;
+  readonly anchor: WritableSignal<HTMLElement | null>;
   /**
    * Define whether to track the trigger element position on every animation frame.
    * Useful for moving elements like slider thumbs.
    * @default false
    */
-  readonly trackPosition: Signal<boolean>;
+  readonly trackPosition: WritableSignal<boolean>;
   /**
    * Define the cooldown duration in milliseconds.
    * When moving from one popover to another within this duration,
    * the showDelay is skipped for the new popover.
    * @default 0
    */
-  readonly cooldown: Signal<number>;
+  readonly cooldown: WritableSignal<number>;
   /**
    * The overlay that manages the popover
    * @internal
@@ -126,15 +127,38 @@ export interface NgpPopoverTriggerState<T> {
    * @internal
    */
   readonly open: Signal<boolean>;
-  /** @internal onDestroy callback */
-  destroy: () => void;
-  /**
-   * Set the container in which the popover should be attached. Takes effect the
-   * next time the popover is opened; it does not move a popover that is already
-   * open.
-   * @param container - The new container
-   */
+  /** Set the popover content. */
+  setPopover: (popover: NgpOverlayContent<T> | undefined) => void;
+  /** Set whether the trigger is disabled. */
+  setDisabled: (disabled: boolean) => void;
+  /** Set the placement of the popover relative to the trigger. */
+  setPlacement: (placement: NgpPlacement) => void;
+  /** Set the offset of the popover relative to the trigger. */
+  setOffset: (offset: NgpOffset) => void;
+  /** Set the delay before the popover is displayed. */
+  setShowDelay: (showDelay: number) => void;
+  /** Set the delay before the popover is hidden. */
+  setHideDelay: (hideDelay: number) => void;
+  /** Set the flip behaviour. */
+  setFlip: (flip: NgpFlip) => void;
+  /** Set the shift behaviour. */
+  setShift: (shift: NgpShift) => void;
+  /** Set the container in which the popover should be attached. */
   setContainer: (container: HTMLElement | string | null) => void;
+  /** Set whether the popover closes when clicking outside of it, or a guard function. */
+  setCloseOnOutsideClick: (closeOnOutsideClick: NgpDismissGuard<Element>) => void;
+  /** Set whether the popover closes when the escape key is pressed, or a guard function. */
+  setCloseOnEscape: (closeOnEscape: NgpDismissGuard<KeyboardEvent>) => void;
+  /** Set how the popover behaves when the window is scrolled. */
+  setScrollBehavior: (scrollBehavior: 'reposition' | 'block' | 'close') => void;
+  /** Set the context passed to the popover content. */
+  setContext: (context: T | undefined) => void;
+  /** Set the anchor element the popover is positioned against. */
+  setAnchor: (anchor: HTMLElement | null) => void;
+  /** Set whether the trigger position is tracked on every animation frame. */
+  setTrackPosition: (trackPosition: boolean) => void;
+  /** Set the cooldown duration in milliseconds. */
+  setCooldown: (cooldown: number) => void;
   /**
    * Show the popover.
    * @returns A promise that resolves when the popover has been shown
@@ -243,30 +267,49 @@ export const [
 ] = createPrimitive(
   'NgpPopoverTrigger',
   <T>({
-    popover: _popover = signal<NgpOverlayContent<T> | undefined>(undefined),
-    disabled = signal<boolean>(false),
-    placement = signal<NgpPlacement>('bottom'),
-    offset = signal<NgpOffset>(4),
-    showDelay = signal<number>(0),
-    hideDelay = signal<number>(0),
-    flip = signal<NgpFlip>(true),
-    shift = signal<NgpShift>(undefined),
+    popover: _popover,
+    disabled: _disabled,
+    placement: _placement,
+    offset: _offset,
+    showDelay: _showDelay,
+    hideDelay: _hideDelay,
+    flip: _flip,
+    shift: _shift,
     container: _container,
-    closeOnOutsideClick = signal<NgpDismissGuard<Element>>(true),
-    closeOnEscape = signal<NgpDismissGuard<KeyboardEvent>>(true),
-    scrollBehavior = signal<'reposition' | 'block' | 'close'>('reposition'),
-    context = signal<T | undefined>(undefined),
-    anchor = signal<HTMLElement | null>(null),
-    trackPosition = signal<boolean>(false),
-    cooldown = signal<number>(0),
+    closeOnOutsideClick: _closeOnOutsideClick,
+    closeOnEscape: _closeOnEscape,
+    scrollBehavior: _scrollBehavior,
+    context: _context,
+    anchor: _anchor,
+    trackPosition: _trackPosition,
+    cooldown: _cooldown,
     onOpenChange,
   }: NgpPopoverTriggerProps<T>): NgpPopoverTriggerState<T> => {
     const elementRef = injectElementRef<HTMLElement>();
     const viewContainerRef = inject(ViewContainerRef);
     const injector = inject(Injector);
 
-    const popover = controlled(_popover);
-    const container = controlled(_container, 'body');
+    // Every input is wrapped so the state can expose a setter for it - see the
+    // setter block at the bottom of the factory.
+    const popover = controlled<NgpOverlayContent<T> | undefined>(_popover, undefined);
+    const disabled = controlled(_disabled, false);
+    const placement = controlled<NgpPlacement>(_placement, 'bottom');
+    const offset = controlled<NgpOffset>(_offset, 4);
+    const showDelay = controlled(_showDelay, 0);
+    const hideDelay = controlled(_hideDelay, 0);
+    const flip = controlled<NgpFlip>(_flip, true);
+    const shift = controlled<NgpShift>(_shift, undefined);
+    const container = controlled<HTMLElement | string | null>(_container, 'body');
+    const closeOnOutsideClick = controlled<NgpDismissGuard<Element>>(_closeOnOutsideClick, true);
+    const closeOnEscape = controlled<NgpDismissGuard<KeyboardEvent>>(_closeOnEscape, true);
+    const scrollBehavior = controlled<'reposition' | 'block' | 'close'>(
+      _scrollBehavior,
+      'reposition',
+    );
+    const context = controlled<T | undefined>(_context, undefined);
+    const anchor = controlled<HTMLElement | null>(_anchor, null);
+    const trackPosition = controlled(_trackPosition, false);
+    const cooldown = controlled(_cooldown, 0);
 
     const overlay = signal<NgpOverlay<T> | null>(null);
     const open = computed(() => overlay()?.isOpen() ?? false);
@@ -285,9 +328,14 @@ export const [
     // Event listener
     listener(elementRef, 'click', toggle);
 
-    function destroy(): void {
+    // Tearing the overlay down closes it, but a destroyed directive can no longer
+    // emit through `openChange` (Angular NG0953), so skip the notification.
+    let destroyed = false;
+
+    onDestroy(() => {
+      destroyed = true;
       overlay()?.destroy();
-    }
+    });
 
     function createOverlayInstance(): void {
       const popoverInstance = popover();
@@ -318,7 +366,11 @@ export const [
         trackPosition: trackPosition(),
         overlayType: 'popover',
         cooldown: cooldown(),
-        onClose: () => onOpenChange?.(false),
+        onClose: () => {
+          if (!destroyed) {
+            onOpenChange?.(false);
+          }
+        },
       };
 
       overlay.set(createOverlay(config));
@@ -370,32 +422,110 @@ export const [
       await overlay()?.hide({ origin });
     }
 
+    function setPopover(newPopover: NgpOverlayContent<T> | undefined): void {
+      popover.set(newPopover);
+    }
+
+    function setDisabled(isDisabled: boolean): void {
+      disabled.set(isDisabled);
+    }
+
+    function setPlacement(newPlacement: NgpPlacement): void {
+      placement.set(newPlacement);
+    }
+
+    function setOffset(newOffset: NgpOffset): void {
+      offset.set(newOffset);
+    }
+
+    function setShowDelay(delay: number): void {
+      showDelay.set(delay);
+    }
+
+    function setHideDelay(delay: number): void {
+      hideDelay.set(delay);
+    }
+
+    function setFlip(shouldFlip: NgpFlip): void {
+      flip.set(shouldFlip);
+    }
+
+    function setShift(shouldShift: NgpShift): void {
+      shift.set(shouldShift);
+    }
+
     function setContainer(newContainer: HTMLElement | string | null): void {
       container.set(newContainer);
     }
 
+    function setCloseOnOutsideClick(guard: NgpDismissGuard<Element>): void {
+      closeOnOutsideClick.set(guard);
+    }
+
+    function setCloseOnEscape(guard: NgpDismissGuard<KeyboardEvent>): void {
+      closeOnEscape.set(guard);
+    }
+
+    function setScrollBehavior(behavior: 'reposition' | 'block' | 'close'): void {
+      scrollBehavior.set(behavior);
+    }
+
+    function setContext(newContext: T | undefined): void {
+      context.set(newContext);
+    }
+
+    function setAnchor(newAnchor: HTMLElement | null): void {
+      anchor.set(newAnchor);
+    }
+
+    function setTrackPosition(shouldTrack: boolean): void {
+      trackPosition.set(shouldTrack);
+    }
+
+    function setCooldown(duration: number): void {
+      cooldown.set(duration);
+    }
+
     return {
       elementRef,
-      popover,
-      disabled,
-      placement,
-      offset,
-      showDelay,
-      hideDelay,
-      flip,
-      shift,
+      popover: deprecatedSetter(popover, 'setPopover', setPopover),
+      disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
+      placement: deprecatedSetter(placement, 'setPlacement', setPlacement),
+      offset: deprecatedSetter(offset, 'setOffset', setOffset),
+      showDelay: deprecatedSetter(showDelay, 'setShowDelay', setShowDelay),
+      hideDelay: deprecatedSetter(hideDelay, 'setHideDelay', setHideDelay),
+      flip: deprecatedSetter(flip, 'setFlip', setFlip),
+      shift: deprecatedSetter(shift, 'setShift', setShift),
       container: deprecatedSetter(container, 'setContainer', setContainer),
-      closeOnOutsideClick,
-      closeOnEscape,
-      scrollBehavior,
-      context,
-      anchor,
-      trackPosition,
-      cooldown,
+      closeOnOutsideClick: deprecatedSetter(
+        closeOnOutsideClick,
+        'setCloseOnOutsideClick',
+        setCloseOnOutsideClick,
+      ),
+      closeOnEscape: deprecatedSetter(closeOnEscape, 'setCloseOnEscape', setCloseOnEscape),
+      scrollBehavior: deprecatedSetter(scrollBehavior, 'setScrollBehavior', setScrollBehavior),
+      context: deprecatedSetter(context, 'setContext', setContext),
+      anchor: deprecatedSetter(anchor, 'setAnchor', setAnchor),
+      trackPosition: deprecatedSetter(trackPosition, 'setTrackPosition', setTrackPosition),
+      cooldown: deprecatedSetter(cooldown, 'setCooldown', setCooldown),
       overlay,
       open,
-      destroy,
+      setPopover,
+      setDisabled,
+      setPlacement,
+      setOffset,
+      setShowDelay,
+      setHideDelay,
+      setFlip,
+      setShift,
       setContainer,
+      setCloseOnOutsideClick,
+      setCloseOnEscape,
+      setScrollBehavior,
+      setContext,
+      setAnchor,
+      setTrackPosition,
+      setCooldown,
       show,
       hide,
     } satisfies NgpPopoverTriggerState<T>;

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -44,13 +44,13 @@ export interface NgpPopoverTriggerState<T> {
   readonly disabled: WritableSignal<boolean>;
   /**
    * Define the placement of the popover relative to the trigger.
-   * @default 'top'
+   * @default 'bottom'
    */
   readonly placement: WritableSignal<NgpPlacement>;
   /**
    * Define the offset of the popover relative to the trigger.
    * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
-   * @default 0
+   * @default 4
    */
   readonly offset: WritableSignal<NgpOffset>;
   /**
@@ -182,13 +182,13 @@ export interface NgpPopoverTriggerProps<T> {
   readonly disabled?: Signal<boolean>;
   /**
    * Define the placement of the popover relative to the trigger.
-   * @default 'top'
+   * @default 'bottom'
    */
   readonly placement?: Signal<NgpPlacement>;
   /**
    * Define the offset of the popover relative to the trigger.
    * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
-   * @default 0
+   * @default 4
    */
   readonly offset?: Signal<NgpOffset>;
   /**

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
@@ -1,13 +1,6 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
-import {
-  booleanAttribute,
-  Directive,
-  input,
-  numberAttribute,
-  OnDestroy,
-  output,
-} from '@angular/core';
+import { booleanAttribute, Directive, input, numberAttribute, output } from '@angular/core';
 import {
   coerceFlip,
   dismissGuardAttribute,
@@ -35,7 +28,7 @@ import { ngpPopoverTrigger, providePopoverTriggerState } from './popover-trigger
   exportAs: 'ngpPopoverTrigger',
   providers: [providePopoverTriggerState({ inherit: false })],
 })
-export class NgpPopoverTrigger<T = null> implements OnDestroy {
+export class NgpPopoverTrigger<T = null> {
   /**
    * Access the global popover configuration.
    */
@@ -218,10 +211,6 @@ export class NgpPopoverTrigger<T = null> implements OnDestroy {
     cooldown: this.cooldown,
     onOpenChange: (value: boolean) => this.openChange.emit(value),
   });
-
-  ngOnDestroy(): void {
-    this.state.destroy();
-  }
 
   /**
    * Show the popover.

--- a/packages/ng-primitives/popover/src/popover/tests/popover-component.test.ts
+++ b/packages/ng-primitives/popover/src/popover/tests/popover-component.test.ts
@@ -46,7 +46,7 @@ class PopoverTrigger {
   readonly content = input.required<string>({ alias: 'appPopoverTrigger' });
 
   constructor() {
-    this.popoverTrigger().popover.set(Popover);
+    this.popoverTrigger().setPopover(Popover);
   }
 }
 

--- a/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
+++ b/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
@@ -2,7 +2,12 @@ import { Component, Directive, OnInit, signal } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
-import { injectPopoverTriggerState, NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+import {
+  injectPopoverTriggerState,
+  NgpPopover,
+  NgpPopoverTrigger,
+  NgpPopoverTriggerState,
+} from 'ng-primitives/popover';
 import { NgpPlacement } from 'ng-primitives/portal';
 import { NgpTooltip, NgpTooltipTrigger, provideTooltipConfig } from 'ng-primitives/tooltip';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -442,7 +447,7 @@ describe('NgpPopover', () => {
       });
     });
 
-    it('should emit openChange false when destroyed while open', async () => {
+    it('should tear the overlay down, without emitting, when destroyed while open', async () => {
       const { fixture, getByRole } = await render(OpenChangeTestComponent);
       const component = fixture.componentInstance;
 
@@ -455,10 +460,14 @@ describe('NgpPopover', () => {
 
       component.onOpenChange.mockClear();
 
-      // Destroy while open — should emit false
+      // Teardown runs from the state's onDestroy, by which point Angular has already
+      // destroyed the `openChange` OutputRef - emitting there throws NG0953.
       fixture.destroy();
-      expect(component.onOpenChange).toHaveBeenCalledWith(false);
-      expect(component.onOpenChange).toHaveBeenCalledTimes(1);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      });
+      expect(component.onOpenChange).not.toHaveBeenCalled();
     });
 
     it('should not emit openChange on destroy when already closed', async () => {
@@ -1036,6 +1045,348 @@ describe('NgpPopover', () => {
       });
     });
   });
+
+  describe('injected state setters', () => {
+    // Every input on NgpPopoverTrigger has a matching setter on the state, so a
+    // wrapper component can configure the trigger it hosts.
+    @Directive({ selector: '[popoverState]' })
+    class PopoverStateDirective {
+      readonly trigger = injectPopoverTriggerState();
+    }
+
+    // The panel needs an explicit size and position for the positioning assertions
+    // below - Floating UI writes `top`/`left`, which a static element ignores.
+    const template = `
+      <button [ngpPopoverTrigger]="content" popoverState>Open Popover</button>
+
+      <ng-template #content>
+        <div ngpPopover style="position: fixed; width: 120px; height: 60px;">Popover content</div>
+      </ng-template>
+    `;
+
+    async function renderWithState() {
+      const result = await render(template, {
+        imports: [NgpPopoverTrigger, NgpPopover, PopoverStateDirective],
+      });
+
+      const state = result.fixture.debugElement
+        .query(By.directive(PopoverStateDirective))
+        .injector.get(PopoverStateDirective).trigger;
+
+      return { ...result, state, trigger: result.getByRole('button') };
+    }
+
+    type PopoverState = NgpPopoverTriggerState<unknown>;
+
+    const anchorElement = document.createElement('div');
+    const guard = () => false;
+
+    const cases: Array<{
+      setter: string;
+      set: (state: PopoverState) => void;
+      read: (state: PopoverState) => unknown;
+      expected: unknown;
+    }> = [
+      {
+        setter: 'setPopover',
+        set: state => state.setPopover(undefined),
+        read: state => state.popover(),
+        expected: undefined,
+      },
+      {
+        setter: 'setDisabled',
+        set: state => state.setDisabled(true),
+        read: state => state.disabled(),
+        expected: true,
+      },
+      {
+        setter: 'setPlacement',
+        set: state => state.setPlacement('right'),
+        read: state => state.placement(),
+        expected: 'right',
+      },
+      {
+        setter: 'setOffset',
+        set: state => state.setOffset(12),
+        read: state => state.offset(),
+        expected: 12,
+      },
+      {
+        setter: 'setShowDelay',
+        set: state => state.setShowDelay(50),
+        read: state => state.showDelay(),
+        expected: 50,
+      },
+      {
+        setter: 'setHideDelay',
+        set: state => state.setHideDelay(75),
+        read: state => state.hideDelay(),
+        expected: 75,
+      },
+      {
+        setter: 'setFlip',
+        set: state => state.setFlip(false),
+        read: state => state.flip(),
+        expected: false,
+      },
+      {
+        setter: 'setShift',
+        set: state => state.setShift(false),
+        read: state => state.shift(),
+        expected: false,
+      },
+      {
+        setter: 'setContainer',
+        set: state => state.setContainer('#host'),
+        read: state => state.container(),
+        expected: '#host',
+      },
+      {
+        setter: 'setCloseOnOutsideClick',
+        set: state => state.setCloseOnOutsideClick(guard),
+        read: state => state.closeOnOutsideClick(),
+        expected: guard,
+      },
+      {
+        setter: 'setCloseOnEscape',
+        set: state => state.setCloseOnEscape(guard),
+        read: state => state.closeOnEscape(),
+        expected: guard,
+      },
+      {
+        setter: 'setScrollBehavior',
+        set: state => state.setScrollBehavior('close'),
+        read: state => state.scrollBehavior(),
+        expected: 'close',
+      },
+      {
+        setter: 'setContext',
+        set: state => state.setContext('ctx'),
+        read: state => state.context(),
+        expected: 'ctx',
+      },
+      {
+        setter: 'setAnchor',
+        set: state => state.setAnchor(anchorElement),
+        read: state => state.anchor(),
+        expected: anchorElement,
+      },
+      {
+        setter: 'setTrackPosition',
+        set: state => state.setTrackPosition(true),
+        read: state => state.trackPosition(),
+        expected: true,
+      },
+      {
+        setter: 'setCooldown',
+        set: state => state.setCooldown(250),
+        read: state => state.cooldown(),
+        expected: 250,
+      },
+    ];
+
+    it.each(cases)('should update the state through $setter', async ({ set, read, expected }) => {
+      const { state } = await renderWithState();
+
+      set(state());
+
+      expect(read(state())).toBe(expected);
+    });
+
+    it('should warn but still apply when a state signal is written directly', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { state } = await renderWithState();
+
+      state().offset.set(16);
+
+      expect(state().offset()).toBe(16);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('setOffset'));
+      warn.mockRestore();
+    });
+
+    it('should render the content passed to setPopover', async () => {
+      @Component({
+        template: `
+          <div ngpPopover>Replacement popover</div>
+        `,
+        imports: [NgpPopover],
+      })
+      class ReplacementPopover {}
+
+      const { fixture, state, trigger } = await renderWithState();
+
+      state().setPopover(ReplacementPopover);
+      fixture.detectChanges();
+
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')?.textContent?.trim()).toBe(
+          'Replacement popover',
+        );
+      });
+    });
+
+    it('should reflect setPlacement on the trigger and the open popover', async () => {
+      const { fixture, state, trigger } = await renderWithState();
+
+      state().setPlacement('right');
+      fixture.detectChanges();
+
+      expect(trigger).toHaveAttribute('data-placement', 'right');
+
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toHaveAttribute('data-placement', 'right');
+      });
+    });
+
+    it('should not open once disabled through setDisabled', async () => {
+      const { fixture, state, trigger } = await renderWithState();
+
+      state().setDisabled(true);
+      fixture.detectChanges();
+
+      expect(trigger).toHaveAttribute('data-disabled', '');
+
+      fireEvent.click(trigger);
+
+      // Give the overlay a chance to appear so the assertion is not trivially true.
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+    });
+
+    it('should delay opening by the value passed to setShowDelay', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setShowDelay(150);
+      fireEvent.click(trigger);
+
+      expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+    });
+
+    it('should delay closing by the value passed to setHideDelay', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setHideDelay(150);
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      fireEvent.click(trigger);
+
+      expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should offset the popover by the value passed to setOffset', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setPlacement('bottom');
+      state().setOffset(60);
+      state().setFlip(false);
+      state().setShift(false);
+      fireEvent.click(trigger);
+
+      // Floating UI positions asynchronously, so poll rather than measuring once.
+      await waitFor(() => {
+        const gap =
+          document.querySelector('[ngpPopover]')!.getBoundingClientRect().top -
+          trigger.getBoundingClientRect().bottom;
+
+        expect(gap).toBeCloseTo(60, 0);
+      });
+    });
+
+    it('should keep the popover open when setCloseOnOutsideClick refuses', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setCloseOnOutsideClick(false);
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      fireEvent.mouseUp(document.body);
+
+      // Dismissal is async, so settle before asserting the guard held.
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+    });
+
+    it('should keep the popover open when setCloseOnEscape refuses', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setCloseOnEscape(false);
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      fireEvent.keyDown(document.querySelector('[ngpPopover]')!, { key: 'Escape' });
+
+      // Dismissal is async, so settle before asserting the guard held.
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+    });
+
+    it('should position the popover against the element passed to setAnchor', async () => {
+      const { state, trigger } = await renderWithState();
+
+      const anchor = document.createElement('div');
+      anchor.style.cssText = 'position:fixed;top:400px;left:40px;width:80px;height:20px;';
+      document.body.appendChild(anchor);
+
+      state().setAnchor(anchor);
+      state().setPlacement('bottom');
+      state().setOffset(0);
+      state().setFlip(false);
+      state().setShift(false);
+
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        const popoverTop = document.querySelector('[ngpPopover]')!.getBoundingClientRect().top;
+
+        expect(popoverTop).toBeCloseTo(anchor.getBoundingClientRect().bottom, 0);
+      });
+
+      anchor.remove();
+    });
+
+    it('should attach the popover to the element passed to setContainer', async () => {
+      const host = document.createElement('div');
+      host.id = 'setter-popover-host';
+      document.body.appendChild(host);
+
+      const { state, trigger } = await renderWithState();
+
+      state().setContainer(host);
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(host.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      host.remove();
+    });
+  });
+
   describe('dynamic content', () => {
     const template = `
       <button [ngpPopoverTrigger]="useFirst ? first : second">Open Popover</button>

--- a/packages/ng-primitives/schematics/ng-generate/templates/popover/popover-trigger.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/popover/popover-trigger.__fileSuffix@dasherize__.ts.template
@@ -34,6 +34,6 @@ export class PopoverTrigger {
   });
 
   constructor() {
-    this.popoverTrigger().popover.set(Popover<%= componentSuffix %>);
+    this.popoverTrigger().setPopover(Popover<%= componentSuffix %>);
   }
 }

--- a/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip-trigger.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/tooltip/tooltip-trigger.__fileSuffix@dasherize__.ts.template
@@ -32,6 +32,6 @@ export class TooltipTrigger {
   });
 
   constructor() {
-    this.tooltipTrigger().tooltip.set(Tooltip<%= componentSuffix %>);
+    this.tooltipTrigger().setTooltip(Tooltip<%= componentSuffix %>);
   }
 }

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tests/tooltip-component.test.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tests/tooltip-component.test.ts
@@ -49,7 +49,7 @@ class TooltipTrigger {
   readonly content = input.required<string>({ alias: 'appTooltipTrigger' });
 
   constructor() {
-    this.tooltipTrigger().tooltip.set(TooltipContent);
+    this.tooltipTrigger().setTooltip(TooltipContent);
   }
 }
 

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tests/tooltip-primitive.test.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tests/tooltip-primitive.test.ts
@@ -1,9 +1,11 @@
 import { Directive, effect, input, OnInit, TemplateRef } from '@angular/core';
+import { By } from '@angular/platform-browser';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
 import {
   injectTooltipTriggerState,
   NgpTooltip,
   NgpTooltipTrigger,
+  NgpTooltipTriggerState,
   provideTooltipConfig,
 } from 'ng-primitives/tooltip';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -2211,7 +2213,7 @@ describe('NgpTooltipTrigger (primitive)', () => {
         readonly text = input<string>('', { alias: 'setTooltipText' });
 
         constructor() {
-          effect(() => this.trigger().tooltip.set(this.text()));
+          effect(() => this.trigger().setTooltip(this.text()));
         }
       }
 
@@ -2261,7 +2263,7 @@ describe('NgpTooltipTrigger (primitive)', () => {
         readonly content = input<TemplateRef<void> | null>(null, { alias: 'setTooltipContent' });
 
         constructor() {
-          effect(() => this.trigger().tooltip.set(this.content()));
+          effect(() => this.trigger().setTooltip(this.content()));
         }
       }
 
@@ -2299,6 +2301,398 @@ describe('NgpTooltipTrigger (primitive)', () => {
       await waitFor(() => {
         expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('injected state setters', () => {
+    // Every input on NgpTooltipTrigger has a matching setter on the state, so a
+    // wrapper component can configure the trigger it hosts.
+    @Directive({ selector: '[tooltipState]' })
+    class TooltipStateDirective {
+      readonly trigger = injectTooltipTriggerState();
+    }
+
+    // The panel needs an explicit size and position for the positioning assertions
+    // below - Floating UI writes `top`/`left`, which a static element ignores.
+    const template = `
+      <button [ngpTooltipTrigger]="content" ngpTooltipTriggerShowDelay="0" tooltipState>
+        Trigger
+      </button>
+
+      <ng-template #content>
+        <div ngpTooltip style="position: fixed; width: 120px; height: 60px;">Tooltip content</div>
+      </ng-template>
+    `;
+
+    async function renderWithState(markup: string = template) {
+      const result = await render(markup, {
+        imports: [NgpTooltipTrigger, NgpTooltip, TooltipStateDirective],
+      });
+
+      const state = result.fixture.debugElement
+        .query(By.directive(TooltipStateDirective))
+        .injector.get(TooltipStateDirective).trigger;
+
+      return { ...result, state, trigger: result.getByRole('button') };
+    }
+
+    type TooltipState = NgpTooltipTriggerState<unknown>;
+
+    const anchorElement = document.createElement('div');
+
+    const cases: Array<{
+      setter: string;
+      set: (state: TooltipState) => void;
+      read: (state: TooltipState) => unknown;
+      expected: unknown;
+    }> = [
+      {
+        setter: 'setTooltip',
+        set: state => state.setTooltip('text'),
+        read: state => state.tooltip(),
+        expected: 'text',
+      },
+      {
+        setter: 'setDisabled',
+        set: state => state.setDisabled(true),
+        read: state => state.disabled(),
+        expected: true,
+      },
+      {
+        setter: 'setPlacement',
+        set: state => state.setPlacement('right'),
+        read: state => state.placement(),
+        expected: 'right',
+      },
+      {
+        setter: 'setOffset',
+        set: state => state.setOffset(12),
+        read: state => state.offset(),
+        expected: 12,
+      },
+      {
+        setter: 'setShowDelay',
+        set: state => state.setShowDelay(50),
+        read: state => state.showDelay(),
+        expected: 50,
+      },
+      {
+        setter: 'setHideDelay',
+        set: state => state.setHideDelay(75),
+        read: state => state.hideDelay(),
+        expected: 75,
+      },
+      {
+        setter: 'setFlip',
+        set: state => state.setFlip(false),
+        read: state => state.flip(),
+        expected: false,
+      },
+      {
+        setter: 'setShift',
+        set: state => state.setShift(false),
+        read: state => state.shift(),
+        expected: false,
+      },
+      {
+        setter: 'setContainer',
+        set: state => state.setContainer('#host'),
+        read: state => state.container(),
+        expected: '#host',
+      },
+      {
+        setter: 'setShowOnOverflow',
+        set: state => state.setShowOnOverflow(true),
+        read: state => state.showOnOverflow(),
+        expected: true,
+      },
+      {
+        setter: 'setAnchor',
+        set: state => state.setAnchor(anchorElement),
+        read: state => state.anchor(),
+        expected: anchorElement,
+      },
+      {
+        setter: 'setContext',
+        set: state => state.setContext('ctx'),
+        read: state => state.context(),
+        expected: 'ctx',
+      },
+      {
+        setter: 'setUseTextContent',
+        set: state => state.setUseTextContent(false),
+        read: state => state.useTextContent(),
+        expected: false,
+      },
+      {
+        setter: 'setTrackPosition',
+        set: state => state.setTrackPosition(true),
+        read: state => state.trackPosition(),
+        expected: true,
+      },
+      {
+        setter: 'setScrollBehavior',
+        set: state => state.setScrollBehavior('close'),
+        read: state => state.scrollBehavior(),
+        expected: 'close',
+      },
+      {
+        setter: 'setCooldown',
+        set: state => state.setCooldown(250),
+        read: state => state.cooldown(),
+        expected: 250,
+      },
+      {
+        setter: 'setHoverableContent',
+        set: state => state.setHoverableContent(true),
+        read: state => state.hoverableContent(),
+        expected: true,
+      },
+      {
+        setter: 'setTooltipId',
+        set: state => state.setTooltipId('custom-id'),
+        read: state => state.tooltipId(),
+        expected: 'custom-id',
+      },
+    ];
+
+    it.each(cases)('should update the state through $setter', async ({ set, read, expected }) => {
+      const { state } = await renderWithState();
+
+      set(state());
+
+      expect(read(state())).toBe(expected);
+    });
+
+    it('should update the state through setPosition', async () => {
+      const { state } = await renderWithState();
+
+      state().setPosition({ x: 10, y: 20 });
+
+      expect(state().position()).toEqual({ x: 10, y: 20 });
+    });
+
+    it('should warn but still apply when a state signal is written directly', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const { state } = await renderWithState();
+
+      state().offset.set(16);
+
+      expect(state().offset()).toBe(16);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('setOffset'));
+      warn.mockRestore();
+    });
+
+    it('should render the content passed to setTooltip', async () => {
+      const { fixture, state, trigger } = await renderWithState();
+
+      state().setTooltip('Replacement tooltip');
+      fixture.detectChanges();
+
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[role="tooltip"]')?.textContent?.trim()).toBe(
+          'Replacement tooltip',
+        );
+      });
+    });
+
+    it('should not show once disabled through setDisabled', async () => {
+      const { fixture, state, trigger } = await renderWithState();
+
+      state().setDisabled(true);
+      fixture.detectChanges();
+
+      fireEvent.mouseEnter(trigger);
+
+      // Give the overlay a chance to appear so the assertion is not trivially true.
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+    });
+
+    it('should reflect setPlacement on the tooltip', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setPlacement('right');
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toHaveAttribute('data-placement', 'right');
+      });
+    });
+
+    it('should offset the tooltip by the value passed to setOffset', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setPlacement('bottom');
+      state().setOffset(60);
+      state().setFlip(false);
+      state().setShift(false);
+      fireEvent.mouseEnter(trigger);
+
+      // Floating UI positions asynchronously, so poll rather than measuring once.
+      await waitFor(() => {
+        const gap =
+          document.querySelector('[ngpTooltip]')!.getBoundingClientRect().top -
+          trigger.getBoundingClientRect().bottom;
+
+        expect(gap).toBeCloseTo(60, 0);
+      });
+    });
+
+    it('should delay showing by the value passed to setShowDelay', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setShowDelay(150);
+      fireEvent.mouseEnter(trigger);
+
+      expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+    });
+
+    it('should delay hiding by the value passed to setHideDelay', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setHideDelay(150);
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+
+      fireEvent.mouseLeave(trigger);
+
+      expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should attach the tooltip to the element passed to setContainer', async () => {
+      const host = document.createElement('div');
+      host.id = 'setter-tooltip-host';
+      document.body.appendChild(host);
+
+      const { state, trigger } = await renderWithState();
+
+      state().setContainer(host);
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        expect(host.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+
+      host.remove();
+    });
+
+    it('should position the tooltip against the element passed to setAnchor', async () => {
+      const { state, trigger } = await renderWithState();
+
+      const anchor = document.createElement('div');
+      anchor.style.cssText = 'position:fixed;top:400px;left:40px;width:80px;height:20px;';
+      document.body.appendChild(anchor);
+
+      state().setAnchor(anchor);
+      state().setPlacement('bottom');
+      state().setOffset(0);
+      state().setFlip(false);
+      state().setShift(false);
+
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        const tooltipTop = document.querySelector('[ngpTooltip]')!.getBoundingClientRect().top;
+
+        expect(tooltipTop).toBeCloseTo(anchor.getBoundingClientRect().bottom, 0);
+      });
+
+      anchor.remove();
+    });
+
+    it('should position the tooltip at the coordinates passed to setPosition', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setPlacement('bottom');
+      state().setOffset(0);
+      state().setFlip(false);
+      state().setShift(false);
+      state().setPosition({ x: 150, y: 250 });
+
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        const tooltip = document.querySelector('[ngpTooltip]')!.getBoundingClientRect();
+
+        expect(tooltip.top).toBeCloseTo(250, 0);
+      });
+    });
+
+    it('should suppress the tooltip when setShowOnOverflow is enabled and the trigger fits', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setShowOnOverflow(true);
+      fireEvent.mouseEnter(trigger);
+
+      // Give the overlay a chance to appear so the assertion is not trivially true.
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+    });
+
+    it('should stop falling back to the trigger text when setUseTextContent is disabled', async () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const markup = `<button ngpTooltipTrigger ngpTooltipTriggerShowDelay="0" tooltipState>Trigger text</button>`;
+
+      const { state, trigger } = await renderWithState(markup);
+
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[role="tooltip"]')?.textContent?.trim()).toBe(
+          'Trigger text',
+        );
+      });
+
+      fireEvent.mouseLeave(trigger);
+      await waitFor(() => {
+        expect(document.querySelector('[role="tooltip"]')).not.toBeInTheDocument();
+      });
+
+      state().setUseTextContent(false);
+      fireEvent.mouseEnter(trigger);
+
+      // Give the overlay a chance to appear so the assertion is not trivially true.
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(document.querySelector('[role="tooltip"]')).not.toBeInTheDocument();
+
+      error.mockRestore();
+    });
+
+    it('should keep the tooltip open on content hover once setHoverableContent is enabled', async () => {
+      const { state, trigger } = await renderWithState();
+
+      state().setHoverableContent(true);
+      fireEvent.mouseEnter(trigger);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+
+      const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement;
+      fireEvent.mouseLeave(trigger, { clientX: 0, clientY: 0 });
+      fireEvent.mouseEnter(tooltip);
+
+      // Without hoverable content the tooltip hides on mouseleave, so settle first.
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
     });
   });
 });

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
@@ -32,6 +32,7 @@ import {
   dataBinding,
   deprecatedSetter,
   listener,
+  onDestroy,
   StateInjectionOptions,
 } from 'ng-primitives/state';
 import { isString } from 'ng-primitives/utils';
@@ -44,40 +45,40 @@ export interface NgpTooltipTriggerState<T> {
    * Whether the tooltip is disabled. This allows the tooltip to be enabled or disabled dynamically.
    * @default false
    */
-  readonly disabled: Signal<boolean>;
+  readonly disabled: WritableSignal<boolean>;
   /**
    * Define the placement of the tooltip relative to the trigger.
    * @default 'top'
    */
-  readonly placement: Signal<NgpPlacement>;
+  readonly placement: WritableSignal<NgpPlacement>;
   /**
    * Define the offset of the tooltip relative to the trigger.
    * Can be a number (applies to mainAxis) or an object with mainAxis, crossAxis, and alignmentAxis.
    * @default 0
    */
-  readonly offset: Signal<NgpOffset>;
+  readonly offset: WritableSignal<NgpOffset>;
   /**
    * Define the delay before the tooltip is displayed.
    * @default 500
    */
-  readonly showDelay: Signal<number>;
+  readonly showDelay: WritableSignal<number>;
   /**
    * Define the delay before the tooltip is hidden.
    * @default 0
    */
-  readonly hideDelay: Signal<number>;
+  readonly hideDelay: WritableSignal<number>;
   /**
    * Define whether the tooltip should flip when there is not enough space for the tooltip.
    * Can be a boolean to enable/disable, or an object with padding and fallbackPlacements options.
    * @default true
    */
-  readonly flip: Signal<NgpFlip>;
+  readonly flip: WritableSignal<NgpFlip>;
   /**
    * Configure shift behavior to keep the tooltip in view.
    * Can be a boolean to enable/disable, or an object with padding and limiter options.
    * @default undefined (enabled by default in overlay)
    */
-  readonly shift: Signal<NgpShift>;
+  readonly shift: WritableSignal<NgpShift>;
   /**
    * Define the container in which the tooltip should be attached.
    * @default document.body
@@ -87,51 +88,51 @@ export interface NgpTooltipTriggerState<T> {
    * Define whether the tooltip should only show when the trigger element overflows.
    * @default false
    */
-  readonly showOnOverflow: Signal<boolean>;
+  readonly showOnOverflow: WritableSignal<boolean>;
   /**
    * Define an anchor element for positioning the tooltip.
    * If provided, the tooltip will be positioned relative to this element instead of the trigger.
    */
-  readonly anchor: Signal<HTMLElement | null>;
+  readonly anchor: WritableSignal<HTMLElement | null>;
   /**
    * Provide context to the tooltip. This can be used to pass data to the tooltip content.
    */
-  readonly context: Signal<T | undefined>;
+  readonly context: WritableSignal<T | undefined>;
   /**
    * Define whether to use the text content of the trigger element as the tooltip content.
    * When enabled, the tooltip will display the text content of the trigger element.
    * @default true
    */
-  readonly useTextContent: Signal<boolean>;
+  readonly useTextContent: WritableSignal<boolean>;
   /**
    * Define whether to track the trigger element position on every animation frame.
    * Useful for moving elements like slider thumbs.
    * @default false
    */
-  readonly trackPosition: Signal<boolean>;
+  readonly trackPosition: WritableSignal<boolean>;
   /**
    * Programmatic position for the tooltip. When provided, the tooltip
    * will be positioned at these coordinates instead of the trigger element.
    * Use with trackPosition="true" for smooth cursor following.
    */
-  readonly position: Signal<NgpPosition | null>;
+  readonly position: WritableSignal<NgpPosition | null>;
   /**
    * Defines how the tooltip behaves when the window is scrolled.
    * @default 'reposition'
    */
-  readonly scrollBehavior: Signal<'reposition' | 'close'>;
+  readonly scrollBehavior: WritableSignal<'reposition' | 'close'>;
   /**
    * Define the cooldown duration in milliseconds.
    * When moving from one tooltip to another within this duration,
    * the showDelay is skipped for the new tooltip.
    * @default 300
    */
-  readonly cooldown: Signal<number>;
+  readonly cooldown: WritableSignal<number>;
   /**
    * Whether hovering tooltip content keeps the tooltip open.
    * @default false
    */
-  readonly hoverableContent: Signal<boolean>;
+  readonly hoverableContent: WritableSignal<boolean>;
   /**
    * The overlay that manages the tooltip
    * @internal
@@ -170,13 +171,42 @@ export interface NgpTooltipTriggerState<T> {
    * Set the tooltip id.
    */
   setTooltipId: (id: string) => void;
-  /**
-   * Set the container in which the tooltip should be attached. Takes effect the
-   * next time the tooltip is shown; it does not move a tooltip that is already
-   * visible.
-   * @param container - The new container
-   */
+  /** Set the tooltip content. */
+  setTooltip: (tooltip: NgpOverlayContent<T> | string | null) => void;
+  /** Set whether the tooltip is disabled. */
+  setDisabled: (disabled: boolean) => void;
+  /** Set the placement of the tooltip relative to the trigger. */
+  setPlacement: (placement: NgpPlacement) => void;
+  /** Set the offset of the tooltip relative to the trigger. */
+  setOffset: (offset: NgpOffset) => void;
+  /** Set the delay before the tooltip is displayed. */
+  setShowDelay: (showDelay: number) => void;
+  /** Set the delay before the tooltip is hidden. */
+  setHideDelay: (hideDelay: number) => void;
+  /** Set the flip behaviour. */
+  setFlip: (flip: NgpFlip) => void;
+  /** Set the shift behaviour. */
+  setShift: (shift: NgpShift) => void;
+  /** Set the container in which the tooltip should be attached. */
   setContainer: (container: HTMLElement | string | null) => void;
+  /** Set whether the tooltip only shows when the trigger element overflows. */
+  setShowOnOverflow: (showOnOverflow: boolean) => void;
+  /** Set the anchor element the tooltip is positioned against. */
+  setAnchor: (anchor: HTMLElement | null) => void;
+  /** Set the context passed to the tooltip content. */
+  setContext: (context: T | undefined) => void;
+  /** Set whether the trigger's text content is used as the tooltip content. */
+  setUseTextContent: (useTextContent: boolean) => void;
+  /** Set whether the trigger position is tracked on every animation frame. */
+  setTrackPosition: (trackPosition: boolean) => void;
+  /** Set the programmatic position the tooltip is placed at. */
+  setPosition: (position: NgpPosition | null) => void;
+  /** Set how the tooltip behaves when the window is scrolled. */
+  setScrollBehavior: (scrollBehavior: 'reposition' | 'close') => void;
+  /** Set the cooldown duration in milliseconds. */
+  setCooldown: (cooldown: number) => void;
+  /** Set whether hovering the tooltip content keeps it open. */
+  setHoverableContent: (hoverableContent: boolean) => void;
   /**
    * Called by tooltip content when pointer enters the tooltip.
    * @internal
@@ -187,7 +217,6 @@ export interface NgpTooltipTriggerState<T> {
    * @internal
    */
   onTooltipHoverEnd: () => void;
-  destroy: () => void;
 }
 
 export interface NgpTooltipTriggerProps<T> {
@@ -295,24 +324,24 @@ export const [
 ] = createPrimitive(
   'NgpTooltipTrigger',
   <T>({
-    tooltip: _tooltip = signal<NgpOverlayContent<T> | string | null>(null),
-    disabled = signal<boolean>(false),
-    placement = signal<NgpPlacement>('top'),
-    offset = signal<NgpOffset>(0),
-    showDelay = signal<number>(500),
-    hideDelay = signal<number>(0),
-    flip = signal<NgpFlip>(true),
-    shift = signal<NgpShift | undefined>(undefined),
+    tooltip: _tooltip,
+    disabled: _disabled,
+    placement: _placement,
+    offset: _offset,
+    showDelay: _showDelay,
+    hideDelay: _hideDelay,
+    flip: _flip,
+    shift: _shift,
     container: _container,
-    showOnOverflow = signal<boolean>(false),
-    anchor = signal<HTMLElement | null>(null),
-    context = signal<T | undefined>(undefined),
-    useTextContent = signal<boolean>(true),
-    trackPosition = signal<boolean>(false),
-    position = signal<NgpPosition | null>(null),
-    scrollBehavior = signal<'reposition' | 'close'>('reposition'),
-    cooldown = signal<number>(300),
-    hoverableContent = signal<boolean>(false),
+    showOnOverflow: _showOnOverflow,
+    anchor: _anchor,
+    context: _context,
+    useTextContent: _useTextContent,
+    trackPosition: _trackPosition,
+    position: _position,
+    scrollBehavior: _scrollBehavior,
+    cooldown: _cooldown,
+    hoverableContent: _hoverableContent,
   }: NgpTooltipTriggerProps<T>) => {
     const elementRef = injectElementRef();
     const injector = inject(Injector);
@@ -320,8 +349,26 @@ export const [
     const trigger = inject(ElementRef<HTMLElement>);
     const tooltipTriggerState = injectTooltipTriggerState<T>();
 
-    const tooltip = controlled(_tooltip);
-    const container = controlled(_container, 'body');
+    // Every input is wrapped so the state can expose a setter for it - see the
+    // setter block further down the factory.
+    const tooltip = controlled<NgpOverlayContent<T> | string | null>(_tooltip, null);
+    const disabled = controlled(_disabled, false);
+    const placement = controlled<NgpPlacement>(_placement, 'top');
+    const offset = controlled<NgpOffset>(_offset, 0);
+    const showDelay = controlled(_showDelay, 500);
+    const hideDelay = controlled(_hideDelay, 0);
+    const flip = controlled<NgpFlip>(_flip, true);
+    const shift = controlled<NgpShift>(_shift, undefined);
+    const container = controlled<HTMLElement | string | null>(_container, 'body');
+    const showOnOverflow = controlled(_showOnOverflow, false);
+    const anchor = controlled<HTMLElement | null>(_anchor, null);
+    const context = controlled<T | undefined>(_context, undefined);
+    const useTextContent = controlled(_useTextContent, true);
+    const trackPosition = controlled(_trackPosition, false);
+    const position = controlled<NgpPosition | null>(_position, null);
+    const scrollBehavior = controlled<'reposition' | 'close'>(_scrollBehavior, 'reposition');
+    const cooldown = controlled(_cooldown, 300);
+    const hoverableContent = controlled(_hoverableContent, false);
 
     const tooltipId = signal<string | undefined>(undefined);
     const triggerHovered = signal<boolean>(false);
@@ -352,10 +399,10 @@ export const [
     listener(elementRef, 'mouseleave', hideFromInteraction);
     listener(elementRef, 'blur', () => hideFromInteraction());
 
-    function destroy(): void {
+    onDestroy(() => {
       hoverBridge.clear();
       overlay()?.destroy();
-    }
+    });
 
     function show(): void {
       performShow(true);
@@ -407,8 +454,76 @@ export const [
       tooltipId.set(id);
     }
 
+    function setTooltip(newTooltip: NgpOverlayContent<T> | string | null): void {
+      tooltip.set(newTooltip);
+    }
+
+    function setDisabled(isDisabled: boolean): void {
+      disabled.set(isDisabled);
+    }
+
+    function setPlacement(newPlacement: NgpPlacement): void {
+      placement.set(newPlacement);
+    }
+
+    function setOffset(newOffset: NgpOffset): void {
+      offset.set(newOffset);
+    }
+
+    function setShowDelay(delay: number): void {
+      showDelay.set(delay);
+    }
+
+    function setHideDelay(delay: number): void {
+      hideDelay.set(delay);
+    }
+
+    function setFlip(shouldFlip: NgpFlip): void {
+      flip.set(shouldFlip);
+    }
+
+    function setShift(shouldShift: NgpShift): void {
+      shift.set(shouldShift);
+    }
+
     function setContainer(newContainer: HTMLElement | string | null): void {
       container.set(newContainer);
+    }
+
+    function setShowOnOverflow(shouldShowOnOverflow: boolean): void {
+      showOnOverflow.set(shouldShowOnOverflow);
+    }
+
+    function setAnchor(newAnchor: HTMLElement | null): void {
+      anchor.set(newAnchor);
+    }
+
+    function setContext(newContext: T | undefined): void {
+      context.set(newContext);
+    }
+
+    function setUseTextContent(shouldUseTextContent: boolean): void {
+      useTextContent.set(shouldUseTextContent);
+    }
+
+    function setTrackPosition(shouldTrack: boolean): void {
+      trackPosition.set(shouldTrack);
+    }
+
+    function setPosition(newPosition: NgpPosition | null): void {
+      position.set(newPosition);
+    }
+
+    function setScrollBehavior(behavior: 'reposition' | 'close'): void {
+      scrollBehavior.set(behavior);
+    }
+
+    function setCooldown(duration: number): void {
+      cooldown.set(duration);
+    }
+
+    function setHoverableContent(isHoverable: boolean): void {
+      hoverableContent.set(isHoverable);
     }
 
     /**
@@ -568,24 +683,28 @@ export const [
     }
 
     const state = {
-      tooltip,
-      disabled,
-      placement,
-      offset,
-      showDelay,
-      hideDelay,
-      flip,
-      shift,
+      tooltip: deprecatedSetter(tooltip, 'setTooltip', setTooltip),
+      disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
+      placement: deprecatedSetter(placement, 'setPlacement', setPlacement),
+      offset: deprecatedSetter(offset, 'setOffset', setOffset),
+      showDelay: deprecatedSetter(showDelay, 'setShowDelay', setShowDelay),
+      hideDelay: deprecatedSetter(hideDelay, 'setHideDelay', setHideDelay),
+      flip: deprecatedSetter(flip, 'setFlip', setFlip),
+      shift: deprecatedSetter(shift, 'setShift', setShift),
       container: deprecatedSetter(container, 'setContainer', setContainer),
-      showOnOverflow,
-      anchor,
-      context,
-      useTextContent,
-      trackPosition,
-      position,
-      scrollBehavior,
-      cooldown,
-      hoverableContent,
+      showOnOverflow: deprecatedSetter(showOnOverflow, 'setShowOnOverflow', setShowOnOverflow),
+      anchor: deprecatedSetter(anchor, 'setAnchor', setAnchor),
+      context: deprecatedSetter(context, 'setContext', setContext),
+      useTextContent: deprecatedSetter(useTextContent, 'setUseTextContent', setUseTextContent),
+      trackPosition: deprecatedSetter(trackPosition, 'setTrackPosition', setTrackPosition),
+      position: deprecatedSetter(position, 'setPosition', setPosition),
+      scrollBehavior: deprecatedSetter(scrollBehavior, 'setScrollBehavior', setScrollBehavior),
+      cooldown: deprecatedSetter(cooldown, 'setCooldown', setCooldown),
+      hoverableContent: deprecatedSetter(
+        hoverableContent,
+        'setHoverableContent',
+        setHoverableContent,
+      ),
       overlay,
       tooltipId,
       open,
@@ -595,10 +714,26 @@ export const [
       show,
       hide,
       setTooltipId,
+      setTooltip,
+      setDisabled,
+      setPlacement,
+      setOffset,
+      setShowDelay,
+      setHideDelay,
+      setFlip,
+      setShift,
       setContainer,
+      setShowOnOverflow,
+      setAnchor,
+      setContext,
+      setUseTextContent,
+      setTrackPosition,
+      setPosition,
+      setScrollBehavior,
+      setCooldown,
+      setHoverableContent,
       onTooltipHoverStart,
       onTooltipHoverEnd,
-      destroy,
     } satisfies NgpTooltipTriggerState<T>;
 
     return state;

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -1,5 +1,5 @@
 import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Directive, input, numberAttribute, OnDestroy } from '@angular/core';
+import { booleanAttribute, Directive, input, numberAttribute } from '@angular/core';
 import {
   coerceFlip,
   coerceOffset,
@@ -28,7 +28,7 @@ type TooltipInput<T> = NgpOverlayContent<T> | string | null | undefined;
   exportAs: 'ngpTooltipTrigger',
   providers: [provideTooltipTriggerState({ inherit: false })],
 })
-export class NgpTooltipTrigger<T = null> implements OnDestroy {
+export class NgpTooltipTrigger<T = null> {
   /**
    * Access the global tooltip configuration.
    */
@@ -214,10 +214,6 @@ export class NgpTooltipTrigger<T = null> implements OnDestroy {
     cooldown: this.cooldown,
     hoverableContent: this.hoverableContent,
   });
-
-  ngOnDestroy(): void {
-    return this.state.destroy();
-  }
 
   /**
    * Show the tooltip programmatically (skips cooldown so multiple tooltips can coexist).


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

No linked issue. Found while reviewing the tooltip and popover state migrations.

## What does this PR implement/fix?

The tooltip (#773) and popover (#761) state migrations moved both triggers to
`createPrimitive`, which passes props through as read-only `Signal`s. Under the
previous `createState` pattern every input was writable on the state, so a
wrapper component could configure the trigger it hosts. After the migration only
`container` kept a setter, and everything else - `offset`, `placement`, `flip`
and the rest - became read-only. `menu-trigger` and `submenu-trigger` were
migrated with their setters intact, so tooltip and popover were the outliers.

This restores that, and completes it: every input on `NgpPopoverTrigger` (16) and
`NgpTooltipTrigger` (18) now has a matching `setX` on the state. Each input is
wrapped in `controlled()` and exposed through `deprecatedSetter`, so existing
direct signal writes keep working and are routed to the new setter with a
deprecation warning.

`state().popover` / `state().tooltip` were previously writable without a warning,
including in the code the schematics generate. Those templates and the
`apps/components` wrappers now use `setPopover()` / `setTooltip()`; already
generated code keeps working but will log the deprecation warning.

Overlay teardown also moves out of the directives' `ngOnDestroy` and into the
state factories via `onDestroy`, matching `navigation-menu-trigger`, and
`destroy` is dropped from both state interfaces. One consequence worth noting:
`NgpPopoverTrigger` no longer emits `openChange(false)` when it is destroyed
while open. `DestroyRef` callbacks run after Angular has torn down the
`OutputRef`, and emitting there is NG0953, so the notification is skipped rather
than logging a warning. Select and combobox are unchanged and still emit.

### Tests

New `injected state setters` blocks in both primitive test files - 27 for popover,
32 for tooltip:

- one table-driven case per setter, asserting it writes its signal
- one asserting a direct `.set()` still applies and warns
- behavioural coverage where the effect is observable: content swap,
  `data-placement`, disabled not opening, show/hide delay timing, measured offset
  gap, anchor and programmatic position, container attachment, dismiss guards
  refusing, text-content fallback, hoverable content

Verified by mutation testing: blanking every setter body fails at least one test
per setter. That first pass surfaced four negative assertions that were passing
trivially (`waitFor` with a "not present" assertion resolves on the first tick);
those now settle before asserting, matching the convention in the existing
`disabled` and `showOnOverflow` blocks.

The API reference on the docs site is generated from `<api-docs>` and does not
surface state members, so no docs changes were needed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose setter methods for every input on `NgpPopoverTrigger` and `NgpTooltipTrigger` for easy programmatic control. Also corrects the documented popover defaults: `placement` is `'bottom'` and `offset` is `4`.

- **New Features**
  - Added `setX` setters for all trigger inputs, including `setPopover()`/`setTooltip()`, placement, offset, delays, flip/shift, container, guards/behavior, context, anchor, position, tracking, cooldown, and hoverable content.
  - Wrapped inputs with `controlled()` and `deprecatedSetter` so direct `.set()` still applies but warns; prefer the new setters.
  - Moved overlay teardown into state via `onDestroy`; removed `destroy` from state. `NgpPopoverTrigger` no longer emits `openChange(false)` on destroy to avoid NG0953.
  - Updated app wrappers and `schematics` templates to use `setPopover()`/`setTooltip()`. Added comprehensive setter tests for popover and tooltip.

- **Migration**
  - Replace `state().popover.set(...)` and `state().tooltip.set(...)` with `setPopover(...)` and `setTooltip(...)`, and prefer `setX(...)` for other inputs. Existing direct writes still work but log a deprecation warning.

<sup>Written for commit 5714bdeb9e7335526ceb337327bbdd39619cb186. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit setter APIs for configuring popover and tooltip triggers (content/component, disabled state, placement/offset, delays, flip/shift, containers/anchors, and interaction/positioning behavior).
* **Bug Fixes**
  * Improved teardown behavior for popovers and tooltips to prevent unwanted lifecycle events during destruction; trigger directives now clean up without relying on Angular `OnDestroy`.
* **Tests**
  * Expanded test coverage for injected state setters, positioning/visibility behavior, disabled/refusal-to-close rules, and warning scenarios when writing state signals directly.
  * Updated generator wiring and relevant fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->