### PR TITLE
feat(popover,portal): add keepMounted option to preserve overlay content across close/reopen

### DIFF
--- a/apps/documentation/src/app/examples/popover/popover-keep-mounted.example.ts
+++ b/apps/documentation/src/app/examples/popover/popover-keep-mounted.example.ts
@@ -1,0 +1,158 @@
+import { Component } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+
+@Component({
+  selector: 'app-popover-keep-mounted',
+  imports: [NgpPopoverTrigger, NgpPopover, NgpButton],
+  template: `
+    <p class="hint">Type a note, close the popover, then open it again.</p>
+
+    <div class="triggers">
+      <button [ngpPopoverTrigger]="defaultPopover" ngpButton type="button">Default</button>
+
+      <button
+        [ngpPopoverTrigger]="keptPopover"
+        ngpButton
+        ngpPopoverTriggerKeepMounted
+        type="button"
+      >
+        Keep mounted
+      </button>
+    </div>
+
+    <ng-template #defaultPopover>
+      <div ngpPopover>
+        <h3>Default</h3>
+        <textarea rows="2" placeholder="Discarded on close..."></textarea>
+        <p>Starts empty every time.</p>
+      </div>
+    </ng-template>
+
+    <ng-template #keptPopover>
+      <div ngpPopover>
+        <h3>Kept mounted</h3>
+        <textarea rows="2" placeholder="Still here on reopen..."></textarea>
+        <p>Whatever you typed is still here.</p>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    .hint {
+      margin: 0 0 0.75rem;
+      font-size: 13px;
+      letter-spacing: -0.011em;
+      color: var(--ngp-text-tertiary);
+      text-align: center;
+    }
+
+    .triggers {
+      display: flex;
+      justify-content: center;
+      column-gap: 0.5rem;
+    }
+
+    button {
+      height: 2.125rem;
+      padding-inline: 0.875rem;
+      border-radius: 0.5rem;
+      background-color: var(--ngp-background);
+      color: var(--ngp-text-primary);
+      font-weight: 510;
+      letter-spacing: -0.006em;
+      outline: none;
+      box-shadow:
+        inset 0 0 0 1px var(--ngp-border),
+        0 1px 2px 0 rgba(0, 0, 0, 0.04);
+      transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    button[data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    button[data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    button[data-focus-visible] {
+      box-shadow: 0 0 0 2px var(--ngp-focus-ring);
+    }
+
+    [ngpPopover] {
+      position: absolute;
+      display: flex;
+      width: 260px;
+      flex-direction: column;
+      row-gap: 0.5rem;
+      border: 1px solid var(--ngp-border);
+      border-radius: 0.75rem;
+      background: var(--ngp-background);
+      padding: 0.75rem;
+      box-shadow: var(--ngp-shadow);
+      outline: none;
+      transform-origin: var(--ngp-popover-transform-origin);
+      animation: popover-show 0.15s ease-out;
+    }
+
+    [ngpPopover][data-exit] {
+      animation: popover-hide 0.15s ease-out;
+    }
+
+    [ngpPopover] h3 {
+      margin: 0;
+      font-size: 13px;
+      font-weight: 590;
+      letter-spacing: -0.014em;
+      color: var(--ngp-text-primary);
+    }
+
+    [ngpPopover] p {
+      margin: 0;
+      font-size: 12px;
+      letter-spacing: -0.011em;
+      color: var(--ngp-text-tertiary);
+    }
+
+    [ngpPopover] textarea {
+      border: 1px solid var(--ngp-border);
+      border-radius: 0.5rem;
+      background-color: var(--ngp-background);
+      padding: 0.5rem;
+      color: var(--ngp-text-primary);
+      font-family: inherit;
+      font-size: 13px;
+      letter-spacing: -0.006em;
+      resize: none;
+      outline: none;
+    }
+
+    [ngpPopover] textarea:focus {
+      border-color: var(--ngp-focus-ring);
+      box-shadow: 0 0 0 1px var(--ngp-focus-ring);
+    }
+
+    @keyframes popover-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.96);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes popover-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.96);
+      }
+    }
+  `,
+})
+export default class PopoverKeepMountedExample {}

--- a/apps/documentation/src/app/examples/popover/popover-keep-mounted.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/popover/popover-keep-mounted.tailwind.example.ts
@@ -1,0 +1,108 @@
+import { Component } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+
+@Component({
+  selector: 'app-popover-keep-mounted-tailwind',
+  imports: [NgpPopoverTrigger, NgpPopover, NgpButton],
+  template: `
+    <p class="mb-3 text-center text-[13px] tracking-[-0.011em] text-gray-500 dark:text-gray-400">
+      Type a note, close the popover, then open it again.
+    </p>
+
+    <div class="flex justify-center gap-2">
+      <button
+        class="h-[2.125rem] rounded-lg bg-white px-3.5 font-[510] tracking-[-0.006em] text-gray-900 shadow-sm ring-1 ring-black/5 transition-colors duration-150 ease-in-out outline-none data-focus-visible:ring-2 data-focus-visible:ring-blue-500 data-hover:bg-gray-50 data-press:bg-gray-100 dark:bg-transparent dark:text-gray-100 dark:ring-white/10 dark:data-focus-visible:ring-blue-400 dark:data-hover:bg-zinc-900 dark:data-press:bg-zinc-800"
+        [ngpPopoverTrigger]="defaultPopover"
+        ngpButton
+        type="button"
+      >
+        Default
+      </button>
+
+      <button
+        class="h-[2.125rem] rounded-lg bg-white px-3.5 font-[510] tracking-[-0.006em] text-gray-900 shadow-sm ring-1 ring-black/5 transition-colors duration-150 ease-in-out outline-none data-focus-visible:ring-2 data-focus-visible:ring-blue-500 data-hover:bg-gray-50 data-press:bg-gray-100 dark:bg-transparent dark:text-gray-100 dark:ring-white/10 dark:data-focus-visible:ring-blue-400 dark:data-hover:bg-zinc-900 dark:data-press:bg-zinc-800"
+        [ngpPopoverTrigger]="keptPopover"
+        ngpButton
+        ngpPopoverTriggerKeepMounted
+        type="button"
+      >
+        Keep mounted
+      </button>
+    </div>
+
+    <ng-template #defaultPopover>
+      <div
+        class="animate-in absolute flex w-[260px] flex-col gap-2 rounded-xl border border-gray-200 bg-white p-3 shadow-lg outline-hidden dark:border-zinc-800 dark:bg-zinc-950"
+        ngpPopover
+      >
+        <h3 class="m-0 text-[13px] font-[590] tracking-[-0.014em] text-gray-900 dark:text-gray-100">
+          Default
+        </h3>
+        <textarea
+          class="resize-none rounded-lg border border-gray-200 bg-white p-2 text-[13px] tracking-[-0.006em] text-gray-900 outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-zinc-800 dark:bg-zinc-950 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-400"
+          rows="2"
+          placeholder="Discarded on close..."
+        ></textarea>
+        <p class="m-0 text-[12px] tracking-[-0.011em] text-gray-500 dark:text-gray-400">
+          Starts empty every time.
+        </p>
+      </div>
+    </ng-template>
+
+    <ng-template #keptPopover>
+      <div
+        class="animate-in absolute flex w-[260px] flex-col gap-2 rounded-xl border border-gray-200 bg-white p-3 shadow-lg outline-hidden dark:border-zinc-800 dark:bg-zinc-950"
+        ngpPopover
+      >
+        <h3 class="m-0 text-[13px] font-[590] tracking-[-0.014em] text-gray-900 dark:text-gray-100">
+          Kept mounted
+        </h3>
+        <textarea
+          class="resize-none rounded-lg border border-gray-200 bg-white p-2 text-[13px] tracking-[-0.006em] text-gray-900 outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 dark:border-zinc-800 dark:bg-zinc-950 dark:text-gray-100 dark:focus:border-blue-400 dark:focus:ring-blue-400"
+          rows="2"
+          placeholder="Still here on reopen..."
+        ></textarea>
+        <p class="m-0 text-[12px] tracking-[-0.011em] text-gray-500 dark:text-gray-400">
+          Whatever you typed is still here.
+        </p>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    @keyframes popover-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.96);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes popover-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.96);
+      }
+    }
+
+    [ngpPopover] {
+      transform-origin: var(--ngp-popover-transform-origin);
+    }
+
+    .animate-in {
+      animation: popover-show 0.15s ease-out;
+    }
+
+    [ngpPopover][data-exit] {
+      animation: popover-hide 0.15s ease-out;
+    }
+  `,
+})
+export default class PopoverKeepMountedTailwindExample {}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -146,7 +146,7 @@ Use dismiss guards to prevent a popover from closing when there are unsaved chan
 
 ### Keeping Content Mounted
 
-By default the popover content is destroyed when the popover closes and created again on the next open, so any one-time setup runs every time. Set `ngpPopoverTriggerKeepMounted` to keep the content instance alive between opens instead.
+By default, the popover content is destroyed when the popover closes and created again on the next open, so any one-time setup runs every time. Set `ngpPopoverTriggerKeepMounted` to keep the content instance alive between opens instead.
 
 <docs-example name="popover-keep-mounted"></docs-example>
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -144,6 +144,19 @@ Use dismiss guards to prevent a popover from closing when there are unsaved chan
 
 <docs-example name="popover-dismiss-guard"></docs-example>
 
+### Keeping Content Mounted
+
+By default the popover content is destroyed when the popover closes and created again on the next open, so any one-time setup runs every time. Set `ngpPopoverTriggerKeepMounted` to keep the content instance alive between opens instead.
+
+<docs-example name="popover-keep-mounted"></docs-example>
+
+The content is still removed from the DOM while the popover is closed, so nothing is left rendered behind the scenes. What survives is the component instance and its DOM nodes: the content is not re-instantiated, so one-time work (such as a network request) is not repeated and unsaved state (such as a partly filled form or a scroll position) is preserved.
+
+Two things to weigh before enabling it:
+
+- The kept-alive view stays attached to change detection while the popover is hidden, so its bindings continue to be checked.
+- The instance lives until the trigger itself is destroyed, or until the `ngpPopoverTrigger` content changes, so anything expensive it holds on to stays in memory.
+
 ## API Reference
 
 The following directives are available to import from the `ng-primitives/popover` package:
@@ -247,6 +260,7 @@ bootstrapApplication(AppComponent, {
       closeOnOutsideClick: true,
       scrollBehavior: 'reposition',
       cooldown: 0,
+      keepMounted: false,
     }),
   ],
 });

--- a/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-ref.ts
@@ -1,7 +1,7 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { inject, InjectOptions, Injector } from '@angular/core';
 import { NgpExitAnimationManager } from 'ng-primitives/internal';
-import { NgpDismissGuard, NgpOverlayRef } from 'ng-primitives/portal';
+import { NgpDismissGuard, NgpOverlayRef, NgpPortalDetachOptions } from 'ng-primitives/portal';
 import { defer, EMPTY, fromEvent, Observable, Subject } from 'rxjs';
 import { filter, map, takeUntil } from 'rxjs/operators';
 import { NgpDialogConfig } from '../config/dialog-config';
@@ -9,7 +9,7 @@ import { NgpDialogConfig } from '../config/dialog-config';
 /** Minimal portal interface needed by the dialog ref. */
 export interface NgpDialogPortalRef {
   getElements(): HTMLElement[];
-  detach(immediate?: boolean): Promise<void>;
+  detach(options?: NgpPortalDetachOptions): Promise<void>;
 }
 
 /**
@@ -119,7 +119,7 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
 
     // Detach the portal immediately — no exit animation
     if (this.portal) {
-      await this.portal.detach(true);
+      await this.portal.detach({ immediate: true });
       this.portal = null;
     }
 
@@ -153,7 +153,7 @@ export class NgpDialogRef<T = unknown, R = unknown> implements NgpOverlayRef {
 
     // Detach the portal (immediate since exit animation already ran)
     if (this.portal) {
-      await this.portal.detach(true);
+      await this.portal.detach({ immediate: true });
       this.portal = null;
     }
 

--- a/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap-state.ts
+++ b/packages/ng-primitives/focus-trap/src/focus-trap/focus-trap-state.ts
@@ -1,6 +1,6 @@
 import { FocusMonitor, FocusOrigin, InteractivityChecker } from '@angular/cdk/a11y';
 import { afterNextRender, inject, Injector, NgZone, signal, Signal } from '@angular/core';
-import { injectElementRef } from 'ng-primitives/internal';
+import { explicitEffect, injectElementRef } from 'ng-primitives/internal';
 import { NgpOverlay, NgpOverlayRegistry } from 'ng-primitives/portal';
 import {
   attrBinding,
@@ -128,12 +128,22 @@ export const [NgpFocusTrapStateToken, ngpFocusTrap, injectFocusTrapState, provid
       // Store the last focused element
       let lastFocusedElement: HTMLElement | null = null;
 
+      // Whether the trap is currently armed - on the stack, observing, and listening.
+      // Setup and teardown can each be reached more than once (an overlay closing, then
+      // being shown again with the same view), so both are idempotent.
+      let armed = false;
+
       // Host bindings
       attrBinding(element, 'tabindex', '-1');
       dataBinding(element, 'data-focus-trap', () => (disabled() ? null : ''));
 
       // Setup the focus trap
       function setupFocusTrap(): void {
+        if (armed) {
+          return;
+        }
+
+        armed = true;
         focusTrapStack.add(focusTrap);
 
         mutationObserver = new MutationObserver(handleMutations);
@@ -172,6 +182,12 @@ export const [NgpFocusTrapStateToken, ngpFocusTrap, injectFocusTrapState, provid
       }
 
       function teardownFocusTrap(): void {
+        if (!armed) {
+          return;
+        }
+
+        armed = false;
+
         // Remove from stack (this also deactivates the trap)
         focusTrapStack.remove(focusTrap);
         mutationObserver?.disconnect();
@@ -364,11 +380,21 @@ export const [NgpFocusTrapStateToken, ngpFocusTrap, injectFocusTrapState, provid
       // Listen to keydown events
       listener(element, 'keydown', handleKeyDown);
 
-      // if this is used within an overlay we must remove the focus trap from the stack as soon as the overlay is closing
-      // this prevents reactivation of parent focus traps during component destruction
-      overlay?.closing.pipe(safeTakeUntilDestroyed()).subscribe(() => {
-        focusTrapStack.remove(focusTrap);
-      });
+      // if this is used within an overlay we must tear the focus trap down as soon as the
+      // overlay is closing rather than waiting for destruction - this prevents reactivation
+      // of parent focus traps during component destruction
+      overlay?.closing.pipe(safeTakeUntilDestroyed()).subscribe(() => teardownFocusTrap());
+
+      // An overlay that keeps its content mounted reuses this view when shown again, so the
+      // factory - and the `setupFocusTrap()` above - does not run a second time. Re-arm on
+      // each open instead, or a reopened overlay would neither move focus inside nor trap it.
+      if (overlay) {
+        explicitEffect([overlay.isOpen], ([isOpen]) => {
+          if (isOpen) {
+            setupFocusTrap();
+          }
+        });
+      }
 
       return {} satisfies NgpFocusTrapState;
     },

--- a/packages/ng-primitives/popover/src/config/popover-config.ts
+++ b/packages/ng-primitives/popover/src/config/popover-config.ts
@@ -79,6 +79,16 @@ export interface NgpPopoverConfig {
    * @default 0
    */
   cooldown: number;
+
+  /**
+   * When true, hiding the popover removes its content from the DOM but keeps the
+   * underlying component/view instance alive in memory instead of destroying it - a
+   * later show reuses the same instance rather than creating a new one, so the content
+   * is not re-instantiated and any one-time setup (e.g. a network fetch) is not repeated.
+   * The kept-alive view stays attached to change detection while it is hidden.
+   * @default false
+   */
+  keepMounted: boolean;
 }
 
 export const defaultPopoverConfig: NgpPopoverConfig = {
@@ -94,6 +104,7 @@ export const defaultPopoverConfig: NgpPopoverConfig = {
   shift: undefined,
   trackPosition: false,
   cooldown: 0,
+  keepMounted: false,
 };
 
 export const NgpPopoverConfigToken = new InjectionToken<NgpPopoverConfig>('NgpPopoverConfigToken');

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -118,6 +118,15 @@ export interface NgpPopoverTriggerState<T> {
    */
   readonly cooldown: WritableSignal<number>;
   /**
+   * When true, hiding the popover removes its content from the DOM but keeps the
+   * underlying component/view instance alive in memory instead of destroying it - a
+   * later show reuses the same instance rather than creating a new one, so the content
+   * is not re-instantiated and any one-time setup (e.g. a network fetch) is not repeated.
+   * The kept-alive view stays attached to change detection while it is hidden.
+   * @default false
+   */
+  readonly keepMounted: Signal<boolean>;
+  /**
    * The overlay that manages the popover
    * @internal
    */
@@ -159,6 +168,8 @@ export interface NgpPopoverTriggerState<T> {
   setTrackPosition: (trackPosition: boolean) => void;
   /** Set the cooldown duration in milliseconds. */
   setCooldown: (cooldown: number) => void;
+  /** Set whether hiding the popover keeps its content mounted instead of destroying it. */
+  setKeepMounted: (keepMounted: boolean) => void;
   /**
    * Show the popover.
    * @returns A promise that resolves when the popover has been shown
@@ -255,6 +266,15 @@ export interface NgpPopoverTriggerProps<T> {
    * @default 0
    */
   readonly cooldown?: Signal<number>;
+  /**
+   * When true, hiding the popover removes its content from the DOM but keeps the
+   * underlying component/view instance alive in memory instead of destroying it - a
+   * later show reuses the same instance rather than creating a new one, so the content
+   * is not re-instantiated and any one-time setup (e.g. a network fetch) is not repeated.
+   * The kept-alive view stays attached to change detection while it is hidden.
+   * @default false
+   */
+  readonly keepMounted?: Signal<boolean>;
   /** Callback fired when the open state changes.  */
   readonly onOpenChange?: (value: boolean) => void;
 }
@@ -283,6 +303,7 @@ export const [
     anchor: _anchor,
     trackPosition: _trackPosition,
     cooldown: _cooldown,
+    keepMounted: _keepMounted,
     onOpenChange,
   }: NgpPopoverTriggerProps<T>): NgpPopoverTriggerState<T> => {
     const elementRef = injectElementRef<HTMLElement>();
@@ -310,6 +331,7 @@ export const [
     const anchor = controlled<HTMLElement | null>(_anchor, null);
     const trackPosition = controlled(_trackPosition, false);
     const cooldown = controlled(_cooldown, 0);
+    const keepMounted = controlled(_keepMounted, false);
 
     const overlay = signal<NgpOverlay<T> | null>(null);
     const open = computed(() => overlay()?.isOpen() ?? false);
@@ -366,6 +388,7 @@ export const [
         trackPosition: trackPosition(),
         overlayType: 'popover',
         cooldown: cooldown(),
+        keepMounted: keepMounted,
         onClose: () => {
           if (!destroyed) {
             onOpenChange?.(false);
@@ -486,6 +509,10 @@ export const [
       cooldown.set(duration);
     }
 
+    function setKeepMounted(shouldKeepMounted: boolean): void {
+      keepMounted.set(shouldKeepMounted);
+    }
+
     return {
       elementRef,
       popover: deprecatedSetter(popover, 'setPopover', setPopover),
@@ -508,6 +535,7 @@ export const [
       anchor: deprecatedSetter(anchor, 'setAnchor', setAnchor),
       trackPosition: deprecatedSetter(trackPosition, 'setTrackPosition', setTrackPosition),
       cooldown: deprecatedSetter(cooldown, 'setCooldown', setCooldown),
+      keepMounted,
       overlay,
       open,
       setPopover,
@@ -526,6 +554,7 @@ export const [
       setAnchor,
       setTrackPosition,
       setCooldown,
+      setKeepMounted,
       show,
       hide,
     } satisfies NgpPopoverTriggerState<T>;

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
@@ -183,6 +183,19 @@ export class NgpPopoverTrigger<T = null> {
   });
 
   /**
+   * When true, hiding the popover removes its content from the DOM but keeps the
+   * underlying component/view instance alive in memory instead of destroying it - a
+   * later show reuses the same instance rather than creating a new one, so the content
+   * is not re-instantiated and any one-time setup (e.g. a network fetch) is not repeated.
+   * The kept-alive view stays attached to change detection while it is hidden.
+   * @default false
+   */
+  readonly keepMounted = input<boolean, BooleanInput>(this.config.keepMounted, {
+    alias: 'ngpPopoverTriggerKeepMounted',
+    transform: booleanAttribute,
+  });
+
+  /**
    * Event emitted when the popover open state changes.
    */
   readonly openChange = output<boolean>({
@@ -209,6 +222,7 @@ export class NgpPopoverTrigger<T = null> {
     anchor: this.anchor,
     trackPosition: this.trackPosition,
     cooldown: this.cooldown,
+    keepMounted: this.keepMounted,
     onOpenChange: (value: boolean) => this.openChange.emit(value),
   });
 

--- a/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
+++ b/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
@@ -931,9 +931,10 @@ describe('NgpPopover', () => {
 
         // A show() landing between the teardown and the detach settling must not resurrect
         // the overlay, which would leave its view mounted with no trigger left to own it.
-        void overlay?.show();
+        const shown = overlay?.show();
 
         gate.release();
+        await shown;
         await waitFor(() => {
           expect(destroyView).toHaveBeenCalledTimes(1);
         });

--- a/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
+++ b/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
@@ -112,7 +112,7 @@ class KeepMountedTestComponent {
 class KeepMountedSwapTestComponent {
   readonly first = viewChild.required<TemplateRef<unknown>>('first');
   readonly second = viewChild.required<TemplateRef<unknown>>('second');
-  readonly content = signal<TemplateRef<unknown> | null>(null);
+  readonly content = signal<TemplateRef<unknown> | undefined>(undefined);
 }
 
 describe('NgpPopover', () => {
@@ -841,6 +841,47 @@ describe('NgpPopover', () => {
         });
         expect(destroyView).toHaveBeenCalledTimes(1);
       } finally {
+        destroyView.mockRestore();
+      }
+    });
+
+    it('should destroy the kept-mounted view when the trigger is destroyed mid-close', async () => {
+      // The close is held open (as an exit animation would) so teardown happens while the
+      // detach is still in flight - the pending detach must not hand its view back for reuse.
+      const realDetach = NgpTemplatePortal.prototype.detach;
+      let releaseDetach: (() => void) | undefined;
+      const detachGate = new Promise<void>(resolve => (releaseDetach = resolve));
+      const detach = vi
+        .spyOn(NgpTemplatePortal.prototype, 'detach')
+        .mockImplementation(async function (this: NgpTemplatePortal<unknown>, options) {
+          await detachGate;
+          return realDetach.call(this, options);
+        });
+      const destroyView = vi.spyOn(NgpTemplatePortal.prototype, 'destroyView');
+
+      try {
+        const { fixture, getByRole } = await render(KeepMountedTestComponent);
+        fixture.componentInstance.keepMounted.set(true);
+        fixture.detectChanges();
+        const trigger = getByRole('button');
+
+        fireEvent.click(trigger);
+        await waitFor(() => {
+          expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+        });
+
+        fireEvent.click(trigger); // close - blocks inside detach()
+        fixture.destroy();
+
+        // The close finishes on its own clock, and must release the view rather than keeping
+        // it mounted for a reuse that can never happen.
+        releaseDetach?.();
+        await waitFor(() => {
+          expect(destroyView).toHaveBeenCalledTimes(1);
+        });
+        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      } finally {
+        detach.mockRestore();
         destroyView.mockRestore();
       }
     });

--- a/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
+++ b/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
@@ -16,7 +16,7 @@ import {
   NgpPopoverTrigger,
   NgpPopoverTriggerState,
 } from 'ng-primitives/popover';
-import { NgpPlacement, NgpTemplatePortal } from 'ng-primitives/portal';
+import { injectOverlay, NgpOverlay, NgpPlacement, NgpTemplatePortal } from 'ng-primitives/portal';
 import { NgpTooltip, NgpTooltipTrigger, provideTooltipConfig } from 'ng-primitives/tooltip';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -73,6 +73,18 @@ class KeepMountedContentComponent implements OnInit, OnDestroy {
   }
 }
 
+/** Hands the overlay instance to a test, which can only reach it from inside the content. */
+@Directive({
+  selector: '[testCaptureOverlay]',
+})
+class CaptureOverlayDirective {
+  static overlay: NgpOverlay<unknown> | null = null;
+
+  constructor() {
+    CaptureOverlayDirective.overlay = injectOverlay();
+  }
+}
+
 @Component({
   template: `
     <button [ngpPopoverTrigger]="content" [ngpPopoverTriggerKeepMounted]="keepMounted()">
@@ -80,12 +92,12 @@ class KeepMountedContentComponent implements OnInit, OnDestroy {
     </button>
 
     <ng-template #content>
-      <div ngpPopover>
+      <div ngpPopover testCaptureOverlay>
         <test-keep-mounted-content />
       </div>
     </ng-template>
   `,
-  imports: [NgpPopoverTrigger, NgpPopover, KeepMountedContentComponent],
+  imports: [NgpPopoverTrigger, NgpPopover, KeepMountedContentComponent, CaptureOverlayDirective],
 })
 class KeepMountedTestComponent {
   readonly keepMounted = signal(false);
@@ -597,7 +609,26 @@ describe('NgpPopover', () => {
       KeepMountedContentComponent.onInitSpy.mockClear();
       KeepMountedContentComponent.onDestroySpy.mockClear();
       KeepMountedContentComponent.instanceCount = 0;
+      CaptureOverlayDirective.overlay = null;
     });
+
+    /**
+     * Hold `detach()` open the way a pending exit animation would, so a test can act while
+     * a close is still in flight. `release()` lets the real detach proceed.
+     */
+    function gateDetach(): { release: () => void; restore: () => void } {
+      const realDetach = NgpTemplatePortal.prototype.detach;
+      let release!: () => void;
+      const gate = new Promise<void>(resolve => (release = resolve));
+      const spy = vi
+        .spyOn(NgpTemplatePortal.prototype, 'detach')
+        .mockImplementation(async function (this: NgpTemplatePortal<unknown>, options) {
+          await gate;
+          return realDetach.call(this, options);
+        });
+
+      return { release, restore: () => spy.mockRestore() };
+    }
 
     it('should destroy and recreate the content on every close/reopen by default', async () => {
       const { getByRole } = await render(KeepMountedTestComponent);
@@ -846,17 +877,9 @@ describe('NgpPopover', () => {
     });
 
     it('should destroy the kept-mounted view when the trigger is destroyed mid-close', async () => {
-      // The close is held open (as an exit animation would) so teardown happens while the
-      // detach is still in flight - the pending detach must not hand its view back for reuse.
-      const realDetach = NgpTemplatePortal.prototype.detach;
-      let releaseDetach: (() => void) | undefined;
-      const detachGate = new Promise<void>(resolve => (releaseDetach = resolve));
-      const detach = vi
-        .spyOn(NgpTemplatePortal.prototype, 'detach')
-        .mockImplementation(async function (this: NgpTemplatePortal<unknown>, options) {
-          await detachGate;
-          return realDetach.call(this, options);
-        });
+      // Teardown happens while the detach is still in flight - the pending detach must not
+      // hand its view back for reuse.
+      const gate = gateDetach();
       const destroyView = vi.spyOn(NgpTemplatePortal.prototype, 'destroyView');
 
       try {
@@ -875,13 +898,49 @@ describe('NgpPopover', () => {
 
         // The close finishes on its own clock, and must release the view rather than keeping
         // it mounted for a reuse that can never happen.
-        releaseDetach?.();
+        gate.release();
         await waitFor(() => {
           expect(destroyView).toHaveBeenCalledTimes(1);
         });
         expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
       } finally {
-        detach.mockRestore();
+        gate.restore();
+        destroyView.mockRestore();
+      }
+    });
+
+    it('should not revive a kept-mounted overlay shown after it was destroyed mid-close', async () => {
+      const gate = gateDetach();
+      const destroyView = vi.spyOn(NgpTemplatePortal.prototype, 'destroyView');
+
+      try {
+        const { fixture, getByRole } = await render(KeepMountedTestComponent);
+        fixture.componentInstance.keepMounted.set(true);
+        fixture.detectChanges();
+        const trigger = getByRole('button');
+
+        fireEvent.click(trigger);
+        await waitFor(() => {
+          expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+        });
+        const overlay = CaptureOverlayDirective.overlay;
+        expect(overlay).toBeTruthy();
+
+        fireEvent.click(trigger); // close - blocks inside detach()
+        fixture.destroy();
+
+        // A show() landing between the teardown and the detach settling must not resurrect
+        // the overlay, which would leave its view mounted with no trigger left to own it.
+        void overlay?.show();
+
+        gate.release();
+        await waitFor(() => {
+          expect(destroyView).toHaveBeenCalledTimes(1);
+        });
+        expect(overlay?.isOpen()).toBe(false);
+        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      } finally {
+        gate.restore();
         destroyView.mockRestore();
       }
     });

--- a/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
+++ b/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
@@ -1,4 +1,12 @@
-import { Component, Directive, OnInit, signal } from '@angular/core';
+import {
+  Component,
+  Directive,
+  OnDestroy,
+  OnInit,
+  TemplateRef,
+  signal,
+  viewChild,
+} from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
@@ -8,9 +16,9 @@ import {
   NgpPopoverTrigger,
   NgpPopoverTriggerState,
 } from 'ng-primitives/popover';
-import { NgpPlacement } from 'ng-primitives/portal';
+import { NgpPlacement, NgpTemplatePortal } from 'ng-primitives/portal';
 import { NgpTooltip, NgpTooltipTrigger, provideTooltipConfig } from 'ng-primitives/tooltip';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 @Component({
   template: `
@@ -40,6 +48,71 @@ class PopoverTestComponent {}
 })
 class OpenChangeTestComponent {
   readonly onOpenChange = vi.fn();
+}
+
+@Component({
+  selector: 'test-keep-mounted-content',
+  template: `
+    Content instance {{ id }}
+    <input data-testid="keep-mounted-input" />
+  `,
+})
+class KeepMountedContentComponent implements OnInit, OnDestroy {
+  static instanceCount = 0;
+  static readonly onInitSpy = vi.fn();
+  static readonly onDestroySpy = vi.fn();
+
+  readonly id = ++KeepMountedContentComponent.instanceCount;
+
+  ngOnInit(): void {
+    KeepMountedContentComponent.onInitSpy(this.id);
+  }
+
+  ngOnDestroy(): void {
+    KeepMountedContentComponent.onDestroySpy(this.id);
+  }
+}
+
+@Component({
+  template: `
+    <button [ngpPopoverTrigger]="content" [ngpPopoverTriggerKeepMounted]="keepMounted()">
+      Open Popover
+    </button>
+
+    <ng-template #content>
+      <div ngpPopover>
+        <test-keep-mounted-content />
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpPopoverTrigger, NgpPopover, KeepMountedContentComponent],
+})
+class KeepMountedTestComponent {
+  readonly keepMounted = signal(false);
+}
+
+@Component({
+  template: `
+    <button [ngpPopoverTrigger]="content()" [ngpPopoverTriggerKeepMounted]="true">
+      Open Popover
+    </button>
+
+    <ng-template #first>
+      <div ngpPopover data-which="first">
+        <test-keep-mounted-content />
+      </div>
+    </ng-template>
+
+    <ng-template #second>
+      <div ngpPopover data-which="second">Second content</div>
+    </ng-template>
+  `,
+  imports: [NgpPopoverTrigger, NgpPopover, KeepMountedContentComponent],
+})
+class KeepMountedSwapTestComponent {
+  readonly first = viewChild.required<TemplateRef<unknown>>('first');
+  readonly second = viewChild.required<TemplateRef<unknown>>('second');
+  readonly content = signal<TemplateRef<unknown> | null>(null);
 }
 
 describe('NgpPopover', () => {
@@ -511,6 +584,265 @@ describe('NgpPopover', () => {
       await waitFor(() => {
         expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe('keepMounted', () => {
+    // Cleared at the start (not end) of each test: `@testing-library/angular`'s own
+    // automatic fixture cleanup runs *after* this describe block's own afterEach in
+    // vitest's hook ordering, so a leftover fixture teardown from the previous test
+    // (destroying a still-open/kept-mounted component) can call these spies after an
+    // afterEach-based clear already ran, leaking a stray call into the next test.
+    beforeEach(() => {
+      KeepMountedContentComponent.onInitSpy.mockClear();
+      KeepMountedContentComponent.onDestroySpy.mockClear();
+      KeepMountedContentComponent.instanceCount = 0;
+    });
+
+    it('should destroy and recreate the content on every close/reopen by default', async () => {
+      const { getByRole } = await render(KeepMountedTestComponent);
+      const trigger = getByRole('button');
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+      expect(KeepMountedContentComponent.onInitSpy).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(trigger); // close
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      });
+      expect(KeepMountedContentComponent.onDestroySpy).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(trigger); // reopen
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+      expect(KeepMountedContentComponent.onInitSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should preserve the content component instance across repeated close and reopen when true', async () => {
+      const { fixture, getByRole } = await render(KeepMountedTestComponent);
+      fixture.componentInstance.keepMounted.set(true);
+      fixture.detectChanges();
+      const trigger = getByRole('button');
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+      expect(KeepMountedContentComponent.onInitSpy).toHaveBeenCalledTimes(1);
+      expect(KeepMountedContentComponent.onInitSpy).toHaveBeenCalledWith(1);
+
+      // Three close/reopen cycles - the portal must be handed back for reuse on every
+      // hide, not just the first.
+      for (let cycle = 0; cycle < 3; cycle++) {
+        fireEvent.click(trigger); // close
+        await waitFor(() => {
+          // Absent from the document entirely while hidden, not hidden in place via CSS.
+          expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+        });
+
+        // Not destroyed on hide - the instance is kept alive in memory.
+        expect(KeepMountedContentComponent.onDestroySpy).not.toHaveBeenCalled();
+
+        fireEvent.click(trigger); // reopen
+        await waitFor(() => {
+          expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+        });
+
+        // Still only initialized once - the same instance was reused, not recreated.
+        expect(KeepMountedContentComponent.onInitSpy).toHaveBeenCalledTimes(1);
+      }
+    });
+
+    it('should preserve live DOM state in the content across close and reopen when true', async () => {
+      // The popover content is portalled to the body, so it has to be queried from the
+      // document rather than the fixture.
+      const queryInput = () =>
+        document.querySelector<HTMLInputElement>('[data-testid="keep-mounted-input"]');
+
+      const { fixture, getByRole } = await render(KeepMountedTestComponent);
+      fixture.componentInstance.keepMounted.set(true);
+      fixture.detectChanges();
+      const trigger = getByRole('button');
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      const input = queryInput()!;
+      fireEvent.input(input, { target: { value: 'typed while open' } });
+
+      fireEvent.click(trigger); // close
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      });
+
+      fireEvent.click(trigger); // reopen
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      // The very same DOM node comes back, with whatever the user left in it.
+      const reopened = queryInput();
+      expect(reopened).toBe(input);
+      expect(reopened?.value).toBe('typed while open');
+    });
+
+    it('should trap focus again when a kept-mounted popover is reopened', async () => {
+      const { fixture, getByRole } = await render(KeepMountedTestComponent);
+      fixture.componentInstance.keepMounted.set(true);
+      fixture.detectChanges();
+      const trigger = getByRole('button');
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      fireEvent.click(trigger); // close
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      });
+
+      fireEvent.click(trigger); // reopen - the reused view does not re-run ngOnInit
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      const popover = document.querySelector('[ngpPopover]');
+
+      // Focus is moved into the reopened popover...
+      await waitFor(() => {
+        expect(popover?.contains(document.activeElement)).toBe(true);
+      });
+
+      // ...and is still trapped there.
+      const outside = document.createElement('button');
+      document.body.appendChild(outside);
+
+      try {
+        outside.focus();
+        await waitFor(() => {
+          expect(popover?.contains(document.activeElement)).toBe(true);
+        });
+      } finally {
+        outside.remove();
+      }
+    });
+
+    it('should not re-insert kept-mounted content still marked as exiting', async () => {
+      const { fixture, getByRole } = await render(KeepMountedTestComponent);
+      fixture.componentInstance.keepMounted.set(true);
+      fixture.detectChanges();
+      const trigger = getByRole('button');
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      fireEvent.click(trigger); // close - leaves the element marked data-exit
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      });
+
+      // Capture the attributes at the moment the element is put back in the document. A
+      // re-inserted element restarts its CSS animations, so arriving still marked
+      // `data-exit` would replay the exit animation over the reopened popover.
+      let attributesOnInsertion: string[] | null = null;
+      const observer = new MutationObserver(records => {
+        for (const record of records) {
+          for (const node of Array.from(record.addedNodes)) {
+            if (node instanceof HTMLElement && node.hasAttribute('ngpPopover')) {
+              attributesOnInsertion ??= node.getAttributeNames();
+            }
+          }
+        }
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+
+      try {
+        fireEvent.click(trigger); // reopen
+        await waitFor(() => {
+          expect(attributesOnInsertion).not.toBeNull();
+        });
+      } finally {
+        observer.disconnect();
+      }
+
+      expect(attributesOnInsertion).not.toContain('data-exit');
+    });
+
+    it('should discard the kept-mounted content when the content changes while hidden', async () => {
+      const { fixture, getByRole } = await render(KeepMountedSwapTestComponent);
+      const host = fixture.componentInstance;
+      host.content.set(host.first());
+      fixture.detectChanges();
+      const trigger = getByRole('button');
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+      expect(KeepMountedContentComponent.onInitSpy).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(trigger); // close - the first template is kept mounted
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      });
+
+      host.content.set(host.second());
+      fixture.detectChanges();
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      // The kept-mounted view can no longer be reused, so it is destroyed rather than
+      // leaked, and only the new content is in the DOM.
+      expect(document.querySelector('[ngpPopover]')?.getAttribute('data-which')).toBe('second');
+      expect(document.querySelectorAll('[ngpPopover]')).toHaveLength(1);
+      expect(KeepMountedContentComponent.onDestroySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should destroy the kept-mounted view via the portal when the trigger is destroyed', async () => {
+      // Spying on the portal is what makes this test meaningful: the content view lives in
+      // the trigger's ViewContainerRef, so Angular would destroy it on teardown regardless.
+      // Only the overlay's own force-destroy path routes through `destroyView()`.
+      const destroyView = vi.spyOn(NgpTemplatePortal.prototype, 'destroyView');
+
+      try {
+        const { fixture, getByRole } = await render(KeepMountedTestComponent);
+        fixture.componentInstance.keepMounted.set(true);
+        fixture.detectChanges();
+        const trigger = getByRole('button');
+
+        fireEvent.click(trigger);
+        await waitFor(() => {
+          expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+        });
+
+        fireEvent.click(trigger); // close (kept mounted, not destroyed)
+        await waitFor(() => {
+          expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+        });
+        expect(KeepMountedContentComponent.onDestroySpy).not.toHaveBeenCalled();
+        expect(destroyView).not.toHaveBeenCalled();
+
+        fixture.destroy();
+
+        await waitFor(() => {
+          expect(KeepMountedContentComponent.onDestroySpy).toHaveBeenCalledTimes(1);
+        });
+        expect(destroyView).toHaveBeenCalledTimes(1);
+      } finally {
+        destroyView.mockRestore();
+      }
     });
   });
 

--- a/packages/ng-primitives/portal/src/index.ts
+++ b/packages/ng-primitives/portal/src/index.ts
@@ -28,7 +28,14 @@ export {
   provideOverlayArrowState,
 } from './overlay-arrow-state';
 export { injectOverlayContext, provideOverlayContext } from './overlay-token';
-export { createPortal, NgpComponentPortal, NgpPortal, NgpTemplatePortal } from './portal';
+export {
+  createPortal,
+  NgpComponentPortal,
+  NgpPortal,
+  NgpPortalAttachOptions,
+  NgpPortalDetachOptions,
+  NgpTemplatePortal,
+} from './portal';
 export { NgpPosition } from './position';
 export {
   NgpBoundary,

--- a/packages/ng-primitives/portal/src/index.ts
+++ b/packages/ng-primitives/portal/src/index.ts
@@ -8,6 +8,7 @@ export {
   NgpOverlayConfig,
   NgpOverlayContent,
   NgpOverlayTemplateContext,
+  OverlayHideImmediateOptions,
 } from './overlay';
 export { NgpOverlayCooldownManager } from './overlay-cooldown';
 export {

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -332,6 +332,12 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    */
   private keptMounted: { portal: NgpPortal; content: NgpOverlayContent<T> } | null = null;
 
+  /**
+   * Whether the overlay itself has been torn down. A hide already in flight when that happens
+   * finishes on its own clock, so it checks this before keeping its view mounted for reuse.
+   */
+  private forceDestroyed = false;
+
   /** Signal tracking whether the overlay is open */
   readonly isOpen = signal(false);
 
@@ -1136,6 +1142,10 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     immediate,
     forceDestroy,
   }: OverlayDestroyOptions = {}): Promise<void> {
+    if (forceDestroy) {
+      this.forceDestroyed = true;
+    }
+
     const portal = this.portal();
 
     if (!portal) {
@@ -1196,7 +1206,14 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       this.registeredOutletElement = null;
 
       if (reusableContent) {
-        this.keptMounted = { portal, content: reusableContent };
+        // The overlay was torn down while this hide was still awaiting its exit animation,
+        // so there is nothing left to reuse the view - release it rather than keeping it
+        // alive past the teardown that already ran.
+        if (this.forceDestroyed) {
+          portal.destroyView();
+        } else {
+          this.keptMounted = { portal, content: reusableContent };
+        }
       }
 
       this.renderedContent = null;

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -232,6 +232,18 @@ export interface NgpOverlayConfig<T = unknown> {
   overlayType?: string;
 
   /**
+   * When true, hiding the overlay removes its content from the DOM but keeps the
+   * underlying component/view instance alive in memory instead of destroying it -
+   * a later `show()` re-inserts the same instance rather than creating a new one, so
+   * the content is not re-instantiated and any one-time setup is not repeated.
+   * The kept-alive view stays attached to change detection while it is hidden.
+   *
+   * Read on each hide, so a trigger can hand over an input signal and let it change.
+   * @default false
+   */
+  keepMounted?: Signal<boolean>;
+
+  /**
    * Cooldown duration in milliseconds.
    * When moving from one overlay of the same type to another within this duration,
    * the showDelay is skipped for the new overlay.
@@ -313,6 +325,12 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
 
   /** Portal currently being destroyed (for cancel support during exit animations) */
   private destroyingPortal: NgpPortal | null = null;
+
+  /**
+   * Portal kept alive (detached from the DOM but not destroyed) after a keepMounted hide,
+   * with the content it was built from so a later show can check it is still reusable.
+   */
+  private keptMounted: { portal: NgpPortal; content: NgpOverlayContent<T> } | null = null;
 
   /** Signal tracking whether the overlay is open */
   readonly isOpen = signal(false);
@@ -639,7 +657,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     // Immediate on both sides: the exit animation belongs to the content being
     // replaced, and replaying the entrance would read as a close and reopen rather
     // than a content change.
-    portal.detach(true);
+    portal.detach({ immediate: true });
     this.attachPortal(content, true);
   }
 
@@ -660,8 +678,9 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    * Immediately hide the overlay without any delay.
    * When called during cooldown transitions, this destroys the overlay
    * immediately without exit animations.
+   * @param options Optional hide configuration
    */
-  hideImmediate(): void {
+  hideImmediate(options?: OverlayHideImmediateOptions): void {
     // Cancel any pending operations
     if (this.openTimeout) {
       this.openTimeout();
@@ -686,7 +705,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       this.closeOrigin.set('program');
       this.config.onClose?.('program');
     }
-    this.destroyOverlay(true);
+    this.destroyOverlay({ immediate: true, forceDestroy: options?.forceDestroy });
   }
 
   /**
@@ -724,7 +743,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    * Completely destroy this overlay instance
    */
   destroy(): void {
-    this.hideImmediate();
+    this.hideImmediate({ forceDestroy: true });
     this.disposePositioning?.();
     this.scrollStrategy.disable();
   }
@@ -880,29 +899,46 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   private attachPortal(content: NgpOverlayContent<T>, immediate: boolean): void {
     this.renderedContent = content;
 
-    // Create a new portal with context.
-    // The injector is wrapped in EmbeddedViewInjector to work around an Angular 19 bug
-    // where @SkipSelf() causes the embedded view injector's ControlContainer: null to be
-    // bypassed. See https://github.com/angular/angular/issues/57390
-    const portal = createPortal(
-      content,
-      this.viewContainerRef,
-      new EmbeddedViewInjector(
-        Injector.create({
-          parent: this.config.injector,
-          providers: [
-            ...(this.config.providers || []),
-            { provide: NgpOverlay, useValue: this },
-            provideOverlayContext<T>(this.config.context),
-            { provide: ControlContainer, useValue: null },
-          ],
-        }),
-      ),
-      { $implicit: this.config.context } as NgpOverlayTemplateContext<T>,
-    );
+    let portal: NgpPortal;
+    const keptMounted = this.keptMounted;
 
-    // Attach portal to container
-    portal.attach(this.resolveContainer(), { immediate });
+    if (keptMounted?.content === content) {
+      // Reuse the portal kept alive from a previous keepMounted hide - re-inserts its
+      // existing DOM nodes rather than creating a new view/component instance, so the
+      // content is not re-instantiated and its one-time setup does not re-run.
+      this.keptMounted = null;
+      portal = keptMounted.portal;
+      portal.reattach(this.resolveContainer(), { immediate });
+    } else {
+      // A kept-mounted portal from a previous hide no longer matches the current
+      // content (e.g. the overlay's content input changed while it was hidden) -
+      // it can't be reused, so its view is destroyed instead of leaking.
+      this.discardKeptMounted();
+
+      // Create a new portal with context.
+      // The injector is wrapped in EmbeddedViewInjector to work around an Angular 19 bug
+      // where @SkipSelf() causes the embedded view injector's ControlContainer: null to be
+      // bypassed. See https://github.com/angular/angular/issues/57390
+      portal = createPortal(
+        content,
+        this.viewContainerRef,
+        new EmbeddedViewInjector(
+          Injector.create({
+            parent: this.config.injector,
+            providers: [
+              ...(this.config.providers || []),
+              { provide: NgpOverlay, useValue: this },
+              provideOverlayContext<T>(this.config.context),
+              { provide: ControlContainer, useValue: null },
+            ],
+          }),
+        ),
+        { $implicit: this.config.context } as NgpOverlayTemplateContext<T>,
+      );
+
+      // Attach portal to container
+      portal.attach(this.resolveContainer(), { immediate });
+    }
 
     // Update portal signal
     this.portal.set(portal);
@@ -1094,12 +1130,21 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
 
   /**
    * Internal method to destroy the overlay portal
-   * @param immediate If true, skip exit animations and remove immediately
+   * @param options Optional destroy configuration
    */
-  private async destroyOverlay(immediate?: boolean): Promise<void> {
+  private async destroyOverlay({
+    immediate,
+    forceDestroy,
+  }: OverlayDestroyOptions = {}): Promise<void> {
     const portal = this.portal();
 
     if (!portal) {
+      // Nothing currently shown - but if a kept-mounted portal is sitting hidden from a
+      // previous close and we're being force-destroyed (overlay itself torn down), its
+      // underlying view still needs to be destroyed too.
+      if (forceDestroy) {
+        this.discardKeptMounted();
+      }
       return;
     }
 
@@ -1129,10 +1174,19 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     this.scrollStrategy.disable();
     this.scrollStrategy = new NoopScrollStrategy();
 
+    // The content the portal was built from, captured up front because it is cleared below
+    // but is needed to hand the portal back for reuse. It is the single source of truth for
+    // whether to keep the view alive, so the flag `detach()` is given cannot drift from the
+    // one acted on after the await.
+    const reusableContent =
+      !forceDestroy && (this.config.keepMounted?.() ?? false) ? this.renderedContent : null;
+
     // Detach the portal (waits for exit animations unless immediate).
     // During this await, cancelDestruction() may be called if the user
     // re-hovers the trigger. (See: https://github.com/ng-primitives/ng-primitives/issues/681)
-    await portal.detach(immediate);
+    // When keeping the content mounted, this removes the DOM nodes but leaves the underlying
+    // view/component instance alive so attachPortal() can reuse it later.
+    await portal.detach({ immediate, keepMounted: reusableContent !== null });
 
     // Only complete destruction if it was not cancelled during exit animation.
     // finalPlacement and instantTransition are intentionally cleared here
@@ -1140,11 +1194,25 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     if (this.destroyingPortal === portal) {
       this.destroyingPortal = null;
       this.registeredOutletElement = null;
+
+      if (reusableContent) {
+        this.keptMounted = { portal, content: reusableContent };
+      }
+
       this.renderedContent = null;
       this.isOpen.set(false);
       this.finalPlacement.set(undefined);
       this.instantTransition.set(false);
     }
+  }
+
+  /**
+   * Destroy the view of a portal kept alive by `keepMounted`, if there is one. Used when it
+   * can no longer be reused (the content changed) or when the overlay itself is torn down.
+   */
+  private discardKeptMounted(): void {
+    this.keptMounted?.portal.destroyView();
+    this.keptMounted = null;
   }
 
   /**
@@ -1238,6 +1306,19 @@ export function createOverlay<T>(config: NgpOverlayConfig<T>): NgpOverlay<T> {
  */
 export function injectOverlay<T>(): NgpOverlay<T> {
   return inject(NgpOverlay);
+}
+
+export interface OverlayHideImmediateOptions {
+  /**
+   * When true, bypass `keepMounted` and fully destroy any kept-alive portal - used when the
+   * overlay itself is being torn down (see `destroy()`), not just hidden.
+   */
+  forceDestroy?: boolean;
+}
+
+interface OverlayDestroyOptions extends OverlayHideImmediateOptions {
+  /** If true, skip exit animations and remove immediately. */
+  immediate?: boolean;
 }
 
 export interface OverlayTriggerOptions {

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -505,7 +505,10 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    */
   private cancelDestruction(): void {
     const portal = this.destroyingPortal;
-    if (!portal) {
+
+    // Teardown is terminal - a destroyed overlay must not be brought back, and its portal
+    // stays on the destroy path so the view is released when the detach settles.
+    if (!portal || this.forceDestroyed) {
       return;
     }
 

--- a/packages/ng-primitives/portal/src/portal.ts
+++ b/packages/ng-primitives/portal/src/portal.ts
@@ -16,6 +16,29 @@ export interface NgpPortalAttachOptions {
   immediate?: boolean;
 }
 
+export interface NgpPortalDetachOptions {
+  /** If true, skip exit animations and remove immediately. */
+  immediate?: boolean;
+  /**
+   * If true, remove the root nodes from the DOM but keep the underlying view/component
+   * instance alive instead of destroying it, so `reattach()` can cheaply re-insert it
+   * later without the content being re-created.
+   */
+  keepMounted?: boolean;
+}
+
+/**
+ * Clear the animation state a previous attach cycle left on a node. Re-inserting an element
+ * restarts its CSS animations, so a kept-mounted node still marked `data-exit` would replay
+ * its exit animation; a fresh attach starts with neither attribute set.
+ */
+function clearAnimationState(node: Node): void {
+  if (node instanceof HTMLElement) {
+    node.removeAttribute('data-enter');
+    node.removeAttribute('data-exit');
+  }
+}
+
 export abstract class NgpPortal {
   constructor(
     protected readonly viewContainerRef: ViewContainerRef | null,
@@ -46,15 +69,29 @@ export abstract class NgpPortal {
 
   /**
    * Detach the portal from the DOM.
-   * @param immediate If true, skip exit animations and remove immediately
+   * @param options Optional detach configuration
    */
-  abstract detach(immediate?: boolean): Promise<void>;
+  abstract detach(options?: NgpPortalDetachOptions): Promise<void>;
 
   /**
    * Cancel an in-progress detach operation. If exit animations are running,
    * they are cancelled and the portal transitions back to the enter state.
    */
   abstract cancelDetach(): void;
+
+  /**
+   * Re-insert a previously detached-but-kept-mounted portal's root nodes into a container.
+   * Only valid after a `detach({ keepMounted: true })` call that left the underlying view alive.
+   * @param container The DOM element to reattach the portal to.
+   * @param options Optional attach configuration
+   */
+  abstract reattach(container: HTMLElement, options?: NgpPortalAttachOptions): void;
+
+  /**
+   * Destroy the underlying view, releasing the content instance. Safe to call more than
+   * once, and the only way to release a portal left alive by `detach({ keepMounted: true })`.
+   */
+  abstract destroyView(): void;
 
   /**
    * Angular v20 removes `_unusedComponentFactoryResolver` and `_document` from DomPortalOutlet's
@@ -141,9 +178,9 @@ export class NgpComponentPortal<T> extends NgpPortal {
 
   /**
    * Detach the portal from the DOM.
-   * @param immediate If true, skip exit animations and remove immediately
+   * @param options Optional detach configuration
    */
-  async detach(immediate?: boolean): Promise<void> {
+  async detach({ immediate, keepMounted }: NgpPortalDetachOptions = {}): Promise<void> {
     if (this.isDestroying) {
       return;
     }
@@ -161,6 +198,36 @@ export class NgpComponentPortal<T> extends NgpPortal {
       return;
     }
 
+    if (!keepMounted) {
+      this.destroyView();
+      return;
+    }
+
+    if (this.viewRef) {
+      (this.viewRef.location.nativeElement as HTMLElement).remove();
+      // Reusable for a future detach() cycle once reattach() is called.
+      this.isDestroying = false;
+    }
+  }
+
+  /**
+   * Re-insert a previously detached-but-kept-mounted component's root element into a container.
+   */
+  reattach(container: HTMLElement, options?: NgpPortalAttachOptions): void {
+    if (!this.viewRef) {
+      throw new Error('Cannot reattach a component portal that has been destroyed.');
+    }
+
+    const element = this.viewRef.location.nativeElement as HTMLElement;
+    clearAnimationState(element);
+    container.appendChild(element);
+    this.exitAnimationRef = setupExitAnimation({ element, immediate: options?.immediate });
+  }
+
+  /**
+   * Destroy the underlying view. Safe to call more than once.
+   */
+  destroyView(): void {
     if (this.viewRef) {
       this.viewRef.destroy();
       this.viewRef = null;
@@ -230,7 +297,8 @@ export class NgpTemplatePortal<T> extends NgpPortal {
    * Whether the portal is attached to a DOM element.
    */
   getAttached(): boolean {
-    return !!this.viewRef && this.viewRef.rootNodes.length > 0;
+    // A kept-mounted view still has its root nodes, so being in the document is what counts.
+    return !!this.viewRef && this.viewRef.rootNodes.some((node: Node) => node.isConnected);
   }
 
   /**
@@ -248,9 +316,9 @@ export class NgpTemplatePortal<T> extends NgpPortal {
 
   /**
    * Detach the portal from the DOM.
-   * @param immediate If true, skip exit animations and remove immediately
+   * @param options Optional detach configuration
    */
-  async detach(immediate?: boolean): Promise<void> {
+  async detach({ immediate, keepMounted }: NgpPortalDetachOptions = {}): Promise<void> {
     if (this.isDestroying) {
       return;
     }
@@ -269,6 +337,42 @@ export class NgpTemplatePortal<T> extends NgpPortal {
       return;
     }
 
+    if (!keepMounted) {
+      this.destroyView();
+      return;
+    }
+
+    if (this.viewRef) {
+      for (const node of this.viewRef.rootNodes) {
+        node.parentNode?.removeChild(node);
+      }
+      // Reusable for a future detach() cycle once reattach() is called.
+      this.isDestroying = false;
+    }
+  }
+
+  /**
+   * Re-insert a previously detached-but-kept-mounted embedded view's root nodes into a container.
+   */
+  reattach(container: HTMLElement, options?: NgpPortalAttachOptions): void {
+    if (!this.viewRef) {
+      throw new Error('Cannot reattach a template portal that has been destroyed.');
+    }
+
+    for (const node of this.viewRef.rootNodes) {
+      clearAnimationState(node);
+      container.appendChild(node);
+    }
+
+    this.exitAnimationRefs = this.viewRef.rootNodes
+      .filter((node): node is HTMLElement => node instanceof HTMLElement)
+      .map(element => setupExitAnimation({ element, immediate: options?.immediate }));
+  }
+
+  /**
+   * Destroy the underlying view. Safe to call more than once.
+   */
+  destroyView(): void {
     if (this.viewRef) {
       this.viewRef.destroy();
       this.viewRef = null;


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

## What does this PR implement/fix?

Adds `ngpPopoverTriggerKeepMounted` so a popover's content view can survive close/reopen instead of being destroyed and recreated on every cycle. This avoids repeating one-time setup (e.g. a network fetch in the content component) and preserves unsaved state (a partly filled form, scroll position) while the popover is hidden. The content is still removed from the DOM while closed - only the underlying view instance is kept alive, reused on the next open via a new `NgpPortal.reattach()`.

Supporting changes to `ng-primitives/portal`:

- `NgpOverlayConfig.keepMounted` (a `Signal<boolean>`, read on each hide) drives whether `NgpOverlay` hands its portal to `attachPortal()` for reuse or destroys it as before.
- `NgpPortal` gains `reattach()` (re-insert a kept-alive view's root nodes) and `destroyView()` (release a kept-alive view when its content no longer matches, or when the overlay itself is torn down).
- `NgpPortal.detach()`/`NgpOverlay.hideImmediate()` now take options objects (`{ immediate, keepMounted }` / `{ forceDestroy }`) instead of positional booleans, which was already the shape `attach()` used. This is a breaking change for any external subclass of `NgpPortal` (see below) - all in-repo callers (`dialog-ref.ts`, `toast-manager.ts`, `combobox.ts`) are updated.
- `NgpFocusTrap` now re-arms on every overlay open (via an effect on `overlay.isOpen`) instead of only once in its factory, since a kept-mounted view's factory doesn't run again on reopen. Without this, focus would neither move into nor be trapped in a reopened kept-mounted popover. Overlays with no focus trap (tooltip, menu, combobox, select, etc.) are unaffected; dialogs are unaffected since `NgpDialog` has no `NgpOverlay` in its injector chain.

Docs: new "Keeping Content Mounted" example under Popover → Examples (CSS + Tailwind variants), config example and API docs updated.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

`NgpPortal` is abstract and exported publicly. This PR adds two new abstract methods (`reattach`, `destroyView`) and changes `detach(immediate?: boolean)` to `detach(options?: NgpPortalDetachOptions)`. Any external subclass of `NgpPortal` will need to implement the two new methods and update its `detach` signature. All built-in subclasses and callers are updated in this PR; `NgpComponentPortal`/`NgpTemplatePortal` consumers calling `.detach(true)` should switch to `.detach({ immediate: true })`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a keepMounted option to `ng-primitives/popover` and the portal so overlay content survives close/reopen without re-instantiation while still removing the DOM on close. Forced teardown is terminal; kept-mounted views are released if the overlay is destroyed mid-close, and a later show cannot revive it.

- **New Features**
  - `ngpPopoverTriggerKeepMounted` and `NgpPopoverConfig.keepMounted` (default false) to keep popover content alive between opens.
  - `NgpOverlayConfig.keepMounted` (Signal, read on each hide); portal adds `reattach()` and `destroyView()` and clears exit state on reuse; hidden kept views are discarded if content changes.
  - `NgpPortal.detach()` now accepts `{ immediate, keepMounted }`; `reattach()` uses `{ immediate }`; `NgpOverlay.hideImmediate(options)` accepts `{ forceDestroy }` and exports `OverlayHideImmediateOptions`. Forced destroys ignore cancel and cannot be revived by `show()`.
  - Focus trap re-arms on each open and tears down on close to work with kept-mounted views.
  - Docs: new “Keeping Content Mounted” examples (CSS and Tailwind) and API updates.

- **Migration**
  - If you subclass `NgpPortal`, implement `reattach()` and `destroyView()`, and change `detach(immediate?: boolean)` to `detach(options?: NgpPortalDetachOptions)`.
  - Replace `.detach(true)` with `.detach({ immediate: true })` when using `NgpComponentPortal`/`NgpTemplatePortal`.

<sup>Written for commit d4544d959c920e7b9cddc8ebd4d004d81cd1f6f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Popovers can now keep their content mounted when hidden, preserving user input, state, and focus when reopened.
  - Added a `keepMounted` option with new Angular popover examples, including a Tailwind variant.
- **Bug Fixes**
  - Improved overlay/portal teardown and focus-trap reliability across repeated hide/reopen cycles.
- **Documentation**
  - Added a “Keeping Content Mounted” section and documented the default (`keepMounted: false`) in configuration.
- **Tests**
  - Expanded coverage for content preservation, template swapping, animations, and mid-close teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->