### PR TITLE
fix(menu): shorten the hover corridor's idle wait over a sibling

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -214,6 +214,14 @@ Nested `NgpSubmenuTrigger`s inside an already-open menu are protected from this 
 
 <docs-example name="menu-trigger-group"></docs-example>
 
+The coordination only earns its keep while the siblings actually sit between a trigger and its menu. In a collapsible navigation, that stops being true once the rail collapses to icons - the pointer reaches the panel without crossing anything, so all the group does is hold the siblings inert a moment longer than they need to be. Bind `ngpMenuTriggerGroupSiblingTracking` to turn it off for as long as that is the case:
+
+```html
+<nav ngpMenuTriggerGroup [ngpMenuTriggerGroupSiblingTracking]="!collapsed()">
+  <!-- triggers -->
+</nav>
+```
+
 ## API Reference
 
 The following directives are available to import from the `ng-primitives/menu` package:

--- a/packages/ng-primitives/internal/src/hover-bridge/hover-bridge-controller.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/hover-bridge-controller.ts
@@ -4,6 +4,7 @@ import {
   createHoverBridgePolygon,
   getHoverBridgeDirection,
   HOVER_BRIDGE_DIRECTION_TOLERANCE_PX,
+  HOVER_BRIDGE_SIBLING_TIMEOUT_MS,
   HOVER_BRIDGE_TIMEOUT_MS,
   HoverBridgeDirection,
   HoverBridgePoint,
@@ -104,6 +105,10 @@ export function createHoverBridge({
   let removePointerMoveListener: (() => void) | undefined = undefined;
   let fallbackTimeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
   let suppressedElement: HTMLElement | null = null;
+  // Captured once per corridor: neither element moves while one is in flight,
+  // and reading them back would force layout on every pointermove.
+  let siblingBounds: DOMRect | null = null;
+  let triggerBounds: DOMRect | null = null;
   let previousTriggerPointerEvents = '';
   let removePressGuards: (() => void) | undefined = undefined;
 
@@ -256,8 +261,21 @@ export function createHoverBridge({
     return delta * direction.sign < -HOVER_BRIDGE_DIRECTION_TOLERANCE_PX;
   }
 
+  /**
+   * Whether the pointer is over one of the trigger's siblings rather than the
+   * open gap. This never rejects the point - the corridor deliberately covers
+   * that ground, because a diagonal approach to the panel has to cross it. It
+   * only shortens how long a pointer that has *stopped* there is waited on.
+   */
+  function isOverSibling({ x, y }: HoverBridgePoint): boolean {
+    const within = (rect: DOMRect | null): boolean =>
+      !!rect && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+
+    return within(siblingBounds) && !within(triggerBounds);
+  }
+
   /** (Re)start the idle timer - reset on valid movement so it only fires when idle. */
-  function scheduleFallback(): void {
+  function scheduleFallback(delay: number = timeoutMs): void {
     clearTimeout(fallbackTimeoutId);
 
     fallbackTimeoutId = setTimeout(() => {
@@ -277,7 +295,7 @@ export function createHoverBridge({
       if (shouldClose) {
         close();
       }
-    }, timeoutMs);
+    }, delay);
   }
 
   function registerPointerMoveListener(): void {
@@ -309,7 +327,9 @@ export function createHoverBridge({
         // but continuous traversal isn't cut off mid-corridor. Callers that want
         // a fixed cap (tooltip) opt out via resetFallbackOnMove: false.
         if (resetFallbackOnMove) {
-          scheduleFallback();
+          scheduleFallback(
+            isOverSibling(point) ? Math.min(HOVER_BRIDGE_SIBLING_TIMEOUT_MS, timeoutMs) : timeoutMs,
+          );
         }
       },
       true,
@@ -330,7 +350,13 @@ export function createHoverBridge({
     polygon.set(points);
     direction = getHoverBridgeDirection(triggerRect, targetRect);
     lastPointer = exitPoint;
+    siblingBounds = siblingContainer?.()?.getBoundingClientRect() ?? null;
+    triggerBounds = trigger?.nativeElement.getBoundingClientRect() ?? null;
     registerPointerMoveListener();
+    // Deliberately the full window, whatever the exit point sits over: the gap
+    // between two stacked triggers belongs to the container, so leaving one and
+    // pausing to aim would otherwise get the short sibling window at the very
+    // moment a pause is most likely. The first move re-evaluates.
     scheduleFallback();
     suppressSiblingPointerEvents();
     return true;
@@ -340,6 +366,8 @@ export function createHoverBridge({
     polygon.set(null);
     direction = null;
     lastPointer = null;
+    siblingBounds = null;
+    triggerBounds = null;
     clearTimeout(fallbackTimeoutId);
     fallbackTimeoutId = undefined;
     removePointerMoveListener?.();

--- a/packages/ng-primitives/internal/src/hover-bridge/hover-bridge.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/hover-bridge.ts
@@ -10,6 +10,16 @@ export const HOVER_BRIDGE_TIMEOUT_MS = 150;
  */
 export const HOVER_BRIDGE_DIRECTION_TOLERANCE_PX = 2;
 
+/**
+ * Idle timeout (ms) applied while the pointer is resting over one of the
+ * trigger's siblings instead of the open gap. The corridor holds the sibling
+ * container inert for its whole lifetime, so a pointer that has stopped there
+ * is waiting on the corridor to end, and gets a much shorter benefit of the
+ * doubt than the gap does. Movement still resets the timer either way - only a
+ * pointer that has genuinely settled over a sibling closes early.
+ */
+export const HOVER_BRIDGE_SIBLING_TIMEOUT_MS = 80;
+
 export interface HoverBridgePoint {
   x: number;
   y: number;

--- a/packages/ng-primitives/internal/src/hover-bridge/tests/hover-bridge-controller.test.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/tests/hover-bridge-controller.test.ts
@@ -6,10 +6,12 @@ import {
 import { TestBed } from '@angular/core/testing';
 import {
   createHoverBridge,
+  HOVER_BRIDGE_SIBLING_TIMEOUT_MS,
+  HOVER_BRIDGE_TIMEOUT_MS,
   HoverBridgeController,
   HoverBridgeOptions,
 } from 'ng-primitives/internal';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * A horizontal corridor from a trigger on the left to a panel on the right,
@@ -58,6 +60,95 @@ function setup(options: Partial<HoverBridgeOptions> = {}) {
 function movePointer(point: { x: number; y: number }): void {
   document.dispatchEvent(new PointerEvent('pointermove', { clientX: point.x, clientY: point.y }));
 }
+
+describe('createHoverBridge - idling over a sibling', () => {
+  /**
+   * The measured shape of a menu trigger group: a 200x120 container of stacked
+   * triggers, the open panel 4px off its right edge, and a pointer that left the
+   * first trigger through its bottom edge. The corridor fans from there across
+   * the siblings below - a diagonal approach to a lower row of the panel has to
+   * cross them, so being over one is never on its own a reason to close.
+   */
+  const GROUP_OPTIONS = {
+    triggerRect: new DOMRect(0, 0, 200, 32),
+    targetRect: new DOMRect(204, 0, 180, 240),
+    exitPoint: { x: 100, y: 32 },
+  };
+  const OVER_SIBLING = { x: 160, y: 60 };
+  const IN_THE_GAP = { x: 202, y: 60 };
+
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    container.style.cssText = 'position:fixed;left:0;top:0;width:200px;height:120px';
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  function trackOverGroup(options = {}) {
+    const harness = setup({ siblingContainer: () => container, ...options });
+    harness.bridge.track(GROUP_OPTIONS);
+    return harness;
+  }
+
+  it('keeps the corridor open while the pointer is moving across a sibling', () => {
+    const { bridge, close } = trackOverGroup();
+
+    // Each sample resets the idle timer, so a traversal never trips it however
+    // long it spends over the siblings.
+    for (const y of [40, 48, 56, 60]) {
+      movePointer({ x: 120 + y, y });
+      vi.advanceTimersByTime(HOVER_BRIDGE_SIBLING_TIMEOUT_MS - 1);
+    }
+
+    expect(close).not.toHaveBeenCalled();
+    expect(bridge.isActive()).toBe(true);
+  });
+
+  it('closes on the shorter window once the pointer settles over a sibling', () => {
+    const { bridge, close } = trackOverGroup();
+
+    movePointer(OVER_SIBLING);
+
+    vi.advanceTimersByTime(HOVER_BRIDGE_SIBLING_TIMEOUT_MS - 1);
+    expect(close).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(bridge.isActive()).toBe(false);
+  });
+
+  it('still waits the full idle timeout when the pointer settles in the gap', () => {
+    const { bridge, close } = trackOverGroup();
+
+    movePointer(IN_THE_GAP);
+
+    vi.advanceTimersByTime(HOVER_BRIDGE_SIBLING_TIMEOUT_MS);
+    expect(close).not.toHaveBeenCalled();
+    expect(bridge.isActive()).toBe(true);
+
+    vi.advanceTimersByTime(HOVER_BRIDGE_TIMEOUT_MS - HOVER_BRIDGE_SIBLING_TIMEOUT_MS);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('never shortens past a caller that configured a tighter timeout', () => {
+    const { close } = trackOverGroup({ timeoutMs: 40 });
+
+    movePointer(OVER_SIBLING);
+
+    vi.advanceTimersByTime(39);
+    expect(close).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('createHoverBridge - sibling pointer-events suppression', () => {
   afterEach(() => {

--- a/packages/ng-primitives/internal/src/hover-bridge/tests/hover-bridge.test.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/tests/hover-bridge.test.ts
@@ -2,6 +2,7 @@ import {
   createHoverBridgePolygon,
   getHoverBridgeDirection,
   HOVER_BRIDGE_DIRECTION_TOLERANCE_PX,
+  HOVER_BRIDGE_SIBLING_TIMEOUT_MS,
   HOVER_BRIDGE_TIMEOUT_MS,
   isPointInHoverBridgePolygon,
 } from 'ng-primitives/internal';
@@ -129,6 +130,11 @@ describe('hover-bridge', () => {
 
     it('pins the direction jitter tolerance', () => {
       expect(HOVER_BRIDGE_DIRECTION_TOLERANCE_PX).toBe(2);
+    });
+
+    it('pins the sibling idle timeout below the gap timeout', () => {
+      expect(HOVER_BRIDGE_SIBLING_TIMEOUT_MS).toBe(80);
+      expect(HOVER_BRIDGE_SIBLING_TIMEOUT_MS).toBeLessThan(HOVER_BRIDGE_TIMEOUT_MS);
     });
   });
 });

--- a/packages/ng-primitives/internal/src/index.ts
+++ b/packages/ng-primitives/internal/src/index.ts
@@ -12,6 +12,7 @@ export {
   createHoverBridgePolygon,
   getHoverBridgeDirection,
   HOVER_BRIDGE_DIRECTION_TOLERANCE_PX,
+  HOVER_BRIDGE_SIBLING_TIMEOUT_MS,
   HOVER_BRIDGE_TIMEOUT_MS,
   HoverBridgeDirection,
   HoverBridgePoint,

--- a/packages/ng-primitives/menu/src/menu-trigger-group/menu-trigger-group-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger-group/menu-trigger-group-state.ts
@@ -1,4 +1,4 @@
-import { ElementRef } from '@angular/core';
+import { computed, Signal, signal } from '@angular/core';
 import {
   createHoverTransitTracker,
   HoverTransitTracker,
@@ -8,25 +8,39 @@ import { createPrimitive } from 'ng-primitives/state';
 
 export interface NgpMenuTriggerGroupState extends HoverTransitTracker {
   /**
-   * The group's host element - the shared container a root NgpMenuTrigger
-   * suppresses pointer-events on while a sibling's hover-bridge is active.
+   * The shared container a root NgpMenuTrigger suppresses pointer-events on
+   * while its hover bridge is active, or null while sibling tracking is off.
    * @internal
    */
-  readonly element: ElementRef<HTMLElement>;
+  readonly siblingContainer: Signal<HTMLElement | null>;
 }
 
-export interface NgpMenuTriggerGroupProps {}
+export interface NgpMenuTriggerGroupProps {
+  /** Whether the group coordinates hover between its sibling triggers. */
+  siblingTracking?: Signal<boolean>;
+}
 
 export const [
   NgpMenuTriggerGroupStateToken,
   ngpMenuTriggerGroup,
   injectMenuTriggerGroupState,
   provideMenuTriggerGroupState,
-] = createPrimitive('NgpMenuTriggerGroup', (_: NgpMenuTriggerGroupProps) => {
-  const element = injectElementRef<HTMLElement>();
+] = createPrimitive(
+  'NgpMenuTriggerGroup',
+  ({ siblingTracking = signal(true) }: NgpMenuTriggerGroupProps) => {
+    const element = injectElementRef<HTMLElement>();
+    const tracker = createHoverTransitTracker();
 
-  return {
-    element,
-    ...createHoverTransitTracker(),
-  } satisfies NgpMenuTriggerGroupState;
-});
+    // Only read when a corridor starts, so switching tracking off takes effect
+    // from the next transit rather than stranding one already in flight.
+    const siblingContainer = computed(() => (siblingTracking() ? element.nativeElement : null));
+
+    return {
+      siblingContainer,
+      ...tracker,
+      // A trigger that never suppressed its siblings must not decline their
+      // hovers either, or they would be inert with nothing to release them.
+      isTransitBlocked: trigger => siblingTracking() && tracker.isTransitBlocked(trigger),
+    } satisfies NgpMenuTriggerGroupState;
+  },
+);

--- a/packages/ng-primitives/menu/src/menu-trigger-group/menu-trigger-group.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger-group/menu-trigger-group.ts
@@ -1,4 +1,5 @@
-import { Directive } from '@angular/core';
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input } from '@angular/core';
 import { ngpMenuTriggerGroup, provideMenuTriggerGroupState } from './menu-trigger-group-state';
 
 /**
@@ -13,5 +14,17 @@ import { ngpMenuTriggerGroup, provideMenuTriggerGroupState } from './menu-trigge
   providers: [provideMenuTriggerGroupState()],
 })
 export class NgpMenuTriggerGroup {
-  protected readonly state = ngpMenuTriggerGroup({});
+  /**
+   * Whether the group coordinates hover between its sibling triggers. Turn it off
+   * when the siblings no longer sit between a trigger and its menu - a collapsed
+   * icon rail, say, where the pointer reaches the panel without crossing anything,
+   * so the coordination only costs the siblings their responsiveness. Takes effect
+   * from the next transit; one already in flight finishes as it started.
+   */
+  readonly siblingTracking = input<boolean, BooleanInput>(true, {
+    alias: 'ngpMenuTriggerGroupSiblingTracking',
+    transform: booleanAttribute,
+  });
+
+  protected readonly state = ngpMenuTriggerGroup({ siblingTracking: this.siblingTracking });
 }

--- a/packages/ng-primitives/menu/src/menu-trigger-group/tests/menu-trigger-group.test.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger-group/tests/menu-trigger-group.test.ts
@@ -103,9 +103,104 @@ class GroupedRootTriggersComponent {
 })
 class UngroupedRootTriggersComponent {}
 
+/** The grouped fixture with sibling tracking switched off, as a collapsed rail would. */
+@Component({
+  template: `
+    <div
+      [ngpMenuTriggerGroupSiblingTracking]="false"
+      ngpMenuTriggerGroup
+      data-testid="trigger-group"
+      style="display: flex; flex-direction: column; position: relative;"
+    >
+      <button
+        [ngpMenuTrigger]="menuA"
+        [ngpMenuTriggerOpenTriggers]="['hover']"
+        [ngpMenuTriggerPlacement]="'right-start'"
+        [ngpMenuTriggerOffset]="60"
+        data-testid="trigger-a"
+        style="width: 100px; height: 32px; padding: 0; margin: 0;"
+      >
+        Trigger A
+      </button>
+      <button
+        [ngpMenuTrigger]="menuB"
+        [ngpMenuTriggerOpenTriggers]="['hover']"
+        [ngpMenuTriggerPlacement]="'right-start'"
+        data-testid="trigger-b"
+        style="width: 100px; height: 32px; padding: 0; margin: 0;"
+      >
+        Trigger B
+      </button>
+    </div>
+
+    <ng-template #menuA>
+      <div ngpMenu data-testid="menu-a" style="width: 140px; height: 80px;">
+        <button ngpMenuItem data-testid="menu-a-item-1">A Item 1</button>
+      </div>
+    </ng-template>
+
+    <ng-template #menuB>
+      <div ngpMenu data-testid="menu-b" style="width: 140px; height: 80px;">
+        <button ngpMenuItem data-testid="menu-b-item-1">B Item 1</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem, NgpMenuTriggerGroup],
+})
+class UntrackedRootTriggersComponent {
+  readonly menuA = viewChild<TemplateRef<unknown>>('menuA');
+  readonly menuB = viewChild<TemplateRef<unknown>>('menuB');
+}
+
 describe('NgpMenuTriggerGroup sibling suppression - real layout, real pointer movement', () => {
   afterEach(() => {
     document.querySelectorAll('[data-overlay]').forEach(el => el.remove());
+  });
+
+  it('leaves the sibling row hit-testable when sibling tracking is off', async () => {
+    await render(UntrackedRootTriggersComponent);
+    const triggerA = document.querySelector('[data-testid="trigger-a"]') as HTMLElement;
+    const triggerB = document.querySelector('[data-testid="trigger-b"]') as HTMLElement;
+    const group = document.querySelector('[data-testid="trigger-group"]') as HTMLElement;
+
+    await userEvent.pointer({ target: triggerA, coords: { x: 10, y: 16 } });
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="menu-a"]')).toBeInTheDocument(),
+    );
+
+    const rectA = triggerA.getBoundingClientRect();
+    const rectB = triggerB.getBoundingClientRect();
+    const onSibling = { x: rectB.left + 10, y: rectB.top + rectB.height / 2 };
+
+    leavePointerAt(triggerA, { x: rectA.left + 10, y: rectB.top + 2 });
+    movePointerTo({ x: rectA.left + 10, y: rectB.top + 2 });
+
+    expect(group.style.pointerEvents).toBe('');
+    expect(document.elementFromPoint(onSibling.x, onSibling.y)).toBe(triggerB);
+  });
+
+  it('opens a sibling immediately when sibling tracking is off', async () => {
+    await render(UntrackedRootTriggersComponent);
+    const triggerA = document.querySelector('[data-testid="trigger-a"]') as HTMLElement;
+    const triggerB = document.querySelector('[data-testid="trigger-b"]') as HTMLElement;
+
+    await userEvent.pointer({ target: triggerA, coords: { x: 10, y: 16 } });
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="menu-a"]')).toBeInTheDocument(),
+    );
+
+    const rectA = triggerA.getBoundingClientRect();
+    const rectB = triggerB.getBoundingClientRect();
+
+    // The same transit the grouped fixture protects. Without tracking the
+    // sibling takes the hover rather than declining it.
+    leavePointerAt(triggerA, { x: rectA.left + 10, y: rectB.top + 2 });
+    movePointerTo({ x: rectA.left + 10, y: rectB.top + 2 });
+    await userEvent.pointer({ target: triggerB, coords: { x: 10, y: 16 } });
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="menu-b"]')).toBeInTheDocument(),
+    );
   });
 
   it('does not open a sibling root trigger while the pointer transits validly toward the open menu', async () => {

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -272,7 +272,7 @@ export const [
       isPointerInAnchor: isPointerOverMenuArea,
       close: () => hide(),
       requireForwardMovement: true,
-      siblingContainer: () => triggerGroup()?.element.nativeElement ?? null,
+      siblingContainer: () => triggerGroup()?.siblingContainer() ?? null,
       onSuppressionChange: active =>
         active
           ? triggerGroup()?.setTransitSource(element.nativeElement)

--- a/packages/ng-primitives/menu/src/menu/tests/menu-hover-bridge.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-hover-bridge.test.ts
@@ -1,5 +1,6 @@
 import { Component, TemplateRef, viewChild } from '@angular/core';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { HOVER_BRIDGE_SIBLING_TIMEOUT_MS } from 'ng-primitives/internal';
 import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpSubmenuTrigger } from 'ng-primitives/menu';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -353,5 +354,69 @@ describe('NgpMenuTrigger safe-polygon hover bridge', () => {
     await waitFor(() =>
       expect(document.querySelector('[data-testid="menu"]')).not.toBeInTheDocument(),
     );
+  });
+
+  /**
+   * Opens the submenu and pins real menu proportions: the trigger spans the full
+   * width of the parent menu, with the submenu just off its right edge. The
+   * pointer leaves through the trigger's bottom edge, so the sibling rows below
+   * it sit between the pointer and the panel. Time is frozen first, so anything
+   * the corridor decides afterwards is the pointermove path, never the fallback.
+   */
+  async function leaveSubmenuTriggerDownward(): Promise<void> {
+    const { fixture } = await render(SubmenuComponent);
+    const rootTrigger = fixture.debugElement.nativeElement.querySelector(
+      '[data-testid="root-trigger"]',
+    ) as HTMLElement;
+
+    fireEvent.click(rootTrigger);
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="submenu-trigger"]')).toBeInTheDocument(),
+    );
+
+    const submenuTrigger = document.querySelector('[data-testid="submenu-trigger"]') as HTMLElement;
+    fireEvent.pointerEnter(submenuTrigger, { pointerType: 'mouse' });
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument(),
+    );
+
+    const submenu = document.querySelector('[data-testid="submenu"]') as HTMLElement;
+    const rootMenu = document.querySelector('[data-testid="root-menu"]') as HTMLElement;
+    vi.spyOn(submenuTrigger, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 200, 32));
+    vi.spyOn(submenu, 'getBoundingClientRect').mockReturnValue(new DOMRect(204, 0, 180, 240));
+    // The sibling container the corridor suppresses, and the ground a diagonal
+    // approach to a lower row of the submenu has to cross.
+    vi.spyOn(rootMenu, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 200, 120));
+
+    vi.useFakeTimers();
+    fireEvent.pointerLeave(submenuTrigger, { pointerType: 'mouse', clientX: 100, clientY: 32 });
+  }
+
+  it('closes the submenu once the pointer settles over a sibling row', async () => {
+    await leaveSubmenuTriggerDownward();
+
+    // Still inside the corridor, and over the sibling rows - which a real
+    // approach crosses - so it is the pointer settling there, not the position,
+    // that ends the corridor.
+    fireEvent.pointerMove(document, { clientX: 140, clientY: 90 });
+
+    await vi.advanceTimersByTimeAsync(HOVER_BRIDGE_SIBLING_TIMEOUT_MS - 1);
+    expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
+
+    // Well short of the gap timeout, so it is the sibling window that ended it.
+    await vi.advanceTimersByTimeAsync(20);
+    expect(document.querySelector('[data-testid="submenu"]')).not.toBeInTheDocument();
+  });
+
+  it('keeps the submenu open while the pointer crosses the sibling rows toward the panel', async () => {
+    await leaveSubmenuTriggerDownward();
+
+    // The same sibling rows, but tracking toward the panel - a diagonal approach
+    // has to cross them, so this must not read as leaving.
+    fireEvent.pointerMove(document, { clientX: 160, clientY: 60 });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [x] Feature

## Issue

Closes #

No linked issue - found and diagnosed interactively while investigating a reported hover-intent delay in menus.

## What does this PR implement/fix?

Move the pointer off a menu trigger toward one of its siblings and the sibling cannot respond for about 165ms - it does not highlight, and its own menu does not open. Then everything catches up at once.

The corridor holds the sibling container `pointer-events: none` for its whole lifetime (#885), and its idle timer resets on every in-corridor `pointermove`. So the timer measures *time since the pointer last moved*, not time in transit. A pointer that has come to rest on a sibling is still geometrically inside the corridor, so it waits out the full `HOVER_BRIDGE_TIMEOUT_MS` before anything can happen - even though it stopped moving long before that.

This gives a pointer that has **settled** over a sibling a shorter window than the open gap gets. Movement still resets the timer either way, so this never rejects a position: the corridor deliberately covers the siblings, because a diagonal approach to a lower row of the panel has to cross them. Crossing a sibling at any speed or angle keeps the panel open exactly as before. Only a pointer that has stopped there closes early.

### Measured

Driven with a real pointer against the `menu-trigger-group` example (190x34 triggers stacked 4px apart, panel 4px to the right):

| | before | after |
|---|---|---|
| stop on the sibling nearest the panel edge | sibling responds after 165ms | **93ms** |
| straight right into the panel | stays open | stays open |
| diagonal to the panel's bottom row, crossing two siblings | stays open | stays open |
| the same diagonal at a third of the speed | stays open | stays open |

The one behaviour change beyond the fix: pausing on a sibling for longer than the sibling window mid-transit now switches to it, where it previously took 150ms to do so. That is the dwell threshold doing its job - any threshold means a long enough pause reads as intent - and it is a single exported constant if it wants tuning.

## Turning the coordination off

The group's coordination only earns its keep while the siblings actually sit between a trigger and its menu. A collapsible navigation stops meeting that description once its rail collapses to icons - the pointer reaches the panel without crossing anything, so suppressing the siblings buys nothing and costs them their responsiveness until the corridor ends.

`ngpMenuTriggerGroupSiblingTracking` (defaults to `true`) turns it off without unwrapping the group, so it can follow the collapsed state:

```html
<nav ngpMenuTriggerGroup [ngpMenuTriggerGroupSiblingTracking]="!collapsed()">
  <!-- triggers -->
</nav>
```

Both halves hang off the one flag: the group stops offering itself as the container to suppress, and stops reporting a transit for siblings to decline - a trigger that never suppressed its siblings must not have them declining hovers with nothing left to release them. It is read when a corridor starts, so switching it off leaves a transit already in flight to finish as it started.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
