### PR TITLE
feat(input-otp): add valueChange and completeChange Observable in InputOtp state

### DIFF
--- a/packages/ng-primitives/input-otp/src/input-otp/input-otp-state.ts
+++ b/packages/ng-primitives/input-otp/src/input-otp/input-otp-state.ts
@@ -108,12 +108,13 @@ export interface NgpInputOtpState {
   readonly selectionEnd: Signal<number>;
 
   /**
-   * Emits when the value state changes.
+   * Emits when the value changes.
    */
   readonly valueChange: Observable<string>;
 
   /**
-   * Emits when the complete state changes.
+   * Emits once the OTP is complete (`maxLength` characters entered). It does
+   * not emit when a complete value is shortened.
    */
   readonly complete: Observable<string>;
 

--- a/packages/ng-primitives/input-otp/src/input-otp/input-otp-state.ts
+++ b/packages/ng-primitives/input-otp/src/input-otp/input-otp-state.ts
@@ -107,8 +107,15 @@ export interface NgpInputOtpState {
    */
   readonly selectionEnd: Signal<number>;
 
+  /**
+   * Emits when the value state changes.
+   */
   readonly valueChange: Observable<string>;
-  readonly completeChange: Observable<string>;
+
+  /**
+   * Emits when the complete state changes.
+   */
+  readonly complete: Observable<string>;
 
   /**
    * Register the hidden input with the input-otp.
@@ -175,8 +182,7 @@ export const [NgpInputOtpStateToken, ngpInputOtp, injectInputOtpState, provideIn
       // The value is mutated internally as the user types, so it is controlled.
       const value = controlled(_value);
       const valueChange = emitter<string>();
-
-      const completeChange = emitter<string>();
+      const complete = emitter<string>();
 
       // The registered hidden input and slots stay private to the factory — no other
       // part reads them directly, only the derived `maxLength` and the methods below.
@@ -225,7 +231,7 @@ export const [NgpInputOtpStateToken, ngpInputOtp, injectInputOtpState, provideIn
         // Emit complete once the OTP has been fully entered.
         if (newValue.length === maxLength()) {
           onComplete?.(newValue);
-          completeChange.emit(newValue);
+          complete.emit(newValue);
         }
       }
 
@@ -260,7 +266,7 @@ export const [NgpInputOtpStateToken, ngpInputOtp, injectInputOtpState, provideIn
         selectionStart,
         selectionEnd,
         valueChange: valueChange.asObservable(),
-        completeChange: completeChange.asObservable(),
+        complete: complete.asObservable(),
         registerInput,
         registerSlot,
         unregisterSlot,

--- a/packages/ng-primitives/input-otp/src/input-otp/input-otp-state.ts
+++ b/packages/ng-primitives/input-otp/src/input-otp/input-otp-state.ts
@@ -1,6 +1,7 @@
 import { computed, signal, Signal } from '@angular/core';
 import { ngpInteractions } from 'ng-primitives/interactions';
-import { controlled, createPrimitive } from 'ng-primitives/state';
+import { controlled, createPrimitive, emitter } from 'ng-primitives/state';
+import { Observable } from 'rxjs';
 import type { NgpInputOtpInputState } from '../input-otp-input/input-otp-input-state';
 import type { NgpInputOtpSlotState } from '../input-otp-slot/input-otp-slot-state';
 import type { NgpInputOtpInputMode } from './input-otp';
@@ -106,6 +107,9 @@ export interface NgpInputOtpState {
    */
   readonly selectionEnd: Signal<number>;
 
+  readonly valueChange: Observable<string>;
+  readonly completeChange: Observable<string>;
+
   /**
    * Register the hidden input with the input-otp.
    * @internal
@@ -170,6 +174,9 @@ export const [NgpInputOtpStateToken, ngpInputOtp, injectInputOtpState, provideIn
     }: NgpInputOtpProps): NgpInputOtpState => {
       // The value is mutated internally as the user types, so it is controlled.
       const value = controlled(_value);
+      const valueChange = emitter<string>();
+
+      const completeChange = emitter<string>();
 
       // The registered hidden input and slots stay private to the factory — no other
       // part reads them directly, only the derived `maxLength` and the methods below.
@@ -213,10 +220,12 @@ export const [NgpInputOtpStateToken, ngpInputOtp, injectInputOtpState, provideIn
 
         value.set(newValue);
         onValueChange?.(newValue);
+        valueChange.emit(newValue);
 
         // Emit complete once the OTP has been fully entered.
         if (newValue.length === maxLength()) {
           onComplete?.(newValue);
+          completeChange.emit(newValue);
         }
       }
 
@@ -250,6 +259,8 @@ export const [NgpInputOtpStateToken, ngpInputOtp, injectInputOtpState, provideIn
         isFocused,
         selectionStart,
         selectionEnd,
+        valueChange: valueChange.asObservable(),
+        completeChange: completeChange.asObservable(),
         registerInput,
         registerSlot,
         unregisterSlot,

--- a/packages/ng-primitives/input-otp/src/input-otp/tests/input-otp-primitive.test.ts
+++ b/packages/ng-primitives/input-otp/src/input-otp/tests/input-otp-primitive.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { NgpInputOtpInput } from '../../input-otp-input/input-otp-input';
 import { NgpInputOtpSlot } from '../../input-otp-slot/input-otp-slot';
 import { NgpInputOtp } from '../input-otp';
+import { NgpInputOtpStateToken } from '../input-otp-state';
 
 const imports = [NgpInputOtp, NgpInputOtpInput, NgpInputOtpSlot];
 
@@ -484,6 +485,68 @@ describe('NgpInputOtp', () => {
       fireEvent.input(input, { target: { value: '12' } });
 
       expect(valueChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('state observables', () => {
+    async function renderWithState(slotCount: number, attrs = '') {
+      const { fixture } = await renderOtp(slotCount, attrs);
+      const state = fixture.debugElement
+        .query(By.directive(NgpInputOtp))
+        .injector.get(NgpInputOtpStateToken)();
+
+      const valueChange = vi.fn();
+      const complete = vi.fn();
+      state.valueChange.subscribe(valueChange);
+      state.complete.subscribe(complete);
+
+      return { valueChange, complete };
+    }
+
+    it('emits state.valueChange as the value changes', async () => {
+      const { valueChange } = await renderWithState(3);
+      const input = getInput();
+
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: '1' } });
+      fireEvent.input(input, { target: { value: '12' } });
+
+      expect(valueChange).toHaveBeenNthCalledWith(1, '1');
+      expect(valueChange).toHaveBeenNthCalledWith(2, '12');
+    });
+
+    it('does not emit state.valueChange when the value is unchanged', async () => {
+      const { valueChange } = await renderWithState(2, `[ngpInputOtpValue]="'12'"`);
+      const input = getInput();
+
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: '12' } });
+
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+
+    it('emits state.complete only once the OTP reaches maxLength', async () => {
+      const { complete } = await renderWithState(3);
+      const input = getInput();
+
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: '12' } });
+      expect(complete).not.toHaveBeenCalled();
+
+      fireEvent.input(input, { target: { value: '123' } });
+      expect(complete).toHaveBeenCalledWith('123');
+      expect(complete).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not emit state.complete when a complete value is shortened', async () => {
+      const { complete } = await renderWithState(3);
+      const input = getInput();
+
+      fireEvent.focus(input);
+      fireEvent.input(input, { target: { value: '123' } });
+      fireEvent.input(input, { target: { value: '12' } });
+
+      expect(complete).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

Introduce `valueChange` and `completeChange` in `InputOtpState`. Updated at the same time as `onValueChange` and `onCompleteChange`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `valueChange` and `complete` Observables to the Input OTP state so apps can subscribe to value updates and completion. They emit in sync with existing callbacks; `complete` fires only when the OTP reaches `maxLength`.

- **New Features**
  - `valueChange: Observable<string>` emits on every value change.
  - `complete: Observable<string>` emits once at `maxLength` and not when a complete value is shortened.

<sup>Written for commit ee10889403ef07890823c1586978fb04ebf53fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added observable events for OTP value changes.
  * Added an observable event that fires when the OTP reaches its maximum length.
  * Existing completion callbacks continue to be supported.
* **Tests**
  * Added coverage for the new OTP state observables, including emission rules and “complete” firing behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->