### PR TITLE
feat(tooltip,popover,input-otp): round out the imperative trigger APIs

### DIFF
--- a/packages/ng-primitives/input-otp/src/input-otp-input/input-otp-input-state.ts
+++ b/packages/ng-primitives/input-otp/src/input-otp-input/input-otp-input-state.ts
@@ -7,7 +7,6 @@ import { injectInputOtpState } from '../input-otp/input-otp-state';
 export interface NgpInputOtpInputState {
   /**
    * Focus the input.
-   * @internal
    */
   focus(): void;
 

--- a/packages/ng-primitives/input-otp/src/input-otp-input/input-otp-input.ts
+++ b/packages/ng-primitives/input-otp/src/input-otp-input/input-otp-input.ts
@@ -10,4 +10,11 @@ export class NgpInputOtpInput {
    * The state of the input-otp input.
    */
   protected readonly state = ngpInputOtpInput();
+
+  /**
+   * Focus the input.
+   */
+  focus(): void {
+    this.state.focus();
+  }
 }

--- a/packages/ng-primitives/input-otp/src/input-otp/tests/input-otp-primitive.test.ts
+++ b/packages/ng-primitives/input-otp/src/input-otp/tests/input-otp-primitive.test.ts
@@ -1,3 +1,4 @@
+import { By } from '@angular/platform-browser';
 import { fireEvent, render, screen } from '@testing-library/angular';
 import { userEvent } from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
@@ -408,6 +409,17 @@ describe('NgpInputOtp', () => {
   });
 
   describe('directive API', () => {
+    it('focuses the hidden input via the input directive focus()', async () => {
+      const { fixture } = await renderOtp(3);
+      const inputDirective = fixture.debugElement
+        .query(By.directive(NgpInputOtpInput))
+        .injector.get(NgpInputOtpInput);
+
+      inputDirective.focus();
+
+      expect(document.activeElement).toBe(getInput());
+    });
+
     it('emits valueChange as the value changes', async () => {
       const valueChange = vi.fn();
       await render(

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -169,7 +169,7 @@ export interface NgpPopoverTriggerState<T> {
    * Hide the popover.
    * @returns A promise that resolves when the popover has been hidden
    */
-  hide: (origin: FocusOrigin) => Promise<void>;
+  hide: (origin?: FocusOrigin) => Promise<void>;
 }
 
 export interface NgpPopoverTriggerProps<T> {
@@ -412,7 +412,7 @@ export const [
       }
     }
 
-    async function hide(origin: FocusOrigin): Promise<void> {
+    async function hide(origin: FocusOrigin = 'program'): Promise<void> {
       // If the trigger is disabled or the popover is not open, do nothing
       if (disabled() || !open()) {
         return;

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tests/tooltip-primitive.test.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tests/tooltip-primitive.test.ts
@@ -289,6 +289,36 @@ describe('NgpTooltipTrigger (primitive)', () => {
         expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
       });
     });
+
+    it('should skip the hideDelay when hide(true) is called', async () => {
+      const { fixture } = await render(
+        `
+          <button
+            [ngpTooltipTrigger]="content"
+            ngpTooltipTriggerShowDelay="0"
+            ngpTooltipTriggerHideDelay="5000"
+          ></button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        { imports: [NgpTooltipTrigger, NgpTooltip] },
+      );
+
+      const triggerDirective = fixture.debugElement.children[0].injector.get(NgpTooltipTrigger);
+      triggerDirective.show();
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+      });
+
+      triggerDirective.hide(true);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('escape to close', () => {

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
@@ -164,9 +164,9 @@ export interface NgpTooltipTriggerState<T> {
    */
   show: () => void;
   /**
-   * Hide the tooltip.
+   * Hide the tooltip. Pass `true` to skip the hide delay.
    */
-  hide: () => void;
+  hide: (immediate?: boolean) => void;
   /**
    * Set the tooltip id.
    */
@@ -408,9 +408,9 @@ export const [
       performShow(true);
     }
 
-    function hide(): void {
+    function hide(immediate = false): void {
       hoverBridge.clear();
-      overlay()?.hide();
+      overlay()?.hide({ immediate });
     }
 
     /**

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -224,9 +224,10 @@ export class NgpTooltipTrigger<T = null> {
 
   /**
    * Hide the tooltip.
+   * @param immediate Skip the hide delay and exit animation.
    */
-  hide(): void {
-    return this.state.hide();
+  hide(immediate = false): void {
+    return this.state.hide(immediate);
   }
 
   /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

## What does this PR implement/fix?

Three small gaps in the imperative APIs of the trigger primitives:

- **tooltip** - `NgpTooltipTrigger.hide(immediate = false)` (and the state's `hide`) now takes an optional flag that closes the tooltip straight away, skipping `hideDelay` and the exit animation. Existing calls are unchanged.
- **popover** - the trigger state's `hide()` accepts an optional `origin` again, defaulting to `program` to match the directive, so callers no longer have to pass one.
- **input-otp** - `NgpInputOtpInput.focus()` is back on the directive, delegating to the state, and the state's `focus` is no longer marked `@internal` (it is a legitimate consumer-facing method; `setSelectionRange` stays internal).

Tests cover the two behavioural changes: `hide(true)` dismisses a tooltip with a 5000ms `hideDelay`, and `focus()` moves focus to the hidden OTP input.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rounded out the imperative trigger APIs for `tooltip`, `popover`, and `input-otp` to make programmatic control consistent. Adds instant hide for tooltips, optional origin for popover hide, and restores focus control on the OTP input.

- **New Features**
  - `tooltip`: `NgpTooltipTrigger.hide(immediate?)` (and state `hide`) can skip `hideDelay` and the exit animation.
  - `popover`: trigger state `hide(origin?)` defaults to `program`, matching the directive.
  - `input-otp`: `NgpInputOtpInput.focus()` restored; state `focus()` is public.

<sup>Written for commit 27b0504e8c57192d1618c7a1354ab7b2ccd17fff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Input OTP fields can now be focused programmatically.
  * Tooltips can now be hidden immediately, bypassing configured hide delays.
  * Popovers support hiding without explicitly specifying a focus origin.

* **Bug Fixes**
  * Improved tooltip hiding behaviour and focus handling when closing overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->