### PR TITLE
feat(schematics): add a tailwind value to the styles option

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/accordion.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/accordion.md
@@ -65,7 +65,10 @@ ng g ng-primitives:primitive accordion
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/avatar.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/avatar.md
@@ -49,7 +49,10 @@ ng g ng-primitives:primitive avatar
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/button.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/button.md
@@ -46,7 +46,10 @@ ng g ng-primitives:primitive button
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/checkbox.md
@@ -48,7 +48,10 @@ ng g ng-primitives:primitive checkbox
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/combobox.md
@@ -78,7 +78,10 @@ ng g ng-primitives:primitive combobox
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
@@ -78,7 +78,10 @@ ng g ng-primitives:primitive date-picker
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/dialog.md
@@ -67,7 +67,10 @@ ng g ng-primitives:primitive dialog
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/file-upload.md
@@ -50,7 +50,10 @@ ng g ng-primitives:primitive file-upload
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
@@ -56,7 +56,10 @@ ng g ng-primitives:primitive form-field
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/input-otp.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/input-otp.md
@@ -54,7 +54,10 @@ ng g ng-primitives:primitive input-otp
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/input.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/input.md
@@ -46,7 +46,10 @@ ng g ng-primitives:primitive input
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/listbox.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/listbox.md
@@ -50,7 +50,10 @@ ng g ng-primitives:primitive listbox
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -63,7 +63,10 @@ ng g ng-primitives:primitive menu
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/meter.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/meter.md
@@ -58,7 +58,10 @@ ng g ng-primitives:primitive meter
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/number-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/number-field.md
@@ -53,7 +53,10 @@ ng g ng-primitives:primitive number-field
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/pagination.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/pagination.md
@@ -100,7 +100,10 @@ ng g ng-primitives:primitive pagination
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/password.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/password.md
@@ -54,7 +54,10 @@ ng g ng-primitives:primitive password
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -54,7 +54,10 @@ ng g ng-primitives:primitive popover
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/progress.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/progress.md
@@ -59,7 +59,10 @@ ng g ng-primitives:primitive progress
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/radio.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/radio.md
@@ -61,7 +61,10 @@ ng g ng-primitives:primitive radio
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/rating.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/rating.md
@@ -57,7 +57,10 @@ ng g ng-primitives:primitive rating
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/search.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/search.md
@@ -52,7 +52,10 @@ ng g ng-primitives:primitive search
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/select.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/select.md
@@ -57,7 +57,10 @@ ng g ng-primitives:primitive select
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/separator.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/separator.md
@@ -46,7 +46,10 @@ ng g ng-primitives:primitive separator
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/slider.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/slider.md
@@ -51,7 +51,10 @@ ng g ng-primitives:primitive slider
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/switch.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/switch.md
@@ -48,7 +48,10 @@ ng g ng-primitives:primitive switch
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tabs.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tabs.md
@@ -55,7 +55,10 @@ ng g ng-primitives:primitive tabs
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/textarea.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/textarea.md
@@ -46,7 +46,10 @@ ng g ng-primitives:primitive textarea
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toast.md
@@ -65,7 +65,10 @@ ng g ng-primitives:primitive toast
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toggle-group.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toggle-group.md
@@ -50,7 +50,10 @@ ng g ng-primitives:primitive toggle-group
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toggle.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toggle.md
@@ -46,7 +46,10 @@ ng g ng-primitives:primitive toggle
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/apps/documentation/src/app/pages/(documentation)/primitives/toolbar.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/toolbar.md
@@ -48,7 +48,10 @@ ng g ng-primitives:primitive toolbar
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## API Reference

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -50,7 +50,10 @@ ng g ng-primitives:primitive tooltip
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
 ## Examples

--- a/packages/ng-primitives/schematics/ng-generate/compiles.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/compiles.node.test.ts
@@ -186,6 +186,37 @@ describe('generated primitives compile', () => {
     expect(failures).toEqual([]);
   }, 60_000);
 
+  /**
+   * `--styles tailwind` swaps in the pre-generated template set with utility classes on the
+   * elements — every primitive must still come out syntactically valid.
+   */
+  it('produces files that parse when tailwind', async () => {
+    const failures: string[] = [];
+
+    for (const primitive of primitives) {
+      const dir = `projects/bar/src/app/tailwind-${primitive}`;
+      const tree = await schematicRunner.runSchematic(
+        'primitive',
+        { primitive, path: dir, styles: 'tailwind' },
+        appTree,
+      );
+
+      for (const file of tree.files.filter(file => file.includes(`/tailwind-${primitive}/`))) {
+        const content = tree.readContent(file);
+
+        const source = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true);
+        const diagnostics = (source as unknown as { parseDiagnostics?: ts.Diagnostic[] })
+          .parseDiagnostics;
+
+        if (diagnostics?.length) {
+          failures.push(...diagnostics.map(describeDiagnostic));
+        }
+      }
+    }
+
+    expect(failures).toEqual([]);
+  }, 60_000);
+
   function describeDiagnostic(diagnostic: ts.Diagnostic): string {
     const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, ' ');
 

--- a/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.node.test.ts
@@ -406,5 +406,42 @@ describe('Component Schematic', () => {
 
       expect(deprecated.readContent(itemPath)).toEqual(unstyled.readContent(itemPath));
     });
+
+    it('styles the elements with Tailwind classes when tailwind', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'primitive',
+        { primitive: 'accordion', path: 'projects/bar/src/app/tw-accordion', styles: 'tailwind' },
+        appTree,
+      );
+
+      const content = tree.readContent(
+        '/projects/bar/src/app/tw-accordion/accordion-item.component.ts',
+      );
+
+      // utility classes land on the elements and the host
+      expect(content).toContain('class="flex pl-4 pr-4');
+      expect(content).toMatch(/host: \{\n\s*class: 'block/);
+      // only what Tailwind cannot express stays behind as CSS
+      expect(content).toContain('@keyframes slideDown');
+      expect(content).not.toMatch(/styles:[\s\S]*display: flex/);
+      // the prefix and suffix placeholders were rendered as usual
+      expect(content).toContain('export class AccordionItemComponent');
+    });
+
+    it('applies OnPush to the tailwind variant as well', async () => {
+      const tree = await schematicRunner.runSchematic(
+        'primitive',
+        {
+          primitive: 'accordion',
+          path: 'projects/bar/src/app/tw-cd-accordion',
+          styles: 'tailwind',
+        },
+        appTree,
+      );
+
+      expect(
+        tree.readContent('/projects/bar/src/app/tw-cd-accordion/accordion-item.component.ts'),
+      ).toContain('changeDetection: ChangeDetectionStrategy.OnPush');
+    });
   });
 });

--- a/packages/ng-primitives/schematics/ng-generate/index.ts
+++ b/packages/ng-primitives/schematics/ng-generate/index.ts
@@ -21,7 +21,12 @@ export default function generatePrimitive(options: AngularPrimitivesComponentSch
       options.changeDetection = getWorkspaceChangeDetection(tree) ?? 'OnPush';
     }
 
-    const templateSource = apply(url(`./templates/${options.primitive}`), [
+    // the tailwind variant is pre-generated at build time (the Tailwind compiler
+    // never runs in the consumer's workspace), so it is simply a second template set
+    const templatesDir =
+      resolveStylesOption(options) === 'tailwind' ? 'templates-tailwind' : 'templates';
+
+    const templateSource = apply(url(`./${templatesDir}/${options.primitive}`), [
       template({
         ...options,
         ...strings,
@@ -163,8 +168,10 @@ function processStyles(content: Buffer, options: AngularPrimitivesComponentSchem
  * Resolve the effective styles option, honouring the deprecated `exampleStyles` boolean:
  * `styles` wins when set, otherwise `exampleStyles: false` maps to `unstyled`.
  */
-function resolveStylesOption(options: AngularPrimitivesComponentSchema): 'css' | 'unstyled' {
-  if (options.styles === 'css' || options.styles === 'unstyled') {
+function resolveStylesOption(
+  options: AngularPrimitivesComponentSchema,
+): 'css' | 'tailwind' | 'unstyled' {
+  if (options.styles === 'css' || options.styles === 'tailwind' || options.styles === 'unstyled') {
     return options.styles;
   }
   return options.exampleStyles === false ? 'unstyled' : 'css';

--- a/packages/ng-primitives/schematics/ng-generate/schema.d.ts
+++ b/packages/ng-primitives/schematics/ng-generate/schema.d.ts
@@ -64,10 +64,12 @@ export interface AngularPrimitivesComponentSchema {
 
   /**
    * How component styles should be generated.
-   * `css` includes the full example styles; `unstyled` omits them entirely so you
-   * can style the component yourself.
+   * `css` includes the full example styles; `tailwind` styles the elements with
+   * Tailwind CSS classes instead, keeping a small CSS block only for what
+   * Tailwind cannot express (keyframes); `unstyled` omits styling entirely so
+   * you can style the component yourself.
    */
-  styles?: 'css' | 'unstyled';
+  styles?: 'css' | 'tailwind' | 'unstyled';
 
   /**
    * Whether example styles should be included.

--- a/packages/ng-primitives/schematics/ng-generate/schema.json
+++ b/packages/ng-primitives/schematics/ng-generate/schema.json
@@ -81,8 +81,8 @@
     },
     "styles": {
       "type": "string",
-      "description": "How component styles should be generated. `css` includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.",
-      "enum": ["css", "unstyled"]
+      "description": "How component styles should be generated. `css` includes the full example styles; `tailwind` styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express (keyframes); `unstyled` omits styling entirely so you can style the component yourself.",
+      "enum": ["css", "tailwind", "unstyled"]
     },
     "exampleStyles": {
       "type": "boolean",

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/accordion/accordion-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/accordion/accordion-item.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,87 @@
+import { Component, input } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDownMini } from '@ng-icons/heroicons/mini';
+import {
+  NgpAccordionContent,
+  NgpAccordionItem,
+  NgpAccordionTrigger,
+} from 'ng-primitives/accordion';
+import { NgpButton } from 'ng-primitives/button';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>accordion-item',
+  hostDirectives: [
+    {
+      directive: NgpAccordionItem,
+      inputs: ['ngpAccordionItemValue:value', 'ngpAccordionItemDisabled:disabled'],
+    },
+  ],
+  imports: [NgpAccordionContent, NgpAccordionTrigger, NgpButton, NgIcon],
+  providers: [provideIcons({ heroChevronDownMini })],
+  host: {
+    class: 'block',
+  },
+  template: `
+    <button class="flex pl-4 pr-4 text-sm font-medium justify-between items-center w-full h-11 rounded-xl [outline:none] text-(--ngp-text-primary) bg-(--ngp-background) border-none data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)]" ngpAccordionTrigger ngpButton>
+      {{ heading() }}
+
+      <ng-icon class="[font-size:1.25rem] text-(--ngp-text-secondary)" name="heroChevronDownMini" />
+    </button>
+    <div class="[font-size:0.875rem] text-(--ngp-text-secondary) overflow-hidden py-0 px-4 box-border" ngpAccordionContent>
+      <ng-content />
+    </div>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host:has(+ :host) {
+      border-bottom: 1px solid var(--ngp-border);
+    }
+
+    [ngpAccordionContent][data-open] {
+      animation: slideDown 0.2s ease-in-out forwards;
+    }
+
+    [ngpAccordionContent][data-closed] {
+      animation: slideUp 0.2s ease-in-out forwards;
+    }
+
+    [ngpAccordionTrigger][data-open] ng-icon {
+      transform: rotate(180deg);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      [ngpAccordionContent][data-open] {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      [ngpAccordionContent][data-closed] {
+        animation-duration: 0s;
+      }
+    }
+
+    @keyframes slideDown {
+        from {
+          height: 0;
+        }
+        to {
+          height: var(--ngp-accordion-content-height);
+        }
+      }
+
+    @keyframes slideUp {
+        from {
+          height: var(--ngp-accordion-content-height);
+        }
+        to {
+          height: 0;
+        }
+      }
+  `,
+})
+export class AccordionItem<%= componentSuffix %> {
+  /** The accordion item heading */
+  readonly heading = input.required<string>();
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/accordion/accordion.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/accordion/accordion.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,25 @@
+import { Component } from '@angular/core';
+import { NgpAccordion } from 'ng-primitives/accordion';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>accordion',
+  hostDirectives: [
+    {
+      directive: NgpAccordion,
+      inputs: [
+        'ngpAccordionValue:value',
+        'ngpAccordionType:type',
+        'ngpAccordionCollapsible:collapsible',
+        'ngpAccordionDisabled:disabled',
+        'ngpAccordionOrientation:orientation',
+      ],
+    },
+  ],
+  host: {
+    class: 'block w-full max-w-96 rounded-xl border border-(--ngp-border) bg-(--ngp-background) shadow-(--ngp-shadow)',
+  },
+  template: `
+    <ng-content />
+  `,
+})
+export class Accordion<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/avatar/avatar.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/avatar/avatar.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,24 @@
+import { Component, input } from '@angular/core';
+import { NgpAvatar, NgpAvatarFallback, NgpAvatarImage } from 'ng-primitives/avatar';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>avatar',
+  hostDirectives: [NgpAvatar],
+  imports: [NgpAvatarImage, NgpAvatarFallback],
+  host: {
+    class: 'relative inline-flex w-12 h-12 items-center justify-center rounded-full border-2 border-(--ngp-avatar-border) bg-(--ngp-avatar-background) align-middle overflow-hidden before:[content:\'\'] before:absolute before:inset-0 before:rounded-full before:[box-shadow:inset_0_0_0_1px_rgba(0,_0,_0,_0.1)]',
+  },
+  template: `
+    @if (image()) {
+      <img class="w-full h-full" [src]="image()" ngpAvatarImage alt="Profile Image" />
+    }
+    <span class="text-center font-medium text-(--ngp-text-emphasis)" ngpAvatarFallback>{{ fallback() }}</span>
+  `,
+})
+export class Avatar<%= componentSuffix %> {
+  /** Define the avatar image source */
+  readonly image = input<string>();
+
+  /** Define the avatar fallback text */
+  readonly fallback = input<string>();
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/button/button.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/button/button.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,86 @@
+import { Component, input } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+
+/**
+ * The size of the button.
+ */
+export type ButtonSize = 'sm' | 'md' | 'lg' | 'xl';
+
+/**
+ * The variant of the button.
+ */
+export type ButtonVariant = 'primary' | 'secondary' | 'destructive' | 'outline' | 'ghost' | 'link';
+
+@Component({
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>button]',
+  hostDirectives: [{ directive: NgpButton, inputs: ['disabled'] }],
+  template: `
+    <ng-content select="[slot=leading]" />
+    <ng-content />
+    <ng-content select="[slot=trailing]" />
+  `,
+  host: {
+    class: 'pl-4 pr-4 rounded-lg text-(--ngp-text-primary) border-none h-10 font-medium bg-(--ngp-background) [transition:background-color_300ms_cubic-bezier(0.4,_0,_0.2,_1)] shadow-(--ngp-button-shadow) box-border inline-flex items-center justify-center cursor-pointer gap-2 data-hover:bg-(--ngp-background-hover) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-press:bg-(--ngp-background-active) data-[variant=primary]:bg-(--ngp-background) data-[variant=primary]:text-(--ngp-text-primary) data-[variant=primary]:border-none [&:not([data-variant])]:bg-(--ngp-background) [&:not([data-variant])]:text-(--ngp-text-primary) [&:not([data-variant])]:border-none data-[variant=primary]:data-hover:bg-(--ngp-background-hover) [&:not([data-variant])]:data-hover:bg-(--ngp-background-hover) data-[variant=primary]:data-press:bg-(--ngp-background-active) [&:not([data-variant])]:data-press:bg-(--ngp-background-active) data-[variant=secondary]:[background-color:var(--ngp-secondary-background,_#f1f5f9)] data-[variant=secondary]:[color:var(--ngp-secondary-text,_#0f172a)] data-[variant=secondary]:border-none data-[variant=secondary]:data-hover:[background-color:var(--ngp-secondary-background-hover,_#e2e8f0)] data-[variant=secondary]:data-press:[background-color:var(--ngp-secondary-background-active,_#cbd5e1)] data-[variant=destructive]:[background-color:var(--ngp-destructive-background,_#ef4444)] data-[variant=destructive]:[color:var(--ngp-destructive-text,_#ffffff)] data-[variant=destructive]:border-none data-[variant=destructive]:data-hover:[background-color:var(--ngp-destructive-background-hover,_#dc2626)] data-[variant=destructive]:data-press:[background-color:var(--ngp-destructive-background-active,_#b91c1c)] data-[variant=outline]:bg-transparent data-[variant=outline]:text-(--ngp-text-primary) data-[variant=outline]:[border:1px_solid_var(--ngp-outline-border,_#e2e8f0)] data-[variant=outline]:[box-shadow:none] data-[variant=outline]:data-hover:bg-(--ngp-background-hover) data-[variant=outline]:data-hover:[border-color:var(--ngp-outline-border-hover,_#cbd5e1)] data-[variant=outline]:data-press:[background-color:var(--ngp-outline-background-active,_rgba(15,_23,_42,_0.1))] data-[variant=ghost]:bg-transparent data-[variant=ghost]:text-(--ngp-text-primary) data-[variant=ghost]:border-none data-[variant=ghost]:[box-shadow:none] data-[variant=ghost]:data-hover:bg-(--ngp-background-hover) data-[variant=ghost]:data-press:bg-(--ngp-background-active) data-[variant=link]:bg-transparent data-[variant=link]:[color:var(--ngp-link-color,_#3b82f6)] data-[variant=link]:border-none data-[variant=link]:[box-shadow:none] data-[variant=link]:[text-decoration:underline] data-[variant=link]:[text-underline-offset:4px] data-[variant=link]:data-hover:[text-decoration-thickness:2px] motion-reduce:[transition-duration:0s]',
+    '[attr.data-size]': 'size()',
+    '[attr.data-variant]': 'variant()',
+  },
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host[data-size='sm'] {
+      height: 2rem;
+      padding-left: 0.75rem;
+      padding-right: 0.75rem;
+      font-size: 0.875rem;
+      --ng-icon__size: 0.875rem;
+    }
+
+    :host[data-size='md'] {
+      height: 2.5rem;
+      padding-left: 1rem;
+      padding-right: 1rem;
+      font-size: 0.875rem;
+      --ng-icon__size: 0.875rem;
+    }
+
+    :host:not([data-size]) {
+      height: 2.5rem;
+      padding-left: 1rem;
+      padding-right: 1rem;
+      font-size: 0.875rem;
+      --ng-icon__size: 0.875rem;
+    }
+
+    :host[data-size='lg'] {
+      height: 3rem;
+      padding-left: 1.25rem;
+      padding-right: 1.25rem;
+      font-size: 1rem;
+      --ng-icon__size: 1rem;
+    }
+
+    :host[data-size='xl'] {
+      height: 3.5rem;
+      padding-left: 1.5rem;
+      padding-right: 1.5rem;
+      font-size: 1.125rem;
+      --ng-icon__size: 1.125rem;
+    }
+
+    :host[disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  `,
+})
+export class Button<%= componentSuffix %> {
+  /**
+   * The size of the button.
+   */
+  readonly size = input<ButtonSize>('md');
+
+  /**
+   * The variant of the button.
+   */
+  readonly variant = input<ButtonVariant>('primary');
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/checkbox/checkbox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/checkbox/checkbox.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,78 @@
+import { Component } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheckMini, heroMinusMini } from '@ng-icons/heroicons/mini';
+import { injectCheckboxState, NgpCheckbox } from 'ng-primitives/checkbox';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>checkbox',
+  hostDirectives: [
+    {
+      directive: NgpCheckbox,
+      inputs: [
+        'ngpCheckboxChecked:checked',
+        'ngpCheckboxIndeterminate:indeterminate',
+        'ngpCheckboxDisabled:disabled',
+      ],
+      outputs: [
+        'ngpCheckboxCheckedChange:checkedChange',
+        'ngpCheckboxIndeterminateChange:indeterminateChange',
+      ],
+    },
+  ],
+  providers: [provideValueAccessor(Checkbox<%= componentSuffix %>), provideIcons({ heroCheckMini, heroMinusMini })],
+  imports: [NgIcon],
+  template: `
+    @if (state().indeterminate()) {
+      <ng-icon name="heroMinusMini" />
+    } @else if (state().checked()) {
+      <ng-icon name="heroCheckMini" />
+    }
+  `,
+  host: {
+    class: 'flex w-5 h-5 cursor-pointer items-center justify-center rounded border border-(--ngp-border) bg-transparent p-0 [outline:none] [flex:none] text-(--ngp-text-inverse) [font-size:0.75rem] data-hover:bg-(--ngp-background-hover) data-checked:border-(--ngp-background-inverse) data-checked:bg-(--ngp-background-inverse) data-indeterminate:border-(--ngp-background-inverse) data-indeterminate:bg-(--ngp-background-inverse) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:2px]',
+    '(focusout)': 'onTouchedFn?.()',
+  },
+})
+export class Checkbox<%= componentSuffix %> implements ControlValueAccessor {
+  /**
+   * The checked state of the checkbox.
+   */
+  protected readonly state = injectCheckboxState();
+
+  /**
+   * The onChange function for the checkbox.
+   */
+  protected onChangeFn?: ChangeFn<boolean>;
+
+  /**
+   * The onTouched function for the checkbox.
+   */
+  protected onTouchedFn?: TouchedFn;
+
+  constructor() {
+    // Whenever the user interacts with the checkbox, call the onChange function with the new value.
+    this.state()
+      .checkedChange.pipe(takeUntilDestroyed())
+      .subscribe(checked => this.onChangeFn?.(checked));
+  }
+
+  writeValue(checked: boolean): void {
+    // writing a value from the model must not re-emit through onChange
+    this.state().setChecked(checked, { emit: false });
+  }
+
+  registerOnChange(fn: ChangeFn<boolean>): void {
+    this.onChangeFn = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouchedFn = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/combobox/combobox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/combobox/combobox.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,180 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Component, computed, input, model, signal } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDown } from '@ng-icons/heroicons/outline';
+import {
+  NgpCombobox,
+  NgpComboboxButton,
+  NgpComboboxDropdown,
+  NgpComboboxInput,
+  NgpComboboxOption,
+  NgpComboboxPortal,
+} from 'ng-primitives/combobox';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>combobox',
+  imports: [
+    NgpCombobox,
+    NgpComboboxDropdown,
+    NgpComboboxOption,
+    NgpComboboxInput,
+    NgpComboboxPortal,
+    NgpComboboxButton,
+    NgIcon,
+  ],
+  providers: [provideIcons({ heroChevronDown }), provideValueAccessor(Combobox<%= componentSuffix %>)],
+  template: `
+    <div class="flex justify-between items-center h-9 w-75 rounded-lg border-none bg-(--ngp-background) shadow-(--ngp-input-shadow) box-border data-focus:[outline:2px_solid_var(--ngp-focus-ring)] data-focus:[outline-offset:2px]"
+      [(ngpComboboxValue)]="value"
+      [ngpComboboxDisabled]="disabled() || formDisabled()"
+      (ngpComboboxOpenChange)="resetOnClose($event)"
+      (ngpComboboxValueChange)="onValueChange($event)"
+      ngpCombobox
+    >
+      <input class="flex-1 py-0 px-4 border-none bg-transparent text-(--ngp-text) [font-family:inherit] [font-size:14px] py-0 px-4 [outline:none] h-full"
+        [value]="filter()"
+        [placeholder]="placeholder()"
+        (input)="onFilterChange($event)"
+        (blur)="onTouched?.()"
+        ngpComboboxInput
+      />
+
+      <button class="inline-flex justify-center items-center h-full w-9 bg-transparent border-none text-(--ngp-text) cursor-pointer box-border" ngpComboboxButton aria-label="Toggle dropdown">
+        <ng-icon name="heroChevronDown" />
+      </button>
+
+      <div class="bg-(--ngp-background) border border-(--ngp-border) p-1 rounded-xl [outline:none] absolute animate-[popover-show_0.1s_ease-out] [width:var(--ngp-combobox-width)] shadow-(--ngp-shadow-lg) box-border mt-1 max-h-60 overflow-y-auto [transform-origin:var(--ngp-combobox-transform-origin)] motion-reduce:[animation-duration:0s]" *ngpComboboxPortal ngpComboboxDropdown>
+        @for (option of filteredOptions(); track option) {
+          <div class="flex items-center gap-2 [padding:0.375rem_0.75rem] cursor-pointer rounded-lg w-full h-9 [font-size:14px] text-(--ngp-text-primary) box-border data-hover:bg-(--ngp-background-hover) data-press:bg-(--ngp-background-active) data-active:bg-(--ngp-background-active)" [ngpComboboxOptionValue]="option" ngpComboboxOption>
+            {{ option }}
+          </div>
+        } @empty {
+          <div class="empty-message flex justify-center items-center p-2 text-(--ngp-text-secondary) [font-size:14px] font-medium text-center">No options found</div>
+        }
+      </div>
+    </div>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    [ngpComboboxDropdown][data-enter] {
+      animation: combobox-show 0.1s ease-out;
+    }
+
+    [ngpComboboxDropdown][data-exit] {
+      animation: combobox-hide 0.1s ease-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      [ngpComboboxDropdown][data-enter] {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      [ngpComboboxDropdown][data-exit] {
+        animation-duration: 0s;
+      }
+    }
+
+    @keyframes combobox-show {
+        0% {
+          opacity: 0;
+          transform: translateY(-10px) scale(0.9);
+        }
+        100% {
+          opacity: 1;
+          transform: translateY(0) scale(1);
+        }
+      }
+
+    @keyframes combobox-hide {
+        0% {
+          opacity: 1;
+          transform: translateY(0) scale(1);
+        }
+        100% {
+          opacity: 0;
+          transform: translateY(-10px) scale(0.9);
+        }
+      }
+  `,
+})
+export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
+  /** The options for the combobox. */
+  readonly options = input<string[]>([]);
+
+  /** The selected value. */
+  readonly value = model<string | undefined>();
+
+  /** The placeholder for the input. */
+  readonly placeholder = input<string>('');
+
+  /** The disabled state of the combobox. */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    transform: booleanAttribute,
+  });
+
+  /** The filter value. */
+  protected readonly filter = signal<string>('');
+
+  /** Get the filtered options. */
+  protected readonly filteredOptions = computed(() =>
+    this.options().filter(option => option.toLowerCase().includes(this.filter().toLowerCase())),
+  );
+
+  /** Store the form disabled state */
+  protected readonly formDisabled = signal(false);
+
+  /** The on change callback */
+  private onChange?: ChangeFn<string | undefined>;
+
+  /** The on touch callback */
+  protected onTouched?: TouchedFn;
+
+  onFilterChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.filter.set(input.value);
+  }
+
+  writeValue(value: string | undefined): void {
+    this.value.set(value);
+    this.filter.set(value ?? '');
+  }
+
+  registerOnChange(fn: ChangeFn<string | undefined>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.formDisabled.set(isDisabled);
+  }
+
+  protected onValueChange(value: string): void {
+    this.onChange?.(value);
+    // update the filter value
+    this.filter.set(value);
+  }
+
+  protected resetOnClose(open: boolean): void {
+    // if the dropdown is closed, reset the filter value
+    if (open) {
+      return;
+    }
+
+    // if the filter value is empty, clear the value and notify the form control
+    if (this.filter() === '') {
+      this.value.set(undefined);
+      this.onChange?.(undefined);
+    } else {
+      // otherwise set the filter value to the selected value
+      this.filter.set(this.value() ?? '');
+    }
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/context-menu/context-menu-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/context-menu/context-menu-item.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { NgpContextMenuItem } from 'ng-primitives/context-menu';
+
+@Component({
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>context-menu-item]',
+  hostDirectives: [NgpContextMenuItem],
+  host: {
+    class: 'flex items-center justify-between [padding:6px_8px_6px_14px] border-none [background:none] cursor-pointer [transition:background-color_0.2s] rounded min-w-30 [text-align:start] [outline:none] [font-size:14px] [font-weight:400] data-hover:bg-(--ngp-background-active) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:z-1 motion-reduce:[transition-duration:0s]', type: 'button' },
+  template: `
+    <ng-content />
+  `,
+})
+export class ContextMenuItem<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/context-menu/context-menu.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/context-menu/context-menu.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,66 @@
+import { Component } from '@angular/core';
+import { NgpContextMenu } from 'ng-primitives/context-menu';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>context-menu',
+  hostDirectives: [NgpContextMenu],
+  template: `
+    <ng-content />
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host {
+      position: fixed;
+      display: flex;
+      flex-direction: column;
+      width: max-content;
+      background: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      box-shadow: var(--ngp-shadow);
+      border-radius: 8px;
+      padding: 4px;
+      transform-origin: var(--ngp-menu-transform-origin);
+      animation: menu-show 300ms ease-out;
+    }
+
+    :host[data-exit] {
+      animation: menu-hide 300ms ease-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
+
+    @keyframes menu-show {
+        0% {
+          opacity: 0;
+          transform: scale(0.9);
+        }
+        100% {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+
+    @keyframes menu-hide {
+        0% {
+          opacity: 1;
+          transform: scale(1);
+        }
+        100% {
+          opacity: 0;
+          transform: scale(0.9);
+        }
+      }
+  `,
+})
+export class ContextMenu<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/date-picker/date-picker.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/date-picker/date-picker.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,170 @@
+import { Component, computed } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronLeftMini, heroChevronRightMini } from '@ng-icons/heroicons/mini';
+import {
+  injectDatePickerState,
+  NgpDatePicker,
+  NgpDatePickerCell,
+  NgpDatePickerCellRender,
+  NgpDatePickerDateButton,
+  NgpDatePickerGrid,
+  NgpDatePickerLabel,
+  NgpDatePickerNextMonth,
+  NgpDatePickerPreviousMonth,
+  NgpDatePickerRowRender,
+} from 'ng-primitives/date-picker';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>date-picker',
+  hostDirectives: [
+    {
+      directive: NgpDatePicker,
+      inputs: [
+        'ngpDatePickerDate: date',
+        'ngpDatePickerMin: min',
+        'ngpDatePickerMax: max',
+        'ngpDatePickerDisabled: disabled',
+      ],
+      outputs: ['ngpDatePickerDateChange: dateChange'],
+    },
+  ],
+  imports: [
+    NgIcon,
+    NgpDatePickerLabel,
+    NgpDatePickerNextMonth,
+    NgpDatePickerPreviousMonth,
+    NgpDatePickerGrid,
+    NgpDatePickerCell,
+    NgpDatePickerRowRender,
+    NgpDatePickerCellRender,
+    NgpDatePickerDateButton,
+  ],
+  providers: [
+    provideIcons({ heroChevronRightMini, heroChevronLeftMini }),
+    provideValueAccessor(DatePicker<%= componentSuffix %>),
+  ],
+  template: `
+    <div class="date-picker-header flex items-center justify-between h-9 mb-4">
+      <button class="data-hover:bg-(--ngp-background-hover) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-press:bg-(--ngp-background-active) data-disabled:cursor-not-allowed data-disabled:text-(--ngp-text-disabled)" ngpDatePickerPreviousMonth aria-label="previous month">
+        <ng-icon name="heroChevronLeftMini" />
+      </button>
+      <h2 class="[font-size:14px] font-medium text-(--ngp-text-primary)" ngpDatePickerLabel>{{ label() }}</h2>
+      <button class="data-hover:bg-(--ngp-background-hover) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-press:bg-(--ngp-background-active) data-disabled:cursor-not-allowed data-disabled:text-(--ngp-text-disabled)" ngpDatePickerNextMonth aria-label="next month">
+        <ng-icon name="heroChevronRightMini" />
+      </button>
+    </div>
+    <table ngpDatePickerGrid>
+      <thead>
+        <tr>
+          <th class="[font-size:14px] font-medium w-10 h-10 text-center text-(--ngp-text-secondary)" scope="col" abbr="Sunday">S</th>
+          <th class="[font-size:14px] font-medium w-10 h-10 text-center text-(--ngp-text-secondary)" scope="col" abbr="Monday">M</th>
+          <th class="[font-size:14px] font-medium w-10 h-10 text-center text-(--ngp-text-secondary)" scope="col" abbr="Tuesday">T</th>
+          <th class="[font-size:14px] font-medium w-10 h-10 text-center text-(--ngp-text-secondary)" scope="col" abbr="Wednesday">W</th>
+          <th class="[font-size:14px] font-medium w-10 h-10 text-center text-(--ngp-text-secondary)" scope="col" abbr="Thursday">T</th>
+          <th class="[font-size:14px] font-medium w-10 h-10 text-center text-(--ngp-text-secondary)" scope="col" abbr="Friday">F</th>
+          <th class="[font-size:14px] font-medium w-10 h-10 text-center text-(--ngp-text-secondary)" scope="col" abbr="Saturday">S</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngpDatePickerRowRender>
+          <td *ngpDatePickerCellRender="let date" ngpDatePickerCell>
+            <button class="data-today:text-(--ngp-text-blue) data-hover:bg-(--ngp-background-hover) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:2px] data-press:bg-(--ngp-background-active) data-outside-month:text-(--ngp-text-disabled) data-selected:bg-(--ngp-background-inverse) data-selected:text-(--ngp-text-inverse) data-selected:data-outside-month:bg-(--ngp-background-disabled) data-selected:data-outside-month:text-(--ngp-text-disabled) data-disabled:cursor-not-allowed data-disabled:text-(--ngp-text-disabled)" ngpDatePickerDateButton>
+              {{ date.getDate() }}
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    [ngpDatePickerPreviousMonth] {
+      all: unset;
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      font-size: 20px;
+      border: 1px solid var(--ngp-border);
+      cursor: pointer;
+    }
+
+    [ngpDatePickerNextMonth] {
+      all: unset;
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      font-size: 20px;
+      border: 1px solid var(--ngp-border);
+      cursor: pointer;
+    }
+
+    [ngpDatePickerDateButton] {
+      all: unset;
+      width: 40px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      cursor: pointer;
+    }
+  `,
+  host: {
+    class: 'inline-block bg-(--ngp-background) rounded-xl p-4 shadow-(--ngp-shadow) border border-(--ngp-border)',
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class DatePicker<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the date picker host directive */
+  private readonly state = injectDatePickerState<Date>();
+
+  /**
+   * Get the current focused date in string format.
+   * @returns The focused date in "February 2024" format.
+   */
+  readonly label = computed(
+    () =>
+      `${this.state().focusedDate().toLocaleString('default', { month: 'long' })} ${this.state().focusedDate().getFullYear()}`,
+  );
+
+  /**
+   * The onChange callback function for the date picker.
+   */
+  protected onChange?: ChangeFn<Date | undefined>;
+
+  /**
+   * The onTouched callback function for the date picker.
+   */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    // Whenever the user interacts with the date picker, call the onChange function with the new value.
+    this.state().dateChange.subscribe(date => this.onChange?.(date));
+  }
+
+  writeValue(date: Date): void {
+    // writing a value from the model must not re-emit through onChange
+    this.state().select(date, false, { emit: false });
+  }
+
+  registerOnChange(fn: ChangeFn<Date | undefined>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/dialog/dialog.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/dialog/dialog.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,126 @@
+import { Component, input } from '@angular/core';
+import {
+  NgpDialog,
+  NgpDialogDescription,
+  NgpDialogOverlay,
+  NgpDialogTitle,
+  provideDialogState,
+} from 'ng-primitives/dialog';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>dialog',
+  hostDirectives: [NgpDialogOverlay],
+  imports: [NgpDialog, NgpDialogTitle, NgpDialogDescription],
+  providers: [
+    // We need to hoist the dialog state to the host component so that it can be used
+    // within ng-content
+    provideDialogState(),
+  ],
+  template: `
+    <div ngpDialog>
+      <h2 class="[font-size:18px] [line-height:28px] font-semibold text-(--ngp-text-primary) [margin:0_0_4px]" ngpDialogTitle>{{ header() }}</h2>
+      <p class="[font-size:14px] [line-height:20px] text-(--ngp-text-secondary) m-0" ngpDialogDescription>
+        <ng-content />
+      </p>
+    </div>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host {
+      background-color: rgba(0, 0, 0, 0.5);
+      backdrop-filter: blur(4px);
+      position: fixed;
+      inset: 0;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      animation: fadeIn 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    :host[data-exit] {
+      animation: fadeOut 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpDialog] {
+      background-color: var(--ngp-background);
+      padding: 24px;
+      border-radius: 8px;
+      box-shadow: var(--ngp-shadow);
+      animation: slideIn 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpDialog][data-exit] {
+      animation: slideOut 300ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      [ngpDialog] {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      [ngpDialog][data-exit] {
+        animation-duration: 0s;
+      }
+    }
+
+    @keyframes fadeIn {
+        0% {
+          opacity: 0;
+        }
+        100% {
+          opacity: 1;
+        }
+      }
+
+    @keyframes fadeOut {
+        0% {
+          opacity: 1;
+        }
+        100% {
+          opacity: 0;
+        }
+      }
+
+    @keyframes slideIn {
+        0% {
+          transform: translateY(-20px);
+          opacity: 0;
+        }
+        100% {
+          transform: translateY(0);
+          opacity: 1;
+        }
+      }
+
+    @keyframes slideOut {
+        0% {
+          transform: translateY(0);
+          opacity: 1;
+        }
+
+        100% {
+          transform: translateY(-20px);
+          opacity: 0;
+        }
+      }
+  `,
+})
+export class Dialog<%= componentSuffix %> {
+  /** The dialog title */
+  readonly header = input.required<string>();
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/file-upload/file-upload.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/file-upload/file-upload.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { NgpFileUpload } from 'ng-primitives/file-upload';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>file-upload',
+  hostDirectives: [
+    {
+      directive: NgpFileUpload,
+      inputs: [
+        'ngpFileUploadFileTypes:types',
+        'ngpFileUploadMultiple:multiple',
+        'ngpFileUploadDirectory:directory',
+        'ngpFileUploadDragDrop:dragDrop',
+        'ngpFileUploadDisabled:disabled',
+      ],
+      outputs: ['ngpFileUploadSelected:selected', 'ngpFileUploadCanceled:canceled'],
+    },
+  ],
+  host: {
+    class: 'flex cursor-pointer flex-col items-center justify-center gap-y-1 rounded-lg [border:1px_dashed_var(--ngp-border-secondary)] bg-(--ngp-background) py-8 px-12 data-dragover:border-(--ngp-border) data-dragover:bg-(--ngp-background-hover)',
+  },
+  template: `
+    Drop files here or click to upload
+  `,
+})
+export class FileUpload<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/form-field/field.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/form-field/field.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { NgpFormField } from 'ng-primitives/form-field';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>field',
+  hostDirectives: [NgpFormField],
+  host: {
+    class: 'flex flex-col [gap:6px] [width:90%]',
+  },
+  template: `
+    <ng-content />
+  `,
+})
+export class Field<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/input-otp/input-otp.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/input-otp/input-otp.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,168 @@
+import { BooleanInput, NumberInput } from '@angular/cdk/coercion';
+import {
+  booleanAttribute,
+  Component,
+  computed,
+  forwardRef,
+  input,
+  model,
+  numberAttribute,
+  signal,
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { NgpInputOtp, NgpInputOtpInput, NgpInputOtpSlot } from 'ng-primitives/input-otp';
+import { ChangeFn, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>input-otp',
+  imports: [NgpInputOtp, NgpInputOtpInput, NgpInputOtpSlot],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => InputOtp<%= componentSuffix %>),
+      multi: true,
+    },
+  ],
+  host: {
+    class: 'inline-flex flex-col gap-3 [max-width:100%]',
+  },
+  template: `
+    <div
+      [ngpInputOtpValue]="value()"
+      [ngpInputOtpDisabled]="disabled() || formDisabled()"
+      [ngpInputOtpPattern]="pattern()"
+      [ngpInputOtpPlaceholder]="placeholder()"
+      [ngpInputOtpInputMode]="inputMode()"
+      (ngpInputOtpValueChange)="onValueChange($event)"
+      (ngpInputOtpComplete)="onComplete()"
+      ngpInputOtp
+    >
+      <input [attr.aria-label]="ariaLabel()" ngpInputOtpInput />
+      <div class="slots flex gap-2">
+        @for (_ of slots(); track $index) {
+          <div class="slot flex items-center justify-center w-12 h-12 border-2 border-(--ngp-border) rounded-lg [background:var(--ngp-background)] [font-size:18px] font-semibold text-(--ngp-text-primary) [transition:all_150ms_cubic-bezier(0.4,_0,_0.2,_1)] cursor-pointer relative data-filled:border-(--ngp-border-strong) data-filled:[background:var(--ngp-background-accent)] data-active:border-(--ngp-focus-ring) data-active:[box-shadow:0_0_0_1px_var(--ngp-focus-ring)] data-placeholder:text-(--ngp-text-placeholder) motion-reduce:[transition-duration:0s]" ngpInputOtpSlot></div>
+        }
+      </div>
+    </div>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    .slot[data-caret]::after {
+      content: '';
+      position: absolute;
+      width: 2px;
+      height: 20px;
+      background: var(--ngp-focus-ring);
+      animation: blink 1s infinite;
+    }
+
+    :host([data-disabled]) .slot {
+      background: var(--ngp-background-disabled);
+      color: var(--ngp-text-disabled);
+      border-color: var(--ngp-border-disabled);
+      cursor: not-allowed;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .slot[data-caret]::after {
+        animation: none;
+      }
+    }
+
+    @keyframes blink {
+        0%,
+        50% {
+          opacity: 1;
+        }
+        51%,
+        100% {
+          opacity: 0;
+        }
+      }
+  `,
+})
+export class InputOtp<%= componentSuffix %> implements ControlValueAccessor {
+  /**
+   * The number of slots to display.
+   */
+  readonly length = input<number, NumberInput>(6, {
+    transform: numberAttribute,
+  });
+
+  /**
+   * Whether the input is disabled.
+   */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    transform: booleanAttribute,
+  });
+
+  /**
+   * The pattern for allowed characters.
+   */
+  readonly pattern = input('[0-9]');
+
+  /**
+   * The placeholder character for empty slots.
+   */
+  readonly placeholder = input('');
+
+  /**
+   * The accessible label for the hidden input.
+   */
+  readonly ariaLabel = input('');
+
+  /**
+   * The input mode for the hidden input.
+   */
+  readonly inputMode = input<'numeric' | 'text' | 'decimal' | 'tel' | 'search' | 'email' | 'url'>(
+    'numeric',
+  );
+
+  /**
+   * Create an array for tracking slots.
+   */
+  protected readonly slots = computed(() => Array.from({ length: this.length() }, (_, i) => i));
+
+  /**
+   * The current value.
+   */
+  readonly value = model<string>('');
+
+  private onChange: ChangeFn<string> = () => {};
+  private onTouched: TouchedFn = () => {};
+
+  protected readonly formDisabled = signal(false);
+
+  /**
+   * Handle value changes from the input-otp directive.
+   */
+  onValueChange(value: string): void {
+    this.value.set(value);
+    this.onChange(value);
+  }
+
+  /**
+   * Handle completion events from the input-otp directive.
+   */
+  onComplete(): void {
+    this.onTouched();
+  }
+
+  // ControlValueAccessor implementation
+  writeValue(value: string): void {
+    this.value.set(value);
+  }
+
+  registerOnChange(fn: ChangeFn<string>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.formDisabled.set(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/input/input.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/input/input.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { NgpInput } from 'ng-primitives/input';
+
+@Component({
+  selector: 'input[<% if (prefix) { %><%= prefix %>-<% } %>input]',
+  hostDirectives: [{ directive: NgpInput, inputs: ['disabled'] }],
+  host: {
+    class: 'h-9 w-full rounded-lg py-0 px-4 border-none shadow-(--ngp-input-shadow) [outline:none] box-border focus:[outline:2px_solid_var(--ngp-focus-ring)] focus:[outline-offset:2px] placeholder:text-(--ngp-text-placeholder)',
+  },
+  template: '',
+})
+export class Input<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/listbox/listbox-option.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/listbox/listbox-option.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheckSolid } from '@ng-icons/heroicons/solid';
+import { NgpListboxOption } from 'ng-primitives/listbox';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>listbox-option',
+  hostDirectives: [
+    {
+      directive: NgpListboxOption,
+      inputs: ['id', 'ngpListboxOptionValue:value', 'ngpListboxOptionDisabled:disabled'],
+    },
+  ],
+  imports: [NgIcon],
+  providers: [provideIcons({ heroCheckSolid })],
+  host: {
+    class: 'flex items-center gap-2 [padding:0.375rem_0.75rem] cursor-pointer rounded-lg w-full h-9 box-border data-hover:bg-(--ngp-background-hover) data-press:bg-(--ngp-background-active) data-active:bg-(--ngp-background-active)',
+  },
+  template: `
+    <ng-icon name="heroCheckSolid" size="16px" />
+    <ng-content />
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host ng-icon {
+      visibility: hidden;
+    }
+
+    :host[data-selected] ng-icon {
+      visibility: visible;
+    }
+  `,
+})
+export class ListboxOption<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/listbox/listbox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/listbox/listbox.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,100 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Component, input } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { provideIcons } from '@ng-icons/core';
+import { heroChevronDownSolid } from '@ng-icons/heroicons/solid';
+import { NgpSelectionMode } from 'ng-primitives/common';
+import { injectListboxState, NgpListbox, provideListboxState } from 'ng-primitives/listbox';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>listbox',
+  providers: [
+    provideIcons({ heroChevronDownSolid }),
+    provideListboxState(),
+    provideValueAccessor(Listbox<%= componentSuffix %>),
+  ],
+  imports: [NgpListbox],
+  template: `
+    <div class="bg-(--ngp-background) border border-(--ngp-border) p-1 rounded-xl [outline:none] [width:var(--ngp-popover-trigger-width)] box-border"
+      [ngpListboxMode]="mode()"
+      [ngpListboxDisabled]="disabled()"
+      [ngpListboxCompareWith]="compareWith()"
+      [attr.aria-label]="ariaLabel()"
+      (ngpListboxValueChange)="onListboxValueChange($event)"
+      ngpListbox
+    >
+      <ng-content />
+    </div>
+  `,
+  host: {
+    '[attr.aria-label]': 'null',
+    '(focusout)': 'onTouch?.()',
+  },
+})
+export class Listbox<%= componentSuffix %> implements ControlValueAccessor {
+  /**
+   * Access the listbox state
+   */
+  protected readonly state = injectListboxState<string>();
+
+  /**
+   * The listbox mode.
+   */
+  readonly mode = input<NgpSelectionMode>('single');
+
+  /**
+   * The listbox disabled state.
+   */
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    transform: booleanAttribute,
+  });
+
+  /**
+   * The comparator function to use when comparing values.
+   */
+  readonly compareWith = input<(a: string, b: string) => boolean>((a, b) => a === b);
+
+  /**
+   * The placeholder text.
+   */
+  readonly placeholder = input<string>('Select an option');
+
+  /**
+   * The aria-label attribute for the listbox.
+   */
+  readonly ariaLabel = input<string>('Listbox', {
+    alias: 'aria-label',
+  });
+
+  /**
+   * The onChange callback.
+   */
+  protected onChange?: ChangeFn<string[]>;
+
+  /**
+   * The onTouch callback.
+   */
+  protected onTouch?: TouchedFn;
+
+  writeValue(value: string[]): void {
+    // writing a value from the model must not re-emit through onChange
+    this.state()?.setValue(value, { emit: false });
+  }
+
+  registerOnChange(fn: ChangeFn<string[]>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouch = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state()?.setDisabled(isDisabled);
+  }
+
+  onListboxValueChange(value: string[]): void {
+    this.onChange?.(value);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/menu/menu-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/menu/menu-item.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { NgpMenuItem } from 'ng-primitives/menu';
+
+@Component({
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>menu-item]',
+  hostDirectives: [NgpMenuItem],
+  host: {
+    class: 'flex items-center justify-between [padding:6px_8px_6px_14px] border-none [background:none] cursor-pointer [transition:background-color_0.2s] rounded min-w-30 [text-align:start] [outline:none] [font-size:14px] [font-weight:400] data-hover:bg-(--ngp-background-active) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:z-1 motion-reduce:[transition-duration:0s]',
+  },
+  template: `
+    <ng-content />
+  `,
+})
+export class MenuItem<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/menu/menu.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/menu/menu.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,65 @@
+import { Component } from '@angular/core';
+import { NgpMenu } from 'ng-primitives/menu';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>menu',
+  hostDirectives: [NgpMenu],
+  template: `
+    <ng-content />
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host {
+      position: fixed;
+      display: flex;
+      flex-direction: column;
+      width: max-content;
+      background: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      box-shadow: var(--ngp-shadow);
+      border-radius: 8px;
+      padding: 4px;
+      animation: menu-show 300ms ease-out;
+    }
+
+    :host[data-exit] {
+      animation: menu-hide 300ms ease-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
+
+    @keyframes menu-show {
+        0% {
+          opacity: 0;
+          transform: scale(0.9);
+        }
+        100% {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+
+    @keyframes menu-hide {
+        0% {
+          opacity: 1;
+          transform: scale(1);
+        }
+        100% {
+          opacity: 0;
+          transform: scale(0.9);
+        }
+      }
+  `,
+})
+export class Menu<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/meter/meter.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/meter/meter.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,37 @@
+import { NumberInput } from '@angular/cdk/coercion';
+import { Component, input, numberAttribute } from '@angular/core';
+import {
+  NgpMeter,
+  NgpMeterIndicator,
+  NgpMeterLabel,
+  NgpMeterTrack,
+  NgpMeterValue,
+} from 'ng-primitives/meter';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>meter',
+  hostDirectives: [
+    { directive: NgpMeter, inputs: ['ngpMeterValue:value', 'ngpMeterMin:min', 'ngpMeterMax:max'] },
+  ],
+  imports: [NgpMeterIndicator, NgpMeterLabel, NgpMeterValue, NgpMeterTrack],
+  host: {
+    class: 'grid [grid-template-columns:1fr_1fr] [grid-row-gap:0.5rem] w-50 box-border p-2',
+  },
+  template: `
+    <span class="text-(--ngp-text-emphasis) [font-size:14px] font-semibold" ngpMeterLabel>{{ label() }}</span>
+    <span class="text-(--ngp-text-secondary) [font-size:14px] font-medium [text-align:right] [grid-column-start:2] [text-align:end]" ngpMeterValue>{{ value() }}%</span>
+
+    <div class="[grid-column:1_/_3] overflow-hidden bg-(--ngp-background) shadow-(--ngp-shadow-border) rounded h-2" ngpMeterTrack>
+      <div class="bg-(--ngp-background-success) h-full [transition:width_0.2s_ease-in-out] [inset-inline-start:0px] rounded motion-reduce:[transition-duration:0s]" ngpMeterIndicator></div>
+    </div>
+  `,
+})
+export class Meter<%= componentSuffix %> {
+  /** The value of the meter. */
+  readonly value = input<number, NumberInput>(0, {
+    transform: numberAttribute,
+  });
+
+  /** The label of the meter. */
+  readonly label = input.required<string>();
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/native-select/native-select.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/native-select/native-select.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { NgpNativeSelect } from 'ng-primitives/select';
+
+@Component({
+  selector: 'select[<% if (prefix) { %><%= prefix %>-<% } %>select]',
+  hostDirectives: [{ directive: NgpNativeSelect, inputs: ['ngpNativeSelectDisabled:disabled'] }],
+  host: {
+    class: 'data-hover:bg-(--ngp-background-hover) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:0] data-press:bg-(--ngp-background-active)',
+  },
+  template: `
+    <ng-content />
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host {
+      all: unset;
+      appearance: none;
+      display: flex;
+      width: 90%;
+      align-items: center;
+      height: 2.5rem;
+      padding: 0 1rem;
+      border-radius: 0.5rem;
+      background-color: var(--ngp-background);
+      text-align: start;
+      box-shadow: var(--ngp-button-shadow);
+      outline: none;
+      background-position-x: calc(100% - 10px);
+      background-position-y: 50%;
+      background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCIgZmlsbD0iIzczNzM3MyI+PHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBkPSJNNS4yMiA4LjIyYS43NS43NSAwIDAgMSAxLjA2IDBMMTAgMTEuOTRsMy43Mi0zLjcyYS43NS43NSAwIDEgMSAxLjA2IDEuMDZsLTQuMjUgNC4yNWEuNzUuNzUgMCAwIDEtMS4wNiAwTDUuMjIgOS4yOGEuNzUuNzUgMCAwIDEgMC0xLjA2WiIgY2xpcC1ydWxlPSJldmVub2RkIj48L3BhdGg+PC9zdmc+');
+      background-size: 1.25rem;
+      background-repeat: no-repeat;
+    }
+  `,
+})
+export class NativeSelect<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/number-field/number-field.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/number-field/number-field.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import {
+  NgpNumberField,
+  NgpNumberFieldDecrement,
+  NgpNumberFieldIncrement,
+  NgpNumberFieldInput,
+} from 'ng-primitives/number-field';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>number-field',
+  hostDirectives: [
+    {
+      directive: NgpNumberField,
+      inputs: [
+        'ngpNumberFieldValue:value',
+        'ngpNumberFieldMin:min',
+        'ngpNumberFieldMax:max',
+        'ngpNumberFieldStep:step',
+        'ngpNumberFieldLargeStep:largeStep',
+        'ngpNumberFieldDisabled:disabled',
+        'ngpNumberFieldReadonly:readonly',
+      ],
+      outputs: ['ngpNumberFieldValueChange:valueChange'],
+    },
+  ],
+  imports: [NgpNumberFieldInput, NgpNumberFieldIncrement, NgpNumberFieldDecrement],
+  host: {
+    class: 'inline-flex items-center rounded-lg shadow-(--ngp-input-shadow) bg-(--ngp-background) overflow-hidden focus-within:[outline:2px_solid_var(--ngp-focus-ring)] focus-within:[outline-offset:2px]',
+  },
+  template: `
+    <button class="flex items-center justify-center w-9 h-9 border-none bg-transparent text-(--ngp-text-secondary) cursor-pointer [font-size:1rem] select-none [-webkit-touch-callout:none] [transition:color_150ms_ease,_background-color_150ms_ease] data-hover:bg-(--ngp-background-hover) data-hover:text-(--ngp-text-primary) data-press:bg-(--ngp-background-active) data-disabled:opacity-40 data-disabled:cursor-not-allowed data-disabled:data-hover:bg-transparent data-disabled:data-hover:text-(--ngp-text-secondary) motion-reduce:[transition-duration:0s]" ngpNumberFieldDecrement aria-label="Decrement">−</button>
+    <input class="w-16 h-9 border-none [outline:none] text-center [font-size:0.875rem] text-(--ngp-text-primary) bg-transparent box-border p-0 placeholder:text-(--ngp-text-placeholder)" ngpNumberFieldInput />
+    <button class="flex items-center justify-center w-9 h-9 border-none bg-transparent text-(--ngp-text-secondary) cursor-pointer [font-size:1rem] select-none [-webkit-touch-callout:none] [transition:color_150ms_ease,_background-color_150ms_ease] data-hover:bg-(--ngp-background-hover) data-hover:text-(--ngp-text-primary) data-press:bg-(--ngp-background-active) data-disabled:opacity-40 data-disabled:cursor-not-allowed data-disabled:data-hover:bg-transparent data-disabled:data-hover:text-(--ngp-text-secondary) motion-reduce:[transition-duration:0s]" ngpNumberFieldIncrement aria-label="Increment">+</button>
+  `,
+})
+export class NumberField<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/pagination/pagination.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/pagination/pagination.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,226 @@
+import { Component, computed } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import {
+  heroChevronDoubleLeft,
+  heroChevronDoubleRight,
+  heroChevronLeft,
+  heroChevronRight,
+} from '@ng-icons/heroicons/outline';
+import {
+  injectPaginationState,
+  NgpPagination,
+  NgpPaginationButton,
+  NgpPaginationFirst,
+  NgpPaginationLast,
+  NgpPaginationNext,
+  NgpPaginationPrevious,
+} from 'ng-primitives/pagination';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>pagination',
+  hostDirectives: [
+    {
+      directive: NgpPagination,
+      inputs: [
+        'ngpPaginationPage:page',
+        'ngpPaginationPageCount:pageCount',
+        'ngpPaginationDisabled:disabled',
+      ],
+      outputs: ['ngpPaginationPageChange:pageChange'],
+    },
+  ],
+  imports: [
+    NgpPaginationButton,
+    NgpPaginationFirst,
+    NgpPaginationLast,
+    NgpPaginationNext,
+    NgpPaginationPrevious,
+    NgIcon,
+  ],
+  providers: [
+    provideValueAccessor(Pagination<%= componentSuffix %>),
+    provideIcons({
+      heroChevronDoubleLeft,
+      heroChevronDoubleRight,
+      heroChevronLeft,
+      heroChevronRight,
+    }),
+  ],
+  template: `
+    <ul class="flex items-center gap-x-2 list-none">
+      <li>
+        <button class="data-hover:[&:not([data-disabled])]:[&:not([data-selected])]:bg-(--ngp-background-hover) data-focus-visible:[&:not([data-disabled])]:[outline:2px_solid_var(--ngp-focus-ring)] data-press:[&:not([data-disabled])]:[&:not([data-selected])]:bg-(--ngp-background-active) data-disabled:[color:rgb(210_210_210)] data-disabled:bg-(--ngp-background-disabled) data-disabled:cursor-not-allowed data-disabled:[box-shadow:none] data-selected:bg-(--ngp-background-inverse) data-selected:text-(--ngp-text-inverse) motion-reduce:[transition-duration:0s]" ngpPaginationFirst aria-label="First Page">
+          <ng-icon name="heroChevronDoubleLeft" />
+        </button>
+      </li>
+
+      <li>
+        <button class="data-hover:[&:not([data-disabled])]:[&:not([data-selected])]:bg-(--ngp-background-hover) data-focus-visible:[&:not([data-disabled])]:[outline:2px_solid_var(--ngp-focus-ring)] data-press:[&:not([data-disabled])]:[&:not([data-selected])]:bg-(--ngp-background-active) data-disabled:[color:rgb(210_210_210)] data-disabled:bg-(--ngp-background-disabled) data-disabled:cursor-not-allowed data-disabled:[box-shadow:none] data-selected:bg-(--ngp-background-inverse) data-selected:text-(--ngp-text-inverse) motion-reduce:[transition-duration:0s]" ngpPaginationPrevious aria-label="Previous Page">
+          <ng-icon name="heroChevronLeft" />
+        </button>
+      </li>
+
+      @for (page of pages(); track page) {
+        <li>
+          <button class="data-hover:[&:not([data-disabled])]:[&:not([data-selected])]:bg-(--ngp-background-hover) data-focus-visible:[&:not([data-disabled])]:[outline:2px_solid_var(--ngp-focus-ring)] data-press:[&:not([data-disabled])]:[&:not([data-selected])]:bg-(--ngp-background-active) data-disabled:[color:rgb(210_210_210)] data-disabled:bg-(--ngp-background-disabled) data-disabled:cursor-not-allowed data-disabled:[box-shadow:none] data-selected:bg-(--ngp-background-inverse) data-selected:text-(--ngp-text-inverse) motion-reduce:[transition-duration:0s]"
+            [ngpPaginationButtonPage]="page"
+            [attr.aria-label]="'Page ' + page"
+            ngpPaginationButton
+          >
+            {{ page }}
+          </button>
+        </li>
+      }
+
+      <li>
+        <button class="data-hover:[&:not([data-disabled])]:[&:not([data-selected])]:bg-(--ngp-background-hover) data-focus-visible:[&:not([data-disabled])]:[outline:2px_solid_var(--ngp-focus-ring)] data-press:[&:not([data-disabled])]:[&:not([data-selected])]:bg-(--ngp-background-active) data-disabled:[color:rgb(210_210_210)] data-disabled:bg-(--ngp-background-disabled) data-disabled:cursor-not-allowed data-disabled:[box-shadow:none] data-selected:bg-(--ngp-background-inverse) data-selected:text-(--ngp-text-inverse) motion-reduce:[transition-duration:0s]" ngpPaginationNext aria-label="Next Page">
+          <ng-icon name="heroChevronRight" />
+        </button>
+      </li>
+
+      <li>
+        <button class="data-hover:[&:not([data-disabled])]:[&:not([data-selected])]:bg-(--ngp-background-hover) data-focus-visible:[&:not([data-disabled])]:[outline:2px_solid_var(--ngp-focus-ring)] data-press:[&:not([data-disabled])]:[&:not([data-selected])]:bg-(--ngp-background-active) data-disabled:[color:rgb(210_210_210)] data-disabled:bg-(--ngp-background-disabled) data-disabled:cursor-not-allowed data-disabled:[box-shadow:none] data-selected:bg-(--ngp-background-inverse) data-selected:text-(--ngp-text-inverse) motion-reduce:[transition-duration:0s]" ngpPaginationLast aria-label="Last Page">
+          <ng-icon name="heroChevronDoubleRight" />
+        </button>
+      </li>
+    </ul>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    [ngpPaginationFirst] {
+      all: unset;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 2rem;
+      height: 2rem;
+      border-radius: 0.5rem;
+      color: var(--ngp-text-primary);
+      outline: none;
+      font-size: 14px;
+      font-weight: 500;
+      background-color: var(--ngp-background);
+      box-shadow: var(--ngp-button-shadow);
+      cursor: pointer;
+      transition: background-color 0.2s;
+    }
+
+    [ngpPaginationPrevious] {
+      all: unset;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 2rem;
+      height: 2rem;
+      border-radius: 0.5rem;
+      color: var(--ngp-text-primary);
+      outline: none;
+      font-size: 14px;
+      font-weight: 500;
+      background-color: var(--ngp-background);
+      box-shadow: var(--ngp-button-shadow);
+      cursor: pointer;
+      transition: background-color 0.2s;
+    }
+
+    [ngpPaginationButton] {
+      all: unset;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 2rem;
+      height: 2rem;
+      border-radius: 0.5rem;
+      color: var(--ngp-text-primary);
+      outline: none;
+      font-size: 14px;
+      font-weight: 500;
+      background-color: var(--ngp-background);
+      box-shadow: var(--ngp-button-shadow);
+      cursor: pointer;
+      transition: background-color 0.2s;
+    }
+
+    [ngpPaginationNext] {
+      all: unset;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 2rem;
+      height: 2rem;
+      border-radius: 0.5rem;
+      color: var(--ngp-text-primary);
+      outline: none;
+      font-size: 14px;
+      font-weight: 500;
+      background-color: var(--ngp-background);
+      box-shadow: var(--ngp-button-shadow);
+      cursor: pointer;
+      transition: background-color 0.2s;
+    }
+
+    [ngpPaginationLast] {
+      all: unset;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 2rem;
+      height: 2rem;
+      border-radius: 0.5rem;
+      color: var(--ngp-text-primary);
+      outline: none;
+      font-size: 14px;
+      font-weight: 500;
+      background-color: var(--ngp-background);
+      box-shadow: var(--ngp-button-shadow);
+      cursor: pointer;
+      transition: background-color 0.2s;
+    }
+  `,
+  host: {
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Pagination<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the pagination state */
+  protected readonly state = injectPaginationState();
+
+  /** Get the pages as an array we can iterate over */
+  protected readonly pages = computed(() =>
+    Array.from({ length: this.state().pageCount() }).map((_, i) => i + 1),
+  );
+
+  /** The onChange callback */
+  private onChange?: ChangeFn<number>;
+
+  /** The onTouched callback */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    this.state().pageChange.subscribe(value => this.onChange?.(value));
+  }
+
+  /** Write a new value to the control */
+  writeValue(value: number): void {
+    // writing a value from the model must not re-emit through onChange
+    this.state().setPage(value, { emit: false });
+  }
+
+  /** Register a callback to be called when the value changes */
+  registerOnChange(fn: ChangeFn<number>): void {
+    this.onChange = fn;
+  }
+
+  /** Register a callback to be called when the control is touched */
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  /** Reflect the form control's disabled state onto the pagination. */
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/password/password.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/password/password.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,79 @@
+import { Component, input, signal } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideEye, lucideEyeOff } from '@ng-icons/lucide';
+import { NgpButton } from 'ng-primitives/button';
+import {
+  injectPasswordState,
+  NgpPassword,
+  NgpPasswordInput,
+  NgpPasswordToggle,
+} from 'ng-primitives/password';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>password',
+  hostDirectives: [NgpPassword],
+  imports: [NgIcon, NgpPasswordInput, NgpPasswordToggle, NgpButton],
+  providers: [provideValueAccessor(Password<%= componentSuffix %>), provideIcons({ lucideEye, lucideEyeOff })],
+  template: `
+    <input class="[height:2.125rem] w-full rounded-lg [padding:0_40px_0_12px] border-none [background:var(--ngp-background)] text-(--ngp-text-primary) [font-size:0.875rem] [letter-spacing:-0.006em] shadow-(--ngp-input-shadow) [outline:none] data-focus:[outline:2px_solid_var(--ngp-focus-ring)] data-focus:[outline-offset:2px] placeholder:text-(--ngp-text-placeholder)"
+      [value]="value()"
+      [placeholder]="placeholder()"
+      (input)="onValueChange($event)"
+      ngpPasswordInput
+      type="password"
+      autocomplete="current-password"
+    />
+    <button class="absolute top-0 right-0 flex items-center justify-center [height:2.125rem] [width:2.125rem] border-none rounded-lg bg-transparent text-(--ngp-text-tertiary) [font-size:1.125rem] cursor-pointer [outline:none] [transition:color_150ms_cubic-bezier(0.4,_0,_0.2,_1)] data-hover:text-(--ngp-text-secondary) data-visible:text-(--ngp-primary) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:-2px] motion-reduce:[transition-duration:0s]" ngpButton ngpPasswordToggle>
+      <ng-icon [name]="state().visible() ? 'lucideEyeOff' : 'lucideEye'" />
+    </button>
+  `,
+  host: {
+    class: 'block relative',
+    '(focusout)': 'onFocusOut($event)',
+  },
+})
+export class Password<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the password state to read the visibility. */
+  protected readonly state = injectPasswordState();
+
+  /** The placeholder text */
+  readonly placeholder = input<string>('');
+
+  /** The current value */
+  protected value = signal<string>('');
+
+  /** The function to call when the value changes */
+  private onChange?: ChangeFn<string>;
+
+  /** The function to call when the control is touched */
+  protected onTouched?: TouchedFn;
+
+  writeValue(value: string): void {
+    this.value.set(value);
+  }
+
+  registerOnChange(fn: ChangeFn<string>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  protected onValueChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.value.set(input.value);
+    this.onChange?.(input.value);
+  }
+
+  protected onFocusOut(event: FocusEvent): void {
+    // only mark as touched when focus leaves the component, not when moving
+    // between the input and the toggle button
+    const host = event.currentTarget as HTMLElement;
+    if (!host.contains(event.relatedTarget as Node | null)) {
+      this.onTouched?.();
+    }
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/popover/popover-trigger.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/popover/popover-trigger.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,39 @@
+import { Directive, input } from '@angular/core';
+import { injectPopoverTriggerState } from 'ng-primitives/popover';
+import { NgpPopoverTrigger } from 'ng-primitives/popover';
+import { Popover<%= componentSuffix %> } from './popover<% if (fileSuffix) { %>.<%= dasherize(fileSuffix) %><% } %>';
+
+@Directive({
+  selector: '[<%= camelize(prefix + "PopoverTrigger") %>]',
+  hostDirectives: [
+    {
+      directive: NgpPopoverTrigger,
+      inputs: [
+        'ngpPopoverTriggerDisabled:<%= camelize(prefix + "PopoverTriggerDisabled") %>',
+        'ngpPopoverTriggerPlacement:<%= camelize(prefix + "PopoverTriggerPlacement") %>',
+        'ngpPopoverTriggerOffset:<%= camelize(prefix + "PopoverTriggerOffset") %>',
+        'ngpPopoverTriggerShowDelay:<%= camelize(prefix + "PopoverTriggerShowDelay") %>',
+        'ngpPopoverTriggerHideDelay:<%= camelize(prefix + "PopoverTriggerHideDelay") %>',
+        'ngpPopoverTriggerFlip:<%= camelize(prefix + "PopoverTriggerFlip") %>',
+        'ngpPopoverTriggerContainer:<%= camelize(prefix + "PopoverTriggerContainer") %>',
+        'ngpPopoverTriggerCloseOnOutsideClick:<%= camelize(prefix + "PopoverTriggerCloseOnOutsideClick") %>',
+        'ngpPopoverTriggerCloseOnEscape:<%= camelize(prefix + "PopoverTriggerCloseOnEscape") %>',
+        'ngpPopoverTriggerScrollBehavior:<%= camelize(prefix + "PopoverTriggerScrollBehavior") %>',
+        'ngpPopoverTriggerContext:<%= camelize(prefix + "PopoverTrigger") %>',
+      ],
+    },
+  ],
+})
+export class PopoverTrigger {
+  /** Access the popover trigger */
+  private readonly popoverTrigger = injectPopoverTriggerState();
+
+  /** Define the content of the popover */
+  readonly content = input.required<string>({
+    alias: '<%= camelize(prefix + "PopoverTrigger") %>',
+  });
+
+  constructor() {
+    this.popoverTrigger().setPopover(Popover<%= componentSuffix %>);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/popover/popover.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/popover/popover.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,61 @@
+import { Component } from '@angular/core';
+import { injectPopoverContext, NgpPopover } from 'ng-primitives/popover';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>popover',
+  hostDirectives: [NgpPopover],
+  host: {
+    class: 'absolute max-w-64 rounded-lg bg-(--ngp-background-inverse) py-2 px-3 border-none [font-size:0.75rem] font-medium text-(--ngp-text-inverse) [transform-origin:var(--ngp-popover-transform-origin)]',
+  },
+  template: `
+    {{ content() }}
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host[data-enter] {
+      animation: popover-show 200ms ease-in-out;
+    }
+
+    :host[data-exit] {
+      animation: popover-hide 200ms ease-in-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-enter] {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
+
+    @keyframes popover-show {
+        0% {
+          opacity: 0;
+          transform: scale(0.5);
+        }
+        100% {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+
+    @keyframes popover-hide {
+        0% {
+          opacity: 1;
+          transform: scale(1);
+        }
+        100% {
+          opacity: 0;
+          transform: scale(0.5);
+        }
+      }
+  `,
+})
+export class Popover<%= componentSuffix %> {
+  readonly content = injectPopoverContext();
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/progress/progress.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/progress/progress.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,40 @@
+import { NumberInput } from '@angular/cdk/coercion';
+import { Component, input, numberAttribute } from '@angular/core';
+import {
+  NgpProgress,
+  NgpProgressIndicator,
+  NgpProgressLabel,
+  NgpProgressTrack,
+  NgpProgressValue,
+} from 'ng-primitives/progress';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>progress',
+  hostDirectives: [
+    {
+      directive: NgpProgress,
+      inputs: ['ngpProgressValue:value', 'ngpProgressMax:max', 'ngpProgressValueLabel:valueLabel'],
+    },
+  ],
+  imports: [NgpProgressIndicator, NgpProgressTrack, NgpProgressLabel, NgpProgressValue],
+  host: {
+    class: 'grid [grid-template-columns:1fr_1fr] [grid-row-gap:0.5rem] w-50 box-border p-2',
+  },
+  template: `
+    <label class="text-(--ngp-text-emphasis) [font-size:14px] font-semibold" ngpProgressLabel>{{ label() }}</label>
+    <span class="text-(--ngp-text-secondary) [font-size:14px] font-medium [text-align:right] [grid-column-start:2] [text-align:end]" ngpProgressValue>{{ value() }}%</span>
+
+    <div class="[grid-column:1_/_3] relative h-3 w-full max-w-80 overflow-hidden rounded-lg border border-(--ngp-border) bg-(--ngp-background)" ngpProgressTrack>
+      <div class="h-full rounded-lg bg-(--ngp-background-inverse) [transition:width_150ms_cubic-bezier(0.4,_0,_0.2,_1)] motion-reduce:[transition-duration:0s]" ngpProgressIndicator></div>
+    </div>
+  `,
+})
+export class Progress<%= componentSuffix %> {
+  /** The value of the progress. */
+  readonly value = input<number, NumberInput>(0, {
+    transform: numberAttribute,
+  });
+
+  /** The label of the progress. */
+  readonly label = input.required<string>();
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/radio/radio-group.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/radio/radio-group.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,68 @@
+import { Component } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { injectRadioGroupState, NgpRadioGroup } from 'ng-primitives/radio';
+import {
+  ChangeFn,
+  provideValueAccessor,
+  safeTakeUntilDestroyed,
+  TouchedFn,
+} from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>radio-group',
+  hostDirectives: [
+    {
+      directive: NgpRadioGroup,
+      inputs: [
+        'ngpRadioGroupValue:value',
+        'ngpRadioGroupDisabled:disabled',
+        'ngpRadioGroupOrientation:orientation',
+      ],
+      outputs: ['ngpRadioGroupValueChange:valueChange'],
+    },
+  ],
+  providers: [provideValueAccessor(RadioGroup<%= componentSuffix %>)],
+  template: `
+    <ng-content />
+  `,
+  host: {
+    class: 'flex flex-col gap-y-4',
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class RadioGroup<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the radio group state */
+  protected readonly state = injectRadioGroupState<string>();
+
+  /** The on change callback */
+  private onChange?: ChangeFn<string | null>;
+
+  /** The on touched callback */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    this.state()
+      .valueChange.pipe(safeTakeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value));
+  }
+
+  /** Write a new value to the radio group */
+  writeValue(value: string | null): void {
+    this.state().setValue(value, { emit: false });
+  }
+
+  /** Register the on change callback */
+  registerOnChange(onChange: ChangeFn<string | null>): void {
+    this.onChange = onChange;
+  }
+
+  /** Register the on touched callback */
+  registerOnTouched(onTouched: TouchedFn): void {
+    this.onTouched = onTouched;
+  }
+
+  /** Set the disabled state of the radio group */
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/radio/radio-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/radio/radio-item.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,36 @@
+import { Component } from '@angular/core';
+import { NgpRadioItem } from 'ng-primitives/radio';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>radio-item',
+  hostDirectives: [
+    {
+      directive: NgpRadioItem,
+      inputs: ['ngpRadioItemValue:value', 'ngpRadioItemDisabled:disabled'],
+    },
+  ],
+  host: {
+    class: 'grid cursor-pointer [grid-template-columns:auto_1fr] [grid-template-rows:repeat(2,_auto)] [column-gap:0.625rem] [row-gap:0.125rem] rounded-lg bg-(--ngp-background) py-3 px-4 shadow-(--ngp-button-shadow) [outline:none] data-hover:bg-(--ngp-background-hover) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:2px] data-press:bg-(--ngp-background-active) data-checked:bg-(--ngp-background-inverse)',
+  },
+  template: `
+    <div class="inline-flex [grid-column-start:1] [grid-row-start:1] justify-center items-center [align-self:center] rounded-full w-4 h-4 border border-(--ngp-border)" ngpRadioIndicator>
+      <span class="indicator-dot w-2 h-2 rounded-full bg-transparent"></span>
+    </div>
+
+    <p class="title [grid-column-start:2] [grid-row-start:1] font-medium text-(--ngp-text-primary) m-0">
+      <ng-content />
+    </p>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host[data-checked] .indicator-dot {
+      background-color: var(--ngp-background);
+    }
+
+    :host[data-checked] .title {
+      color: var(--ngp-text-inverse);
+    }
+  `,
+})
+export class RadioItem<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/range-slider/range-slider.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/range-slider/range-slider.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,90 @@
+import { Component, input } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor } from '@angular/forms';
+import {
+  injectRangeSliderState,
+  NgpRangeSlider,
+  NgpRangeSliderRange,
+  NgpRangeSliderThumb,
+  NgpRangeSliderTrack,
+  provideRangeSliderState,
+} from 'ng-primitives/slider';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+import { merge } from 'rxjs';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>range-slider',
+  hostDirectives: [
+    {
+      directive: NgpRangeSlider,
+      inputs: [
+        'ngpRangeSliderLow:low',
+        'ngpRangeSliderHigh:high',
+        'ngpRangeSliderMin:min',
+        'ngpRangeSliderMax:max',
+        'ngpRangeSliderStep:step',
+        'ngpRangeSliderDisabled:disabled',
+        'ngpRangeSliderOrientation:orientation',
+      ],
+      outputs: ['ngpRangeSliderLowChange:lowChange', 'ngpRangeSliderHighChange:highChange'],
+    },
+  ],
+  imports: [NgpRangeSliderTrack, NgpRangeSliderRange, NgpRangeSliderThumb],
+  providers: [provideRangeSliderState(), provideValueAccessor(RangeSlider<%= componentSuffix %>)],
+  template: `
+    <div class="relative [height:5px] w-full [border-radius:999px] bg-(--ngp-background-secondary)" ngpRangeSliderTrack>
+      <div class="absolute h-full [border-radius:999px] bg-(--ngp-background-inverse)" ngpRangeSliderRange></div>
+    </div>
+    <div class="absolute block h-5 w-5 [border-radius:10px] [background-color:white] shadow-(--ngp-button-shadow) [outline:none] [transform:translateX(-50%)] data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:0] data-[thumb=high]:z-2" ngpRangeSliderThumb></div>
+    <div class="absolute block h-5 w-5 [border-radius:10px] [background-color:white] shadow-(--ngp-button-shadow) [outline:none] [transform:translateX(-50%)] data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:0] data-[thumb=high]:z-2" ngpRangeSliderThumb></div>
+  `,
+  host: {
+    class: 'flex relative w-50 h-5 [touch-action:none] select-none items-center',
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class RangeSlider<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the range slider state */
+  private readonly state = injectRangeSliderState();
+
+  /** Forward aria-labels to each thumb */
+  readonly ariaLabelLow = input<string | null>(null);
+  readonly ariaLabelHigh = input<string | null>(null);
+
+  /** The onChange callback function. */
+  private onChange?: ChangeFn<[number, number]>;
+
+  /** The onTouched callback function. */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    // Whenever either value changes, call the onChange function with the new tuple [low, high].
+    merge(this.state().lowChange, this.state().highChange)
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => this.onChange?.([this.state().low(), this.state().high()]));
+  }
+
+  writeValue(value: [number, number]): void {
+    if (!value || value.length !== 2) {
+      return;
+    }
+
+    const [low, high] = value;
+    // Use the directive's clamping setters to respect min/max and ordering.
+    // writing a value from the model must not re-emit through onChange
+    this.state().setLowValue(low, { emit: false });
+    this.state().setHighValue(high, { emit: false });
+  }
+
+  registerOnChange(fn: ChangeFn<[number, number]>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/rating/rating.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/rating/rating.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,73 @@
+import { Component } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroStarSolid } from '@ng-icons/heroicons/solid';
+import { injectRatingState, NgpRating, NgpRatingItem } from 'ng-primitives/rating';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>rating',
+  hostDirectives: [
+    {
+      directive: NgpRating,
+      inputs: [
+        'ngpRatingValue:value',
+        'ngpRatingCount:count',
+        'ngpRatingAllowHalf:allowHalf',
+        'ngpRatingDisabled:disabled',
+        'ngpRatingReadonly:readonly',
+        'ngpRatingClearable:clearable',
+      ],
+      outputs: ['ngpRatingValueChange:valueChange'],
+    },
+  ],
+  imports: [NgIcon, NgpRatingItem],
+  providers: [provideIcons({ heroStarSolid }), provideValueAccessor(Rating<%= componentSuffix %>)],
+  template: `
+    <span class="star relative inline-flex [font-size:1.5rem] leading-none text-(--ngp-background-secondary) [transition:color_150ms_cubic-bezier(0.4,_0,_0.2,_1)] motion-reduce:[transition-duration:0s]" *ngpRatingItem="let star">
+      <ng-icon class="star-background" name="heroStarSolid" />
+      <span class="star-fill absolute [inset-block-start:0] [inset-inline-start:0] inline-flex overflow-hidden text-(--ngp-primary)" [style.width.%]="star.fraction * 100">
+        <ng-icon name="heroStarSolid" />
+      </span>
+    </span>
+  `,
+  host: {
+    class: 'inline-flex items-center gap-1 [outline:none] rounded-lg cursor-pointer data-disabled:cursor-not-allowed data-disabled:opacity-50 data-readonly:cursor-default data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:2px]',
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Rating<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the rating state. */
+  private readonly state = injectRatingState();
+
+  /** The onChange callback function. */
+  private onChange?: ChangeFn<number>;
+
+  /** The onTouched callback function. */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    // Whenever the user interacts with the rating, call onChange with the new value.
+    this.state()
+      .valueChange.pipe(takeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value));
+  }
+
+  writeValue(value: number): void {
+    // writing a value from the model must not re-emit through onChange
+    this.state().setValue(value, { emit: false });
+  }
+
+  registerOnChange(fn: ChangeFn<number>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/search/search.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/search/search.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,61 @@
+import { Component, input, model } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroMagnifyingGlass } from '@ng-icons/heroicons/outline';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpInput } from 'ng-primitives/input';
+import { NgpSearch, NgpSearchClear } from 'ng-primitives/search';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>search',
+  hostDirectives: [NgpSearch],
+  imports: [NgIcon, NgpSearchClear, NgpInput, NgpButton],
+  providers: [provideValueAccessor(Search<%= componentSuffix %>), provideIcons({ heroMagnifyingGlass })],
+  template: `
+    <ng-icon class="absolute [font-size:1.25rem] [top:18px] left-3 [transform:translateY(-50%)] text-(--ngp-text-tertiary)" name="heroMagnifyingGlass" />
+    <input class="h-9 w-full rounded-lg [padding:0_16px_0_40px] border-none [background:var(--ngp-background)] shadow-(--ngp-input-shadow) [outline:none] [&::-webkit-search-decoration]:hidden [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-results-button]:hidden [&::-webkit-search-results-decoration]:hidden data-focus:[outline:2px_solid_var(--ngp-focus-ring)] data-focus:[outline-offset:0px] placeholder:text-(--ngp-text-placeholder)"
+      [value]="query()"
+      [placeholder]="placeholder()"
+      (input)="onQueryChange($event)"
+      ngpInput
+      type="search"
+    />
+    <button class="absolute top-0 right-0 h-9 py-0 px-4 border-none [border-radius:0_8px_8px_0] bg-transparent text-(--ngp-text-blue) text-sm cursor-pointer [outline:none] hidden [&:not([data-empty])]:block" ngpSearchClear ngpButton aria-label="Clear search">Clear</button>
+  `,
+  host: {
+    class: 'block relative',
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Search<%= componentSuffix %> implements ControlValueAccessor {
+  /** The search query */
+  readonly query = model<string>('');
+
+  /** The placeholder text */
+  readonly placeholder = input<string>('');
+
+  /** The function to call when the value changes */
+  private onChange?: ChangeFn<string>;
+
+  /** The function to call when the control is touched */
+  protected onTouched?: TouchedFn;
+
+  writeValue(value: string): void {
+    this.query.set(value);
+  }
+
+  registerOnChange(fn: ChangeFn<string>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  protected onQueryChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.query.set(input.value);
+    this.onChange?.(input.value);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/select/select.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/select/select.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,138 @@
+import { Component, input } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronDown } from '@ng-icons/heroicons/outline';
+import {
+  injectSelectState,
+  NgpSelect,
+  NgpSelectDropdown,
+  NgpSelectOption,
+  NgpSelectPortal,
+} from 'ng-primitives/select';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>select',
+  hostDirectives: [
+    {
+      directive: NgpSelect,
+      inputs: ['ngpSelectValue:value', 'ngpSelectMultiple:multiple', 'ngpSelectDisabled:disabled'],
+      outputs: ['ngpSelectValueChange:valueChange'],
+    },
+  ],
+  providers: [provideIcons({ heroChevronDown }), provideValueAccessor(Select<%= componentSuffix %>)],
+  imports: [NgpSelectDropdown, NgpSelectOption, NgpSelectPortal, NgIcon],
+  template: `
+    @if (state().value(); as value) {
+      <span class="select-value flex items-center flex-1 py-0 px-4 bg-transparent text-(--ngp-text-primary) [font-family:inherit] [font-size:14px] py-0 px-4 h-full">{{ value }}</span>
+    } @else {
+      <span class="select-placeholder flex items-center flex-1 py-0 px-4 bg-transparent text-(--ngp-text-primary) [font-family:inherit] [font-size:14px] py-0 px-4 h-full text-(--ngp-text-secondary)">{{ placeholder() }}</span>
+    }
+
+    <ng-icon class="inline-flex justify-center items-center h-full mx-2 [font-size:14px]" name="heroChevronDown" />
+
+    <div class="bg-(--ngp-background) border border-(--ngp-border) p-1 rounded-xl [outline:none] absolute animate-[popover-show_0.1s_ease-out] [width:var(--ngp-select-width)] shadow-(--ngp-shadow-lg) box-border mt-1 max-h-60 overflow-y-auto [transform-origin:var(--ngp-select-transform-origin)] motion-reduce:[animation-duration:0s]" *ngpSelectPortal ngpSelectDropdown>
+      @for (option of options(); track option) {
+        <div class="flex items-center gap-2 [padding:0.375rem_0.75rem] cursor-pointer rounded-lg w-full h-9 [font-size:14px] text-(--ngp-text-primary) box-border data-hover:bg-(--ngp-background-hover) data-press:bg-(--ngp-background-active) data-active:bg-(--ngp-background-active)" [ngpSelectOptionValue]="option" ngpSelectOption>
+          {{ option }}
+        </div>
+      } @empty {
+        <div class="empty-message flex justify-center items-center p-2 text-(--ngp-text-secondary) [font-size:14px] font-medium text-center">No options found</div>
+      }
+    </div>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    [ngpSelectDropdown][data-enter] {
+      animation: select-show 0.1s ease-out;
+    }
+
+    [ngpSelectDropdown][data-exit] {
+      animation: select-hide 0.1s ease-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      [ngpSelectDropdown][data-enter] {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      [ngpSelectDropdown][data-exit] {
+        animation-duration: 0s;
+      }
+    }
+
+    @keyframes select-show {
+        0% {
+          opacity: 0;
+          transform: translateY(-10px) scale(0.9);
+        }
+        100% {
+          opacity: 1;
+          transform: translateY(0) scale(1);
+        }
+      }
+
+    @keyframes select-hide {
+        0% {
+          opacity: 1;
+          transform: translateY(0) scale(1);
+        }
+        100% {
+          opacity: 0;
+          transform: translateY(-10px) scale(0.9);
+        }
+      }
+  `,
+  host: {
+    class: 'flex justify-between items-center h-9 w-75 rounded-lg border-none bg-(--ngp-background) shadow-(--ngp-input-shadow) box-border data-focus:[outline:2px_solid_var(--ngp-focus-ring)] data-focus:[outline-offset:2px]',
+    '[attr.aria-label]': 'ariaLabel() || null',
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Select<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the underlying select primitive state. */
+  protected readonly state = injectSelectState<string>();
+
+  /** The options for the select. */
+  readonly options = input<string[]>([]);
+
+  /** The placeholder for the input. */
+  readonly placeholder = input<string>('');
+
+  /** The accessible label for the select trigger. */
+  readonly ariaLabel = input<string>('');
+
+  /** Form change callback. */
+  private onChange?: ChangeFn<string | undefined>;
+
+  /** Form touched callback. */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    // Forward primitive value changes (user-driven selections) to the form.
+    this.state()
+      .valueChange.pipe(takeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value as string | undefined));
+  }
+
+  writeValue(value: string | undefined): void {
+    // Pass { emit: false } so writeValue doesn't bounce back through onChange.
+    this.state().setValue(value, { emit: false });
+  }
+
+  registerOnChange(fn: ChangeFn<string | undefined>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/separator/separator.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/separator/separator.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { NgpSeparator } from 'ng-primitives/separator';
+
+@Component({
+  selector: '[<% if (prefix) { %><%= prefix %>-<% } %>separator]',
+  hostDirectives: [{ directive: NgpSeparator, inputs: ['ngpSeparatorOrientation:orientation'] }],
+  host: {
+    class: 'bg-(--ngp-border) [height:1px]',
+  },
+  template: ``,
+})
+export class Separator<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/slider/slider.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/slider/slider.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,82 @@
+import { Component, input } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor } from '@angular/forms';
+import {
+  injectSliderState,
+  NgpSlider,
+  NgpSliderRange,
+  NgpSliderThumb,
+  NgpSliderTrack,
+} from 'ng-primitives/slider';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>slider',
+  hostDirectives: [
+    {
+      directive: NgpSlider,
+      inputs: [
+        'ngpSliderValue:value',
+        'ngpSliderMin:min',
+        'ngpSliderMax:max',
+        'ngpSliderDisabled:disabled',
+      ],
+      outputs: ['ngpSliderValueChange:valueChange'],
+    },
+  ],
+  imports: [NgpSliderTrack, NgpSliderRange, NgpSliderThumb],
+  providers: [provideValueAccessor(Slider<%= componentSuffix %>)],
+  template: `
+    <div class="relative [height:5px] w-full [border-radius:999px] bg-(--ngp-background-secondary)" ngpSliderTrack>
+      <div class="absolute h-full [border-radius:999px] bg-(--ngp-background-inverse)" ngpSliderRange></div>
+    </div>
+    <div class="absolute block h-5 w-5 [border-radius:10px] [background-color:white] shadow-(--ngp-button-shadow) [outline:none] [transform:translateX(-50%)] data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:0]" [ariaLabel]="ariaLabel()" ngpSliderThumb></div>
+  `,
+  host: {
+    class: 'flex relative w-50 h-5 [touch-action:none] select-none items-center',
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Slider<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the slider state */
+  private readonly state = injectSliderState();
+
+  /** Forward the aria-label to the thumb */
+  readonly ariaLabel = input<string | null>(null, {
+    alias: 'aria-label',
+  });
+
+  /**
+   * The onChange callback function.
+   */
+  private onChange?: ChangeFn<number>;
+
+  /**
+   * The onTouched callback function.
+   */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    // Whenever the user interacts with the slider, call the onChange function with the new value.
+    this.state()
+      .valueChange.pipe(takeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value));
+  }
+
+  writeValue(value: number): void {
+    // writing a value from the model must not re-emit through onChange
+    this.state().setValue(value, { emit: false });
+  }
+
+  registerOnChange(fn: ChangeFn<number>): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/switch/switch.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/switch/switch.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,63 @@
+import { Component } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor } from '@angular/forms';
+import { injectSwitchState, NgpSwitch, NgpSwitchThumb } from 'ng-primitives/switch';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>switch',
+  hostDirectives: [
+    {
+      directive: NgpSwitch,
+      inputs: ['ngpSwitchChecked:checked', 'ngpSwitchDisabled:disabled'],
+      outputs: ['ngpSwitchCheckedChange:checkedChange'],
+    },
+  ],
+  imports: [NgpSwitchThumb],
+  template: `
+    <span class="block h-5 w-5 [border-radius:999px] [background-color:white] shadow-(--ngp-button-shadow) [outline:none] [transition:transform_150ms_cubic-bezier(0.4,_0,_0.2,_1)] [transform:translateX(1px)] box-border data-checked:[transform:translateX(17px)] motion-reduce:[transition-duration:0s]" ngpSwitchThumb></span>
+  `,
+  providers: [provideValueAccessor(Switch<%= componentSuffix %>)],
+  host: {
+    class: 'inline-flex items-center relative w-10 h-6 [border-radius:999px] bg-(--ngp-background-secondary) border border-(--ngp-border) p-0 [outline:none] [transition-property:color,_background-color,_border-color,_text-decoration-color,_fill,_stroke] [transition-timing-function:cubic-bezier(0.4,_0,_0.2,_1)] [transition-duration:150ms] box-border data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-checked:bg-(--ngp-background-blue) data-checked:border-(--ngp-border-blue) motion-reduce:[transition-duration:0s]',
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Switch<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the switch state. */
+  private readonly switch = injectSwitchState();
+
+  /** The on change callback */
+  private onChange?: ChangeFn<boolean>;
+
+  /** The on touched callback */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    // Any time the switch changes, update the form value.
+    this.switch()
+      .checkedChange.pipe(takeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value));
+  }
+
+  /** Write a new value to the switch. */
+  writeValue(value: boolean): void {
+    // writing a value from the model must not re-emit through onChange
+    this.switch().setChecked(value, { emit: false });
+  }
+
+  /** Register a callback function to be called when the value changes. */
+  registerOnChange(fn: ChangeFn<boolean>): void {
+    this.onChange = fn;
+  }
+
+  /** Register a callback function to be called when the switch is touched. */
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  /** Set the disabled state of the switch. */
+  setDisabledState(isDisabled: boolean): void {
+    this.switch().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/tabs/tab.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/tabs/tab.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,26 @@
+import { Component, input, TemplateRef, viewChild } from '@angular/core';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>tab',
+  template: `
+    <ng-template #content>
+      <ng-content />
+    </ng-template>
+  `,
+})
+export class Tab<%= componentSuffix %> {
+  /**
+   * The value of the tab.
+   */
+  readonly value = input<string>();
+
+  /**
+   * The label of the tab.
+   */
+  readonly label = input<string>();
+
+  /**
+   * The content of the tab.
+   */
+  readonly content = viewChild.required<TemplateRef<void>>('content');
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/tabs/tabs.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/tabs/tabs.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,35 @@
+import { NgTemplateOutlet } from '@angular/common';
+import { Component, contentChildren, model } from '@angular/core';
+import { NgpTabButton, NgpTabList, NgpTabPanel, NgpTabset } from 'ng-primitives/tabs';
+import { Tab<%= componentSuffix %> } from './tab<% if (fileSuffix) { %>.<%= dasherize(fileSuffix) %><% } %>';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>tabs',
+  imports: [NgpTabset, NgpTabButton, NgpTabList, NgpTabPanel, NgTemplateOutlet],
+  template: `
+    <div class="w-full max-w-128 rounded-xl bg-(--ngp-background) py-1 px-4 shadow-(--ngp-button-shadow)" [(ngpTabsetValue)]="value" ngpTabset>
+      <div class="flex gap-6 border-b border-(--ngp-border)" ngpTabList>
+        @for (tab of tabs(); track tab.label()) {
+          <button class="border-none bg-transparent [margin-bottom:-1px] [border-bottom:2px_solid_transparent] py-2 px-0 [outline:none] [transition:background-color_150ms_cubic-bezier(0.4,_0,_0.2,_1)] data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:2px] data-active:border-(--ngp-background-inverse) data-active:text-(--ngp-text-primary) motion-reduce:[transition-duration:0s]" [ngpTabButtonValue]="tab.value()" ngpTabButton>{{ tab.label() }}</button>
+        }
+      </div>
+
+      @for (tab of tabs(); track tab.label()) {
+        <div class="py-2 px-0 [outline:none] [&:not([data-active])]:hidden" [ngpTabPanelValue]="tab.value()" ngpTabPanel>
+          <ng-container [ngTemplateOutlet]="tab.content()" />
+        </div>
+      }
+    </div>
+  `,
+})
+export class Tabs<%= componentSuffix %> {
+  /**
+   * The value of the selected tab.
+   */
+  readonly value = model<string>();
+
+  /**
+   * The tabs in the group.
+   */
+  readonly tabs = contentChildren(Tab<%= componentSuffix %>);
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/textarea/textarea.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/textarea/textarea.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { NgpTextarea } from 'ng-primitives/textarea';
+
+@Component({
+  selector: 'textarea[<% if (prefix) { %><%= prefix %>-<% } %>textarea]',
+  hostDirectives: [{ directive: NgpTextarea, inputs: ['disabled'] }],
+  host: {
+    class: 'h-18 [width:90%] rounded-lg py-2 px-3 border-none shadow-(--ngp-input-shadow) [outline:none] [font-family:inherit] data-focus:[outline:2px_solid_var(--ngp-focus-ring)] data-focus:[outline-offset:0] placeholder:text-(--ngp-text-placeholder)',
+  },
+  template: `
+    <ng-content />
+  `,
+})
+export class Textarea<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toast/toast.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toast/toast.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,152 @@
+import { Component, inject } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import { injectToastContext, NgpToast, NgpToastManager } from 'ng-primitives/toast';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>toast',
+  imports: [NgpButton],
+  hostDirectives: [NgpToast],
+  host: {
+    class: 'absolute [touch-action:none] box-border items-center [gap:6px] [display:inline-grid] [background:var(--ngp-background)] shadow-(--ngp-shadow) border border-(--ngp-border) py-3 px-4 opacity-0 rounded-lg [z-index:var(--ngp-toast-z-index)] [grid-template-columns:1fr_auto] [grid-template-rows:min-content_min-content] gap-x-3 items-center [width:350px] h-fit [transform:var(--y)] [transition:all_0.4s_cubic-bezier(0.215,_0.61,_0.355,_1)] data-[position-x=end]:right-0 data-[position-x=start]:left-0 data-[visible=false]:opacity-0 data-[visible=false]:pointer-events-none data-[expanded=true]:after:[content:\'\'] data-[expanded=true]:after:absolute data-[expanded=true]:after:left-0 data-[expanded=true]:after:[height:calc(var(--ngp-toast-gap)_+_1px)] data-[expanded=true]:after:[bottom:100%] data-[expanded=true]:after:w-full data-[swiping=true]:[transform:var(--y)_translateY(var(--ngp-toast-swipe-amount-y,_0))_translateX(var(--ngp-toast-swipe-amount-x,_0))] data-[swiping=true]:[transition:none] data-[swiping=true]:data-[swipe-direction=left]:[opacity:calc(1_-_clamp(0,_((-1_*_var(--ngp-toast-swipe-x,_0px))_-_45)_/_55,_1))] data-[swiping=true]:data-[swipe-direction=right]:[opacity:calc(1_-_clamp(0,_(var(--ngp-toast-swipe-x,_0px)_-_45)_/_55,_1))] data-[swiping=true]:data-[swipe-direction=top]:[opacity:calc(1_-_clamp(0,_((-1_*_var(--ngp-toast-swipe-y,_0px))_-_45)_/_55,_1))] data-[swiping=true]:data-[swipe-direction=bottom]:[opacity:calc(1_-_clamp(0,_(var(--ngp-toast-swipe-y,_0px)_-_45)_/_55,_1))] motion-reduce:[transition-duration:0s]',
+    'animate.enter': 'toast-enter',
+    'animate.leave': 'toast-leave',
+  },
+  template: `
+    <p class="toast-title text-(--ngp-text-primary) [font-size:0.75rem] font-semibold m-0 [grid-column:1_/_2] [grid-row:1] [line-height:16px] select-none">{{ context.header }}</p>
+    <p class="toast-description [font-size:0.75rem] m-0 text-(--ngp-text-secondary) [grid-column:1_/_2] [grid-row:2] [line-height:16px] select-none">{{ context.description }}</p>
+    <button class="toast-dismiss [background:var(--ngp-background-inverse)] text-(--ngp-text-inverse) border-none rounded-lg py-1 px-2 font-semibold [font-size:12px] cursor-pointer [grid-column:2_/_3] [grid-row:1_/_3] [max-height:27px]" (click)="dismiss()" ngpButton>Dismiss</button>
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host[data-position-y='top'] {
+      top: 0;
+      --lift: 1;
+      --lift-amount: calc(var(--lift) * var(--ngp-toast-gap));
+      --y: translateY(-100%);
+    }
+
+    :host[data-position-y='bottom'] {
+      bottom: 0;
+      --lift: -1;
+      --lift-amount: calc(var(--lift) * var(--ngp-toast-gap));
+      --y: translateY(100%);
+    }
+
+    :host[data-enter] {
+      opacity: 1;
+      --y: translateY(0);
+    }
+
+    :host[data-exit] {
+      opacity: 0;
+      --y: translateY(calc(calc(var(--lift) * var(--ngp-toast-gap)) * -1));
+    }
+
+    :host[data-expanded='false'][data-front='false'] {
+      --scale: var(--ngp-toasts-before) * 0.05 + 1;
+      --y: translateY(calc(var(--lift-amount) * var(--ngp-toasts-before)))
+            scale(calc(-1 * var(--scale)));
+      height: var(--ngp-toast-front-height);
+    }
+
+    :host[data-expanded='true'] {
+      --y: translateY(calc(var(--lift) * var(--ngp-toast-offset)));
+      height: auto;
+    }
+
+    :host[data-front='false'][data-expanded='false'] .toast-title {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    :host[data-front='false'][data-expanded='false'] .toast-description {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    :host[data-position-y='bottom'].toast-enter {
+      animation: toast-slide-in-bottom 400ms cubic-bezier(0.215, 0.61, 0.355, 1);
+    }
+
+    :host[data-position-y='bottom'].toast-leave {
+      opacity: 0;
+      transform: translateY(100%);
+      transition: opacity 400ms cubic-bezier(0.215, 0.61, 0.355, 1),
+            transform 400ms cubic-bezier(0.215, 0.61, 0.355, 1);
+    }
+
+    :host[data-position-y='top'].toast-enter {
+      animation: toast-slide-in-top 400ms cubic-bezier(0.215, 0.61, 0.355, 1);
+    }
+
+    :host[data-position-y='top'].toast-leave {
+      opacity: 0;
+      transform: translateY(-100%);
+      transition: opacity 400ms cubic-bezier(0.215, 0.61, 0.355, 1),
+            transform 400ms cubic-bezier(0.215, 0.61, 0.355, 1);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-position-y='bottom'].toast-enter {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-position-y='top'].toast-enter {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-position-y='bottom'].toast-leave {
+        transition-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-position-y='top'].toast-leave {
+        transition-duration: 0s;
+      }
+    }
+
+    @keyframes toast-slide-in-bottom {
+        from {
+          opacity: 0;
+          transform: translateY(100%);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+
+    @keyframes toast-slide-in-top {
+        from {
+          opacity: 0;
+          transform: translateY(-100%);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+  `,
+})
+export class Toast<%= componentSuffix %> {
+  private readonly toastManager = inject(NgpToastManager);
+  private readonly toast = inject(NgpToast);
+  protected readonly context = injectToastContext<ToastContext>();
+
+  dismiss(): void {
+    this.toastManager.dismiss(this.toast);
+  }
+}
+
+interface ToastContext {
+  header: string;
+  description: string;
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toggle-group/toggle-group-item.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toggle-group/toggle-group-item.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpToggleGroupItem } from 'ng-primitives/toggle-group';
+
+@Component({
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>toggle-group-item]',
+  hostDirectives: [
+    {
+      directive: NgpToggleGroupItem,
+      inputs: ['ngpToggleGroupItemValue:value', 'ngpToggleGroupItemDisabled:disabled'],
+    },
+    {
+      directive: NgpButton,
+      inputs: ['disabled'],
+    },
+  ],
+  host: {
+    class: 'flex w-8 h-8 items-center justify-center rounded [border:1px_solid_transparent] bg-transparent [outline:none] [transition:background-color_150ms_cubic-bezier(0.4,_0,_0.2,_1)] box-border text-(--ngp-text-primary) [font-size:1.125rem] data-hover:bg-(--ngp-background-hover) data-hover:border-(--ngp-border) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-press:bg-(--ngp-background-active) data-selected:bg-(--ngp-background-inverse) data-selected:text-(--ngp-text-inverse) data-selected:[border-color:transparent] motion-reduce:[transition-duration:0s]',
+  },
+  template: `
+    <ng-content />
+  `,
+})
+export class ToggleGroupItem<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toggle-group/toggle-group.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toggle-group/toggle-group.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,66 @@
+import { Component } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor } from '@angular/forms';
+import { injectToggleGroupState, NgpToggleGroup } from 'ng-primitives/toggle-group';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>toggle-group',
+  hostDirectives: [
+    {
+      directive: NgpToggleGroup,
+      inputs: [
+        'ngpToggleGroupOrientation:orientation',
+        'ngpToggleGroupType:type',
+        'ngpToggleGroupValue:value',
+        'ngpToggleGroupDisabled:disabled',
+      ],
+      outputs: ['ngpToggleGroupValueChange:valueChange'],
+    },
+  ],
+  template: `
+    <ng-content />
+  `,
+  providers: [provideValueAccessor(ToggleGroup<%= componentSuffix %>)],
+  host: {
+    class: 'inline-flex gap-x-1 items-center rounded-md bg-(--ngp-background) shadow-(--ngp-button-shadow) p-1',
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class ToggleGroup<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the toggle state. */
+  private readonly toggleGroup = injectToggleGroupState();
+
+  /** The on change callback */
+  private onChange?: ChangeFn<string[]>;
+
+  /** The on touched callback */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    // Any time the toggle group changes, update the form value.
+    this.toggleGroup()
+      .valueChange.pipe(takeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value));
+  }
+
+  /** Write a new value to the toggle group. */
+  writeValue(value: string[] | null): void {
+    this.toggleGroup().setValue(value ?? [], { emit: false });
+  }
+
+  /** Register a callback function to be called when the value changes. */
+  registerOnChange(fn: ChangeFn<string[]>): void {
+    this.onChange = fn;
+  }
+
+  /** Register a callback function to be called when the toggle group is touched. */
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  /** Set the disabled state of the toggle group. */
+  setDisabledState(isDisabled: boolean): void {
+    this.toggleGroup().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toggle/toggle.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toggle/toggle.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,63 @@
+import { Component } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ControlValueAccessor } from '@angular/forms';
+import { NgpButton } from 'ng-primitives/button';
+import { injectToggleState, NgpToggle } from 'ng-primitives/toggle';
+import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
+
+@Component({
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>toggle]',
+  hostDirectives: [
+    {
+      directive: NgpToggle,
+      inputs: ['ngpToggleSelected:selected', 'ngpToggleDisabled:disabled'],
+      outputs: ['ngpToggleSelectedChange:selectedChange'],
+    },
+    { directive: NgpButton, inputs: ['disabled'] },
+  ],
+  template: `
+    <ng-content />
+  `,
+  providers: [provideValueAccessor(Toggle<%= componentSuffix %>)],
+  host: {
+    class: 'pl-4 pr-4 rounded-lg text-(--ngp-text-primary) border-none [outline:none] h-10 font-medium bg-(--ngp-background) [transition:background-color_300ms_cubic-bezier(0.4,_0,_0.2,_1)] shadow-(--ngp-button-shadow) data-hover:bg-(--ngp-background-hover) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-focus-visible:[outline-offset:2px] data-press:bg-(--ngp-background-active) data-selected:bg-(--ngp-background-inverse) data-selected:text-(--ngp-text-inverse) motion-reduce:[transition-duration:0s]',
+    '(focusout)': 'onTouched?.()',
+  },
+})
+export class Toggle<%= componentSuffix %> implements ControlValueAccessor {
+  /** Access the toggle state. */
+  private readonly toggle = injectToggleState();
+
+  /** The on change callback */
+  private onChange?: ChangeFn<boolean>;
+
+  /** The on touched callback */
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    // Any time the toggle changes, update the form value.
+    this.toggle()
+      .selectedChange.pipe(takeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value));
+  }
+
+  /** Write a new value to the toggle. */
+  writeValue(value: boolean): void {
+    this.toggle().setSelected(value, { emit: false });
+  }
+
+  /** Register a callback function to be called when the value changes. */
+  registerOnChange(fn: ChangeFn<boolean>): void {
+    this.onChange = fn;
+  }
+
+  /** Register a callback function to be called when the toggle is touched. */
+  registerOnTouched(fn: TouchedFn): void {
+    this.onTouched = fn;
+  }
+
+  /** Set the disabled state of the toggle. */
+  setDisabledState(isDisabled: boolean): void {
+    this.toggle().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toolbar/toolbar-button.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toolbar/toolbar-button.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpRovingFocusItem } from 'ng-primitives/roving-focus';
+
+@Component({
+  selector: 'button[<% if (prefix) { %><%= prefix %>-<% } %>toolbar-button]',
+  hostDirectives: [
+    { directive: NgpButton, inputs: ['disabled'] },
+    {
+      directive: NgpRovingFocusItem,
+      inputs: ['ngpRovingFocusItemDisabled:disabled'],
+    },
+  ],
+  host: {
+    class: 'flex w-8 h-8 items-center justify-center rounded [border:1px_solid_transparent] bg-transparent [outline:none] [transition:background-color_150ms_cubic-bezier(0.4,_0,_0.2,_1)] box-border text-(--ngp-text-primary) cursor-pointer data-hover:bg-(--ngp-background-hover) data-hover:border-(--ngp-border) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)] data-press:bg-(--ngp-background-active) data-selected:bg-(--ngp-background-inverse) data-selected:text-(--ngp-text-inverse) motion-reduce:[transition-duration:0s]',
+    type: 'button',
+  },
+  template: `
+    <ng-content />
+  `,
+})
+export class ToolbarButton<%= componentSuffix %> {}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toolbar/toolbar.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/toolbar/toolbar.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { injectToolbarState, NgpToolbar } from 'ng-primitives/toolbar';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>toolbar',
+  hostDirectives: [{ directive: NgpToolbar, inputs: ['ngpToolbarOrientation:orientation'] }],
+  host: {
+    class: 'flex gap-x-1 items-center rounded-md bg-(--ngp-background) shadow-(--ngp-button-shadow) p-1 data-[orientation=vertical]:flex-col data-[orientation=vertical]:gap-y-1',
+  },
+  template: `
+    <ng-content />
+  `,
+})
+export class Toolbar<%= componentSuffix %> {
+  /** Access the toolbar state */
+  private readonly toolbar = injectToolbarState();
+
+  constructor() {
+    // default to horizontal orientation
+    this.toolbar().setOrientation('horizontal');
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/tooltip/tooltip-trigger.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/tooltip/tooltip-trigger.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,37 @@
+import { Directive, input } from '@angular/core';
+import { injectTooltipTriggerState, NgpTooltipTrigger } from 'ng-primitives/tooltip';
+import { Tooltip<%= componentSuffix %> } from './tooltip<% if (fileSuffix) { %>.<%= dasherize(fileSuffix) %><% } %>';
+
+@Directive({
+  selector: '[<%= camelize(prefix + "TooltipTrigger") %>]',
+  hostDirectives: [
+    {
+      directive: NgpTooltipTrigger,
+      inputs: [
+        'ngpTooltipTriggerPlacement:<%= camelize(prefix + "TooltipTriggerPlacement") %>',
+        'ngpTooltipTriggerDisabled:<%= camelize(prefix + "TooltipTriggerDisabled") %>',
+        'ngpTooltipTriggerOffset:<%= camelize(prefix + "TooltipTriggerOffset") %>',
+        'ngpTooltipTriggerShowDelay:<%= camelize(prefix + "TooltipTriggerShowDelay") %>',
+        'ngpTooltipTriggerHideDelay:<%= camelize(prefix + "TooltipTriggerHideDelay") %>',
+        'ngpTooltipTriggerFlip:<%= camelize(prefix + "TooltipTriggerFlip") %>',
+        'ngpTooltipTriggerContainer:<%= camelize(prefix + "TooltipTriggerContainer") %>',
+        'ngpTooltipTriggerShowOnOverflow:<%= camelize(prefix + "TooltipTriggerShowOnOverflow") %>',
+        'ngpTooltipTriggerHoverableContent:<%= camelize(prefix + "TooltipTriggerHoverableContent") %>',
+        'ngpTooltipTriggerContext:<%= camelize(prefix + "TooltipTrigger") %>',
+      ],
+    },
+  ],
+})
+export class TooltipTrigger {
+  /** Access the tooltip trigger */
+  private readonly tooltipTrigger = injectTooltipTriggerState();
+
+  /** Define the content of the tooltip */
+  readonly content = input.required<string>({
+    alias: '<%= camelize(prefix + "TooltipTrigger") %>',
+  });
+
+  constructor() {
+    this.tooltipTrigger().setTooltip(Tooltip<%= componentSuffix %>);
+  }
+}

--- a/packages/ng-primitives/schematics/ng-generate/templates-tailwind/tooltip/tooltip.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates-tailwind/tooltip/tooltip.__fileSuffix@dasherize__.ts.template
@@ -1,0 +1,62 @@
+import { Component } from '@angular/core';
+import { injectTooltipContext, NgpTooltip } from 'ng-primitives/tooltip';
+
+@Component({
+  selector: '<% if (prefix) { %><%= prefix %>-<% } %>tooltip',
+  hostDirectives: [NgpTooltip],
+  host: {
+    class: 'absolute max-w-64 rounded-lg bg-(--ngp-background-inverse) py-2 px-3 border-none [font-size:0.75rem] font-medium text-(--ngp-text-inverse) [transform-origin:var(--ngp-tooltip-transform-origin)]',
+  },
+  template: `
+    {{ content() }}
+  `,
+  styles: `
+/* These styles rely on CSS variables that can be imported from ng-primitives/example-theme/index.css in your global styles */
+
+    :host[data-enter] {
+      animation: tooltip-show 200ms ease-in-out;
+    }
+
+    :host[data-exit] {
+      animation: tooltip-hide 200ms ease-in-out;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-enter] {
+        animation-duration: 0s;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      :host[data-exit] {
+        animation-duration: 0s;
+      }
+    }
+
+    @keyframes tooltip-show {
+        0% {
+          opacity: 0;
+          transform: scale(0.9);
+        }
+        100% {
+          opacity: 1;
+          transform: scale(1);
+        }
+      }
+
+    @keyframes tooltip-hide {
+        0% {
+          opacity: 1;
+          transform: scale(1);
+        }
+        100% {
+          opacity: 0;
+          transform: scale(0.9);
+        }
+      }
+  `,
+})
+export class Tooltip<%= componentSuffix %> {
+  /** Access the tooltip context where the content is stored. */
+  protected readonly content = injectTooltipContext<string>();
+}

--- a/packages/tools/src/generators/documentation/files/__name__.md.template
+++ b/packages/tools/src/generators/documentation/files/__name__.md.template
@@ -48,7 +48,10 @@ ng g ng-primitives:primitive <%= fileName %>
 - `prefix`: The prefix to apply to the generated component selector.
 - `component-suffix`: The suffix to apply to the generated component class name.
 - `file-suffix`: The suffix to apply to the generated component file name. Defaults to `component`.
-- `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
+- `styles`: How component styles should be generated.
+  - `css` (default): includes the full example styles.
+  - `tailwind`: styles the elements with Tailwind CSS classes instead, keeping a small CSS block only for what Tailwind cannot express.
+  - `unstyled`: omits styling entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 <% } %>
 

--- a/packages/tools/src/generators/templates/templates.ts
+++ b/packages/tools/src/generators/templates/templates.ts
@@ -1,12 +1,14 @@
 import { formatFiles, Tree } from '@nx/devkit';
 import { query } from '@phenomnomnominal/tsquery';
 import * as ts from 'typescript';
+import { generateTailwindComponentVariant } from '../../tailwind-variant';
 
 export async function templatesGenerator(tree: Tree) {
   const templatesPath = 'apps/components/src/app/pages/reusable-components';
 
   // delete the existing templates
   tree.delete('packages/ng-primitives/schematics/ng-generate/templates');
+  tree.delete('packages/ng-primitives/schematics/ng-generate/templates-tailwind');
 
   // each folder in this directory is a primitive that can be used as a template
   for (const primitive of tree.children(templatesPath)) {
@@ -56,9 +58,24 @@ export async function templatesGenerator(tree: Tree) {
       assertPrefixReplaced(content, filePath);
 
       // write the new file to packages/ng-primitives/schematics/ng-generate/templates
+      const templateFileName = `${file.replace('.ts', '.__fileSuffix@dasherize__.ts')}.template`;
       tree.write(
-        `packages/ng-primitives/schematics/ng-generate/templates/${primitive}/${file.replace('.ts', '.__fileSuffix@dasherize__.ts')}.template`,
+        `packages/ng-primitives/schematics/ng-generate/templates/${primitive}/${templateFileName}`,
         content,
+      );
+
+      // the tailwind variant: utility classes on the elements, raw CSS only for
+      // what Tailwind cannot express (keyframes, combinators, ordered cascades)
+      const tailwindContent = processTemplate(
+        generateTailwindComponentVariant(source).source,
+        componentClasses,
+      );
+
+      assertPrefixReplaced(tailwindContent, filePath);
+
+      tree.write(
+        `packages/ng-primitives/schematics/ng-generate/templates-tailwind/${primitive}/${templateFileName}`,
+        tailwindContent,
       );
     }
   }

--- a/packages/tools/src/tailwind-variant/component-styles-parser.ts
+++ b/packages/tools/src/tailwind-variant/component-styles-parser.ts
@@ -1,0 +1,106 @@
+import postcss, { AtRule, Rule } from 'postcss';
+
+export interface CssDeclaration {
+  prop: string;
+  value: string;
+}
+
+export interface CssRuleEntry {
+  kind: 'rule';
+  selector: string;
+  decls: CssDeclaration[];
+}
+
+export interface CssMediaEntry {
+  kind: 'media';
+  params: string;
+  rules: { selector: string; decls: CssDeclaration[] }[];
+}
+
+export interface CssKeyframesEntry {
+  kind: 'keyframes';
+  name: string;
+  css: string;
+}
+
+export type ParsedCssEntry = CssRuleEntry | CssMediaEntry | CssKeyframesEntry;
+
+/**
+ * Extract the `styles` template literal from a component source file.
+ * Returns null when the component has no styles block.
+ */
+export function extractComponentStyles(source: string): string | null {
+  const match = source.match(
+    /styles:\s*`([\s\S]*?)`\s*,?\s*\n\s*(?:host|template|imports|providers|changeDetection|animations|encapsulation|\}\))/,
+  );
+  return match ? match[1] : null;
+}
+
+/**
+ * Parse component CSS into an ordered entry list, flattening `&` nesting onto
+ * the parent selector so every rule carries a complete, standalone selector.
+ * Source order is preserved — the cascade between equal-specificity rules
+ * depends on it.
+ */
+export function parseCssRules(css: string): ParsedCssEntry[] {
+  const root = postcss.parse(css);
+  const entries: ParsedCssEntry[] = [];
+
+  const declarationsOf = (node: Rule | AtRule): CssDeclaration[] => {
+    const declarations: CssDeclaration[] = [];
+    node.each(child => {
+      if (child.type === 'decl') {
+        declarations.push({ prop: child.prop, value: child.value });
+      }
+    });
+    return declarations;
+  };
+
+  const walkRule = (rule: Rule, parentSelector: string | null, sink: ParsedCssEntry[]): void => {
+    for (const rawSelector of rule.selectors) {
+      const selector = (
+        parentSelector ? rawSelector.replace(/&/g, parentSelector) : rawSelector
+      ).trim();
+      const declarations = declarationsOf(rule);
+      if (declarations.length) {
+        sink.push({ kind: 'rule', selector, decls: declarations });
+      }
+      rule.each(child => {
+        if (child.type === 'rule') {
+          walkRule(child, selector, sink);
+        } else if (child.type === 'atrule' && child.name === 'media') {
+          const inner = declarationsOf(child);
+          if (inner.length) {
+            sink.push({ kind: 'media', params: child.params, rules: [{ selector, decls: inner }] });
+          }
+          child.each(grandchild => {
+            if (grandchild.type === 'rule') {
+              walkRule(grandchild, selector, sink);
+            }
+          });
+        }
+      });
+    }
+  };
+
+  root.each(node => {
+    if (node.type === 'rule') {
+      walkRule(node, null, entries);
+    } else if (node.type === 'atrule' && node.name === 'keyframes') {
+      entries.push({ kind: 'keyframes', name: node.params, css: node.toString() });
+    } else if (node.type === 'atrule' && node.name === 'media') {
+      const inner: ParsedCssEntry[] = [];
+      node.each(child => {
+        if (child.type === 'rule') {
+          walkRule(child, null, inner);
+        }
+      });
+      const rules = inner.filter((entry): entry is CssRuleEntry => entry.kind === 'rule');
+      if (rules.length) {
+        entries.push({ kind: 'media', params: node.params, rules });
+      }
+    }
+  });
+
+  return entries;
+}

--- a/packages/tools/src/tailwind-variant/css-parity-gate.ts
+++ b/packages/tools/src/tailwind-variant/css-parity-gate.ts
@@ -1,0 +1,252 @@
+import { ParsedCssEntry } from './component-styles-parser';
+
+// Semantic parity: normalise hand-written and derived CSS to a canonical
+// (selector, physical longhand, canonical value) map and compare. This is the
+// gate that makes deriving CSS from Tailwind safe — any drift the compiler
+// introduces surfaces as a diff instead of shipping silently.
+
+const SIDES = ['top', 'right', 'bottom', 'left'] as const;
+
+function normaliseCssValue(value: string): string {
+  return value
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/'/g, '"')
+    .replace(/(\d*\.?\d+)px\b/g, (_, n: string) => `${Number((Number(n) / 16).toFixed(5))}rem`)
+    .replace(/\b0(?:rem|px|em|%)\b/g, '0')
+    .replace(/(\d*\.?\d+)s\b/g, (_, n: string) => `${Number(n) * 1000}ms`)
+    .replace(/\b0\./g, '.')
+    .replace(/,\s+/g, ',')
+    .replace(/calc\(infinity \* 1px\)/g, '9999px');
+}
+
+/** Split a multi-part value on spaces outside parentheses (var fallbacks contain both). */
+function splitOutsideParentheses(value: string): string[] {
+  return value.trim().split(/\s+(?![^(]*\))/);
+}
+
+function expandBoxShorthand(value: string): [string, string, string, string] {
+  const parts = splitOutsideParentheses(value);
+  if (parts.length === 1) {
+    return [parts[0], parts[0], parts[0], parts[0]];
+  }
+  if (parts.length === 2) {
+    return [parts[0], parts[1], parts[0], parts[1]];
+  }
+  if (parts.length === 3) {
+    return [parts[0], parts[1], parts[2], parts[1]];
+  }
+  return [parts[0], parts[1], parts[2], parts[3]];
+}
+
+const COLOR_VALUE_PATTERN =
+  /^(#|rgb|hsl|oklch|var\(|transparent$|currentcolor$|inherit$|white$|black$)/i;
+const COLOR_TOKEN_PATTERN =
+  /(var\([^)]*\)|rgba?\([^)]*\)|hsla?\([^)]*\)|oklch\([^)]*\)|#[0-9a-fA-F]+|transparent|currentcolor)/i;
+
+/** Expand a declaration into physical longhands so shorthand vs longhand compare equal. */
+function expandToPhysicalLonghands(prop: string, value: string): [string, string][] {
+  const v = value.trim();
+  switch (prop) {
+    case 'padding':
+    case 'margin': {
+      const box = expandBoxShorthand(v);
+      return SIDES.map((side, i) => [`${prop}-${side}`, box[i]] as [string, string]);
+    }
+    case 'padding-inline':
+    case 'margin-inline': {
+      const base = prop.split('-')[0];
+      const parts = splitOutsideParentheses(v);
+      return [
+        [`${base}-left`, parts[0]],
+        [`${base}-right`, parts[1] ?? parts[0]],
+      ];
+    }
+    case 'padding-block':
+    case 'margin-block': {
+      const base = prop.split('-')[0];
+      const parts = splitOutsideParentheses(v);
+      return [
+        [`${base}-top`, parts[0]],
+        [`${base}-bottom`, parts[1] ?? parts[0]],
+      ];
+    }
+    case 'inset': {
+      const [top, right, bottom, left] = expandBoxShorthand(v);
+      return [
+        ['top', top],
+        ['right', right],
+        ['bottom', bottom],
+        ['left', left],
+      ];
+    }
+    case 'border':
+    case 'border-top':
+    case 'border-right':
+    case 'border-bottom':
+    case 'border-left': {
+      const sides = prop === 'border' ? SIDES : [prop.slice(7)];
+      const out: [string, string][] = [];
+      const emit = (kind: string, val: string): void => {
+        for (const side of sides) {
+          out.push([`border-${side}-${kind}`, val]);
+        }
+      };
+      if (v === 'none' || v === '0') {
+        emit('style', 'none');
+        return out;
+      }
+      // pull the color out first so its internal spaces don't break the split
+      let rest = v;
+      const color = rest.match(COLOR_TOKEN_PATTERN);
+      if (color) {
+        emit('color', color[1]);
+        rest = rest.replace(color[1], ' ');
+      }
+      for (const part of rest.split(/\s+/).filter(Boolean)) {
+        if (/^(\d|\.)/.test(part)) {
+          emit('width', part);
+        } else if (/^(solid|dashed|dotted|double|none|hidden)$/.test(part)) {
+          emit('style', part);
+        } else {
+          emit('color', part);
+        }
+      }
+      return out;
+    }
+    case 'border-width':
+    case 'border-style':
+    case 'border-color': {
+      const kind = prop.slice(7);
+      const box = expandBoxShorthand(v);
+      return SIDES.map((side, i) => [`border-${side}-${kind}`, box[i]] as [string, string]);
+    }
+    case 'outline': {
+      if (v === 'none') {
+        return [['outline-style', 'none']];
+      }
+      const out: [string, string][] = [];
+      let rest = v;
+      const color = rest.match(COLOR_TOKEN_PATTERN);
+      if (color) {
+        out.push(['outline-color', color[1]]);
+        rest = rest.replace(color[1], ' ');
+      }
+      for (const part of rest.split(/\s+/).filter(Boolean)) {
+        if (/^(\d|\.)/.test(part)) {
+          out.push(['outline-width', part]);
+        } else if (/^(solid|dashed|dotted|double|none|auto)$/.test(part)) {
+          out.push(['outline-style', part]);
+        } else {
+          out.push(['outline-color', part]);
+        }
+      }
+      return out;
+    }
+    case 'background':
+      return COLOR_VALUE_PATTERN.test(v) ? [['background-color', v]] : [[prop, v]];
+    case 'list-style':
+      return v === 'none' ? [['list-style-type', 'none']] : [[prop, v]];
+    case 'gap': {
+      const parts = splitOutsideParentheses(v);
+      return [
+        ['row-gap', parts[0]],
+        ['column-gap', parts[1] ?? parts[0]],
+      ];
+    }
+    case 'transform': {
+      const rotate = v.match(/^rotate\(([^)]+)\)$/);
+      if (rotate) {
+        return [['rotate', rotate[1]]];
+      }
+      const translateY = v.match(/^translateY\(([^)]+)\)$/);
+      if (translateY) {
+        return [['translate', `0 ${translateY[1]}`]];
+      }
+      const translateX = v.match(/^translateX\(([^)]+)\)$/);
+      if (translateX) {
+        return [['translate', `${translateX[1]} 0`]];
+      }
+      return [[prop, v]];
+    }
+    case 'translate': {
+      const parts = splitOutsideParentheses(v);
+      return [['translate', parts.length === 1 ? `${parts[0]} 0` : v]];
+    }
+    case 'opacity': {
+      const pct = v.match(/^(\d*\.?\d+)%$/);
+      return [[prop, pct ? String(Number(pct[1]) / 100) : v]];
+    }
+    default:
+      return [[prop, v]];
+  }
+}
+
+function normaliseCssSelector(selector: string): string {
+  return selector
+    .replace(/'/g, '"')
+    .replace(/(^|[^:]):(before|after|placeholder|selection)\b/g, '$1::$2')
+    .replace(/\s*([>+~])\s*/g, ' $1 ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** Build the canonical map: `[media ::] selector :: prop` -> canonical value. */
+export function canonicaliseCssDeclarations(entries: ParsedCssEntry[]): Map<string, string> {
+  const map = new Map<string, string>();
+  const push = (selector: string, prop: string, value: string, media: string | null): void => {
+    for (const [longhand, val] of expandToPhysicalLonghands(prop, value)) {
+      const key = `${media ? `@media ${media} :: ` : ''}${normaliseCssSelector(selector)} :: ${longhand}`;
+      map.set(key, normaliseCssValue(val));
+    }
+  };
+  for (const entry of entries) {
+    if (entry.kind === 'rule') {
+      for (const decl of entry.decls) {
+        push(entry.selector, decl.prop, decl.value, null);
+      }
+    } else if (entry.kind === 'media') {
+      for (const rule of entry.rules) {
+        for (const decl of rule.decls) {
+          push(rule.selector, decl.prop, decl.value, entry.params);
+        }
+      }
+    }
+  }
+  return map;
+}
+
+export interface CssParityMismatch {
+  key: string;
+  expected: string;
+  got: string | undefined;
+}
+
+export interface CssParityResult {
+  /** Declarations of the hand-written CSS missing or wrong in the derived CSS. */
+  mismatches: CssParityMismatch[];
+  /** Declarations the derived CSS introduces that the hand-written CSS never set. */
+  extras: { key: string; value: string }[];
+  total: number;
+}
+
+/** Compare hand-written CSS against derived CSS, both in canonical form. */
+export function diffCssParity(
+  hand: Map<string, string>,
+  derived: Map<string, string>,
+): CssParityResult {
+  const mismatches: CssParityMismatch[] = [];
+  const extras: { key: string; value: string }[] = [];
+  for (const [key, expected] of hand) {
+    const got = derived.get(key);
+    if (got !== expected) {
+      mismatches.push({ key, expected, got });
+    }
+  }
+  for (const [key, value] of derived) {
+    if (!hand.has(key)) {
+      extras.push({ key, value });
+    }
+  }
+  return { mismatches, extras, total: hand.size };
+}

--- a/packages/tools/src/tailwind-variant/css-to-tailwind-translator.ts
+++ b/packages/tools/src/tailwind-variant/css-to-tailwind-translator.ts
@@ -1,0 +1,484 @@
+import { CssDeclaration, ParsedCssEntry } from './component-styles-parser';
+
+export interface TranslatedCssRule {
+  /** The original, complete selector of the rule. */
+  selector: string;
+  /** The selector with liftable state/pseudo suffixes removed — where classes would live. */
+  anchor: string;
+  /** The rule's original declarations, for reconstructing it as raw CSS. */
+  decls: CssDeclaration[];
+  /** One Tailwind candidate per declaration (idiomatic pairs may span two classes). */
+  candidates: { cls: string; prop: string; value: string }[];
+  /** Non-motion @media params the rule lives under, if any. */
+  media: string | null;
+  /** The @media params the rule was authored under, motion or not. */
+  sourceMedia: string | null;
+  /** True when the rule cannot be expressed as element classes in raw Tailwind. */
+  requiresRawCss: boolean;
+}
+
+export interface TailwindTranslationPlan {
+  rules: TranslatedCssRule[];
+  /** Raw @keyframes blocks — Tailwind never emits these, they pass through verbatim. */
+  keyframes: string[];
+  /** Authoring hazards for the raw-Tailwind variant that the derived CSS is immune to. */
+  notes: string[];
+}
+
+// Declarations whose named utility compiles (after flattening) to exactly the
+// same output. Everything absent here falls back to an arbitrary property,
+// which compiles to the literal declaration — so this table only affects how
+// idiomatic the authored classes look, never parity.
+const EXACT_DECLARATION_UTILITIES = new Map<string, string>(
+  Object.entries({
+    'display:flex': 'flex',
+    'display:inline-flex': 'inline-flex',
+    'display:block': 'block',
+    'display:inline-block': 'inline-block',
+    'display:grid': 'grid',
+    'display:none': 'hidden',
+    'position:relative': 'relative',
+    'position:absolute': 'absolute',
+    'position:fixed': 'fixed',
+    'position:sticky': 'sticky',
+    'align-items:center': 'items-center',
+    'align-items:flex-start': 'items-start',
+    'align-items:flex-end': 'items-end',
+    'align-items:baseline': 'items-baseline',
+    'align-items:stretch': 'items-stretch',
+    'justify-content:center': 'justify-center',
+    'justify-content:space-between': 'justify-between',
+    'justify-content:flex-start': 'justify-start',
+    'justify-content:flex-end': 'justify-end',
+    'flex-direction:column': 'flex-col',
+    'flex-direction:row': 'flex-row',
+    'flex-wrap:wrap': 'flex-wrap',
+    'overflow:hidden': 'overflow-hidden',
+    'overflow:auto': 'overflow-auto',
+    'overflow-y:auto': 'overflow-y-auto',
+    'overflow-x:auto': 'overflow-x-auto',
+    'cursor:pointer': 'cursor-pointer',
+    'cursor:not-allowed': 'cursor-not-allowed',
+    'cursor:default': 'cursor-default',
+    'box-sizing:border-box': 'box-border',
+    'width:100%': 'w-full',
+    'height:100%': 'h-full',
+    'width:fit-content': 'w-fit',
+    'height:fit-content': 'h-fit',
+    'width:auto': 'w-auto',
+    'height:auto': 'h-auto',
+    'text-align:center': 'text-center',
+    'text-align:left': 'text-left',
+    'user-select:none': 'select-none',
+    'pointer-events:none': 'pointer-events-none',
+    'pointer-events:auto': 'pointer-events-auto',
+    'flex:1': 'flex-1',
+    'flex-shrink:0': 'shrink-0',
+    'flex-grow:1': 'grow',
+    'list-style:none': 'list-none',
+    'text-decoration:none': 'no-underline',
+    'white-space:nowrap': 'whitespace-nowrap',
+    'vertical-align:middle': 'align-middle',
+    'border:none': 'border-none',
+    'background:transparent': 'bg-transparent',
+    'background-color:transparent': 'bg-transparent',
+    'font-weight:500': 'font-medium',
+    'font-weight:600': 'font-semibold',
+    'transform:rotate(180deg)': 'rotate-180',
+    'transform:rotate(90deg)': 'rotate-90',
+    'transform:rotate(45deg)': 'rotate-45',
+    'border-radius:9999px': 'rounded-full',
+    'line-height:1': 'leading-none',
+    'opacity:0': 'opacity-0',
+    'opacity:1': 'opacity-100',
+    'border-collapse:collapse': 'border-collapse',
+    'appearance:none': 'appearance-none',
+  }),
+);
+
+const SPACING_SCALE_PREFIXES = new Map<string, string>(
+  Object.entries({
+    'padding-left': 'pl',
+    'padding-right': 'pr',
+    'padding-top': 'pt',
+    'padding-bottom': 'pb',
+    'padding-inline': 'px',
+    'padding-block': 'py',
+    'margin-left': 'ml',
+    'margin-right': 'mr',
+    'margin-top': 'mt',
+    'margin-bottom': 'mb',
+    'margin-inline': 'mx',
+    'margin-block': 'my',
+    gap: 'gap',
+    'column-gap': 'gap-x',
+    'row-gap': 'gap-y',
+    width: 'w',
+    height: 'h',
+    'min-width': 'min-w',
+    'min-height': 'min-h',
+    'max-width': 'max-w',
+    'max-height': 'max-h',
+    top: 'top',
+    right: 'right',
+    bottom: 'bottom',
+    left: 'left',
+    inset: 'inset',
+  }),
+);
+
+const BORDER_RADIUS_UTILITIES = new Map<string, string>([
+  ['0.25rem', 'rounded'],
+  ['0.375rem', 'rounded-md'],
+  ['0.5rem', 'rounded-lg'],
+  ['0.75rem', 'rounded-xl'],
+  ['1rem', 'rounded-2xl'],
+  ['1.5rem', 'rounded-3xl'],
+]);
+
+const COLOR_PROPERTY_UTILITIES = new Map<string, string>(
+  Object.entries({
+    color: 'text',
+    'background-color': 'bg',
+    'border-color': 'border',
+    'outline-color': 'outline',
+    'accent-color': 'accent',
+    fill: 'fill',
+    stroke: 'stroke',
+  }),
+);
+
+const FONT_SIZE_LINE_HEIGHT_PAIRS = new Map<string, string>([
+  ['0.75rem/1rem', 'text-xs'],
+  ['0.875rem/1.25rem', 'text-sm'],
+  ['1rem/1.5rem', 'text-base'],
+]);
+
+/** rem/px length -> spacing-scale steps, or null when off the 0.25rem scale. */
+function spacingScaleSteps(value: string): number | null {
+  if (value === '0') {
+    return 0;
+  }
+  let rem: number | null = null;
+  const remMatch = value.match(/^(-?\d*\.?\d+)rem$/);
+  if (remMatch) {
+    rem = Number(remMatch[1]);
+  } else {
+    const pxMatch = value.match(/^(-?\d*\.?\d+)px$/);
+    if (pxMatch) {
+      rem = Number(pxMatch[1]) / 16;
+    }
+  }
+  if (rem === null) {
+    return null;
+  }
+  const steps = rem / 0.25;
+  return Number.isInteger(steps) ? steps : null;
+}
+
+/** Arbitrary-value encoding: spaces become underscores. */
+const toArbitraryValue = (value: string): string => value.replace(/\s+/g, '_');
+
+interface TranslatedDeclaration {
+  cls: string;
+  consumedNext?: boolean;
+}
+
+/**
+ * Translate one declaration into Tailwind. `next` allows pairing font-size
+ * with its scale line-height into a single text-* utility.
+ */
+export function translateDeclarationToTailwind(
+  prop: string,
+  value: string,
+  next?: CssDeclaration,
+): TranslatedDeclaration {
+  const v = value.trim().replace(/\s+/g, ' ');
+  const exactUtility = EXACT_DECLARATION_UTILITIES.get(`${prop}:${v}`);
+  if (exactUtility) {
+    return { cls: exactUtility };
+  }
+
+  const spacingPrefix = SPACING_SCALE_PREFIXES.get(prop);
+  if (spacingPrefix && !v.includes(' ')) {
+    const steps = spacingScaleSteps(v);
+    if (steps !== null && steps >= 0) {
+      return { cls: `${spacingPrefix}-${steps}` };
+    }
+    if (v === '50%' && ['top', 'left', 'right', 'bottom'].includes(prop)) {
+      return { cls: `${prop}-1/2` };
+    }
+  }
+
+  if (prop === 'padding' || prop === 'margin') {
+    const prefix = prop === 'padding' ? 'p' : 'm';
+    const parts = v.split(' ').map(spacingScaleSteps);
+    if (!parts.some(steps => steps === null || steps < 0)) {
+      if (parts.length === 1) {
+        return { cls: `${prefix}-${parts[0]}` };
+      }
+      if (parts.length === 2) {
+        return {
+          cls:
+            parts[0] === parts[1]
+              ? `${prefix}-${parts[0]}`
+              : `${prefix}y-${parts[0]} ${prefix}x-${parts[1]}`,
+        };
+      }
+    }
+  }
+
+  if (prop === 'border-radius') {
+    const rem = v.replace(/^(\d+)px$/, (_, px) => `${Number(px) / 16}rem`);
+    const radiusUtility = BORDER_RADIUS_UTILITIES.get(rem);
+    if (radiusUtility) {
+      return { cls: radiusUtility };
+    }
+  }
+
+  const colorUtility = COLOR_PROPERTY_UTILITIES.get(prop);
+  if (colorUtility) {
+    const varMatch = v.match(/^var\((--[\w-]+)\)$/);
+    if (varMatch) {
+      return { cls: `${colorUtility}-(${varMatch[1]})` };
+    }
+  }
+
+  if (prop === 'box-shadow') {
+    const varMatch = v.match(/^var\((--[\w-]+)\)$/);
+    if (varMatch) {
+      return { cls: `shadow-(${varMatch[1]})` };
+    }
+  }
+
+  if (/^border(-top|-right|-bottom|-left)?$/.test(prop)) {
+    const match = v.match(/^(\d+px) solid (var\(--[\w-]+\)|#[0-9a-fA-F]+)$/);
+    if (match) {
+      const width = { '1px': '', '2px': '-2', '4px': '-4' }[match[1]];
+      if (width !== undefined) {
+        const side = prop === 'border' ? '' : `-${prop.slice(7)[0]}`;
+        const varMatch = match[2].match(/^var\((--[\w-]+)\)$/);
+        const color = varMatch ? `border-(${varMatch[1]})` : `border-[${match[2]}]`;
+        return { cls: `border${side}${width} ${color}` };
+      }
+    }
+  }
+  if (prop === 'border-width') {
+    const widthUtility = { '1px': 'border', '2px': 'border-2', '4px': 'border-4' }[v];
+    if (widthUtility) {
+      return { cls: widthUtility };
+    }
+  }
+
+  if (prop === 'font-size' && next?.prop === 'line-height') {
+    const pairUtility = FONT_SIZE_LINE_HEIGHT_PAIRS.get(`${v}/${next.value.trim()}`);
+    if (pairUtility) {
+      return { cls: pairUtility, consumedNext: true };
+    }
+  }
+
+  if (prop === 'animation') {
+    return { cls: `animate-[${toArbitraryValue(v)}]` };
+  }
+
+  if (prop === 'z-index' && /^\d+$/.test(v)) {
+    return { cls: `z-${v}` };
+  }
+  if (prop === 'opacity' && /^0?\.\d+$/.test(v)) {
+    const percentage = Number(v) * 100;
+    if (Number.isInteger(percentage)) {
+      return { cls: `opacity-${percentage}` };
+    }
+  }
+
+  return { cls: `[${prop}:${toArbitraryValue(v)}]` };
+}
+
+// Suffix patterns liftable off the end of a selector into Tailwind variants.
+const LIFTABLE_SELECTOR_SUFFIXES: { re: RegExp; tw: (m: RegExpMatchArray) => string }[] = [
+  { re: /\[data-([a-z-]+)='([^']+)'\]$/, tw: m => `data-[${m[1]}=${m[2]}]` },
+  { re: /\[data-([a-z-]+)="([^"]+)"\]$/, tw: m => `data-[${m[1]}=${m[2]}]` },
+  { re: /\[data-([a-z-]+)\]$/, tw: m => `data-${m[1]}` },
+  { re: /::placeholder$/, tw: () => 'placeholder' },
+  { re: /::?before$/, tw: () => 'before' },
+  { re: /::?after$/, tw: () => 'after' },
+  { re: /::selection$/, tw: () => 'selection' },
+  { re: /:hover$/, tw: () => 'hover' },
+  { re: /:focus-visible$/, tw: () => 'focus-visible' },
+  { re: /:focus-within$/, tw: () => 'focus-within' },
+  { re: /:focus$/, tw: () => 'focus' },
+  { re: /:disabled$/, tw: () => 'disabled' },
+  { re: /:first-child$/, tw: () => 'first' },
+  { re: /:last-child$/, tw: () => 'last' },
+  { re: /(::-webkit-[a-z-]+)$/, tw: m => `[&${m[1]}]` },
+  { re: /(:not\([^()]*(?:\([^()]*\))?[^()]*\))$/, tw: m => `[&${toArbitraryValue(m[1])}]` },
+  { re: /(:has\([^()]*(?:\([^()]*\))?[^()]*\))$/, tw: m => `[&${toArbitraryValue(m[1])}]` },
+];
+
+/**
+ * Split a selector into an anchor plus Tailwind variants by lifting
+ * recognisable state/pseudo suffixes off the end. Anything unliftable stays in
+ * the anchor — the derive step re-scopes onto it directly, so no selector
+ * shape is ever unsupported.
+ */
+export function splitSelectorIntoAnchorAndVariants(selector: string): {
+  anchor: string;
+  variants: string[];
+} {
+  let anchor = selector.trim();
+  const variants: string[] = [];
+  let progressed = true;
+  while (progressed) {
+    progressed = false;
+    for (const { re, tw } of LIFTABLE_SELECTOR_SUFFIXES) {
+      const match = anchor.match(re);
+      if (!match) {
+        continue;
+      }
+      const rest = anchor.slice(0, -match[0].length);
+      // never lift a suffix across a combinator into a different compound
+      if (!rest || /[\s>+~]$/.test(rest)) {
+        break;
+      }
+      variants.unshift(tw(match));
+      anchor = rest;
+      progressed = true;
+      break;
+    }
+  }
+  return { anchor: anchor || selector.trim(), variants };
+}
+
+// Anchors that can carry classes directly: the host, a directive attribute, an
+// element tag, or a semantic class — optionally combined on one compound.
+const CLASS_CARRYING_ANCHOR = /^(:host|\[[\w-]+\]|[a-z][\w-]*|\.[\w-]+)+$/;
+
+/**
+ * Translate parsed CSS entries into a Tailwind candidate plan, collecting the
+ * authoring hazards (`all: unset`, order-dependent custom properties) that the
+ * raw-Tailwind variant cannot express but the derived CSS is immune to.
+ */
+export function translateCssToTailwind(entries: ParsedCssEntry[]): TailwindTranslationPlan {
+  const rules: TranslatedCssRule[] = [];
+  const keyframes: string[] = [];
+  const notes: string[] = [];
+  const customPropertyWriters = new Map<string, Set<string>>();
+  const orderDependentSelectors = new Set<string>();
+
+  // Angular scopes component @keyframes (`slideDown` -> `_ngcontent-x_slideDown`),
+  // so an animation referencing one only resolves from the same styles block — a
+  // global Tailwind class would silently reference a name that no longer exists.
+  const localKeyframeNames = new Set(
+    entries
+      .filter(
+        (entry): entry is ParsedCssEntry & { kind: 'keyframes' } => entry.kind === 'keyframes',
+      )
+      .map(entry => entry.name),
+  );
+  const referencesLocalKeyframe = (decl: CssDeclaration): boolean =>
+    (decl.prop === 'animation' || decl.prop === 'animation-name') &&
+    [...localKeyframeNames].some(name =>
+      new RegExp(`(^|[\\s,])${name}([\\s,]|$)`).test(decl.value),
+    );
+
+  const handleRule = (
+    selector: string,
+    decls: CssDeclaration[],
+    mediaParams: string | null,
+  ): void => {
+    const { anchor, variants } = splitSelectorIntoAnchorAndVariants(selector);
+    const isMotionMedia = mediaParams?.includes('prefers-reduced-motion');
+    const variantPrefix = isMotionMedia ? [...variants, 'motion-reduce'] : variants;
+    const media = mediaParams && !isMotionMedia ? mediaParams : null;
+    const candidates: TranslatedCssRule['candidates'] = [];
+    let requiresRawCss =
+      !CLASS_CARRYING_ANCHOR.test(anchor) || media !== null || decls.some(referencesLocalKeyframe);
+
+    for (let i = 0; i < decls.length; i++) {
+      const { prop, value } = decls[i];
+      if (prop === 'all' && value === 'unset') {
+        // component styles are unlayered and would beat @layer utilities, so a
+        // reset rule can only live in raw CSS with its companions
+        requiresRawCss = true;
+        notes.push(
+          `ALL_UNSET: \`${selector}\` — Tailwind's own emission order would reset later utilities; safe in derived CSS only`,
+        );
+      }
+      if (prop.startsWith('--')) {
+        const writers = customPropertyWriters.get(prop) ?? new Set<string>();
+        writers.add(selector);
+        customPropertyWriters.set(prop, writers);
+      }
+      const translated = translateDeclarationToTailwind(prop, value, decls[i + 1]);
+      for (const cls of translated.cls.split(' ')) {
+        candidates.push({
+          cls: variantPrefix.length ? `${variantPrefix.join(':')}:${cls}` : cls,
+          prop,
+          value,
+        });
+      }
+      if (translated.consumedNext) {
+        i++;
+      }
+    }
+
+    rules.push({
+      selector,
+      anchor,
+      decls,
+      candidates,
+      media,
+      sourceMedia: mediaParams,
+      requiresRawCss,
+    });
+  };
+
+  for (const entry of entries) {
+    if (entry.kind === 'rule') {
+      handleRule(entry.selector, entry.decls, null);
+    } else if (entry.kind === 'media') {
+      for (const rule of entry.rules) {
+        handleRule(rule.selector, rule.decls, entry.params);
+      }
+    } else {
+      keyframes.push(entry.css);
+    }
+  }
+
+  for (const [prop, writers] of customPropertyWriters) {
+    if (writers.size > 1) {
+      notes.push(
+        `ORDER_DEPENDENT: \`${prop}\` written by ${writers.size} selectors — source order decides the cascade; Tailwind's emission order would not preserve it`,
+      );
+      for (const selector of writers) {
+        orderDependentSelectors.add(selector);
+      }
+    }
+  }
+  // rules in an order-dependent cascade only stay correct in raw CSS, where
+  // authored order survives
+  for (const rule of rules) {
+    if (orderDependentSelectors.has(rule.selector)) {
+      rule.requiresRawCss = true;
+    }
+  }
+
+  // an animation kept as raw CSS is unlayered and beats @layer utilities, so a
+  // companion `motion-reduce:[animation-duration:0s]` class could never win —
+  // animation-* tweaks on those selectors must stay raw CSS alongside it
+  const animationResidualSelectors = new Set(
+    rules
+      .filter(rule => rule.requiresRawCss && rule.decls.some(referencesLocalKeyframe))
+      .map(rule => rule.selector),
+  );
+  for (const rule of rules) {
+    if (
+      animationResidualSelectors.has(rule.selector) &&
+      rule.decls.every(decl => decl.prop.startsWith('animation'))
+    ) {
+      rule.requiresRawCss = true;
+    }
+  }
+
+  return { rules, keyframes, notes };
+}

--- a/packages/tools/src/tailwind-variant/index.ts
+++ b/packages/tools/src/tailwind-variant/index.ts
@@ -1,0 +1,5 @@
+export * from './component-styles-parser';
+export * from './css-to-tailwind-translator';
+export * from './tailwind-css-deriver';
+export * from './css-parity-gate';
+export * from './tailwind-component-generator';

--- a/packages/tools/src/tailwind-variant/reusable-components-round-trip.test.ts
+++ b/packages/tools/src/tailwind-variant/reusable-components-round-trip.test.ts
@@ -1,0 +1,77 @@
+import { globSync } from 'glob';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { extractComponentStyles, parseCssRules } from './component-styles-parser';
+import { canonicaliseCssDeclarations, diffCssParity } from './css-parity-gate';
+import { translateCssToTailwind } from './css-to-tailwind-translator';
+import {
+  TailwindCompiler,
+  createTailwindCompiler,
+  deriveCssFromTailwind,
+} from './tailwind-css-deriver';
+
+// Round-trip gate over every styled reusable component: hand-written CSS ->
+// Tailwind candidates -> real compiler -> derived CSS -> semantic diff against
+// the original. 100% parity here is what makes the pre-generated tailwind
+// template variant trustworthy.
+
+const WORKSPACE = path.resolve(__dirname, '../../../..');
+const COMPONENTS = path.join(WORKSPACE, 'apps/components/src/app/pages/reusable-components');
+
+const styled = globSync(`${COMPONENTS}/*/*.ts`)
+  .sort()
+  .map(file => ({
+    name: path.relative(COMPONENTS, file).replace(/\.ts$/, ''),
+    css: extractComponentStyles(readFileSync(file, 'utf8')),
+  }))
+  .filter((entry): entry is { name: string; css: string } => entry.css !== null);
+
+describe('tailwind round-trip parity', () => {
+  let compiler: TailwindCompiler;
+
+  beforeAll(async () => {
+    compiler = await createTailwindCompiler();
+  });
+
+  it('finds the styled reusable components', () => {
+    expect(styled.length).toBeGreaterThanOrEqual(45);
+  });
+
+  it.each(styled.map(entry => [entry.name, entry] as const))(
+    'round-trips %s at 100%% parity',
+    (_, entry) => {
+      const entries = parseCssRules(entry.css);
+      const plan = translateCssToTailwind(entries);
+      const { css: derived } = deriveCssFromTailwind(plan, compiler);
+      const result = diffCssParity(
+        canonicaliseCssDeclarations(entries),
+        canonicaliseCssDeclarations(parseCssRules(derived)),
+      );
+
+      expect(result.mismatches).toEqual([]);
+      expect(result.total).toBeGreaterThan(0);
+    },
+  );
+
+  it('every candidate is understood by the compiler (no verbatim fallbacks)', () => {
+    const failures: string[] = [];
+    for (const entry of styled) {
+      const { failedCandidates } = deriveCssFromTailwind(
+        translateCssToTailwind(parseCssRules(entry.css)),
+        compiler,
+      );
+      failures.push(...failedCandidates.map(failed => `${entry.name}: ${failed.cls}`));
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it('flags the known authoring hazards for the raw-Tailwind variant', () => {
+    const notes = styled.flatMap(entry =>
+      translateCssToTailwind(parseCssRules(entry.css)).notes.map(note => `${entry.name}: ${note}`),
+    );
+    // all: unset appears in date-picker, pagination and native-select today; if
+    // this fails because a component was rewritten, update the count downward.
+    expect(notes.filter(note => note.includes('ALL_UNSET')).length).toBeGreaterThan(0);
+  });
+});

--- a/packages/tools/src/tailwind-variant/tailwind-component-generator.test.ts
+++ b/packages/tools/src/tailwind-variant/tailwind-component-generator.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import { generateTailwindComponentVariant } from './tailwind-component-generator';
+
+const COMPONENT = `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-thing',
+  template: \`
+    <button ngpThingTrigger>
+      {{ heading() }}
+      <ng-icon name="chevron" />
+    </button>
+    <div ngpThingContent>
+      <ng-content />
+    </div>
+  \`,
+  styles: \`
+    :host {
+      display: block;
+    }
+
+    [ngpThingTrigger] {
+      display: flex;
+      height: 2.75rem;
+      color: var(--ngp-text-primary);
+    }
+
+    [ngpThingTrigger][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+    }
+
+    [ngpThingContent][data-open] {
+      animation: slideDown 0.2s ease-in-out forwards;
+    }
+
+    ng-icon {
+      color: var(--ngp-text-secondary);
+    }
+
+    [ngpThingTrigger][data-open] ng-icon {
+      transform: rotate(180deg);
+    }
+
+    @keyframes slideDown {
+      from {
+        height: 0;
+      }
+      to {
+        height: var(--ngp-h);
+      }
+    }
+  \`,
+})
+export class Thing {}
+`;
+
+describe('generateTailwindComponentVariant', () => {
+  const variant = generateTailwindComponentVariant(COMPONENT);
+
+  it('injects utility classes on the element carrying the directive attribute', () => {
+    expect(variant.source).toContain(
+      '<button class="flex h-11 text-(--ngp-text-primary) data-focus-visible:[outline:2px_solid_var(--ngp-focus-ring)]" ngpThingTrigger>',
+    );
+  });
+
+  it('keeps an animation referencing a local keyframe as raw CSS, next to its keyframes', () => {
+    // Angular scopes component @keyframes, so a global Tailwind class could
+    // never resolve the scoped name — both must live in the same styles block
+    expect(variant.source).toContain('<div ngpThingContent>');
+    expect(variant.rawCssRules).toContainEqual(
+      '[ngpThingContent][data-open] {\n  animation: slideDown 0.2s ease-in-out forwards;\n}',
+    );
+  });
+
+  it('injects classes on elements matched by bare tag', () => {
+    expect(variant.source).toContain(
+      '<ng-icon class="text-(--ngp-text-secondary)" name="chevron" />',
+    );
+  });
+
+  it('moves :host rules onto a host class binding', () => {
+    expect(variant.source).toMatch(/host: \{\n\s*class: 'block',\n\s*\},/);
+  });
+
+  it('keeps only the inexpressible rules and keyframes as raw CSS', () => {
+    expect(variant.rawCssRules).toEqual([
+      '[ngpThingContent][data-open] {\n  animation: slideDown 0.2s ease-in-out forwards;\n}',
+      '[ngpThingTrigger][data-open] ng-icon {\n  transform: rotate(180deg);\n}',
+    ]);
+    expect(variant.source).toContain('@keyframes slideDown');
+    // everything else left the styles block
+    expect(variant.source).not.toMatch(/styles:[\s\S]*display: flex/);
+  });
+
+  it('merges host classes into an existing host block without clobbering it', () => {
+    const withHost = COMPONENT.replace(
+      'template:',
+      "host: {\n    '(focusout)': 'onTouched?.()',\n  },\n  template:",
+    );
+    const merged = generateTailwindComponentVariant(withHost);
+    expect(merged.source).toContain("class: 'block',");
+    expect(merged.source).toContain("'(focusout)': 'onTouched?.()'");
+  });
+
+  it('drops the styles property entirely when nothing needs raw CSS', () => {
+    const simple = generateTailwindComponentVariant(`@Component({
+  selector: 'app-x',
+  template: \`
+    <div ngpX></div>
+  \`,
+  styles: \`
+    [ngpX] {
+      display: flex;
+    }
+  \`,
+})
+export class X {}
+`);
+    expect(simple.source).not.toContain('styles:');
+    expect(simple.source).toContain('<div class="flex" ngpX></div>');
+  });
+
+  it('sends a rule whose anchor matches nothing in the template to raw CSS', () => {
+    const unmatched = generateTailwindComponentVariant(`@Component({
+  selector: 'app-x',
+  template: \`
+    <div ngpX></div>
+  \`,
+  styles: \`
+    .missing {
+      display: flex;
+    }
+  \`,
+})
+export class X {}
+`);
+    expect(unmatched.rawCssRules).toEqual(['.missing {\n  display: flex;\n}']);
+    expect(unmatched.source).toContain('styles:');
+  });
+
+  it('keeps a :host referenced inside an arbitrary variant as raw CSS', () => {
+    // in the consumer's global stylesheet :host matches nothing, so a
+    // [&:has(+_:host)] utility would silently never apply
+    const sibling = generateTailwindComponentVariant(`@Component({
+  selector: 'app-x',
+  template: \`
+    <div ngpX></div>
+  \`,
+  styles: \`
+    :host:has(+ :host) {
+      border-bottom: 1px solid var(--ngp-border);
+    }
+  \`,
+})
+export class X {}
+`);
+    expect(sibling.rawCssRules).toHaveLength(1);
+    expect(sibling.rawCssRules[0]).toContain(':host:has(+ :host)');
+  });
+
+  it('restores the @media wrapper of a raw CSS rule', () => {
+    const media = generateTailwindComponentVariant(`@Component({
+  selector: 'app-x',
+  template: \`
+    <div ngpX></div>
+  \`,
+  styles: \`
+    @media (prefers-reduced-motion: reduce) {
+      [ngpX] span {
+        animation-duration: 0s;
+      }
+    }
+  \`,
+})
+export class X {}
+`);
+    expect(media.rawCssRules[0]).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(media.rawCssRules[0]).toContain('animation-duration: 0s;');
+  });
+
+  it('returns the source untouched when there is no styles block', () => {
+    const source = `@Component({ selector: 'app-x', template: '<div></div>' })\nexport class X {}`;
+    expect(generateTailwindComponentVariant(source).source).toBe(source);
+  });
+});

--- a/packages/tools/src/tailwind-variant/tailwind-component-generator.ts
+++ b/packages/tools/src/tailwind-variant/tailwind-component-generator.ts
@@ -1,0 +1,214 @@
+import { extractComponentStyles, parseCssRules } from './component-styles-parser';
+import { TranslatedCssRule, translateCssToTailwind } from './css-to-tailwind-translator';
+
+export interface TailwindComponentVariant {
+  source: string;
+  /** The class list injected on each anchor, for inspection and tests. */
+  classesByAnchor: Map<string, string[]>;
+  /** Rules kept as raw CSS because Tailwind classes cannot express them. */
+  rawCssRules: string[];
+}
+
+interface AnchorTarget {
+  tag: string | null;
+  attributes: string[];
+  classes: string[];
+}
+
+/**
+ * Break a class-carrying anchor into the pieces an element must match:
+ * an optional tag, directive attributes, and static classes.
+ * Returns null for anchors that cannot sit on a single element (`:host`,
+ * combinators, pseudo-classes left in the anchor).
+ */
+function parseAnchorTarget(anchor: string): AnchorTarget | null {
+  const match = anchor.match(/^([a-z][\w-]*)?((?:\[[\w-]+\]|\.[\w-]+)*)$/);
+  if (!match || (!match[1] && !match[2])) {
+    return null;
+  }
+  const attributes: string[] = [];
+  const classes: string[] = [];
+  for (const part of match[2]?.match(/\[[\w-]+\]|\.[\w-]+/g) ?? []) {
+    if (part.startsWith('[')) {
+      attributes.push(part.slice(1, -1));
+    } else {
+      classes.push(part.slice(1));
+    }
+  }
+  return { tag: match[1] ?? null, attributes, classes };
+}
+
+const OPENING_TAG_PATTERN = /<([a-zA-Z][\w-]*)((?:"[^"]*"|'[^']*'|[^'">])*)>/g;
+
+/** Whether one opening tag carries every attribute and class the target demands. */
+function elementMatchesTarget(tag: string, attrs: string, target: AnchorTarget): boolean {
+  if (target.tag && target.tag !== tag.toLowerCase()) {
+    return false;
+  }
+  for (const attribute of target.attributes) {
+    if (!new RegExp(`(?:^|\\s)${attribute}(?:[\\s=/]|$)`).test(attrs)) {
+      return false;
+    }
+  }
+  if (target.classes.length) {
+    const staticClass = attrs.match(/(?:^|\s)class="([^"]*)"/);
+    if (!staticClass) {
+      return false;
+    }
+    const present = staticClass[1].split(/\s+/);
+    if (!target.classes.every(cls => present.includes(cls))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Merge classes into one opening tag, appending to an existing static class attribute. */
+function injectClassesIntoTag(tag: string, attrs: string, classes: string[]): string {
+  const staticClass = attrs.match(/((?:^|\s)class=")([^"]*)"/);
+  if (staticClass) {
+    const merged = attrs.replace(
+      staticClass[0],
+      `${staticClass[1]}${staticClass[2]} ${classes.join(' ')}"`,
+    );
+    return `<${tag}${merged}>`;
+  }
+  return `<${tag} class="${classes.join(' ')}"${attrs}>`;
+}
+
+/** Reconstruct a translated rule as raw CSS, restoring its @media wrapper. */
+function reconstructRawCssRule(rule: TranslatedCssRule): string {
+  const declarations = rule.decls.map(decl => `${decl.prop}: ${decl.value};`);
+  const body = `${rule.selector} {\n${declarations.map(line => `  ${line}`).join('\n')}\n}`;
+  if (rule.sourceMedia) {
+    return `@media ${rule.sourceMedia} {\n${body
+      .split('\n')
+      .map(line => `  ${line}`)
+      .join('\n')}\n}`;
+  }
+  return body;
+}
+
+/**
+ * Generate the Tailwind variant of a reusable component: every rule whose
+ * anchor is an element the template actually contains becomes classes on that
+ * element (`:host` rules become a `host` class binding), and everything
+ * Tailwind cannot express — keyframes, combinator rules, `all: unset` resets,
+ * order-dependent cascades — stays behind as a raw `styles` block.
+ *
+ * Falls back to raw CSS whenever an anchor matches nothing in the template, so
+ * a rule is never silently dropped.
+ */
+export function generateTailwindComponentVariant(source: string): TailwindComponentVariant {
+  const css = extractComponentStyles(source);
+  if (!css) {
+    return { source, classesByAnchor: new Map(), rawCssRules: [] };
+  }
+
+  const plan = translateCssToTailwind(parseCssRules(css));
+  const templateMatch = source.match(/template:\s*`([\s\S]*?)`/);
+  let template = templateMatch ? templateMatch[1] : null;
+
+  const classesByAnchor = new Map<string, string[]>();
+  const hostClasses: string[] = [];
+  const rawCssRules: string[] = [];
+
+  for (const rule of plan.rules) {
+    const classes = rule.candidates.map(candidate => candidate.cls);
+    // a `:host` inside an arbitrary variant would land in the consumer's global
+    // stylesheet, where :host matches nothing — only raw component CSS can say it
+    const variantReferencesHost = classes.some(cls => cls.includes(':host'));
+    // a double quote would close the template's class="..." attribute
+    const breaksClassAttribute = rule.anchor !== ':host' && classes.some(cls => cls.includes('"'));
+    if (rule.requiresRawCss || variantReferencesHost || breaksClassAttribute) {
+      rawCssRules.push(reconstructRawCssRule(rule));
+      continue;
+    }
+    if (rule.anchor === ':host') {
+      hostClasses.push(...classes);
+      classesByAnchor.set(':host', [...(classesByAnchor.get(':host') ?? []), ...classes]);
+      continue;
+    }
+    const target = template ? parseAnchorTarget(rule.anchor) : null;
+    const matches = target
+      ? [...template!.matchAll(OPENING_TAG_PATTERN)].filter(m =>
+          elementMatchesTarget(m[1], m[2], target),
+        )
+      : [];
+    if (!target || matches.length === 0) {
+      rawCssRules.push(reconstructRawCssRule(rule));
+      continue;
+    }
+    classesByAnchor.set(rule.anchor, [...(classesByAnchor.get(rule.anchor) ?? []), ...classes]);
+  }
+
+  // inject the accumulated classes per anchor in one template pass each
+  if (template) {
+    for (const [anchor, classes] of classesByAnchor) {
+      if (anchor === ':host') {
+        continue;
+      }
+      const target = parseAnchorTarget(anchor);
+      if (!target) {
+        continue;
+      }
+      template = template.replace(OPENING_TAG_PATTERN, (full, tag: string, attrs: string) =>
+        elementMatchesTarget(tag, attrs, target) ? injectClassesIntoTag(tag, attrs, classes) : full,
+      );
+    }
+  }
+
+  let result = source;
+  if (template !== null && templateMatch) {
+    result = result.replace(templateMatch[0], `template: \`${template}\``);
+  }
+
+  if (hostClasses.length) {
+    // the host class lives in a single-quoted TS string — `[content:'']` must not close it
+    const hostClassValue = hostClasses.join(' ').replace(/'/g, "\\'");
+    const existingHost = result.match(/host:\s*\{/);
+    if (existingHost) {
+      const existingClass = result.match(/(host:\s*\{[\s\S]*?class:\s*')([^']*)'/);
+      result = existingClass
+        ? result.replace(
+            existingClass[0],
+            `${existingClass[1]}${existingClass[2]} ${hostClassValue}'`,
+          )
+        : result.replace(/host:\s*\{/, `host: {\n    class: '${hostClassValue}',`);
+    } else {
+      result = result.replace(
+        /(\n\s*)template:/,
+        `$1host: {$1  class: '${hostClassValue}',$1},$1template:`,
+      );
+    }
+  }
+
+  // keyframes keep their source indentation; strip it so the block re-indents cleanly
+  const reindentedKeyframes = plan.keyframes.map(block => {
+    const lines = block.split('\n');
+    const indents = lines
+      .slice(1)
+      .filter(line => line.trim())
+      .map(line => line.match(/^\s*/)![0].length);
+    const common = indents.length ? Math.min(...indents) - 2 : 0;
+    return [lines[0], ...lines.slice(1).map(line => line.slice(Math.max(common, 0)))].join('\n');
+  });
+  const residual = [...rawCssRules, ...reindentedKeyframes];
+  const stylesMatch = result.match(
+    /(\s*)styles:\s*`[\s\S]*?`\s*,?(?=\s*\n\s*(?:host|template|imports|providers|changeDetection|animations|encapsulation|\}\)))/,
+  );
+  if (stylesMatch) {
+    if (residual.length === 0) {
+      result = result.replace(stylesMatch[0], '');
+    } else {
+      const indented = residual
+        .join('\n\n')
+        .split('\n')
+        .map(line => (line.trim() ? `    ${line}` : line))
+        .join('\n');
+      result = result.replace(stylesMatch[0], `${stylesMatch[1]}styles: \`\n${indented}\n  \`,`);
+    }
+  }
+
+  return { source: result, classesByAnchor, rawCssRules };
+}

--- a/packages/tools/src/tailwind-variant/tailwind-css-deriver.test.ts
+++ b/packages/tools/src/tailwind-variant/tailwind-css-deriver.test.ts
@@ -1,0 +1,258 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { parseCssRules } from './component-styles-parser';
+import { canonicaliseCssDeclarations, diffCssParity } from './css-parity-gate';
+import {
+  splitSelectorIntoAnchorAndVariants,
+  translateCssToTailwind,
+  translateDeclarationToTailwind,
+} from './css-to-tailwind-translator';
+import {
+  TailwindCompiler,
+  createTailwindCompiler,
+  deriveCssFromTailwind,
+} from './tailwind-css-deriver';
+
+describe('translateDeclarationToTailwind', () => {
+  it('maps exact declarations to idiomatic utilities', () => {
+    expect(translateDeclarationToTailwind('display', 'flex').cls).toBe('flex');
+    expect(translateDeclarationToTailwind('padding-left', '1rem').cls).toBe('pl-4');
+    expect(translateDeclarationToTailwind('height', '2.75rem').cls).toBe('h-11');
+    expect(translateDeclarationToTailwind('width', '40px').cls).toBe('w-10');
+    expect(translateDeclarationToTailwind('border-radius', '0.75rem').cls).toBe('rounded-xl');
+    expect(translateDeclarationToTailwind('color', 'var(--ngp-text-primary)').cls).toBe(
+      'text-(--ngp-text-primary)',
+    );
+    expect(translateDeclarationToTailwind('box-shadow', 'var(--ngp-button-shadow)').cls).toBe(
+      'shadow-(--ngp-button-shadow)',
+    );
+    expect(translateDeclarationToTailwind('border', '1px solid var(--ngp-border)').cls).toBe(
+      'border border-(--ngp-border)',
+    );
+  });
+
+  it('pairs font-size with its scale line-height into one text utility', () => {
+    const result = translateDeclarationToTailwind('font-size', '0.875rem', {
+      prop: 'line-height',
+      value: '1.25rem',
+    });
+    expect(result).toEqual({ cls: 'text-sm', consumedNext: true });
+  });
+
+  it('falls back to an arbitrary property for anything else', () => {
+    expect(translateDeclarationToTailwind('font-size', '0.875rem').cls).toBe(
+      '[font-size:0.875rem]',
+    );
+    expect(translateDeclarationToTailwind('grid-template-columns', 'repeat(7, 1fr)').cls).toBe(
+      '[grid-template-columns:repeat(7,_1fr)]',
+    );
+    // outline stays arbitrary on purpose: `outline-none` writes the
+    // --tw-outline-style variable a later `outline-2` would read back
+    expect(translateDeclarationToTailwind('outline', 'none').cls).toBe('[outline:none]');
+  });
+});
+
+describe('splitSelectorIntoAnchorAndVariants', () => {
+  it('lifts state and pseudo suffixes into variants', () => {
+    expect(splitSelectorIntoAnchorAndVariants('[ngpInput][data-focus-visible]')).toEqual({
+      anchor: '[ngpInput]',
+      variants: ['data-focus-visible'],
+    });
+    expect(splitSelectorIntoAnchorAndVariants(":host[data-orientation='vertical']")).toEqual({
+      anchor: ':host',
+      variants: ['data-[orientation=vertical]'],
+    });
+    expect(splitSelectorIntoAnchorAndVariants('[ngpInput]::placeholder')).toEqual({
+      anchor: '[ngpInput]',
+      variants: ['placeholder'],
+    });
+    expect(splitSelectorIntoAnchorAndVariants('[ngpInput]::-webkit-search-cancel-button')).toEqual({
+      anchor: '[ngpInput]',
+      variants: ['[&::-webkit-search-cancel-button]'],
+    });
+    expect(splitSelectorIntoAnchorAndVariants('.slot[data-caret]::after')).toEqual({
+      anchor: '.slot',
+      variants: ['data-caret', 'after'],
+    });
+  });
+
+  it('never lifts a suffix across a combinator', () => {
+    // the [data-open] belongs to the trigger, not to ng-icon
+    expect(splitSelectorIntoAnchorAndVariants('[ngpAccordionTrigger][data-open] ng-icon')).toEqual({
+      anchor: '[ngpAccordionTrigger][data-open] ng-icon',
+      variants: [],
+    });
+  });
+});
+
+describe('translateCssToTailwind hazard notes', () => {
+  it('flags all: unset and keeps its rule as raw CSS', () => {
+    const plan = translateCssToTailwind(
+      parseCssRules(`[ngpButton] { all: unset; display: flex; }`),
+    );
+    expect(plan.notes.some(note => note.startsWith('ALL_UNSET'))).toBe(true);
+    expect(plan.rules[0].requiresRawCss).toBe(true);
+  });
+
+  it('flags a custom property written by multiple rules and keeps them as raw CSS', () => {
+    const plan = translateCssToTailwind(
+      parseCssRules(`
+        :host[data-position-y='top'] { --y: translateY(-100%); }
+        :host[data-enter] { --y: translateY(0); }
+      `),
+    );
+    expect(
+      plan.notes.some(note => note.startsWith('ORDER_DEPENDENT') && note.includes('--y')),
+    ).toBe(true);
+    expect(plan.rules.every(rule => rule.requiresRawCss)).toBe(true);
+  });
+
+  it('marks a combinator rule as raw CSS', () => {
+    const plan = translateCssToTailwind(
+      parseCssRules(`[ngpTrigger][data-open] ng-icon { transform: rotate(180deg); }`),
+    );
+    expect(plan.rules[0].requiresRawCss).toBe(true);
+  });
+});
+
+describe('deriveCssFromTailwind', () => {
+  let compiler: TailwindCompiler;
+
+  beforeAll(async () => {
+    compiler = await createTailwindCompiler();
+  });
+
+  const derive = (css: string) =>
+    deriveCssFromTailwind(translateCssToTailwind(parseCssRules(css)), compiler);
+
+  it('flattens every --tw-* variable out of the output', () => {
+    const { css } = derive(`[ngpButton] { border: 1px solid var(--ngp-border); }`);
+    expect(css).not.toContain('--tw-');
+    expect(css).toContain('border-style: solid');
+    expect(css).toContain('border-width: 1px');
+    expect(css).toContain('border-color: var(--ngp-border)');
+  });
+
+  it('keeps the base+focus outline pair working (the outline-none trap)', () => {
+    const { css } = derive(`
+      [ngpInput] { outline: none; }
+      [ngpInput][data-focus-visible] { outline: 2px solid var(--ngp-focus-ring); }
+    `);
+    // the focus state must not inherit the base rule's none
+    expect(css).toMatch(
+      /\[ngpInput\]\[data-focus-visible\] \{\n {2}outline: 2px solid var\(--ngp-focus-ring\);/,
+    );
+  });
+
+  it('emits declarations in authored order, not the compiler order (all: unset)', () => {
+    const { css } = derive(`[ngpButton] { all: unset; display: flex; width: 100%; }`);
+    const allIndex = css.indexOf('all: unset');
+    const flexIndex = css.indexOf('display: flex');
+    expect(allIndex).toBeGreaterThanOrEqual(0);
+    expect(allIndex).toBeLessThan(flexIndex);
+  });
+
+  it('preserves the source cascade between equal-specificity rules (toast)', () => {
+    const { css } = derive(`
+      :host[data-position-y='top'] { --y: translateY(-100%); }
+      :host[data-enter] { --y: translateY(0); }
+    `);
+    // last in source must be last in output so it wins the cascade
+    expect(css.indexOf("[data-position-y='top']")).toBeLessThan(css.indexOf('[data-enter]'));
+  });
+
+  it('hoists prefers-reduced-motion to a top-level @media block', () => {
+    const { css } = derive(`
+      [ngpContent] { overflow: hidden; }
+      @media (prefers-reduced-motion: reduce) {
+        [ngpContent] { animation-duration: 0s; }
+      }
+    `);
+    expect(css).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{\n {2}\[ngpContent\] \{\n {4}animation-duration: 0s;/,
+    );
+  });
+
+  it('passes @keyframes through verbatim', () => {
+    const { css } = derive(`
+      [ngpContent][data-open] { animation: slideDown 0.2s ease-in-out forwards; }
+      @keyframes slideDown { from { height: 0; } to { height: var(--ngp-h); } }
+    `);
+    expect(css).toContain('animation: slideDown 0.2s ease-in-out forwards');
+    expect(css).toContain('@keyframes slideDown');
+  });
+
+  it('collapses the repeated content declarations of before/after utilities', () => {
+    const { css } = derive(`
+      :host::before { content: ''; position: absolute; inset: 0; border-radius: 9999px; }
+    `);
+    expect(css.match(/content:/g)).toHaveLength(1);
+  });
+
+  it('strips box-shadow zero sentinels around a real shadow', () => {
+    const { css } = derive(`[ngpInput] { box-shadow: var(--ngp-input-shadow); }`);
+    expect(css).toContain('box-shadow: var(--ngp-input-shadow);');
+    expect(css).not.toContain('0 0 #0000');
+  });
+});
+
+describe('parity gate', () => {
+  let compiler: TailwindCompiler;
+
+  const SAMPLE = `
+    :host { display: block; }
+    [ngpTrigger] {
+      display: flex;
+      height: 2.75rem;
+      border-radius: 0.75rem;
+      outline: none;
+      color: var(--ngp-text-primary);
+    }
+    [ngpTrigger][data-focus-visible] { outline: 2px solid var(--ngp-focus-ring); }
+    @media (prefers-reduced-motion: reduce) {
+      [ngpTrigger] { animation-duration: 0s; }
+    }
+  `;
+
+  beforeAll(async () => {
+    compiler = await createTailwindCompiler();
+  });
+
+  it('is green on a faithful round trip', () => {
+    const entries = parseCssRules(SAMPLE);
+    const { css } = deriveCssFromTailwind(translateCssToTailwind(entries), compiler);
+    const result = diffCssParity(
+      canonicaliseCssDeclarations(entries),
+      canonicaliseCssDeclarations(parseCssRules(css)),
+    );
+    expect(result.mismatches).toEqual([]);
+  });
+
+  // a green gate that inspects nothing is worse than none: prove each failure
+  // mode of the derived output turns the gate red
+  it.each([
+    ['a changed value', (css: string) => css.replace('height: 2.75rem', 'height: 2.5rem')],
+    ['a dropped declaration', (css: string) => css.replace(/\s*display: flex;/, '')],
+    [
+      'a dropped state rule',
+      (css: string) => css.replace(/\[ngpTrigger\]\[data-focus-visible\] \{[^}]*\}/, ''),
+    ],
+    [
+      'a dropped @media block',
+      (css: string) => css.replace(/@media \(prefers-reduced-motion[^{]*\{[\s\S]*?\n\}/, ''),
+    ],
+    [
+      'a swapped token',
+      (css: string) => css.replace('var(--ngp-text-primary)', 'var(--ngp-text-secondary)'),
+    ],
+  ])('turns red on %s', (_, sabotage) => {
+    const entries = parseCssRules(SAMPLE);
+    const { css } = deriveCssFromTailwind(translateCssToTailwind(entries), compiler);
+    const broken = sabotage(css);
+    expect(broken).not.toBe(css);
+    const result = diffCssParity(
+      canonicaliseCssDeclarations(entries),
+      canonicaliseCssDeclarations(parseCssRules(broken)),
+    );
+    expect(result.mismatches.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/tools/src/tailwind-variant/tailwind-css-deriver.ts
+++ b/packages/tools/src/tailwind-variant/tailwind-css-deriver.ts
@@ -1,0 +1,290 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import postcss, { AtRule, Container, Rule } from 'postcss';
+import { compile } from 'tailwindcss';
+import { TailwindTranslationPlan } from './css-to-tailwind-translator';
+
+export interface TailwindCompiler {
+  build(candidates: string[]): string;
+}
+
+export interface DerivedCssResult {
+  css: string;
+  /** Candidates the compiler did not recognise; their declarations were emitted verbatim. */
+  failedCandidates: { selector: string; cls: string }[];
+}
+
+// Inline theme so scale utilities flatten to plain values instead of
+// referencing Tailwind-owned theme variables in the derived CSS.
+const INLINE_THEME = `@theme inline {
+  --spacing: 0.25rem;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+  --radius-2xl: 1rem;
+  --radius-3xl: 1.5rem;
+  --text-xs: 0.75rem;
+  --text-xs--line-height: 1rem;
+  --text-sm: 0.875rem;
+  --text-sm--line-height: 1.25rem;
+  --text-base: 1rem;
+  --text-base--line-height: 1.5rem;
+}`;
+
+/**
+ * Create a standalone Tailwind compiler (theme + utilities, no preflight),
+ * resolving the tailwindcss stylesheets from the workspace's node_modules.
+ */
+export async function createTailwindCompiler(): Promise<TailwindCompiler> {
+  const resolver = createRequire(path.join(process.cwd(), 'noop.js'));
+  return compile(
+    `@import 'tailwindcss/theme.css' layer(theme);\n@import 'tailwindcss/utilities.css' layer(utilities);\n${INLINE_THEME}`,
+    {
+      loadStylesheet: async (id: string) => {
+        const resolved = resolver.resolve(id);
+        return {
+          path: resolved,
+          base: path.dirname(resolved),
+          content: readFileSync(resolved, 'utf8'),
+        };
+      },
+    },
+  );
+}
+
+const unescapeClassName = (selector: string): string => selector.replace(/\\(.)/g, '$1');
+
+/** Index the compiled sheet: utility AST nodes by class name + @property initial values. */
+function indexCompiledStylesheet(css: string): {
+  utilities: Map<string, Rule>;
+  propertyInitialValues: Map<string, string>;
+} {
+  const root = postcss.parse(css);
+  const utilities = new Map<string, Rule>();
+  const propertyInitialValues = new Map<string, string>();
+
+  root.walkAtRules('property', atRule => {
+    atRule.walkDecls('initial-value', decl => {
+      propertyInitialValues.set(atRule.params, decl.value);
+    });
+  });
+  root.walkAtRules('layer', layer => {
+    if (layer.params !== 'utilities') {
+      return;
+    }
+    layer.each(node => {
+      if (node.type === 'rule' && node.selector.startsWith('.')) {
+        utilities.set(unescapeClassName(node.selector.slice(1)), node);
+      }
+    });
+  });
+
+  return { utilities, propertyInitialValues };
+}
+
+/** Resolve spacing arithmetic and other compiler artifacts into plain values. */
+function resolveCompilerArithmetic(value: string): string {
+  return value
+    .replace(/calc\((\d*\.?\d+)rem\s*\*\s*(-?\d*\.?\d+)\)/g, (_, a: string, b: string) => {
+      const rem = Number(a) * Number(b);
+      return `${Number(rem.toFixed(5))}rem`;
+    })
+    .replace(/calc\(infinity\s*\*\s*1px\)/g, '9999px');
+}
+
+interface FlattenedDeclaration {
+  selectorSuffixes: string[];
+  media: string | null;
+  prop: string;
+  value: string;
+}
+
+/**
+ * Flatten one utility into plain declarations. Every var(--tw-*) resolves from
+ * the utility's own scope first, then the @property initial values, then the
+ * var() fallback — so no Tailwind-owned variable survives into the output.
+ * Scopes are per-utility on purpose: one utility's `--tw-*` write must never
+ * leak into another's read (the `outline-none` + `outline-2` focus-ring trap).
+ */
+function flattenUtilityDeclarations(
+  utilityNode: Rule,
+  propertyInitialValues: Map<string, string>,
+): FlattenedDeclaration[] {
+  const flattened: FlattenedDeclaration[] = [];
+
+  const resolveTailwindVariables = (value: string, scopes: Map<string, string>[]): string => {
+    let resolved = value;
+    for (let pass = 0; pass < 8; pass++) {
+      const before = resolved;
+      resolved = resolved.replace(
+        /var\((--tw-[\w-]+)(?:,\s*([^()]*(?:\([^()]*\)[^()]*)*))?\)/g,
+        (full, name: string, fallback: string | undefined) => {
+          for (let i = scopes.length - 1; i >= 0; i--) {
+            const local = scopes[i].get(name);
+            if (local !== undefined) {
+              return local;
+            }
+          }
+          return propertyInitialValues.get(name) ?? fallback ?? full;
+        },
+      );
+      if (resolved === before) {
+        break;
+      }
+    }
+    return resolved;
+  };
+
+  const walk = (
+    container: Container,
+    selectorSuffixes: string[],
+    media: string | null,
+    scopes: Map<string, string>[],
+  ): void => {
+    const localVariables = new Map<string, string>();
+    container.each(child => {
+      if (child.type === 'decl' && child.prop.startsWith('--tw-')) {
+        localVariables.set(child.prop, child.value);
+      }
+    });
+    const scopeChain = [...scopes, localVariables];
+
+    container.each(child => {
+      if (child.type === 'decl') {
+        if (child.prop.startsWith('--tw-')) {
+          return;
+        }
+        let value = resolveCompilerArithmetic(resolveTailwindVariables(child.value, scopeChain));
+        if (child.prop === 'box-shadow') {
+          // strip the zero sentinels the ring/shadow machinery threads through
+          const terms = value
+            .split(/,(?![^(]*\))/)
+            .map(term => term.trim())
+            .filter(term => term !== '0 0 #0000');
+          if (terms.length === 0) {
+            return;
+          }
+          value = terms.join(', ');
+        }
+        flattened.push({ selectorSuffixes, media, prop: child.prop, value });
+      } else if (child.type === 'rule') {
+        walk(child, [...selectorSuffixes, child.selector], media, scopeChain);
+      } else if (child.type === 'atrule' && child.name === 'media') {
+        walk(child as AtRule, selectorSuffixes, child.params, scopeChain);
+      }
+      // @supports blocks are progressive enhancement (forced-colors) — the base
+      // declaration stands without them.
+    });
+  };
+
+  walk(utilityNode, [], null, []);
+  return flattened;
+}
+
+/** Compose a nested-selector suffix chain onto the anchor selector. */
+function composeNestedSelector(anchor: string, selectorSuffixes: string[]): string {
+  let selector = anchor;
+  for (const suffix of selectorSuffixes) {
+    selector = suffix.includes('&') ? suffix.replace(/&/g, selector) : `${selector} ${suffix}`;
+  }
+  return selector;
+}
+
+interface GroupedCssRule {
+  selector: string;
+  decls: { prop: string; value: string }[];
+}
+
+/**
+ * Derive flat, readable CSS from a translation plan.
+ *
+ * Rules are emitted in authored order — never the compiler's — which is what
+ * neutralises `all: unset` resets and order-dependent cascades in the derived
+ * output. @media blocks are hoisted to the end, matching how the repo's
+ * hand-written CSS is laid out.
+ */
+export function deriveCssFromTailwind(
+  plan: TailwindTranslationPlan,
+  compiler: TailwindCompiler,
+): DerivedCssResult {
+  const candidates = [...new Set(plan.rules.flatMap(rule => rule.candidates.map(c => c.cls)))];
+  const { utilities, propertyInitialValues } = indexCompiledStylesheet(compiler.build(candidates));
+
+  const flat: { selector: string; prop: string; value: string }[] = [];
+  const mediaBuckets = new Map<string, { selector: string; prop: string; value: string }[]>();
+  const failedCandidates: DerivedCssResult['failedCandidates'] = [];
+
+  for (const rule of plan.rules) {
+    for (const candidate of rule.candidates) {
+      const utilityNode = utilities.get(candidate.cls);
+      if (!utilityNode) {
+        // unknown to the compiler — emit the original declaration verbatim
+        failedCandidates.push({ selector: rule.selector, cls: candidate.cls });
+        flat.push({ selector: rule.selector, prop: candidate.prop, value: candidate.value });
+        continue;
+      }
+      for (const declaration of flattenUtilityDeclarations(utilityNode, propertyInitialValues)) {
+        const selector = composeNestedSelector(rule.anchor, declaration.selectorSuffixes);
+        const mediaParams = declaration.media ?? rule.media;
+        if (mediaParams) {
+          const bucket = mediaBuckets.get(mediaParams) ?? [];
+          bucket.push({ selector, prop: declaration.prop, value: declaration.value });
+          mediaBuckets.set(mediaParams, bucket);
+        } else {
+          flat.push({ selector, prop: declaration.prop, value: declaration.value });
+        }
+      }
+    }
+  }
+
+  const groupIntoRules = (
+    declarations: { selector: string; prop: string; value: string }[],
+  ): GroupedCssRule[] => {
+    const grouped: GroupedCssRule[] = [];
+    for (const declaration of declarations) {
+      const value =
+        declaration.prop === 'content'
+          ? declaration.value.replace(/^''$/, '""')
+          : declaration.value;
+      const last = grouped[grouped.length - 1];
+      if (last && last.selector === declaration.selector) {
+        // repeated identical declarations are noise (every `before:` utility
+        // re-emits `content`); a repeat with a *different* value must stay
+        const previous = [...last.decls].reverse().find(d => d.prop === declaration.prop);
+        if (previous && previous.value === value) {
+          continue;
+        }
+        last.decls.push({ prop: declaration.prop, value });
+      } else {
+        grouped.push({
+          selector: declaration.selector,
+          decls: [{ prop: declaration.prop, value }],
+        });
+      }
+    }
+    return grouped;
+  };
+
+  const parts: string[] = [];
+  for (const rule of groupIntoRules(flat)) {
+    parts.push(
+      `${rule.selector} {\n${rule.decls.map(d => `  ${d.prop}: ${d.value};`).join('\n')}\n}`,
+    );
+  }
+  for (const [params, declarations] of mediaBuckets) {
+    const inner = groupIntoRules(declarations)
+      .map(
+        rule =>
+          `  ${rule.selector} {\n${rule.decls.map(d => `    ${d.prop}: ${d.value};`).join('\n')}\n  }`,
+      )
+      .join('\n\n');
+    parts.push(`@media ${params} {\n${inner}\n}`);
+  }
+  parts.push(...plan.keyframes);
+
+  return { css: parts.join('\n\n'), failedCandidates };
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

No linked issue — this continues the conversation from #854, where you suggested deriving one styles variant from the other by running the Tailwind compiler.

## What does this PR implement/fix?

Adds `tailwind` to the `--styles` option of the primitive schematic, so consumers get components styled with Tailwind classes on the elements instead of the CSS block.

<img width="796" height="364" alt="image" src="https://github.com/user-attachments/assets/1327a42f-ac41-4ab6-8304-231201842734" />

I started by building exactly what you proposed — compiling each element's classes with `compile()` from `tailwindcss` and re-scoping the output onto selectors. That pipeline lives in `packages/tools/src/tailwind-variant/` and it validated the whole idea: a round-trip test proves every one of the 49 styled reusable components can travel hand-written CSS → Tailwind classes → real compiler → CSS again at 100% declaration parity (49/49, with the gate proven to go red on sabotaged output). Your instinct about the identifier was also right in spirit, just already satisfied: about 77% of the rules anchor on something the elements already carry (`:host`, the `ngp*` directive attribute, a tag or a semantic class), so no `data-testid` pass was needed.

For what ships, the direction is flipped relative to the original idea, for one practical reason: the components stay authored in CSS (nothing changes in `apps/components`), and the templates generator uses that pipeline at build time to produce a second template set, `templates-tailwind/`, with the utility classes injected per element. The schematic just picks the template set — the Tailwind compiler never runs in the consumer's workspace.

Whatever Tailwind genuinely cannot express stays behind as a small raw `styles` block, and each case is load-bearing rather than cosmetic: `@keyframes` and any animation referencing them (Angular scopes keyframe names per component, so a global utility class would reference a name that no longer exists), rules coupling two elements through a combinator, `all: unset` resets and order-dependent custom-property cascades (Tailwind owns its emission order, source order does not survive), and `:host` inside arbitrary variants (matches nothing in a global stylesheet). The classifier routes those to raw CSS automatically and falls back the same way for any anchor it cannot find in the template, so a rule is never silently dropped.

Tests: 89 in `tools` (translator/deriver units, the round-trip gate, the component variant generator) plus schematic tests generating every primitive in the enum with `--styles tailwind` and asserting the output parses and gets OnPush applied. I also verified it end-to-end from a packed tarball in a fresh Angular 21 + Tailwind v4 workspace, comparing the generated `css` and `tailwind` variants side by side. One honest caveat: nothing in this repo renders the tailwind templates in a browser, so visual fidelity relies on the parity gate plus that manual check — happy to discuss whether the components preview app should grow a Tailwind setup as a follow-up.

The templates are regenerated with the existing `nx g @ng-primitives/tools:templates`, same as the css set.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tailwind styling option to the primitive schematic. `--styles tailwind` generates components with utility classes from a prebuilt template set and keeps a small raw CSS block for what Tailwind cannot express. No Tailwind compiler runs in consumer projects.

- **New Features**
  - Adds `tailwind` to the `styles` option for `ng g \`ng-primitives:primitive\``.
  - Schematic switches to pre-generated `templates-tailwind/` (utility classes on elements).
  - Keeps raw CSS only for keyframes/animations, combinators, `all: unset`, order-dependent custom properties, and `:host` inside arbitrary variants.
  - Parity gate ensures derived CSS matches original styles across all reusable components; schematic tests cover `--styles tailwind`.
  - Docs updated to describe `css`, `tailwind`, and `unstyled`; `\`@ng-primitives/tools:templates\`` now regenerates both template sets.

- **Migration**
  - Opt-in only: use `--styles tailwind`. No Tailwind setup is required in the app; the compiler does not run in the consumer workspace.

<sup>Written for commit 1542450e27dbe8f0ca614aecdf3085e7575333ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

