### PR TITLE
ci: run on pushes to next so Codecov has a baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+      # The default branch, and where PRs merge to. Codecov needs a report on each
+      # of its commits to have a baseline to compare pull requests against.
+      - next
   pull_request:
 
 permissions:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Tests and docs are N/A - this is a CI trigger change with no library surface.

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

N/A - follow-up to #886.

## What does this PR implement/fix?

Adds `next` to the workflow's `push` trigger.

#886 wired up Codecov, but its UI reports **"Missing Base Commit - unable to compare commits because no base commit was found"**. This is the cause.

The workflow triggered on `push` only for `main`, plus `pull_request`. But `next` is the default branch and the one PRs merge into; `main` now only moves during a release (`nx release publish` pushes `HEAD:main`). Every CI run in recent history is a `pull_request` run - there have been no `push` runs at all.

That means no commit on the default branch ever produces a coverage report. Codecov compares a PR head against the merge base on the default branch, and with no upload for that commit there is nothing to diff against, so every future PR would report a missing base commit, not just the first one.

Adding `next` to the trigger means each merge uploads a report for the new default-branch commit, which becomes the baseline for the PRs that follow.

## Notes for reviewers

The trade-off is that merges to `next` now run a full CI pass rather than only the pre-merge PR run. That is the cost of having a baseline at all, and it catches a broken merge result as a side benefit.

The first PR opened after this merges will still show no comparison, since the baseline only exists from this commit forward. The one after that gets a real delta.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run CI on pushes to `next` (default branch) so Codecov receives coverage uploads and can compute PR diffs. This fixes the Codecov “Missing Base Commit” issue caused by only running push builds on `main`, which only moves during releases.

<sup>Written for commit 5ffcdd54c0162f4c33adc1cd15de684bda6baad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI checks and Codecov reporting now run for commits pushed to the `next` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->