### PR TITLE
fix(state): run element listeners outside the active reactive consumer

### DIFF
--- a/packages/ng-primitives/state/src/index.ts
+++ b/packages/ng-primitives/state/src/index.ts
@@ -24,6 +24,7 @@ import {
   runInInjectionContext,
   signal,
   Signal,
+  untracked,
   WritableSignal,
 } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
@@ -600,11 +601,17 @@ export function listener<K extends keyof HTMLElementEventMap>(
     const destroyRef = inject(DestroyRef);
     const nativeElement = coerceElement(element);
 
+    // A browser can dispatch an event synchronously while Angular renders, so the
+    // handler would inherit the active reactive consumer and any signal write would
+    // throw NG0600. Angular wraps its own template listeners the same way.
+    const wrappedHandler = ((eventObject: Event) =>
+      untracked(() => handler(eventObject))) as EventListener;
+
     const removeListener = () =>
-      nativeElement.removeEventListener(event, handler as EventListener, options?.config);
+      nativeElement.removeEventListener(event, wrappedHandler, options?.config);
     destroyRef.onDestroy(removeListener);
     ngZone.runOutsideAngular(() =>
-      nativeElement.addEventListener(event, handler as EventListener, options?.config),
+      nativeElement.addEventListener(event, wrappedHandler, options?.config),
     );
 
     return removeListener;

--- a/packages/ng-primitives/state/src/tests/listener.test.ts
+++ b/packages/ng-primitives/state/src/tests/listener.test.ts
@@ -1,0 +1,31 @@
+import { Component, computed, ElementRef, inject, signal } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { listener } from 'ng-primitives/state';
+import { describe, expect, it } from 'vitest';
+
+describe('listener', () => {
+  it('should allow the handler to write signals when the event is dispatched during a reactive context', async () => {
+    @Component({ selector: 'app-test', template: '' })
+    class Test {
+      readonly element = inject<ElementRef<HTMLElement>>(ElementRef);
+      readonly left = signal(false);
+
+      constructor() {
+        listener(this.element, 'mouseleave', () => this.left.set(true));
+      }
+    }
+
+    const { fixture } = await render(Test);
+    const host = fixture.nativeElement as HTMLElement;
+
+    // A browser can dispatch an event synchronously while Angular renders, so the
+    // handler must not inherit whichever reactive consumer is active.
+    const dispatchWhileReactive = computed(() => {
+      host.dispatchEvent(new MouseEvent('mouseleave'));
+      return true;
+    });
+
+    expect(() => dispatchWhileReactive()).not.toThrow();
+    expect(fixture.componentInstance.left()).toBe(true);
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

## What does this PR implement/fix?

A browser can dispatch an event synchronously while Angular is rendering. The clearest case: Chrome fires `mouseleave` the moment a hovered button is given the `disabled` property, and that property write happens during change detection.

The `listener` helper added the handler as-is, so when that happened the handler ran with the render's reactive consumer active and any signal write inside it threw `NG0600` ("Writing to signals is not allowed while Angular renders the template"). Reproducible with a tooltip trigger on a button that disables itself on click:

```html
<button ngpTooltipTrigger="Copy to clipboard" [disabled]="done()" (click)="done.set(true)">
  Copy
</button>
```

`listener` now invokes handlers inside `untracked`, which is what Angular itself does for template listeners (`executeListenerWithErrorHandling` clears the active consumer). This applies to every primitive rather than just the tooltip, since any primitive whose element can be disabled or removed mid-render hits the same path.

Added a test in `packages/ng-primitives/state/src/tests/listener.test.ts` that dispatches the event from inside a reactive context and asserts the handler's signal write is allowed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap `listener` callbacks in `untracked` so element events run outside the active reactive consumer. This prevents NG0600 errors when browsers fire events during change detection (e.g., `mouseleave` on a button that becomes `disabled`), avoiding crashes across primitives.

- **Bug Fixes**
  - Run handlers in `untracked` and register the wrapped function for add/remove, matching Angular template listener behavior.
  - Add a test that dispatches the event inside a reactive context and verifies signal writes succeed.

<sup>Written for commit d93375840f1aeb172fb5aca821dc3774b95218fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event handlers triggered during Angular rendering no longer inherit the active reactive context.
  * Synchronous events can safely update reactive state without causing rendering errors.

* **Tests**
  * Added coverage confirming event handlers update state correctly when dispatched during reactive computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->