### PR TITLE
feat(file-upload): add file upload/dropzone config

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
@@ -91,6 +91,38 @@ The following directives are available to import from the `ng-primitives/file-up
   <api-attribute name="data-disabled" description="Applied when the element is disabled." />
 </api-reference-attributes>
 
+## Global Configuration
+
+You can configure the default options for all file uploads and file dropzones in your application by using the `provideFileUploadConfig` and `provideFileDropzoneConfig` functions in a providers array.
+
+```ts
+import { provideFileDropzoneConfig, provideFileUploadConfig } from 'ng-primitives/file-upload';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideFileUploadConfig({
+      fileTypes: ['image/png', '.jpg'],
+      multiple: true,
+      dragAndDrop: false,
+    }),
+    provideFileDropzoneConfig({
+      fileTypes: ['image/png', '.jpg'],
+      multiple: true,
+    }),
+  ],
+});
+```
+
+Any input set on a primitive takes precedence over the configured default.
+
+### NgpFileUploadConfig
+
+<api-reference-config name="NgpFileUploadConfig"></api-reference-config>
+
+### NgpFileDropzoneConfig
+
+<api-reference-config name="NgpFileDropzoneConfig"></api-reference-config>
+
 ## Accessibility
 
 The file upload primitive should be applied to a `<button>` element or another interactive element for keyboard accessibility. The file dropzone is a drag-and-drop target and is not keyboard accessible by default — ensure an alternative method (such as the file upload trigger) is always available.

--- a/packages/ng-primitives/file-upload/src/config/file-dropzone-config.ts
+++ b/packages/ng-primitives/file-upload/src/config/file-dropzone-config.ts
@@ -1,0 +1,58 @@
+import { InjectionToken, Provider, inject } from '@angular/core';
+
+export interface NgpFileDropzoneConfig {
+  /**
+   * The accepted file types. This can be an array of strings or a comma-separated string.
+   * Accepted types can either be file extensions (e.g. `.jpg`) or MIME types (e.g. `image/jpeg`).
+   * @default undefined
+   */
+  fileTypes: string[] | undefined;
+  /**
+   * Whether to allow multiple files to be selected.
+   * @default false
+   */
+  multiple: boolean;
+  /**
+   * Whether to allow the user to select directories.
+   * @default false
+   */
+  directory: boolean;
+  /**
+   * Whether the file dropzone is disabled.
+   * @default false
+   */
+  disabled: boolean;
+}
+
+export const defaultFileDropzoneConfig: NgpFileDropzoneConfig = {
+  fileTypes: undefined,
+  multiple: false,
+  directory: false,
+  disabled: false,
+};
+
+export const NgpFileDropzoneConfigToken = new InjectionToken<NgpFileDropzoneConfig>(
+  'NgpFileDropzoneConfigToken',
+);
+
+/**
+ * Provide the default File Dropzone configuration
+ * @param config The File Dropzone configuration
+ * @returns The provider
+ */
+export function provideFileDropzoneConfig(config: Partial<NgpFileDropzoneConfig>): Provider[] {
+  return [
+    {
+      provide: NgpFileDropzoneConfigToken,
+      useValue: { ...defaultFileDropzoneConfig, ...config },
+    },
+  ];
+}
+
+/**
+ * Inject the File Dropzone configuration
+ * @returns The global File Dropzone configuration
+ */
+export function injectFileDropzoneConfig(): NgpFileDropzoneConfig {
+  return inject(NgpFileDropzoneConfigToken, { optional: true }) ?? defaultFileDropzoneConfig;
+}

--- a/packages/ng-primitives/file-upload/src/config/file-dropzone-config.ts
+++ b/packages/ng-primitives/file-upload/src/config/file-dropzone-config.ts
@@ -2,8 +2,7 @@ import { InjectionToken, Provider, inject } from '@angular/core';
 
 export interface NgpFileDropzoneConfig {
   /**
-   * The accepted file types. This can be an array of strings or a comma-separated string.
-   * Accepted types can either be file extensions (e.g. `.jpg`) or MIME types (e.g. `image/jpeg`).
+   * The accepted file types, either file extensions (e.g. `.jpg`) or MIME types (e.g. `image/jpeg`).
    * @default undefined
    */
   fileTypes: string[] | undefined;

--- a/packages/ng-primitives/file-upload/src/config/file-upload-config.ts
+++ b/packages/ng-primitives/file-upload/src/config/file-upload-config.ts
@@ -1,0 +1,64 @@
+import { InjectionToken, Provider, inject } from '@angular/core';
+
+export interface NgpFileUploadConfig {
+  /**
+   * The accepted file types. This can be an array of strings or a comma-separated string.
+   * Accepted types can either be file extensions (e.g. `.jpg`) or MIME types (e.g. `image/jpeg`).
+   * @default undefined
+   */
+  fileTypes: string[] | undefined;
+  /**
+   * Whether to allow multiple files to be selected.
+   * @default false
+   */
+  multiple: boolean;
+  /**
+   * Whether to allow the user to select directories.
+   * @default false
+   */
+  directory: boolean;
+  /**
+   * Whether drag-and-drop is enabled.
+   * @default true
+   */
+  dragAndDrop: boolean;
+  /**
+   * Whether the file upload is disabled.
+   * @default false
+   */
+  disabled: boolean;
+}
+
+export const defaultFileUploadConfig: NgpFileUploadConfig = {
+  fileTypes: undefined,
+  multiple: false,
+  directory: false,
+  dragAndDrop: true,
+  disabled: false,
+};
+
+export const NgpFileUploadConfigToken = new InjectionToken<NgpFileUploadConfig>(
+  'NgpFileUploadConfigToken',
+);
+
+/**
+ * Provide the default File Upload configuration
+ * @param config The File Upload configuration
+ * @returns The provider
+ */
+export function provideFileUploadConfig(config: Partial<NgpFileUploadConfig>): Provider[] {
+  return [
+    {
+      provide: NgpFileUploadConfigToken,
+      useValue: { ...defaultFileUploadConfig, ...config },
+    },
+  ];
+}
+
+/**
+ * Inject the File Upload configuration
+ * @returns The global File Upload configuration
+ */
+export function injectFileUploadConfig(): NgpFileUploadConfig {
+  return inject(NgpFileUploadConfigToken, { optional: true }) ?? defaultFileUploadConfig;
+}

--- a/packages/ng-primitives/file-upload/src/config/file-upload-config.ts
+++ b/packages/ng-primitives/file-upload/src/config/file-upload-config.ts
@@ -2,8 +2,7 @@ import { InjectionToken, Provider, inject } from '@angular/core';
 
 export interface NgpFileUploadConfig {
   /**
-   * The accepted file types. This can be an array of strings or a comma-separated string.
-   * Accepted types can either be file extensions (e.g. `.jpg`) or MIME types (e.g. `image/jpeg`).
+   * The accepted file types, either file extensions (e.g. `.jpg`) or MIME types (e.g. `image/jpeg`).
    * @default undefined
    */
   fileTypes: string[] | undefined;

--- a/packages/ng-primitives/file-upload/src/file-dropzone/file-dropzone.ts
+++ b/packages/ng-primitives/file-upload/src/file-dropzone/file-dropzone.ts
@@ -1,5 +1,6 @@
 import { BooleanInput, coerceStringArray } from '@angular/cdk/coercion';
 import { booleanAttribute, Directive, input, output } from '@angular/core';
+import { injectFileDropzoneConfig } from '../config/file-dropzone-config';
 import { ngpFileDropzone, provideFileDropzoneState } from './file-dropzone-state';
 
 /**
@@ -12,10 +13,15 @@ import { ngpFileDropzone, provideFileDropzoneState } from './file-dropzone-state
 })
 export class NgpFileDropzone {
   /**
+   * Access the global file dropzone configuration.
+   */
+  private readonly config = injectFileDropzoneConfig();
+
+  /**
    * The accepted file types. This can be an array of strings or a comma-separated string.
    * Accepted types can either be file extensions (e.g. `.jpg`) or MIME types (e.g. `image/jpeg`).
    */
-  readonly fileTypes = input<string[], string | string[]>(undefined, {
+  readonly fileTypes = input<string[] | undefined, string | string[]>(this.config.fileTypes, {
     alias: 'ngpFileDropzoneFileTypes',
     transform: types => coerceStringArray(types, ','),
   });
@@ -23,7 +29,7 @@ export class NgpFileDropzone {
   /**
    * Whether to allow multiple files to be selected.
    */
-  readonly multiple = input<boolean, BooleanInput>(false, {
+  readonly multiple = input<boolean, BooleanInput>(this.config.multiple, {
     alias: 'ngpFileDropzoneMultiple',
     transform: booleanAttribute,
   });
@@ -31,15 +37,15 @@ export class NgpFileDropzone {
   /**
    * Whether to allow the user to select directories.
    */
-  readonly directory = input<boolean, BooleanInput>(false, {
+  readonly directory = input<boolean, BooleanInput>(this.config.directory, {
     alias: 'ngpFileDropzoneDirectory',
     transform: booleanAttribute,
   });
 
   /**
-   * Whether the file upload is disabled.
+   * Whether the file dropzone is disabled.
    */
-  readonly disabled = input<boolean, BooleanInput>(false, {
+  readonly disabled = input<boolean, BooleanInput>(this.config.disabled, {
     alias: 'ngpFileDropzoneDisabled',
     transform: booleanAttribute,
   });

--- a/packages/ng-primitives/file-upload/src/file-dropzone/tests/file-dropzone-config.test.ts
+++ b/packages/ng-primitives/file-upload/src/file-dropzone/tests/file-dropzone-config.test.ts
@@ -1,0 +1,54 @@
+import { Component } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { provideFileDropzoneConfig } from 'ng-primitives/file-upload';
+import { describe, expect, it } from 'vitest';
+import { injectFileDropzoneConfig } from '../../config/file-dropzone-config';
+import { NgpFileDropzone } from '../file-dropzone';
+
+@Component({ template: '' })
+class FileDropzoneConfigProbe {
+  readonly config = injectFileDropzoneConfig();
+}
+
+describe('file-dropzone-config', () => {
+  it('should fall back to the default config', async () => {
+    const { fixture } = await render(FileDropzoneConfigProbe);
+
+    expect(fixture.componentInstance.config).toEqual({
+      fileTypes: undefined,
+      multiple: false,
+      directory: false,
+      disabled: false,
+    });
+  });
+
+  it('should merge a partial config with the defaults', async () => {
+    const { fixture } = await render(FileDropzoneConfigProbe, {
+      providers: [provideFileDropzoneConfig({ multiple: true })],
+    });
+
+    expect(fixture.componentInstance.config.multiple).toBe(true);
+    expect(fixture.componentInstance.config.disabled).toBe(false);
+  });
+
+  it('should use the configured defaults in the primitive', async () => {
+    const { getByTestId } = await render(`<div ngpFileDropzone data-testid="dropzone">Drop</div>`, {
+      imports: [NgpFileDropzone],
+      providers: [provideFileDropzoneConfig({ disabled: true })],
+    });
+
+    expect(getByTestId('dropzone')).toHaveAttribute('data-disabled', '');
+  });
+
+  it('should let explicit inputs override the configured defaults', async () => {
+    const { getByTestId } = await render(
+      `<div ngpFileDropzone [ngpFileDropzoneDisabled]="false" data-testid="dropzone">Drop</div>`,
+      {
+        imports: [NgpFileDropzone],
+        providers: [provideFileDropzoneConfig({ disabled: true })],
+      },
+    );
+
+    expect(getByTestId('dropzone')).not.toHaveAttribute('data-disabled');
+  });
+});

--- a/packages/ng-primitives/file-upload/src/file-upload/file-upload.ts
+++ b/packages/ng-primitives/file-upload/src/file-upload/file-upload.ts
@@ -1,5 +1,6 @@
 import { BooleanInput, coerceStringArray } from '@angular/cdk/coercion';
 import { booleanAttribute, Directive, input, output } from '@angular/core';
+import { injectFileUploadConfig } from '../config/file-upload-config';
 import { ngpFileUpload, provideFileUploadState } from './file-upload-state';
 
 /**
@@ -12,10 +13,15 @@ import { ngpFileUpload, provideFileUploadState } from './file-upload-state';
 })
 export class NgpFileUpload {
   /**
+   * Access the global file upload configuration.
+   */
+  private readonly config = injectFileUploadConfig();
+
+  /**
    * The accepted file types. This can be an array of strings or a comma-separated string.
    * Accepted types can either be file extensions (e.g. `.jpg`) or MIME types (e.g. `image/jpeg`).
    */
-  readonly fileTypes = input<string[], string | string[]>(undefined, {
+  readonly fileTypes = input<string[] | undefined, string | string[]>(this.config.fileTypes, {
     alias: 'ngpFileUploadFileTypes',
     transform: types => coerceStringArray(types, ','),
   });
@@ -23,7 +29,7 @@ export class NgpFileUpload {
   /**
    * Whether to allow multiple files to be selected.
    */
-  readonly multiple = input<boolean, BooleanInput>(false, {
+  readonly multiple = input<boolean, BooleanInput>(this.config.multiple, {
     alias: 'ngpFileUploadMultiple',
     transform: booleanAttribute,
   });
@@ -31,7 +37,7 @@ export class NgpFileUpload {
   /**
    * Whether to allow the user to select directories.
    */
-  readonly directory = input<boolean, BooleanInput>(false, {
+  readonly directory = input<boolean, BooleanInput>(this.config.directory, {
     alias: 'ngpFileUploadDirectory',
     transform: booleanAttribute,
   });
@@ -39,7 +45,7 @@ export class NgpFileUpload {
   /**
    * Whether drag-and-drop is enabled.
    */
-  readonly dragAndDrop = input<boolean, BooleanInput>(true, {
+  readonly dragAndDrop = input<boolean, BooleanInput>(this.config.dragAndDrop, {
     alias: 'ngpFileUploadDragDrop',
     transform: booleanAttribute,
   });
@@ -47,7 +53,7 @@ export class NgpFileUpload {
   /**
    * Whether the file upload is disabled.
    */
-  readonly disabled = input<boolean, BooleanInput>(false, {
+  readonly disabled = input<boolean, BooleanInput>(this.config.disabled, {
     alias: 'ngpFileUploadDisabled',
     transform: booleanAttribute,
   });

--- a/packages/ng-primitives/file-upload/src/file-upload/tests/file-upload-config.test.ts
+++ b/packages/ng-primitives/file-upload/src/file-upload/tests/file-upload-config.test.ts
@@ -1,0 +1,67 @@
+import { Component } from '@angular/core';
+import { render } from '@testing-library/angular';
+import { provideFileUploadConfig } from 'ng-primitives/file-upload';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { injectFileUploadConfig } from '../../config/file-upload-config';
+import { NgpFileUpload } from '../file-upload';
+
+@Component({ template: '' })
+class FileUploadConfigProbe {
+  readonly config = injectFileUploadConfig();
+}
+
+describe('file-upload-config', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should fall back to the default config', async () => {
+    const { fixture } = await render(FileUploadConfigProbe);
+
+    expect(fixture.componentInstance.config).toEqual({
+      fileTypes: undefined,
+      multiple: false,
+      directory: false,
+      dragAndDrop: true,
+      disabled: false,
+    });
+  });
+
+  it('should merge a partial config with the defaults', async () => {
+    const { fixture } = await render(FileUploadConfigProbe, {
+      providers: [provideFileUploadConfig({ dragAndDrop: false })],
+    });
+
+    expect(fixture.componentInstance.config.dragAndDrop).toBe(false);
+    expect(fixture.componentInstance.config.multiple).toBe(false);
+  });
+
+  it('should use the configured defaults in the primitive', async () => {
+    const { getByTestId } = await render(`<div ngpFileUpload data-testid="upload">Upload</div>`, {
+      imports: [NgpFileUpload],
+      providers: [provideFileUploadConfig({ disabled: true })],
+    });
+
+    expect(getByTestId('upload')).toHaveAttribute('data-disabled', '');
+  });
+
+  it('should let explicit inputs override the configured defaults', async () => {
+    const clickSpy = vi
+      .spyOn(HTMLInputElement.prototype, 'click')
+      .mockImplementation(() => undefined);
+
+    const { getByTestId } = await render(
+      `<div ngpFileUpload ngpFileUploadFileTypes=".png" data-testid="upload">Upload</div>`,
+      {
+        imports: [NgpFileUpload],
+        providers: [provideFileUploadConfig({ fileTypes: ['.jpg'], multiple: true })],
+      },
+    );
+
+    getByTestId('upload').click();
+
+    const input = clickSpy.mock.instances[0] as unknown as HTMLInputElement;
+    expect(input.accept).toBe('.png');
+    expect(input.multiple).toBe(true);
+  });
+});

--- a/packages/ng-primitives/file-upload/src/index.ts
+++ b/packages/ng-primitives/file-upload/src/index.ts
@@ -14,3 +14,5 @@ export {
   NgpFileUploadState,
   provideFileUploadState,
 } from './file-upload/file-upload-state';
+export { NgpFileDropzoneConfig, provideFileDropzoneConfig } from './config/file-dropzone-config';
+export { NgpFileUploadConfig, provideFileUploadConfig } from './config/file-upload-config';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

File Upload/Dropzone have defaults set e.g. `dragDrop` to true, which can only be overridden by an input. 

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->
Introduce a config for file upload/dropzone (inspired by accordion-config) to allow overriding default configurations and still pass input values.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds global config for File Upload and File Dropzone so you can set sane defaults app-wide while still allowing component inputs to override them. Control `fileTypes`, `multiple`, `directory`, `dragAndDrop` (upload only), and `disabled` in one place.

- **New Features**
  - Added `provideFileUploadConfig` and `provideFileDropzoneConfig` to set defaults via DI; components read these unless inputs are provided.
  - Exported `NgpFileUploadConfig`, `provideFileUploadConfig`, `NgpFileDropzoneConfig`, `provideFileDropzoneConfig` from `ng-primitives/file-upload`.
  - Added tests and docs for the new configuration.

- **Migration**
  - Optional: register defaults in your app providers, e.g., set `dragAndDrop: false` or shared `fileTypes`. No breaking changes.

<sup>Written for commit 6800bae81373c95998b5116cd70ed1713a65fea4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable defaults for file upload and dropzone controls.
  * Added options for accepted file types, multiple files, directory selection, drag-and-drop, and disabled states.
  * File upload components now inherit configured defaults while still allowing individual input overrides.
  * Exposed configuration types and providers through the public package exports.
* **Documentation**
  * Added guidance and examples for configuring application-wide file upload and dropzone defaults.
* **Tests**
  * Added coverage for default settings, configuration merging, and input override behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->