### PR TITLE
fix(radio): disable a radio item when its group is disabled

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/radio.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/radio.md
@@ -87,7 +87,7 @@ The following directives are available to import from the `ng-primitives/radio` 
 
 <api-reference-attributes>
   <api-attribute name="data-checked" description="Applied when the radio item is checked." />
-  <api-attribute name="data-disabled" description="Applied when the radio item is disabled." />
+  <api-attribute name="data-disabled" description="Applied when the radio item is disabled, or the radio group is disabled." />
   <api-attribute name="data-hover" description="Applied when the radio item is hovered." />
   <api-attribute name="data-focus-visible" description="Applied when the radio item is focused." />
   <api-attribute name="data-press" description="Applied when the radio item is pressed." />
@@ -101,7 +101,7 @@ The following directives are available to import from the `ng-primitives/radio` 
 
 <api-reference-attributes>
   <api-attribute name="data-checked" description="Applied when the radio item is checked." />
-  <api-attribute name="data-disabled" description="Applied when the radio item is disabled." />
+  <api-attribute name="data-disabled" description="Applied when the radio item is disabled, or the radio group is disabled." />
 </api-reference-attributes>
 
 ## Accessibility

--- a/packages/ng-primitives/radio/src/radio-group/tests/radio-primitive.test.ts
+++ b/packages/ng-primitives/radio/src/radio-group/tests/radio-primitive.test.ts
@@ -879,6 +879,55 @@ describe('NgpRadioGroup', () => {
       expect(getByRole('radio', { name: 'Two' })).toHaveAttribute('aria-disabled', 'true');
     });
 
+    it('should mark every item disabled when the group is disabled', async () => {
+      const { getByRole } = await render(
+        `<div ngpRadioGroup ngpRadioGroupDisabled>
+          <div ngpRadioItem ngpRadioItemValue="1">One</div>
+          <div ngpRadioItem ngpRadioItemValue="2">Two</div>
+        </div>`,
+        { imports: [NgpRadioGroup, NgpRadioItem] },
+      );
+
+      for (const name of ['One', 'Two']) {
+        expect(getByRole('radio', { name })).toHaveAttribute('data-disabled', '');
+        expect(getByRole('radio', { name })).toHaveAttribute('aria-disabled', 'true');
+      }
+    });
+
+    it('should follow the group disabled state as it changes', async () => {
+      const { getByRole, fixture, detectChanges } = await render(
+        `<div ngpRadioGroup [ngpRadioGroupDisabled]="disabled">
+          <div ngpRadioItem ngpRadioItemValue="1">One</div>
+        </div>`,
+        {
+          imports: [NgpRadioGroup, NgpRadioItem],
+          componentProperties: { disabled: false },
+        },
+      );
+
+      const radio = getByRole('radio', { name: 'One' });
+      expect(radio).not.toHaveAttribute('data-disabled');
+
+      fixture.componentInstance.disabled = true;
+      detectChanges();
+
+      expect(radio).toHaveAttribute('data-disabled', '');
+      expect(radio).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('should keep an item disabled when only the item is disabled', async () => {
+      const { getByRole } = await render(
+        `<div ngpRadioGroup>
+          <div ngpRadioItem ngpRadioItemValue="1">One</div>
+          <div ngpRadioItem ngpRadioItemValue="2" ngpRadioItemDisabled>Two</div>
+        </div>`,
+        { imports: [NgpRadioGroup, NgpRadioItem] },
+      );
+
+      expect(getByRole('radio', { name: 'One' })).not.toHaveAttribute('data-disabled');
+      expect(getByRole('radio', { name: 'Two' })).toHaveAttribute('data-disabled', '');
+    });
+
     it('should throw when a radio item has no value', async () => {
       await expect(
         render(
@@ -914,6 +963,20 @@ describe('NgpRadioGroup', () => {
       expect(getByTestId('indicator-1')).toHaveAttribute('data-checked', '');
       expect(getByTestId('indicator-2')).not.toHaveAttribute('data-checked');
       expect(getByTestId('indicator-2')).toHaveAttribute('data-disabled', '');
+    });
+
+    it('should mirror the group disabled state', async () => {
+      const { getByTestId } = await render(
+        `<div ngpRadioGroup ngpRadioGroupDisabled>
+          <div ngpRadioItem ngpRadioItemValue="1">
+            <span ngpRadioIndicator data-testid="indicator-1"></span>
+            One
+          </div>
+        </div>`,
+        { imports: [NgpRadioGroup, NgpRadioItem, NgpRadioIndicator] },
+      );
+
+      expect(getByTestId('indicator-1')).toHaveAttribute('data-disabled', '');
     });
 
     it('should honour a custom compareWith when computing checked', async () => {

--- a/packages/ng-primitives/radio/src/radio-item/radio-item-state.ts
+++ b/packages/ng-primitives/radio/src/radio-item/radio-item-state.ts
@@ -19,7 +19,8 @@ export interface NgpRadioItemState<T> {
    */
   readonly value: Signal<T>;
   /**
-   * Whether the radio item is disabled.
+   * Whether the radio item is disabled, either in its own right or because the
+   * group it belongs to is disabled.
    */
   readonly disabled: Signal<boolean>;
   /**
@@ -45,11 +46,17 @@ export interface NgpRadioItemProps<T> {
 export const [NgpRadioItemStateToken, ngpRadioItem, _injectRadioItemState, provideRadioItemState] =
   createPrimitive(
     'NgpRadioItem',
-    <T>({ value, disabled = signal(false) }: NgpRadioItemProps<T>): NgpRadioItemState<T> => {
+    <T>({
+      value,
+      disabled: _disabled = signal(false),
+    }: NgpRadioItemProps<T>): NgpRadioItemState<T> => {
       const element = injectElementRef();
       const radioGroup = injectRadioGroupState<T>();
 
       const checked = computed(() => radioGroup().compareWith()(radioGroup().value(), value()));
+
+      // A disabled group disables everything in it, so the item reflects both.
+      const disabled = computed(() => _disabled() || radioGroup().disabled());
 
       // Setup interactions
       ngpInteractions({ hover: true, press: true, focusVisible: true, disabled });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

No linked issue.

## What does this PR implement/fix?

`NgpRadioItem` derived its disabled state from its own `ngpRadioItemDisabled`
input only. Items inside a disabled `NgpRadioGroup` therefore carried neither
`data-disabled` nor `aria-disabled="true"`, so they styled and announced as
enabled even though the group's own guard already blocked selection.

The item's disabled state is now `item disabled || group disabled`. Because the
factory already routed everything through that one signal, the fix is a single
computed and picks up the `aria-disabled` and `data-disabled` bindings, the
`ngpInteractions` hover/press/focus states, the `select()` guard, and
`NgpRadioIndicator` (which reads `disabled` off the item state).

Built test-first. Four tests added to `radio-primitive.test.ts`:

- items in a disabled group expose `data-disabled` and `aria-disabled="true"`
- an item follows the group's disabled state as the binding changes
- an item disabled on its own still works, and its siblings stay enabled - this
  one passed before the fix, pinning the existing behaviour so the change does
  not over-reach
- `NgpRadioIndicator` mirrors the group's disabled state

The `data-disabled` descriptions for `NgpRadioItem` and `NgpRadioIndicator` in
`radio.md` are updated, since the attribute now has a second trigger.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes radio items not reflecting a disabled group. Items now inherit the disabled state from `NgpRadioGroup`, updating `aria-disabled`/`data-disabled`, interactions, and indicators.

- **Bug Fixes**
  - Compute item disabled as `itemDisabled || groupDisabled` in `radio-item-state.ts`.
  - `ngpInteractions`, host bindings, and `NgpRadioIndicator` now reflect the group’s disabled state.
  - Added tests for group-driven disabled state, dynamic updates, and item-only disable cases.
  - Updated docs to note `data-disabled` applies when the item or group is disabled.

<sup>Written for commit 69a09b4b7d3676286bfb60980bde96f324aca2aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Radio groups now correctly disable all contained radio items and indicators when the group is disabled.
  * Disabled radio items now expose the correct `data-disabled` and `aria-disabled` states, including when disabled individually.

* **Documentation**
  * Clarified the disabled-state behaviour for radio items and indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->