### PR TITLE
refactor(portal): inline the Floating UI positioning types

### DIFF
--- a/packages/ng-primitives/portal/src/index.ts
+++ b/packages/ng-primitives/portal/src/index.ts
@@ -35,6 +35,7 @@ export {
   NgpMiddleware,
   NgpPlacement,
   NgpPositioningStrategy,
+  NgpRect,
   NgpRootBoundary,
 } from './positioning';
 export {

--- a/packages/ng-primitives/portal/src/positioning.ts
+++ b/packages/ng-primitives/portal/src/positioning.ts
@@ -54,9 +54,10 @@ type Assert<T extends true> = T;
 
 /**
  * Compile-time guard: a Floating UI upgrade that changes any of these types breaks here rather
- * than silently diverging from the inlined copies. Not exported from the barrel.
+ * than silently diverging from the inlined copies. Never referenced - existing is the test.
  */
-export type NgpFloatingUiParity = [
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type FloatingUiParity = [
   Assert<Exact<NgpPlacement, Placement>>,
   Assert<Exact<NgpBoundary, Boundary>>,
   Assert<Exact<NgpRootBoundary, RootBoundary>>,

--- a/packages/ng-primitives/portal/src/positioning.ts
+++ b/packages/ng-primitives/portal/src/positioning.ts
@@ -1,9 +1,9 @@
 /**
  * The positioning vocabulary the overlay primitives speak, written out in full so the public
  * API (and the generated docs) read as `Ngp*` types rather than re-exported Floating UI ones.
- * `FloatingUiParity` below fails the build if the inlined types drift from upstream.
+ * `positioning.test-d.ts` fails if a copy drifts from the Floating UI type it mirrors.
  */
-import type { Boundary, Middleware, Placement, RootBoundary, Strategy } from '@floating-ui/dom';
+import type { Middleware } from '@floating-ui/dom';
 
 /** Where a floating element is placed relative to its trigger, e.g. `bottom-start`. */
 export type NgpPlacement =
@@ -49,18 +49,3 @@ export type NgpPositioningStrategy = 'absolute' | 'fixed';
  * inlining it would mean copying Floating UI's whole middleware state surface.
  */
 export type NgpMiddleware = Middleware;
-
-type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
-type Assert<T extends true> = T;
-
-/**
- * Compile-time guard: a Floating UI upgrade that changes any of these types breaks here rather
- * than silently diverging from the inlined copies. Never referenced - existing is the test.
- */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type FloatingUiParity = [
-  Assert<Exact<NgpPlacement, Placement>>,
-  Assert<Exact<NgpBoundary, Boundary>>,
-  Assert<Exact<NgpRootBoundary, RootBoundary>>,
-  Assert<Exact<NgpPositioningStrategy, Strategy>>,
-];

--- a/packages/ng-primitives/portal/src/positioning.ts
+++ b/packages/ng-primitives/portal/src/positioning.ts
@@ -1,7 +1,7 @@
 /**
  * The positioning vocabulary the overlay primitives speak, written out in full so the public
  * API (and the generated docs) read as `Ngp*` types rather than re-exported Floating UI ones.
- * `NgpParity` below fails the build if the inlined unions drift from upstream.
+ * `FloatingUiParity` below fails the build if the inlined types drift from upstream.
  */
 import type { Boundary, Middleware, Placement, RootBoundary, Strategy } from '@floating-ui/dom';
 
@@ -30,7 +30,8 @@ export interface NgpRect {
 
 /**
  * The clipping area a floating element is kept within. Pass an element (or elements) to
- * constrain it to a container rather than to its clipping ancestors.
+ * constrain it to a container rather than to its clipping ancestors, or an `NgpRect` to
+ * constrain it to an arbitrary region.
  */
 export type NgpBoundary = 'clippingAncestors' | Element | Element[] | NgpRect;
 

--- a/packages/ng-primitives/portal/src/positioning.ts
+++ b/packages/ng-primitives/portal/src/positioning.ts
@@ -1,27 +1,64 @@
 /**
- * The positioning vocabulary the overlay primitives speak, aliased so the public API is
- * expressed in `Ngp*` names rather than Floating UI's. Aliases, not copies - a hand-written
- * duplicate of a structural type silently drifts when the upstream one changes.
+ * The positioning vocabulary the overlay primitives speak, written out in full so the public
+ * API (and the generated docs) read as `Ngp*` types rather than re-exported Floating UI ones.
+ * `NgpParity` below fails the build if the inlined unions drift from upstream.
  */
 import type { Boundary, Middleware, Placement, RootBoundary, Strategy } from '@floating-ui/dom';
 
 /** Where a floating element is placed relative to its trigger, e.g. `bottom-start`. */
-export type NgpPlacement = Placement;
+export type NgpPlacement =
+  | 'top'
+  | 'top-start'
+  | 'top-end'
+  | 'right'
+  | 'right-start'
+  | 'right-end'
+  | 'bottom'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left'
+  | 'left-start'
+  | 'left-end';
+
+/** A rectangle in viewport coordinates. */
+export interface NgpRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
 
 /**
  * The clipping area a floating element is kept within. Pass an element (or elements) to
  * constrain it to a container rather than to its clipping ancestors.
  */
-export type NgpBoundary = Boundary;
+export type NgpBoundary = 'clippingAncestors' | Element | Element[] | NgpRect;
 
 /** The root clipping area a floating element is kept within. */
-export type NgpRootBoundary = RootBoundary;
+export type NgpRootBoundary = 'viewport' | 'document' | NgpRect;
 
 /**
  * How a floating element is positioned in the document. Named for positioning to keep it
  * distinct from `ScrollStrategy`, which governs what happens when the page scrolls.
  */
-export type NgpPositioningStrategy = Strategy;
+export type NgpPositioningStrategy = 'absolute' | 'fixed';
 
-/** A positioning middleware that can be appended to the overlay's own pipeline. */
+/**
+ * A positioning middleware that can be appended to the overlay's own pipeline. Still an alias -
+ * inlining it would mean copying Floating UI's whole middleware state surface.
+ */
 export type NgpMiddleware = Middleware;
+
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type Assert<T extends true> = T;
+
+/**
+ * Compile-time guard: a Floating UI upgrade that changes any of these types breaks here rather
+ * than silently diverging from the inlined copies. Not exported from the barrel.
+ */
+export type NgpFloatingUiParity = [
+  Assert<Exact<NgpPlacement, Placement>>,
+  Assert<Exact<NgpBoundary, Boundary>>,
+  Assert<Exact<NgpRootBoundary, RootBoundary>>,
+  Assert<Exact<NgpPositioningStrategy, Strategy>>,
+];

--- a/packages/ng-primitives/portal/src/tests/positioning.test-d.ts
+++ b/packages/ng-primitives/portal/src/tests/positioning.test-d.ts
@@ -1,0 +1,21 @@
+import type { Boundary, Placement, RootBoundary, Strategy } from '@floating-ui/dom';
+import { describe, expectTypeOf, it } from 'vitest';
+import type {
+  NgpBoundary,
+  NgpPlacement,
+  NgpPositioningStrategy,
+  NgpRootBoundary,
+} from '../positioning';
+
+/**
+ * The `Ngp*` positioning types are written out rather than aliased from Floating UI, so an
+ * upgrade that changes one upstream must fail here rather than silently diverge.
+ */
+describe('positioning types', () => {
+  it('matches Floating UI', () => {
+    expectTypeOf<NgpPlacement>().toEqualTypeOf<Placement>();
+    expectTypeOf<NgpBoundary>().toEqualTypeOf<Boundary>();
+    expectTypeOf<NgpRootBoundary>().toEqualTypeOf<RootBoundary>();
+    expectTypeOf<NgpPositioningStrategy>().toEqualTypeOf<Strategy>();
+  });
+});

--- a/packages/ng-primitives/tsconfig.vitest.json
+++ b/packages/ng-primitives/tsconfig.vitest.json
@@ -6,5 +6,5 @@
     "types": ["vitest/globals", "node", "@testing-library/jest-dom"]
   },
   "files": ["src/test-setup.vitest.ts"],
-  "include": ["vite.config.ts", "**/*.test.ts", "**/*.d.ts"]
+  "include": ["vite.config.ts", "**/*.test.ts", "**/*.test-d.ts", "**/*.d.ts"]
 }

--- a/packages/ng-primitives/vite.config.ts
+++ b/packages/ng-primitives/vite.config.ts
@@ -17,6 +17,14 @@ export default defineConfig(({ mode }) => ({
     globals: true,
     setupFiles: ['src/test-setup.vitest.ts'],
     include: ['**/*.test.ts'],
+    typecheck: {
+      enabled: true,
+      include: ['**/*.test-d.ts'],
+      // Only the assertions in *.test-d.ts are checked; the rest of the suite has never been
+      // type-checked and reports pre-existing errors.
+      ignoreSourceErrors: true,
+      tsconfig: './tsconfig.vitest.json',
+    },
     exclude: ['schematics/**/*.node.test.ts'],
     reporters: ['default'],
     browser: {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

N/A

## What does this PR implement/fix?

`NgpPlacement`, `NgpBoundary`, `NgpRootBoundary` and `NgpPositioningStrategy` were straight aliases of `Placement`, `Boundary`, `RootBoundary` and `Strategy` from `@floating-ui/dom`. That meant our public API, and the generated API reference, resolved to upstream names instead of ours, and a consumer reading the types was sent to Floating UI's docs to find out what `Placement` actually accepts.

They are now written out in full:

- `NgpPlacement` - the 12 placement literals.
- `NgpRect` - new, the `{ x, y, width, height }` shape the boundary types share. Exported from the `ng-primitives/portal` barrel.
- `NgpBoundary` - `'clippingAncestors' | Element | Element[] | NgpRect`.
- `NgpRootBoundary` - `'viewport' | 'document' | NgpRect`.
- `NgpPositioningStrategy` - `'absolute' | 'fixed'`.

`NgpMiddleware` stays an alias. Inlining it would mean copying `MiddlewareState`, `Derivable`, `Padding` and the rest of Floating UI's middleware surface, which is a lot of duplication for no consumer benefit.

The usual risk with hand-copied structural types is silent drift on an upstream upgrade, so `portal/src/tests/positioning.test-d.ts` asserts parity:

```ts
expectTypeOf<NgpPlacement>().toEqualTypeOf<Placement>();
expectTypeOf<NgpBoundary>().toEqualTypeOf<Boundary>();
expectTypeOf<NgpRootBoundary>().toEqualTypeOf<RootBoundary>();
expectTypeOf<NgpPositioningStrategy>().toEqualTypeOf<Strategy>();
```

If a Floating UI release changes any of these, the test fails rather than the types quietly diverging. Verified by temporarily adding a bogus placement literal.

This needed Vitest's typecheck mode turning on, since `.test.ts` files are transpiled without type checking today (`disableTypeChecking` defaults to `true` in the Analog plugin) - so `vite.config.ts` gains:

```ts
typecheck: {
  enabled: true,
  include: ['**/*.test-d.ts'],
  ignoreSourceErrors: true,
},
```

`ignoreSourceErrors` is on because the existing suite has never been type-checked and currently reports 47 pre-existing errors in `.test.ts` files. Those are worth fixing, but not in this PR - scoping the typecheck to `*.test-d.ts` keeps the guard useful without dragging that cleanup in.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The inlined types are structurally identical to the ones they replace, so assignment in both directions still works and existing code compiles unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inlines Floating UI positioning types so the portal API uses `Ngp*` names and reads clearly in docs. Adds `NgpRect` and enforces upstream parity via a `*.test-d.ts` typecheck test; no functional or breaking changes.

- **Refactors**
  - Inline `NgpPlacement`, `NgpBoundary`, `NgpRootBoundary`, `NgpPositioningStrategy` (replace `@floating-ui/dom` aliases).
  - Add `NgpRect` (`{ x, y, width, height }`) and export from `ng-primitives/portal`.
  - Keep `NgpMiddleware` as an alias; move type parity checks with `@floating-ui/dom` into `positioning.test-d.ts` and enable Vitest typecheck to run them (kept out of the public API).

- **Bug Fixes**
  - Fix stale parity guard name in the positioning docs.

<sup>Written for commit 65e55b5810017b924fe8d21449e968285ca240d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `NgpRect` to the portal positioning API for defining rectangular boundaries.
  - Re-exported `NgpRect` as part of the portal positioning public surface.
- **Improvements**
  - Made placement, boundary, root boundary, and positioning strategy options more explicit with strongly typed unions.
  - Expanded middleware documentation to clarify how it integrates with the overlay pipeline.
- **Tests / Tooling**
  - Improved TypeScript type-check coverage for positioning type assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

