### PR TITLE
feat(ai): make the dictation language configurable and stop it overwriting user edits

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/ai-assistant.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/ai-assistant.md
@@ -145,7 +145,7 @@ You can configure the default options for all AI assistant primitives in your ap
 import { provideAiConfig } from 'ng-primitives/ai';
 
 bootstrapApplication(AppComponent, {
-  providers: [provideAiConfig({ dictationLang: 'es-ES' })],
+  providers: [provideAiConfig({ dictationLanguage: 'es-ES' })],
 });
 ```
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/ai-assistant.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/ai-assistant.md
@@ -137,6 +137,22 @@ The `NgpPromptComposerDictation` directive enables voice input functionality for
   <api-attribute name="data-prompt" description="Added when there is text content in the prompt." />
 </api-reference-attributes>
 
+## Global Configuration
+
+You can configure the default options for all AI assistant primitives in your application by using the `provideAiConfig` function in a providers array.
+
+```ts
+import { provideAiConfig } from 'ng-primitives/ai';
+
+bootstrapApplication(AppComponent, {
+  providers: [provideAiConfig({ dictationLang: 'es-ES' })],
+});
+```
+
+### NgpAiConfig
+
+<api-reference-config name="NgpAiConfig"></api-reference-config>
+
 ## Accessibility
 
 ### Keyboard Interactions

--- a/packages/ng-primitives/ai/src/config/ai-config.ts
+++ b/packages/ng-primitives/ai/src/config/ai-config.ts
@@ -1,0 +1,39 @@
+import { InjectionToken, Provider, inject } from '@angular/core';
+
+export interface NgpAiConfig {
+  /**
+   * The BCP 47 language tag dictation transcribes in, e.g. `en-US` or `es-ES`.
+   * When undefined the page's own language is used: the document's `lang` attribute,
+   * falling back to the browser's language.
+   * @default undefined
+   */
+  dictationLang: string | undefined;
+}
+
+export const defaultAiConfig: NgpAiConfig = {
+  dictationLang: undefined,
+};
+
+export const NgpAiConfigToken = new InjectionToken<NgpAiConfig>('NgpAiConfigToken');
+
+/**
+ * Provide the default Ai configuration
+ * @param config The Ai configuration
+ * @returns The provider
+ */
+export function provideAiConfig(config: Partial<NgpAiConfig>): Provider[] {
+  return [
+    {
+      provide: NgpAiConfigToken,
+      useValue: { ...defaultAiConfig, ...config },
+    },
+  ];
+}
+
+/**
+ * Inject the Ai configuration
+ * @returns The global Ai configuration
+ */
+export function injectAiConfig(): NgpAiConfig {
+  return inject(NgpAiConfigToken, { optional: true }) ?? defaultAiConfig;
+}

--- a/packages/ng-primitives/ai/src/config/ai-config.ts
+++ b/packages/ng-primitives/ai/src/config/ai-config.ts
@@ -7,11 +7,11 @@ export interface NgpAiConfig {
    * falling back to the browser's language.
    * @default undefined
    */
-  dictationLang: string | undefined;
+  dictationLanguage: string | undefined;
 }
 
 export const defaultAiConfig: NgpAiConfig = {
-  dictationLang: undefined,
+  dictationLanguage: undefined,
 };
 
 export const NgpAiConfigToken = new InjectionToken<NgpAiConfig>('NgpAiConfigToken');

--- a/packages/ng-primitives/ai/src/index.ts
+++ b/packages/ng-primitives/ai/src/index.ts
@@ -67,3 +67,4 @@ export {
   injectThreadMessageState,
   type NgpThreadMessageState,
 } from './thread-message/thread-message-state';
+export { NgpAiConfig, provideAiConfig } from './config/ai-config';

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
@@ -11,6 +11,9 @@ import {
 } from 'ng-primitives/state';
 import { injectPromptComposerState } from '../prompt-composer/prompt-composer-state';
 
+/** Used only when neither the consumer nor the page states a language. */
+const DEFAULT_DICTATION_LANG = 'en-US';
+
 export interface NgpPromptComposerDictationState {
   /**
    * Whether dictation is currently active.
@@ -23,6 +26,10 @@ export interface NgpPromptComposerDictationProps {
    * Whether the dictation button should be disabled.
    */
   readonly disabled?: Signal<boolean>;
+  /**
+   * The BCP 47 language tag dictation transcribes in. Falls back to the page's own language.
+   */
+  readonly lang?: Signal<string | undefined>;
 }
 
 export const [
@@ -34,6 +41,7 @@ export const [
   'NgpPromptComposerDictation',
   ({
     disabled = signal(false),
+    lang = signal(undefined),
   }: NgpPromptComposerDictationProps): NgpPromptComposerDictationState => {
     const element = injectElementRef<HTMLElement>();
     const document = inject(DOCUMENT);
@@ -169,8 +177,22 @@ export const [
       lastWritten = null;
     }
 
+    /**
+     * The configured language, or the page's own: the document's `lang`, then the browser's.
+     * Resolved per session so a language bound after construction is picked up.
+     */
+    function resolveLang(): string {
+      return (
+        lang() ||
+        document.documentElement.lang ||
+        globalThis.navigator?.language ||
+        DEFAULT_DICTATION_LANG
+      );
+    }
+
     function startDictation(): void {
       if (recognition && !composer().isDictating()) {
+        recognition.lang = resolveLang();
         recognition.start();
       }
     }

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
@@ -122,6 +122,8 @@ export const [
         // Store the current prompt as the base
         resetTranscript();
         basePrompt = composer().prompt();
+        // counts as written, so an edit made before the first result is still detected below
+        lastWritten = basePrompt;
       };
 
       recognition.onresult = (event: any) => {

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
@@ -46,6 +46,14 @@ export const [
     // Store the prompt before dictation started
     let basePrompt = '';
 
+    // The speech finalised so far this session, and how many results are already folded into it,
+    // so a result is never counted twice.
+    let finalTranscript = '';
+    let finalisedCount = 0;
+
+    // The last value dictation itself wrote. Anything else in the prompt is the user's own edit.
+    let lastWritten: string | null = null;
+
     ngpButton({
       disabled: computed(() => disabled() || composer().dictationSupported === false),
     });
@@ -98,23 +106,37 @@ export const [
       recognition = new SpeechRecognition();
       recognition.continuous = true; // Enable continuous listening
       recognition.interimResults = true; // Enable interim results for live updates
-      recognition.lang = 'en-US';
 
       recognition.onstart = () => {
         composer().setDictating(true);
         // Store the current prompt as the base
+        resetTranscript();
         basePrompt = composer().prompt();
       };
 
       recognition.onresult = (event: any) => {
-        let interimTranscript = '';
-        let finalTranscript = '';
+        // a stray result after the session ended must not rewrite the field
+        if (!composer().isDictating()) {
+          return;
+        }
 
-        // Process all results
-        for (let i = 0; i < event.results.length; i++) {
+        // The user has typed or deleted since we last wrote: take what they left as the new base
+        // and drop the speech accumulated so far, so their edit wins instead of being overwritten.
+        if (lastWritten !== null && composer().prompt() !== lastWritten) {
+          basePrompt = composer().prompt();
+          finalTranscript = '';
+        }
+
+        let interimTranscript = '';
+
+        // Fold in only the results not already accounted for. Re-reading the list from zero would
+        // re-apply every phrase of the session on top of a base that may have moved on.
+        for (let i = finalisedCount; i < event.results.length; i++) {
           const transcript = event.results[i][0].transcript;
+
           if (event.results[i].isFinal) {
             finalTranscript += transcript;
+            finalisedCount = i + 1;
           } else {
             interimTranscript += transcript;
           }
@@ -122,17 +144,29 @@ export const [
 
         // Combine base prompt with final transcript and interim transcript
         const separator = basePrompt ? ' ' : '';
-        const newPrompt = basePrompt + separator + finalTranscript + interimTranscript;
+        const newPrompt = (basePrompt + separator + finalTranscript + interimTranscript).trim();
 
-        composer().setPrompt(newPrompt.trim());
+        lastWritten = newPrompt;
+        composer().setPrompt(newPrompt);
       };
 
-      recognition.onend = () => composer().setDictating(false);
+      recognition.onend = () => {
+        composer().setDictating(false);
+        // the next session starts from whatever the prompt holds then, not from this one's base
+        resetTranscript();
+      };
 
       recognition.onerror = (event: any) => {
         console.error('Speech recognition error:', event.error);
         composer().setDictating(false);
       };
+    }
+
+    function resetTranscript(): void {
+      basePrompt = '';
+      finalTranscript = '';
+      finalisedCount = 0;
+      lastWritten = null;
     }
 
     function startDictation(): void {

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation-state.ts
@@ -12,7 +12,7 @@ import {
 import { injectPromptComposerState } from '../prompt-composer/prompt-composer-state';
 
 /** Used only when neither the consumer nor the page states a language. */
-const DEFAULT_DICTATION_LANG = 'en-US';
+const DEFAULT_DICTATION_LANGUAGE = 'en-US';
 
 export interface NgpPromptComposerDictationState {
   /**
@@ -29,7 +29,7 @@ export interface NgpPromptComposerDictationProps {
   /**
    * The BCP 47 language tag dictation transcribes in. Falls back to the page's own language.
    */
-  readonly lang?: Signal<string | undefined>;
+  readonly language?: Signal<string | undefined>;
 }
 
 export const [
@@ -41,7 +41,7 @@ export const [
   'NgpPromptComposerDictation',
   ({
     disabled = signal(false),
-    lang = signal(undefined),
+    language = signal(undefined),
   }: NgpPromptComposerDictationProps): NgpPromptComposerDictationState => {
     const element = injectElementRef<HTMLElement>();
     const document = inject(DOCUMENT);
@@ -59,8 +59,10 @@ export const [
     let finalTranscript = '';
     let finalisedCount = 0;
 
-    // The last value dictation itself wrote. Anything else in the prompt is the user's own edit.
+    // The last value dictation itself wrote, and how many results it was built from. Anything
+    // else in the prompt is the user's own edit.
     let lastWritten: string | null = null;
+    let writtenCount = 0;
 
     ngpButton({
       disabled: computed(() => disabled() || composer().dictationSupported === false),
@@ -130,9 +132,12 @@ export const [
 
         // The user has typed or deleted since we last wrote: take what they left as the new base
         // and drop the speech accumulated so far, so their edit wins instead of being overwritten.
+        // Everything they had already seen counts as settled — including the phrase still in
+        // flight, which would otherwise be re-applied when it finalises and undo their deletion.
         if (lastWritten !== null && composer().prompt() !== lastWritten) {
           basePrompt = composer().prompt();
           finalTranscript = '';
+          finalisedCount = writtenCount;
         }
 
         let interimTranscript = '';
@@ -155,6 +160,7 @@ export const [
         const newPrompt = (basePrompt + separator + finalTranscript + interimTranscript).trim();
 
         lastWritten = newPrompt;
+        writtenCount = event.results.length;
         composer().setPrompt(newPrompt);
       };
 
@@ -175,24 +181,25 @@ export const [
       finalTranscript = '';
       finalisedCount = 0;
       lastWritten = null;
+      writtenCount = 0;
     }
 
     /**
      * The configured language, or the page's own: the document's `lang`, then the browser's.
      * Resolved per session so a language bound after construction is picked up.
      */
-    function resolveLang(): string {
+    function resolveLanguage(): string {
       return (
-        lang() ||
+        language() ||
         document.documentElement.lang ||
         globalThis.navigator?.language ||
-        DEFAULT_DICTATION_LANG
+        DEFAULT_DICTATION_LANGUAGE
       );
     }
 
     function startDictation(): void {
       if (recognition && !composer().isDictating()) {
-        recognition.lang = resolveLang();
+        recognition.lang = resolveLanguage();
         recognition.start();
       }
     }

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation.ts
@@ -24,14 +24,14 @@ export class NgpPromptComposerDictation {
    * The BCP 47 language tag dictation transcribes in, e.g. `en-US` or `es-ES`.
    * Defaults to the page's own language: the document's `lang` attribute, then the browser's.
    */
-  readonly lang = input<string | undefined>(this.config.dictationLang, {
-    alias: 'ngpPromptComposerDictationLang',
+  readonly language = input<string | undefined>(this.config.dictationLanguage, {
+    alias: 'ngpPromptComposerDictationLanguage',
   });
 
   /** The state of the prompt composer dictation. */
   protected readonly state = ngpPromptComposerDictation({
     disabled: this.disabled,
-    lang: this.lang,
+    language: this.language,
   });
 
   /** Whether dictation is currently active */

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/prompt-composer-dictation.ts
@@ -1,5 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
 import { booleanAttribute, Directive, input } from '@angular/core';
+import { injectAiConfig } from '../config/ai-config';
 import {
   ngpPromptComposerDictation,
   providePromptComposerDictationState,
@@ -11,13 +12,27 @@ import {
   providers: [providePromptComposerDictationState()],
 })
 export class NgpPromptComposerDictation {
+  /** Access the global AI configuration. */
+  private readonly config = injectAiConfig();
+
   /** Whether the dictation button should be disabled. */
   readonly disabled = input<boolean, BooleanInput>(false, {
     transform: booleanAttribute,
   });
 
+  /**
+   * The BCP 47 language tag dictation transcribes in, e.g. `en-US` or `es-ES`.
+   * Defaults to the page's own language: the document's `lang` attribute, then the browser's.
+   */
+  readonly lang = input<string | undefined>(this.config.dictationLang, {
+    alias: 'ngpPromptComposerDictationLang',
+  });
+
   /** The state of the prompt composer dictation. */
-  protected readonly state = ngpPromptComposerDictation({ disabled: this.disabled });
+  protected readonly state = ngpPromptComposerDictation({
+    disabled: this.disabled,
+    lang: this.lang,
+  });
 
   /** Whether dictation is currently active */
   readonly isDictating = this.state.isDictating;

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/tests/mock-speech-recognition.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/tests/mock-speech-recognition.ts
@@ -1,7 +1,16 @@
+interface MockSpeechRecognitionResult {
+  0: { transcript: string };
+  isFinal: boolean;
+  length: number;
+}
+
 /**
  * A minimal SpeechRecognition stand-in shared across the prompt-composer test
  * suites. Kept in a plain (non-`.test.ts`) module so the specs don't depend on
  * one another.
+ *
+ * Like the real API in continuous mode, `results` accumulates for the whole session: an interim
+ * result is refined and finalised in place, and each new phrase takes the next index.
  */
 export class MockSpeechRecognition {
   continuous = false;
@@ -12,7 +21,11 @@ export class MockSpeechRecognition {
   onresult: ((event: unknown) => void) | null = null;
   onerror: ((event: unknown) => void) | null = null;
 
+  /** Every result heard in the current session. */
+  private results: MockSpeechRecognitionResult[] = [];
+
   start() {
+    this.results = [];
     this.onstart?.({});
   }
 
@@ -21,16 +34,17 @@ export class MockSpeechRecognition {
   }
 
   mockResult(transcript: string, isFinal: boolean = true) {
-    const event = {
-      results: [
-        {
-          0: { transcript },
-          isFinal,
-          length: 1,
-        },
-      ],
-      resultIndex: 0,
-    };
+    const pending = this.results[this.results.length - 1];
+
+    if (pending && !pending.isFinal) {
+      // the phrase in flight is refined, and finalised, at the index it already occupies
+      pending[0].transcript = transcript;
+      pending.isFinal = isFinal;
+    } else {
+      this.results.push({ 0: { transcript }, isFinal, length: 1 });
+    }
+
+    const event = { results: this.results, resultIndex: this.results.length - 1 };
     setTimeout(() => this.onresult?.(event), 0);
   }
 

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/tests/prompt-composer-dictation-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/tests/prompt-composer-dictation-primitive.test.ts
@@ -433,6 +433,23 @@ describe('NgpPromptComposerDictation', () => {
       expect(screen.getByText('Current: "world"')).toBeInTheDocument();
     });
 
+    it('should keep an edit the user made before the first speech result', async () => {
+      const { fixture } = await render(template, { imports });
+
+      const input = screen.getByRole('textbox');
+      await userEvent.click(screen.getByRole('button', { name: 'Dictate' }));
+      fixture.detectChanges();
+
+      // the user types between the session starting and the first phrase being heard
+      await userEvent.type(input, 'note');
+      fixture.detectChanges();
+
+      mockSpeechRecognition.mockResult('world');
+      await settle(fixture);
+
+      expect(screen.getByText('Current: "note world"')).toBeInTheDocument();
+    });
+
     it('should keep a partial edit the user made mid-session', async () => {
       const { fixture } = await render(template, { imports });
 

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/tests/prompt-composer-dictation-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/tests/prompt-composer-dictation-primitive.test.ts
@@ -388,6 +388,51 @@ describe('NgpPromptComposerDictation', () => {
       expect(screen.getByText('Current: "world"')).toBeInTheDocument();
     });
 
+    it('should not restore interim text the user deleted before it was finalised', async () => {
+      const { fixture } = await render(template, { imports });
+
+      const input = screen.getByRole('textbox');
+      await userEvent.click(screen.getByRole('button', { name: 'Dictate' }));
+      fixture.detectChanges();
+
+      // the phrase is still in flight when the user removes it
+      mockSpeechRecognition.mockResult('hello', false);
+      await settle(fixture);
+      expect(screen.getByText('Current: "hello"')).toBeInTheDocument();
+
+      await userEvent.clear(input);
+      fixture.detectChanges();
+
+      // the same phrase now finalises — it must not come back
+      mockSpeechRecognition.mockResult('hello', true);
+      await settle(fixture);
+
+      expect(screen.getByText('Current: ""')).toBeInTheDocument();
+    });
+
+    it('should still transcribe a new phrase after deleted interim text', async () => {
+      const { fixture } = await render(template, { imports });
+
+      const input = screen.getByRole('textbox');
+      await userEvent.click(screen.getByRole('button', { name: 'Dictate' }));
+      fixture.detectChanges();
+
+      mockSpeechRecognition.mockResult('hello', false);
+      await settle(fixture);
+
+      await userEvent.clear(input);
+      fixture.detectChanges();
+
+      mockSpeechRecognition.mockResult('hello', true);
+      await settle(fixture);
+
+      // a phrase spoken after the deletion is new, so it is transcribed as normal
+      mockSpeechRecognition.mockResult('world');
+      await settle(fixture);
+
+      expect(screen.getByText('Current: "world"')).toBeInTheDocument();
+    });
+
     it('should keep a partial edit the user made mid-session', async () => {
       const { fixture } = await render(template, { imports });
 
@@ -451,7 +496,7 @@ describe('NgpPromptComposerDictation', () => {
       await render(
         `<div ngpThread>
           <div ngpPromptComposer>
-            <button ngpPromptComposerDictation ngpPromptComposerDictationLang="es-ES">Dictate</button>
+            <button ngpPromptComposerDictation ngpPromptComposerDictationLanguage="es-ES">Dictate</button>
           </div>
         </div>`,
         { imports: [NgpThread, NgpPromptComposer, NgpPromptComposerDictation] },
@@ -492,7 +537,7 @@ describe('NgpPromptComposerDictation', () => {
         </div>`,
         {
           imports: [NgpThread, NgpPromptComposer, NgpPromptComposerDictation],
-          providers: [provideAiConfig({ dictationLang: 'de-DE' })],
+          providers: [provideAiConfig({ dictationLanguage: 'de-DE' })],
         },
       );
 

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/tests/prompt-composer-dictation-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/tests/prompt-composer-dictation-primitive.test.ts
@@ -343,4 +343,105 @@ describe('NgpPromptComposerDictation', () => {
 
     consoleSpy.mockRestore();
   });
+
+  describe('user edits during a session', () => {
+    const template = `<div ngpThread>
+        <div ngpPromptComposer #composer="ngpPromptComposer">
+          <input ngpPromptComposerInput />
+          <button ngpPromptComposerDictation>Dictate</button>
+          Current: "{{ composer.prompt() }}"
+        </div>
+      </div>`;
+
+    const imports = [
+      NgpThread,
+      NgpPromptComposer,
+      NgpPromptComposerInput,
+      NgpPromptComposerDictation,
+    ];
+
+    /** Let the queued result event reach the primitive. */
+    async function settle(fixture: { detectChanges(): void }): Promise<void> {
+      await new Promise(resolve => setTimeout(resolve, 10));
+      fixture.detectChanges();
+    }
+
+    it('should not bring back text the user deleted mid-session', async () => {
+      const { fixture } = await render(template, { imports });
+
+      const input = screen.getByRole('textbox');
+      await userEvent.click(screen.getByRole('button', { name: 'Dictate' }));
+      fixture.detectChanges();
+
+      mockSpeechRecognition.mockResult('hello');
+      await settle(fixture);
+      expect(screen.getByText('Current: "hello"')).toBeInTheDocument();
+
+      // the user empties the field while dictation is still running
+      await userEvent.clear(input);
+      fixture.detectChanges();
+
+      mockSpeechRecognition.mockResult('world');
+      await settle(fixture);
+
+      expect(screen.getByText('Current: "world"')).toBeInTheDocument();
+    });
+
+    it('should keep a partial edit the user made mid-session', async () => {
+      const { fixture } = await render(template, { imports });
+
+      const input = screen.getByRole('textbox');
+      await userEvent.click(screen.getByRole('button', { name: 'Dictate' }));
+      fixture.detectChanges();
+
+      mockSpeechRecognition.mockResult('one');
+      await settle(fixture);
+
+      // the user keeps typing while dictation is running
+      await userEvent.type(input, ' edited');
+      fixture.detectChanges();
+
+      mockSpeechRecognition.mockResult('two');
+      await settle(fixture);
+
+      expect(screen.getByText('Current: "one edited two"')).toBeInTheDocument();
+    });
+
+    it('should accumulate phrases across a continuous session', async () => {
+      const { fixture } = await render(template, { imports });
+
+      await userEvent.click(screen.getByRole('button', { name: 'Dictate' }));
+      fixture.detectChanges();
+
+      mockSpeechRecognition.mockResult('one ');
+      await settle(fixture);
+
+      mockSpeechRecognition.mockResult('two');
+      await settle(fixture);
+
+      expect(screen.getByText('Current: "one two"')).toBeInTheDocument();
+    });
+
+    it('should start from the current prompt after dictation is stopped', async () => {
+      const { fixture } = await render(template, { imports });
+
+      const button = screen.getByRole('button', { name: 'Dictate' });
+
+      await userEvent.click(button);
+      fixture.detectChanges();
+      mockSpeechRecognition.mockResult('first');
+      await settle(fixture);
+
+      // stop, then dictate again — the earlier session must not be replayed
+      await userEvent.click(button);
+      fixture.detectChanges();
+      await userEvent.click(button);
+      fixture.detectChanges();
+
+      mockSpeechRecognition.mockResult('second');
+      await settle(fixture);
+
+      expect(screen.getByText('Current: "first second"')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/ng-primitives/ai/src/prompt-composer-dictation/tests/prompt-composer-dictation-primitive.test.ts
+++ b/packages/ng-primitives/ai/src/prompt-composer-dictation/tests/prompt-composer-dictation-primitive.test.ts
@@ -5,6 +5,7 @@ import {
   NgpPromptComposerDictation,
   NgpPromptComposerInput,
   NgpThread,
+  provideAiConfig,
 } from 'ng-primitives/ai';
 import { describe, beforeEach, afterEach, it, expect, vi } from 'vitest';
 import { MockSpeechRecognition } from './mock-speech-recognition';
@@ -442,6 +443,62 @@ describe('NgpPromptComposerDictation', () => {
       await settle(fixture);
 
       expect(screen.getByText('Current: "first second"')).toBeInTheDocument();
+    });
+  });
+
+  describe('language', () => {
+    it('should use the configured language', async () => {
+      await render(
+        `<div ngpThread>
+          <div ngpPromptComposer>
+            <button ngpPromptComposerDictation ngpPromptComposerDictationLang="es-ES">Dictate</button>
+          </div>
+        </div>`,
+        { imports: [NgpThread, NgpPromptComposer, NgpPromptComposerDictation] },
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Dictate' }));
+
+      expect(mockSpeechRecognition.lang).toBe('es-ES');
+    });
+
+    it('should fall back to the document language', async () => {
+      document.documentElement.lang = 'fr-FR';
+
+      try {
+        await render(
+          `<div ngpThread>
+            <div ngpPromptComposer>
+              <button ngpPromptComposerDictation>Dictate</button>
+            </div>
+          </div>`,
+          { imports: [NgpThread, NgpPromptComposer, NgpPromptComposerDictation] },
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'Dictate' }));
+
+        expect(mockSpeechRecognition.lang).toBe('fr-FR');
+      } finally {
+        document.documentElement.lang = '';
+      }
+    });
+
+    it('should let a global config set the language', async () => {
+      await render(
+        `<div ngpThread>
+          <div ngpPromptComposer>
+            <button ngpPromptComposerDictation>Dictate</button>
+          </div>
+        </div>`,
+        {
+          imports: [NgpThread, NgpPromptComposer, NgpPromptComposerDictation],
+          providers: [provideAiConfig({ dictationLang: 'de-DE' })],
+        },
+      );
+
+      await userEvent.click(screen.getByRole('button', { name: 'Dictate' }));
+
+      expect(mockSpeechRecognition.lang).toBe('de-DE');
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

No issue — both parts were raised with you on Discord, where you were happy for them to land as one
PR.

## What does this PR implement/fix?

Two problems in `NgpPromptComposerDictation`, both inside `initializeSpeechRecognition`.

### Dictation was overwriting the user's edits

The session is `continuous`, so it stays alive until the user clicks or presses Escape — the whole
of it is a window in which they can edit the field. But the prompt was snapshotted once in `onstart`
and never resynced, and `onresult` rebuilt the transcript from `results[0]` on every event. So the
primitive never appended, it **rewrote the whole field from a stale snapshot**. Anything typed or
deleted mid-session was discarded on the next result, and dictated text the user had removed came
back.

Repro: dictate `"hello"`, clear the input with dictation still running, say `"world"` — the field
read `"hello world"` instead of `"world"`.

The fix accumulates finalised speech incrementally, tracking how many results are already folded in
so none is counted twice, and re-derives the base when the prompt no longer matches what dictation
last wrote — so the user's edit wins instead of being overwritten. Ending a session resets that
state, and a stray result arriving after it can no longer rewrite the field.

I accumulate from a `finalisedCount` rather than from `event.resultIndex`: it is idempotent, so a
browser re-reporting an already finalised result cannot duplicate it.

### The dictation language was hardcoded

`recognition.lang` was fixed to `'en-US'`, and `recognition` is local to the factory, so there was
no way to reach it from outside. This adds an `ngpPromptComposerDictationLang` input _and_ a
`provideAiConfig` global config, as discussed. When neither is set the page's own language is used —
the document's `lang` attribute, then the browser's — falling back to `en-US` only if the page says
nothing.

The language is resolved per session rather than at construction, so a value bound after the button
is created applies to the next dictation.

### Test mock

`MockSpeechRecognition` only ever emitted a single result, so the suite could not express a
continuous session at all — the bug above was invisible to it. It now models the real API: an
interim result is refined and finalised at the index it already occupies, and each new phrase takes
the next one. All 12 existing dictation tests pass against it unchanged.

Seven tests are added. I confirmed the two that target the bug fail on `next`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

No API is removed or changed — the input and the config are additive. Two behaviour changes worth
naming, both intended: edits made while dictation runs are now preserved instead of being
overwritten, and an application that relied on dictation always transcribing as `en-US` while
serving a page with a different `lang` will now follow the page. Setting
`ngpPromptComposerDictationLang="en-US"` restores the old behaviour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the dictation language configurable and prevent dictation from overwriting or restoring deleted text. Adds a global config and input; resolves language per session with fallbacks.

- **New Features**
  - Configure language via `ngpPromptComposerDictationLanguage` or global `provideAiConfig({ dictationLanguage })`; resolved per session with fallback: document `lang` → browser → `en-US`.
  - Exported `NgpAiConfig` and `provideAiConfig` from `ng-primitives/ai`; docs updated with a Global Configuration section.

- **Bug Fixes**
  - Preserve user edits by accumulating only new final results and rebasing when the prompt diverges; deleted interim text no longer reappears; edits made before the first result are kept; new sessions start from the current prompt and late results after stop are ignored.
  - Test mock now models continuous sessions; new tests cover edits (including before-first-result), interim deletion, and language resolution.

<sup>Written for commit fb674400c1b641a818b4e56d71a3071da8896c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable dictation language for the AI assistant, with both per-component selection and application-wide defaults.
  * Dictation now supports a `language` input (including the `ngpPromptComposerDictationLanguage` alias) and resolves language with fallbacks.

* **Bug Fixes**
  * Improved dictation session handling to preserve user edits during active dictation.
  * Ensures interim/final transcript accumulation is consistent across start/stop cycles.

* **Documentation**
  * Added a “Global Configuration” section with a TypeScript example and API reference for setting default AI assistant options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->