### PR TITLE
feat(checkbox-group): add checkbox-group primitive

### DIFF
--- a/apps/components/src/app/pages/reusable-components/checkbox/checkbox.ts
+++ b/apps/components/src/app/pages/reusable-components/checkbox/checkbox.ts
@@ -13,6 +13,8 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
       directive: NgpCheckbox,
       inputs: [
         'ngpCheckboxChecked:checked',
+        'ngpCheckboxValue:value',
+        'ngpCheckboxParent:parent',
         'ngpCheckboxIndeterminate:indeterminate',
         'ngpCheckboxDisabled:disabled',
       ],

--- a/apps/documentation/src/app/examples/checkbox-group-nested/checkbox-group-nested.example.ts
+++ b/apps/documentation/src/app/examples/checkbox-group-nested/checkbox-group-nested.example.ts
@@ -1,10 +1,13 @@
 import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheckMini, heroMinusMini } from '@ng-icons/heroicons/mini';
 import { NgpCheckbox } from 'ng-primitives/checkbox';
 import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
 
 @Component({
   selector: 'app-checkbox-group-nested',
-  imports: [NgpCheckbox, NgpCheckboxGroup],
+  imports: [NgIcon, NgpCheckbox, NgpCheckboxGroup],
+  providers: [provideIcons({ heroCheckMini, heroMinusMini })],
   template: `
     <div class="permissions">
       <div
@@ -15,17 +18,31 @@ import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
         aria-label="Permissions"
       >
         <label>
-          <span ngpCheckbox ngpCheckboxParent></span>
+          <span #permissions="ngpCheckbox" ngpCheckbox ngpCheckboxParent>
+            @if (permissions.state.indeterminate()) {
+              <ng-icon name="heroMinusMini" aria-hidden="true" />
+            } @else if (permissions.state.checked()) {
+              <ng-icon name="heroCheckMini" aria-hidden="true" />
+            }
+          </span>
           Permissions
         </label>
 
         <label class="child">
-          <span ngpCheckbox ngpCheckboxValue="view-dashboard"></span>
+          <span #dashboard="ngpCheckbox" ngpCheckbox ngpCheckboxValue="view-dashboard">
+            @if (dashboard.state.checked()) {
+              <ng-icon name="heroCheckMini" aria-hidden="true" />
+            }
+          </span>
           View Dashboard
         </label>
 
         <label class="child">
-          <span ngpCheckbox ngpCheckboxValue="access-reports"></span>
+          <span #reports="ngpCheckbox" ngpCheckbox ngpCheckboxValue="access-reports">
+            @if (reports.state.checked()) {
+              <ng-icon name="heroCheckMini" aria-hidden="true" />
+            }
+          </span>
           Access Reports
         </label>
 
@@ -38,27 +55,49 @@ import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
           aria-label="User permissions"
         >
           <label>
-            <span ngpCheckbox ngpCheckboxParent></span>
+            <span #userPermissions="ngpCheckbox" ngpCheckbox ngpCheckboxParent>
+              @if (userPermissions.state.indeterminate()) {
+                <ng-icon name="heroMinusMini" aria-hidden="true" />
+              } @else if (userPermissions.state.checked()) {
+                <ng-icon name="heroCheckMini" aria-hidden="true" />
+              }
+            </span>
             User Permissions
           </label>
 
           <label class="child">
-            <span ngpCheckbox ngpCheckboxValue="create-user"></span>
+            <span #createUser="ngpCheckbox" ngpCheckbox ngpCheckboxValue="create-user">
+              @if (createUser.state.checked()) {
+                <ng-icon name="heroCheckMini" aria-hidden="true" />
+              }
+            </span>
             Create User
           </label>
 
           <label class="child">
-            <span ngpCheckbox ngpCheckboxValue="edit-user"></span>
+            <span #editUser="ngpCheckbox" ngpCheckbox ngpCheckboxValue="edit-user">
+              @if (editUser.state.checked()) {
+                <ng-icon name="heroCheckMini" aria-hidden="true" />
+              }
+            </span>
             Edit User
           </label>
 
           <label class="child">
-            <span ngpCheckbox ngpCheckboxValue="delete-user"></span>
+            <span #deleteUser="ngpCheckbox" ngpCheckbox ngpCheckboxValue="delete-user">
+              @if (deleteUser.state.checked()) {
+                <ng-icon name="heroCheckMini" aria-hidden="true" />
+              }
+            </span>
             Delete User
           </label>
 
           <label class="child">
-            <span ngpCheckbox ngpCheckboxValue="assign-roles"></span>
+            <span #assignRoles="ngpCheckbox" ngpCheckbox ngpCheckboxValue="assign-roles">
+              @if (assignRoles.state.checked()) {
+                <ng-icon name="heroCheckMini" aria-hidden="true" />
+              }
+            </span>
             Assign Roles
           </label>
         </div>
@@ -95,41 +134,55 @@ import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
 
     [ngpCheckbox] {
       display: inline-flex;
-      width: 1.125rem;
-      height: 1.125rem;
-      flex: none;
+      vertical-align: middle;
+      width: 1.25rem;
+      height: 1.25rem;
+      cursor: pointer;
       align-items: center;
       justify-content: center;
-      border: 1px solid var(--ngp-border-secondary);
-      border-radius: 0.3125rem;
+      border-radius: 0.4375rem;
+      border: 1.5px solid var(--ngp-border-secondary);
+      background-color: var(--ngp-background);
+      padding: 0;
       outline: none;
+      flex: none;
+      color: var(--ngp-primary-text);
+      font-size: 0.8125rem;
+      transition:
+        background-color 160ms cubic-bezier(0.4, 0, 0.2, 1),
+        border-color 160ms cubic-bezier(0.4, 0, 0.2, 1),
+        box-shadow 160ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpCheckbox][data-hover] {
+      border-color: var(--ngp-primary);
     }
 
     [ngpCheckbox][data-checked],
     [ngpCheckbox][data-indeterminate] {
       border-color: var(--ngp-primary);
       background: var(--ngp-primary);
+      box-shadow:
+        inset 0 1px 0 0 rgba(255, 255, 255, 0.28),
+        0 1px 1px 0 rgba(0, 0, 0, 0.06);
     }
 
-    [ngpCheckbox][data-checked]::after {
-      width: 0.35rem;
-      height: 0.6rem;
-      border: solid var(--ngp-primary-text);
-      border-width: 0 2px 2px 0;
-      transform: rotate(45deg) translate(-1px, -1px);
-      content: '';
+    [ngpCheckbox][data-checked][data-hover],
+    [ngpCheckbox][data-indeterminate][data-hover] {
+      border-color: var(--ngp-primary-hover);
+      background: var(--ngp-primary-hover);
     }
 
-    [ngpCheckbox][data-indeterminate]::after {
-      width: 0.55rem;
-      height: 2px;
-      background: var(--ngp-primary-text);
-      content: '';
+    ng-icon {
+      width: 0.8125rem;
+      height: 0.8125rem;
+      color: var(--ngp-primary-text);
     }
 
     [ngpCheckbox][data-focus-visible] {
-      outline: 2px solid var(--ngp-focus-ring);
-      outline-offset: 2px;
+      box-shadow:
+        0 0 0 2px var(--ngp-background),
+        0 0 0 4px var(--ngp-focus-ring);
     }
   `,
 })

--- a/apps/documentation/src/app/examples/checkbox-group-nested/checkbox-group-nested.example.ts
+++ b/apps/documentation/src/app/examples/checkbox-group-nested/checkbox-group-nested.example.ts
@@ -1,0 +1,155 @@
+import { Component, signal } from '@angular/core';
+import { NgpCheckbox } from 'ng-primitives/checkbox';
+import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
+
+@Component({
+  selector: 'app-checkbox-group-nested',
+  imports: [NgpCheckbox, NgpCheckboxGroup],
+  template: `
+    <div class="permissions">
+      <div
+        [ngpCheckboxGroupAllValues]="mainPermissions"
+        [ngpCheckboxGroupValue]="mainValue()"
+        (ngpCheckboxGroupValueChange)="onMainValueChange($event)"
+        ngpCheckboxGroup
+        aria-label="Permissions"
+      >
+        <label>
+          <span ngpCheckbox ngpCheckboxParent></span>
+          Permissions
+        </label>
+
+        <label class="child">
+          <span ngpCheckbox ngpCheckboxValue="view-dashboard"></span>
+          View Dashboard
+        </label>
+
+        <label class="child">
+          <span ngpCheckbox ngpCheckboxValue="access-reports"></span>
+          Access Reports
+        </label>
+
+        <div
+          class="nested"
+          [ngpCheckboxGroupAllValues]="managementPermissions"
+          [ngpCheckboxGroupValue]="managementValue()"
+          (ngpCheckboxGroupValueChange)="onManagementValueChange($event)"
+          ngpCheckboxGroup
+          aria-label="User permissions"
+        >
+          <label>
+            <span ngpCheckbox ngpCheckboxParent></span>
+            User Permissions
+          </label>
+
+          <label class="child">
+            <span ngpCheckbox ngpCheckboxValue="create-user"></span>
+            Create User
+          </label>
+
+          <label class="child">
+            <span ngpCheckbox ngpCheckboxValue="edit-user"></span>
+            Edit User
+          </label>
+
+          <label class="child">
+            <span ngpCheckbox ngpCheckboxValue="delete-user"></span>
+            Delete User
+          </label>
+
+          <label class="child">
+            <span ngpCheckbox ngpCheckboxValue="assign-roles"></span>
+            Assign Roles
+          </label>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: `
+    [ngpCheckboxGroup] {
+      display: grid;
+      gap: 0.625rem;
+    }
+
+    .permissions {
+      width: 15rem;
+    }
+
+    .nested {
+      margin-top: 0.25rem;
+      margin-left: 1.5rem;
+    }
+
+    label {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      color: var(--ngp-text-primary);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+
+    label.child {
+      margin-left: 1.5rem;
+    }
+
+    [ngpCheckbox] {
+      display: inline-flex;
+      width: 1.125rem;
+      height: 1.125rem;
+      flex: none;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--ngp-border-secondary);
+      border-radius: 0.3125rem;
+      outline: none;
+    }
+
+    [ngpCheckbox][data-checked],
+    [ngpCheckbox][data-indeterminate] {
+      border-color: var(--ngp-primary);
+      background: var(--ngp-primary);
+    }
+
+    [ngpCheckbox][data-checked]::after {
+      width: 0.35rem;
+      height: 0.6rem;
+      border: solid var(--ngp-primary-text);
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg) translate(-1px, -1px);
+      content: '';
+    }
+
+    [ngpCheckbox][data-indeterminate]::after {
+      width: 0.55rem;
+      height: 2px;
+      background: var(--ngp-primary-text);
+      content: '';
+    }
+
+    [ngpCheckbox][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+  `,
+})
+export default class CheckboxGroupNestedExample {
+  readonly mainPermissions = ['view-dashboard', 'manage-users', 'access-reports'];
+  readonly managementPermissions = ['create-user', 'edit-user', 'delete-user', 'assign-roles'];
+  readonly mainValue = signal<string[]>([]);
+  readonly managementValue = signal<string[]>([]);
+
+  onMainValueChange(value: string[]): void {
+    this.mainValue.set(value);
+    this.managementValue.set(value.includes('manage-users') ? [...this.managementPermissions] : []);
+  }
+
+  onManagementValueChange(value: string[]): void {
+    this.managementValue.set(value);
+    this.mainValue.update(currentValue =>
+      value.length === this.managementPermissions.length
+        ? Array.from(new Set([...currentValue, 'manage-users']))
+        : currentValue.filter(current => current !== 'manage-users'),
+    );
+  }
+}

--- a/apps/documentation/src/app/examples/checkbox-group-nested/checkbox-group-nested.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/checkbox-group-nested/checkbox-group-nested.tailwind.example.ts
@@ -1,0 +1,158 @@
+import { Component, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheckMini, heroMinusMini } from '@ng-icons/heroicons/mini';
+import { NgpCheckbox } from 'ng-primitives/checkbox';
+import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
+
+const checkboxClass =
+  'inline-flex h-5 w-5 flex-none cursor-pointer items-center justify-center rounded-[0.4375rem] border-[1.5px] border-gray-300 bg-white align-middle text-[0.8125rem] text-white outline-hidden transition-all data-checked:border-[#f01e2b] data-checked:bg-[#f01e2b] data-checked:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.28),0_1px_1px_0_rgba(0,0,0,0.06)] data-focus-visible:ring-2 data-focus-visible:ring-blue-500/40 data-focus-visible:ring-offset-2 data-hover:border-[#f01e2b] data-indeterminate:border-[#f01e2b] data-indeterminate:bg-[#f01e2b] dark:border-zinc-800 dark:bg-zinc-950 dark:data-checked:border-[#ff4651] dark:data-checked:bg-[#ff4651] dark:data-focus-visible:ring-2 dark:data-focus-visible:ring-blue-400/45 dark:data-focus-visible:ring-offset-zinc-950 dark:data-hover:border-[#ff4651] dark:data-indeterminate:border-[#ff4651] dark:data-indeterminate:bg-[#ff4651]';
+
+@Component({
+  selector: 'app-checkbox-group-nested',
+  imports: [NgIcon, NgpCheckbox, NgpCheckboxGroup],
+  providers: [provideIcons({ heroCheckMini, heroMinusMini })],
+  template: `
+    <div
+      class="grid w-60 gap-2.5 text-sm text-gray-900 dark:text-zinc-100"
+      [ngpCheckboxGroupAllValues]="mainPermissions"
+      [ngpCheckboxGroupValue]="mainValue()"
+      (ngpCheckboxGroupValueChange)="onMainValueChange($event)"
+      ngpCheckboxGroup
+      aria-label="Permissions"
+    >
+      <label class="flex cursor-pointer items-center gap-2 font-semibold">
+        <span class="${checkboxClass}" #permissions="ngpCheckbox" ngpCheckbox ngpCheckboxParent>
+          @if (permissions.state.indeterminate()) {
+            <ng-icon name="heroMinusMini" aria-hidden="true" />
+          } @else if (permissions.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
+        Permissions
+      </label>
+      <label class="ml-6 flex cursor-pointer items-center gap-2">
+        <span
+          class="${checkboxClass}"
+          #dashboard="ngpCheckbox"
+          ngpCheckbox
+          ngpCheckboxValue="view-dashboard"
+        >
+          @if (dashboard.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
+        View Dashboard
+      </label>
+      <label class="ml-6 flex cursor-pointer items-center gap-2">
+        <span
+          class="${checkboxClass}"
+          #reports="ngpCheckbox"
+          ngpCheckbox
+          ngpCheckboxValue="access-reports"
+        >
+          @if (reports.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
+        Access Reports
+      </label>
+
+      <div
+        class="ml-6 grid gap-2.5"
+        [ngpCheckboxGroupAllValues]="managementPermissions"
+        [ngpCheckboxGroupValue]="managementValue()"
+        (ngpCheckboxGroupValueChange)="onManagementValueChange($event)"
+        ngpCheckboxGroup
+        aria-label="User permissions"
+      >
+        <label class="flex cursor-pointer items-center gap-2 font-semibold">
+          <span
+            class="${checkboxClass}"
+            #userPermissions="ngpCheckbox"
+            ngpCheckbox
+            ngpCheckboxParent
+          >
+            @if (userPermissions.state.indeterminate()) {
+              <ng-icon name="heroMinusMini" aria-hidden="true" />
+            } @else if (userPermissions.state.checked()) {
+              <ng-icon name="heroCheckMini" aria-hidden="true" />
+            }
+          </span>
+          User Permissions
+        </label>
+        <label class="ml-6 flex cursor-pointer items-center gap-2">
+          <span
+            class="${checkboxClass}"
+            #createUser="ngpCheckbox"
+            ngpCheckbox
+            ngpCheckboxValue="create-user"
+          >
+            @if (createUser.state.checked()) {
+              <ng-icon name="heroCheckMini" aria-hidden="true" />
+            }
+          </span>
+          Create User
+        </label>
+        <label class="ml-6 flex cursor-pointer items-center gap-2">
+          <span
+            class="${checkboxClass}"
+            #editUser="ngpCheckbox"
+            ngpCheckbox
+            ngpCheckboxValue="edit-user"
+          >
+            @if (editUser.state.checked()) {
+              <ng-icon name="heroCheckMini" aria-hidden="true" />
+            }
+          </span>
+          Edit User
+        </label>
+        <label class="ml-6 flex cursor-pointer items-center gap-2">
+          <span
+            class="${checkboxClass}"
+            #deleteUser="ngpCheckbox"
+            ngpCheckbox
+            ngpCheckboxValue="delete-user"
+          >
+            @if (deleteUser.state.checked()) {
+              <ng-icon name="heroCheckMini" aria-hidden="true" />
+            }
+          </span>
+          Delete User
+        </label>
+        <label class="ml-6 flex cursor-pointer items-center gap-2">
+          <span
+            class="${checkboxClass}"
+            #assignRoles="ngpCheckbox"
+            ngpCheckbox
+            ngpCheckboxValue="assign-roles"
+          >
+            @if (assignRoles.state.checked()) {
+              <ng-icon name="heroCheckMini" aria-hidden="true" />
+            }
+          </span>
+          Assign Roles
+        </label>
+      </div>
+    </div>
+  `,
+})
+export default class CheckboxGroupNestedExample {
+  readonly mainPermissions = ['view-dashboard', 'manage-users', 'access-reports'];
+  readonly managementPermissions = ['create-user', 'edit-user', 'delete-user', 'assign-roles'];
+  readonly mainValue = signal<string[]>([]);
+  readonly managementValue = signal<string[]>([]);
+
+  onMainValueChange(value: string[]): void {
+    this.mainValue.set(value);
+    this.managementValue.set(value.includes('manage-users') ? [...this.managementPermissions] : []);
+  }
+
+  onManagementValueChange(value: string[]): void {
+    this.managementValue.set(value);
+    this.mainValue.update(currentValue =>
+      value.length === this.managementPermissions.length
+        ? Array.from(new Set([...currentValue, 'manage-users']))
+        : currentValue.filter(current => current !== 'manage-users'),
+    );
+  }
+}

--- a/apps/documentation/src/app/examples/checkbox-group-parent/checkbox-group-parent.example.ts
+++ b/apps/documentation/src/app/examples/checkbox-group-parent/checkbox-group-parent.example.ts
@@ -1,10 +1,13 @@
 import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheckMini, heroMinusMini } from '@ng-icons/heroicons/mini';
 import { NgpCheckbox } from 'ng-primitives/checkbox';
 import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
 
 @Component({
   selector: 'app-checkbox-group-parent',
-  imports: [NgpCheckbox, NgpCheckboxGroup],
+  imports: [NgIcon, NgpCheckbox, NgpCheckboxGroup],
+  providers: [provideIcons({ heroCheckMini, heroMinusMini })],
   template: `
     <div
       [ngpCheckboxGroupAllValues]="allValues"
@@ -15,17 +18,31 @@ import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
       <div class="label" id="checkbox-group-parent-label">Notification channels</div>
 
       <label>
-        <span ngpCheckbox ngpCheckboxParent></span>
+        <span #parent="ngpCheckbox" ngpCheckbox ngpCheckboxParent>
+          @if (parent.state.indeterminate()) {
+            <ng-icon name="heroMinusMini" aria-hidden="true" />
+          } @else if (parent.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
         All notifications
       </label>
 
       <label class="child">
-        <span ngpCheckbox ngpCheckboxValue="email"></span>
+        <span #email="ngpCheckbox" ngpCheckbox ngpCheckboxValue="email">
+          @if (email.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
         Email
       </label>
 
       <label class="child">
-        <span ngpCheckbox ngpCheckboxValue="sms"></span>
+        <span #sms="ngpCheckbox" ngpCheckbox ngpCheckboxValue="sms">
+          @if (sms.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
         SMS
       </label>
     </div>
@@ -58,41 +75,55 @@ import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
 
     [ngpCheckbox] {
       display: inline-flex;
-      width: 1.125rem;
-      height: 1.125rem;
-      flex: none;
+      vertical-align: middle;
+      width: 1.25rem;
+      height: 1.25rem;
+      cursor: pointer;
       align-items: center;
       justify-content: center;
-      border: 1px solid var(--ngp-border-secondary);
-      border-radius: 0.3125rem;
+      border-radius: 0.4375rem;
+      border: 1.5px solid var(--ngp-border-secondary);
+      background-color: var(--ngp-background);
+      padding: 0;
       outline: none;
+      flex: none;
+      color: var(--ngp-primary-text);
+      font-size: 0.8125rem;
+      transition:
+        background-color 160ms cubic-bezier(0.4, 0, 0.2, 1),
+        border-color 160ms cubic-bezier(0.4, 0, 0.2, 1),
+        box-shadow 160ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpCheckbox][data-hover] {
+      border-color: var(--ngp-primary);
     }
 
     [ngpCheckbox][data-checked],
     [ngpCheckbox][data-indeterminate] {
       border-color: var(--ngp-primary);
       background: var(--ngp-primary);
+      box-shadow:
+        inset 0 1px 0 0 rgba(255, 255, 255, 0.28),
+        0 1px 1px 0 rgba(0, 0, 0, 0.06);
     }
 
-    [ngpCheckbox][data-checked]::after {
-      width: 0.35rem;
-      height: 0.6rem;
-      border: solid var(--ngp-primary-text);
-      border-width: 0 2px 2px 0;
-      transform: rotate(45deg) translate(-1px, -1px);
-      content: '';
+    [ngpCheckbox][data-checked][data-hover],
+    [ngpCheckbox][data-indeterminate][data-hover] {
+      border-color: var(--ngp-primary-hover);
+      background: var(--ngp-primary-hover);
     }
 
-    [ngpCheckbox][data-indeterminate]::after {
-      width: 0.55rem;
-      height: 2px;
-      background: var(--ngp-primary-text);
-      content: '';
+    ng-icon {
+      width: 0.8125rem;
+      height: 0.8125rem;
+      color: var(--ngp-primary-text);
     }
 
     [ngpCheckbox][data-focus-visible] {
-      outline: 2px solid var(--ngp-focus-ring);
-      outline-offset: 2px;
+      box-shadow:
+        0 0 0 2px var(--ngp-background),
+        0 0 0 4px var(--ngp-focus-ring);
     }
   `,
 })

--- a/apps/documentation/src/app/examples/checkbox-group-parent/checkbox-group-parent.example.ts
+++ b/apps/documentation/src/app/examples/checkbox-group-parent/checkbox-group-parent.example.ts
@@ -1,0 +1,102 @@
+import { Component } from '@angular/core';
+import { NgpCheckbox } from 'ng-primitives/checkbox';
+import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
+
+@Component({
+  selector: 'app-checkbox-group-parent',
+  imports: [NgpCheckbox, NgpCheckboxGroup],
+  template: `
+    <div
+      [ngpCheckboxGroupAllValues]="allValues"
+      [ngpCheckboxGroupDefaultValue]="defaultValue"
+      ngpCheckboxGroup
+      aria-labelledby="checkbox-group-parent-label"
+    >
+      <div class="label" id="checkbox-group-parent-label">Notification channels</div>
+
+      <label>
+        <span ngpCheckbox ngpCheckboxParent></span>
+        All notifications
+      </label>
+
+      <label class="child">
+        <span ngpCheckbox ngpCheckboxValue="email"></span>
+        Email
+      </label>
+
+      <label class="child">
+        <span ngpCheckbox ngpCheckboxValue="sms"></span>
+        SMS
+      </label>
+    </div>
+  `,
+  styles: `
+    [ngpCheckboxGroup] {
+      display: grid;
+      gap: 0.625rem;
+      width: 14rem;
+    }
+
+    .label {
+      color: var(--ngp-text-secondary);
+      font-size: 0.8125rem;
+      font-weight: 600;
+    }
+
+    label {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      color: var(--ngp-text-primary);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+
+    label.child {
+      margin-left: 1.5rem;
+    }
+
+    [ngpCheckbox] {
+      display: inline-flex;
+      width: 1.125rem;
+      height: 1.125rem;
+      flex: none;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--ngp-border-secondary);
+      border-radius: 0.3125rem;
+      outline: none;
+    }
+
+    [ngpCheckbox][data-checked],
+    [ngpCheckbox][data-indeterminate] {
+      border-color: var(--ngp-primary);
+      background: var(--ngp-primary);
+    }
+
+    [ngpCheckbox][data-checked]::after {
+      width: 0.35rem;
+      height: 0.6rem;
+      border: solid var(--ngp-primary-text);
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg) translate(-1px, -1px);
+      content: '';
+    }
+
+    [ngpCheckbox][data-indeterminate]::after {
+      width: 0.55rem;
+      height: 2px;
+      background: var(--ngp-primary-text);
+      content: '';
+    }
+
+    [ngpCheckbox][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+  `,
+})
+export default class CheckboxGroupParentExample {
+  readonly allValues = ['email', 'sms'];
+  readonly defaultValue = ['email'];
+}

--- a/apps/documentation/src/app/examples/checkbox-group-parent/checkbox-group-parent.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/checkbox-group-parent/checkbox-group-parent.tailwind.example.ts
@@ -1,0 +1,67 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheckMini, heroMinusMini } from '@ng-icons/heroicons/mini';
+import { NgpCheckbox } from 'ng-primitives/checkbox';
+import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
+
+const checkboxClass =
+  'inline-flex h-5 w-5 flex-none cursor-pointer items-center justify-center rounded-[0.4375rem] border-[1.5px] border-gray-300 bg-white align-middle text-[0.8125rem] text-white outline-hidden transition-all data-checked:border-[#f01e2b] data-checked:bg-[#f01e2b] data-checked:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.28),0_1px_1px_0_rgba(0,0,0,0.06)] data-focus-visible:ring-2 data-focus-visible:ring-blue-500/40 data-focus-visible:ring-offset-2 data-hover:border-[#f01e2b] data-indeterminate:border-[#f01e2b] data-indeterminate:bg-[#f01e2b] dark:border-zinc-800 dark:bg-zinc-950 dark:data-checked:border-[#ff4651] dark:data-checked:bg-[#ff4651] dark:data-focus-visible:ring-2 dark:data-focus-visible:ring-blue-400/45 dark:data-focus-visible:ring-offset-zinc-950 dark:data-hover:border-[#ff4651] dark:data-indeterminate:border-[#ff4651] dark:data-indeterminate:bg-[#ff4651]';
+
+@Component({
+  selector: 'app-checkbox-group-parent',
+  imports: [NgIcon, NgpCheckbox, NgpCheckboxGroup],
+  providers: [provideIcons({ heroCheckMini, heroMinusMini })],
+  template: `
+    <div
+      class="grid w-56 gap-2.5"
+      [ngpCheckboxGroupAllValues]="allValues"
+      [ngpCheckboxGroupDefaultValue]="defaultValue"
+      ngpCheckboxGroup
+      aria-labelledby="checkbox-group-parent-label"
+    >
+      <div
+        class="text-[0.8125rem] font-semibold text-gray-600 dark:text-zinc-400"
+        id="checkbox-group-parent-label"
+      >
+        Notification channels
+      </div>
+
+      <label
+        class="flex cursor-pointer items-center gap-2 text-sm font-semibold text-gray-900 dark:text-zinc-100"
+      >
+        <span class="${checkboxClass}" #parent="ngpCheckbox" ngpCheckbox ngpCheckboxParent>
+          @if (parent.state.indeterminate()) {
+            <ng-icon name="heroMinusMini" aria-hidden="true" />
+          } @else if (parent.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
+        All notifications
+      </label>
+      <label
+        class="ml-6 flex cursor-pointer items-center gap-2 text-sm text-gray-900 dark:text-zinc-100"
+      >
+        <span class="${checkboxClass}" #email="ngpCheckbox" ngpCheckbox ngpCheckboxValue="email">
+          @if (email.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
+        Email
+      </label>
+      <label
+        class="ml-6 flex cursor-pointer items-center gap-2 text-sm text-gray-900 dark:text-zinc-100"
+      >
+        <span class="${checkboxClass}" #sms="ngpCheckbox" ngpCheckbox ngpCheckboxValue="sms">
+          @if (sms.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
+        SMS
+      </label>
+    </div>
+  `,
+})
+export default class CheckboxGroupParentExample {
+  readonly allValues = ['email', 'sms'];
+  readonly defaultValue = ['email'];
+}

--- a/apps/documentation/src/app/examples/checkbox-group/checkbox-group.example.ts
+++ b/apps/documentation/src/app/examples/checkbox-group/checkbox-group.example.ts
@@ -1,0 +1,100 @@
+import { Component } from '@angular/core';
+import { NgpCheckbox } from 'ng-primitives/checkbox';
+import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
+
+@Component({
+  selector: 'app-checkbox-group',
+  imports: [NgpCheckbox, NgpCheckboxGroup],
+  template: `
+    <div
+      [ngpCheckboxGroupDefaultValue]="defaultValue"
+      ngpCheckboxGroup
+      aria-labelledby="checkbox-group-label"
+    >
+      <div class="label" id="checkbox-group-label">Fruits</div>
+
+      <label>
+        <span ngpCheckbox ngpCheckboxValue="fuji-apple"></span>
+        Fuji
+      </label>
+
+      <label>
+        <span ngpCheckbox ngpCheckboxValue="gala-apple"></span>
+        Gala
+      </label>
+
+      <label>
+        <span ngpCheckbox ngpCheckboxValue="granny-smith-apple"></span>
+        Granny Smith
+      </label>
+    </div>
+  `,
+  styles: `
+    [ngpCheckboxGroup] {
+      display: grid;
+      gap: 0.625rem;
+      width: 14rem;
+    }
+
+    .label {
+      color: var(--ngp-text-secondary);
+      font-size: 0.8125rem;
+      font-weight: 600;
+    }
+
+    label {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      color: var(--ngp-text-primary);
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+
+    label.child {
+      margin-left: 1.5rem;
+    }
+
+    [ngpCheckbox] {
+      display: inline-flex;
+      width: 1.125rem;
+      height: 1.125rem;
+      flex: none;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--ngp-border-secondary);
+      border-radius: 0.3125rem;
+      outline: none;
+    }
+
+    [ngpCheckbox][data-checked],
+    [ngpCheckbox][data-indeterminate] {
+      border-color: var(--ngp-primary);
+      background: var(--ngp-primary);
+    }
+
+    [ngpCheckbox][data-checked]::after {
+      width: 0.35rem;
+      height: 0.6rem;
+      border: solid var(--ngp-primary-text);
+      border-width: 0 2px 2px 0;
+      transform: rotate(45deg) translate(-1px, -1px);
+      content: '';
+    }
+
+    [ngpCheckbox][data-indeterminate]::after {
+      width: 0.55rem;
+      height: 2px;
+      background: var(--ngp-primary-text);
+      content: '';
+    }
+
+    [ngpCheckbox][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+  `,
+})
+export default class CheckboxGroupExample {
+  readonly defaultValue = ['fuji-apple'];
+}

--- a/apps/documentation/src/app/examples/checkbox-group/checkbox-group.example.ts
+++ b/apps/documentation/src/app/examples/checkbox-group/checkbox-group.example.ts
@@ -1,10 +1,13 @@
 import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheckMini, heroMinusMini } from '@ng-icons/heroicons/mini';
 import { NgpCheckbox } from 'ng-primitives/checkbox';
 import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
 
 @Component({
   selector: 'app-checkbox-group',
-  imports: [NgpCheckbox, NgpCheckboxGroup],
+  imports: [NgIcon, NgpCheckbox, NgpCheckboxGroup],
+  providers: [provideIcons({ heroCheckMini, heroMinusMini })],
   template: `
     <div
       [ngpCheckboxGroupDefaultValue]="defaultValue"
@@ -14,17 +17,29 @@ import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
       <div class="label" id="checkbox-group-label">Fruits</div>
 
       <label>
-        <span ngpCheckbox ngpCheckboxValue="fuji-apple"></span>
+        <span #fuji="ngpCheckbox" ngpCheckbox ngpCheckboxValue="fuji-apple">
+          @if (fuji.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
         Fuji
       </label>
 
       <label>
-        <span ngpCheckbox ngpCheckboxValue="gala-apple"></span>
+        <span #gala="ngpCheckbox" ngpCheckbox ngpCheckboxValue="gala-apple">
+          @if (gala.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
         Gala
       </label>
 
       <label>
-        <span ngpCheckbox ngpCheckboxValue="granny-smith-apple"></span>
+        <span #granny="ngpCheckbox" ngpCheckbox ngpCheckboxValue="granny-smith-apple">
+          @if (granny.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
         Granny Smith
       </label>
     </div>
@@ -57,41 +72,55 @@ import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
 
     [ngpCheckbox] {
       display: inline-flex;
-      width: 1.125rem;
-      height: 1.125rem;
-      flex: none;
+      vertical-align: middle;
+      width: 1.25rem;
+      height: 1.25rem;
+      cursor: pointer;
       align-items: center;
       justify-content: center;
-      border: 1px solid var(--ngp-border-secondary);
-      border-radius: 0.3125rem;
+      border-radius: 0.4375rem;
+      border: 1.5px solid var(--ngp-border-secondary);
+      background-color: var(--ngp-background);
+      padding: 0;
       outline: none;
+      flex: none;
+      color: var(--ngp-primary-text);
+      font-size: 0.8125rem;
+      transition:
+        background-color 160ms cubic-bezier(0.4, 0, 0.2, 1),
+        border-color 160ms cubic-bezier(0.4, 0, 0.2, 1),
+        box-shadow 160ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+
+    [ngpCheckbox][data-hover] {
+      border-color: var(--ngp-primary);
     }
 
     [ngpCheckbox][data-checked],
     [ngpCheckbox][data-indeterminate] {
       border-color: var(--ngp-primary);
       background: var(--ngp-primary);
+      box-shadow:
+        inset 0 1px 0 0 rgba(255, 255, 255, 0.28),
+        0 1px 1px 0 rgba(0, 0, 0, 0.06);
     }
 
-    [ngpCheckbox][data-checked]::after {
-      width: 0.35rem;
-      height: 0.6rem;
-      border: solid var(--ngp-primary-text);
-      border-width: 0 2px 2px 0;
-      transform: rotate(45deg) translate(-1px, -1px);
-      content: '';
+    [ngpCheckbox][data-checked][data-hover],
+    [ngpCheckbox][data-indeterminate][data-hover] {
+      border-color: var(--ngp-primary-hover);
+      background: var(--ngp-primary-hover);
     }
 
-    [ngpCheckbox][data-indeterminate]::after {
-      width: 0.55rem;
-      height: 2px;
-      background: var(--ngp-primary-text);
-      content: '';
+    ng-icon {
+      width: 0.8125rem;
+      height: 0.8125rem;
+      color: var(--ngp-primary-text);
     }
 
     [ngpCheckbox][data-focus-visible] {
-      outline: 2px solid var(--ngp-focus-ring);
-      outline-offset: 2px;
+      box-shadow:
+        0 0 0 2px var(--ngp-background),
+        0 0 0 4px var(--ngp-focus-ring);
     }
   `,
 })

--- a/apps/documentation/src/app/examples/checkbox-group/checkbox-group.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/checkbox-group/checkbox-group.tailwind.example.ts
@@ -1,0 +1,78 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroCheckMini, heroMinusMini } from '@ng-icons/heroicons/mini';
+import { NgpCheckbox } from 'ng-primitives/checkbox';
+import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
+
+const checkboxClass =
+  'inline-flex h-5 w-5 flex-none cursor-pointer items-center justify-center rounded-[0.4375rem] border-[1.5px] border-gray-300 bg-white align-middle text-[0.8125rem] text-white outline-hidden transition-all data-checked:border-[#f01e2b] data-checked:bg-[#f01e2b] data-checked:shadow-[inset_0_1px_0_0_rgba(255,255,255,0.28),0_1px_1px_0_rgba(0,0,0,0.06)] data-focus-visible:ring-2 data-focus-visible:ring-blue-500/40 data-focus-visible:ring-offset-2 data-hover:border-[#f01e2b] data-indeterminate:border-[#f01e2b] data-indeterminate:bg-[#f01e2b] dark:border-zinc-800 dark:bg-zinc-950 dark:data-checked:border-[#ff4651] dark:data-checked:bg-[#ff4651] dark:data-focus-visible:ring-blue-400/45 dark:data-focus-visible:ring-offset-zinc-950 dark:data-hover:border-[#ff4651] dark:data-indeterminate:border-[#ff4651] dark:data-indeterminate:bg-[#ff4651]';
+
+@Component({
+  selector: 'app-checkbox-group',
+  imports: [NgIcon, NgpCheckbox, NgpCheckboxGroup],
+  providers: [provideIcons({ heroCheckMini, heroMinusMini })],
+  template: `
+    <div
+      class="grid w-56 gap-2.5"
+      [ngpCheckboxGroupDefaultValue]="defaultValue"
+      ngpCheckboxGroup
+      aria-labelledby="checkbox-group-label"
+    >
+      <div
+        class="text-[0.8125rem] font-semibold text-gray-600 dark:text-zinc-400"
+        id="checkbox-group-label"
+      >
+        Fruits
+      </div>
+
+      <label
+        class="flex cursor-pointer items-center gap-2 text-sm text-gray-900 dark:text-zinc-100"
+      >
+        <span
+          class="${checkboxClass}"
+          #fuji="ngpCheckbox"
+          ngpCheckbox
+          ngpCheckboxValue="fuji-apple"
+        >
+          @if (fuji.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
+        Fuji
+      </label>
+      <label
+        class="flex cursor-pointer items-center gap-2 text-sm text-gray-900 dark:text-zinc-100"
+      >
+        <span
+          class="${checkboxClass}"
+          #gala="ngpCheckbox"
+          ngpCheckbox
+          ngpCheckboxValue="gala-apple"
+        >
+          @if (gala.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
+        Gala
+      </label>
+      <label
+        class="flex cursor-pointer items-center gap-2 text-sm text-gray-900 dark:text-zinc-100"
+      >
+        <span
+          class="${checkboxClass}"
+          #granny="ngpCheckbox"
+          ngpCheckbox
+          ngpCheckboxValue="granny-smith-apple"
+        >
+          @if (granny.state.checked()) {
+            <ng-icon name="heroCheckMini" aria-hidden="true" />
+          }
+        </span>
+        Granny Smith
+      </label>
+    </div>
+  `,
+})
+export default class CheckboxGroupExample {
+  readonly defaultValue = ['fuji-apple'];
+}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/checkbox-group.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/checkbox-group.md
@@ -1,0 +1,82 @@
+---
+title: Checkbox Group | Angular Primitives
+name: 'Checkbox Group'
+sourceUrl: 'https://github.com/ng-primitives/ng-primitives/tree/next/packages/ng-primitives/checkbox-group'
+---
+
+# Checkbox Group
+
+Share an array value across a group of checkboxes.
+
+<docs-example name="checkbox-group"></docs-example>
+
+## Import
+
+Import the Checkbox Group and Checkbox primitives.
+
+```ts
+import { NgpCheckbox } from 'ng-primitives/checkbox';
+import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
+```
+
+## Usage
+
+Use `ngpCheckboxGroupDefaultValue` to initially check checkbox values. Use
+`ngpCheckboxGroupValue` for controlled usage.
+
+```html
+<div ngpCheckboxGroup [ngpCheckboxGroupDefaultValue]="['email']">
+  <span ngpCheckbox ngpCheckboxValue="email">Email</span>
+  <span ngpCheckbox ngpCheckboxValue="sms">SMS</span>
+</div>
+```
+
+## Parent Checkbox
+
+Set `ngpCheckboxGroupAllValues` on the group and `ngpCheckboxParent` on a checkbox
+to create a parent checkbox. It selects or clears all values and becomes indeterminate
+when only some values are selected.
+
+```html
+<div
+  ngpCheckboxGroup
+  [ngpCheckboxGroupAllValues]="allValues"
+  [ngpCheckboxGroupDefaultValue]="['email']"
+>
+  <span ngpCheckbox ngpCheckboxParent>All notifications</span>
+  <span ngpCheckbox ngpCheckboxValue="email">Email</span>
+  <span ngpCheckbox ngpCheckboxValue="sms">SMS</span>
+</div>
+```
+
+<docs-example name="checkbox-group-parent"></docs-example>
+
+## Nested Parent Checkbox
+
+Checkbox groups can be nested. Coordinate the parent values when a nested group
+represents one of the values in its outer group.
+
+<docs-example name="checkbox-group-nested"></docs-example>
+
+## API Reference
+
+The Checkbox Group directive is available from the `ng-primitives/checkbox-group` package:
+
+### NgpCheckboxGroup
+
+<api-docs name="NgpCheckboxGroup"></api-docs>
+
+<api-reference-props name="NgpCheckboxGroup"></api-reference-props>
+
+<api-reference-attributes>
+  <api-attribute name="data-disabled" description="Applied when the checkbox group is disabled." />
+</api-reference-attributes>
+
+## Accessibility
+
+The group uses `role="group"`. Each checkbox keeps the Checkbox primitive's `role="checkbox"`
+and supports the standard checkbox keyboard interaction.
+
+### Keyboard Interactions
+
+- <kbd>Space</kbd> - Toggle the focused checkbox.

--- a/packages/ng-primitives/checkbox-group/ng-package.json
+++ b/packages/ng-primitives/checkbox-group/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/packages/ng-primitives/checkbox-group/src/checkbox-group/checkbox-group-state.ts
+++ b/packages/ng-primitives/checkbox-group/src/checkbox-group/checkbox-group-state.ts
@@ -1,0 +1,131 @@
+import { Signal, signal, WritableSignal } from '@angular/core';
+import { ngpFormControl } from 'ng-primitives/form-field';
+import { injectElementRef } from 'ng-primitives/internal';
+import {
+  attrBinding,
+  controlled,
+  controlledState,
+  createPrimitive,
+  dataBinding,
+  deprecatedSetter,
+  SetterOptions,
+  StateInjectionOptions,
+} from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { Observable } from 'rxjs';
+
+export interface NgpCheckboxGroupState<T = string> {
+  readonly id: Signal<string>;
+  readonly value: WritableSignal<T[]>;
+  readonly allValues: Signal<T[] | undefined>;
+  readonly disabled: WritableSignal<boolean>;
+  readonly compareWith: Signal<(a: T, b: T) => boolean>;
+  readonly valueChange: Observable<T[]>;
+  select(value: T): void;
+  deselect(value: T): void;
+  isSelected(value: T): boolean;
+  toggle(value: T): void;
+  setValue(value: T[], options?: SetterOptions): void;
+  setDefaultValue(value: T[]): void;
+  setDisabled(value: boolean): void;
+}
+
+export interface NgpCheckboxGroupProps<T = string> {
+  readonly id?: Signal<string>;
+  readonly value?: Signal<T[] | undefined>;
+  readonly defaultValue?: Signal<T[]>;
+  readonly allValues?: Signal<T[] | undefined>;
+  readonly disabled?: Signal<boolean>;
+  readonly compareWith?: Signal<(a: T, b: T) => boolean>;
+  readonly onValueChange?: (value: T[]) => void;
+}
+
+export const [
+  NgpCheckboxGroupStateToken,
+  ngpCheckboxGroup,
+  _injectCheckboxGroupState,
+  provideCheckboxGroupState,
+] = createPrimitive(
+  'NgpCheckboxGroup',
+  <T = string>({
+    id = signal(uniqueId('ngp-checkbox-group')),
+    value: _value = signal<T[] | undefined>(undefined),
+    defaultValue: _defaultValue,
+    allValues: _allValues = signal<T[] | undefined>(undefined),
+    disabled: _disabled = signal(false),
+    compareWith: _compareWith = signal((a: T, b: T) => a === b),
+    onValueChange,
+  }: NgpCheckboxGroupProps<T>): NgpCheckboxGroupState<T> => {
+    const element = injectElementRef();
+    const disabled = controlled(_disabled, false);
+    const defaultValue = controlled(_defaultValue, []);
+    const compareWith = controlled(_compareWith, (a: T, b: T) => a === b);
+    const [value, setValueInternal, valueChange] = controlledState<T[]>({
+      value: _value,
+      defaultValue,
+      onChange: onValueChange,
+    });
+
+    ngpFormControl({ id, disabled });
+
+    attrBinding(element, 'role', 'group');
+    attrBinding(element, 'id', id);
+    dataBinding(element, 'data-disabled', disabled);
+
+    function isSelected(itemValue: T): boolean {
+      return value().some(currentValue => compareWith()(currentValue, itemValue));
+    }
+
+    function select(itemValue: T): void {
+      if (disabled() || isSelected(itemValue)) {
+        return;
+      }
+      setValue([...value(), itemValue]);
+    }
+
+    function deselect(itemValue: T): void {
+      if (disabled() || !isSelected(itemValue)) {
+        return;
+      }
+      setValue(value().filter(currentValue => !compareWith()(currentValue, itemValue)));
+    }
+
+    function toggle(itemValue: T): void {
+      if (isSelected(itemValue)) {
+        deselect(itemValue);
+      } else {
+        select(itemValue);
+      }
+    }
+
+    function setValue(newValue: T[], options?: SetterOptions): void {
+      setValueInternal(newValue, options);
+    }
+
+    function setDisabled(isDisabled: boolean): void {
+      disabled.set(isDisabled);
+    }
+
+    return {
+      id,
+      value: deprecatedSetter(value, 'setValue', setValue),
+      allValues: _allValues,
+      disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
+      compareWith,
+      valueChange,
+      select,
+      deselect,
+      isSelected,
+      toggle,
+      setValue,
+      setDefaultValue: defaultValue.set,
+      setDisabled,
+    } satisfies NgpCheckboxGroupState<T>;
+  },
+);
+
+export function injectCheckboxGroupState<T = string>(
+  options?: StateInjectionOptions,
+): Signal<NgpCheckboxGroupState<T> | null> {
+  return _injectCheckboxGroupState(options) as Signal<NgpCheckboxGroupState<T> | null>;
+}

--- a/packages/ng-primitives/checkbox-group/src/checkbox-group/checkbox-group-state.ts
+++ b/packages/ng-primitives/checkbox-group/src/checkbox-group/checkbox-group-state.ts
@@ -1,4 +1,4 @@
-import { Signal, signal, WritableSignal } from '@angular/core';
+import { Signal, signal } from '@angular/core';
 import { ngpFormControl } from 'ng-primitives/form-field';
 import { injectElementRef } from 'ng-primitives/internal';
 import {
@@ -7,7 +7,6 @@ import {
   controlledState,
   createPrimitive,
   dataBinding,
-  deprecatedSetter,
   SetterOptions,
   StateInjectionOptions,
 } from 'ng-primitives/state';
@@ -16,9 +15,9 @@ import { Observable } from 'rxjs';
 
 export interface NgpCheckboxGroupState<T = string> {
   readonly id: Signal<string>;
-  readonly value: WritableSignal<T[]>;
+  readonly value: Signal<T[]>;
   readonly allValues: Signal<T[] | undefined>;
-  readonly disabled: WritableSignal<boolean>;
+  readonly disabled: Signal<boolean>;
   readonly compareWith: Signal<(a: T, b: T) => boolean>;
   readonly valueChange: Observable<T[]>;
   select(value: T): void;
@@ -108,9 +107,9 @@ export const [
 
     return {
       id,
-      value: deprecatedSetter(value, 'setValue', setValue),
+      value,
       allValues: _allValues,
-      disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
+      disabled,
       compareWith,
       valueChange,
       select,

--- a/packages/ng-primitives/checkbox-group/src/checkbox-group/checkbox-group-state.ts
+++ b/packages/ng-primitives/checkbox-group/src/checkbox-group/checkbox-group-state.ts
@@ -1,4 +1,4 @@
-import { Signal, signal } from '@angular/core';
+import { Signal, signal, WritableSignal } from '@angular/core';
 import { ngpFormControl } from 'ng-primitives/form-field';
 import { injectElementRef } from 'ng-primitives/internal';
 import {
@@ -7,6 +7,7 @@ import {
   controlledState,
   createPrimitive,
   dataBinding,
+  deprecatedSetter,
   SetterOptions,
   StateInjectionOptions,
 } from 'ng-primitives/state';
@@ -15,9 +16,9 @@ import { Observable } from 'rxjs';
 
 export interface NgpCheckboxGroupState<T = string> {
   readonly id: Signal<string>;
-  readonly value: Signal<T[]>;
+  readonly value: WritableSignal<T[]>;
   readonly allValues: Signal<T[] | undefined>;
-  readonly disabled: Signal<boolean>;
+  readonly disabled: WritableSignal<boolean>;
   readonly compareWith: Signal<(a: T, b: T) => boolean>;
   readonly valueChange: Observable<T[]>;
   select(value: T): void;
@@ -107,9 +108,9 @@ export const [
 
     return {
       id,
-      value,
+      value: deprecatedSetter(value, 'setValue', setValue),
       allValues: _allValues,
-      disabled,
+      disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
       compareWith,
       valueChange,
       select,

--- a/packages/ng-primitives/checkbox-group/src/checkbox-group/checkbox-group.ts
+++ b/packages/ng-primitives/checkbox-group/src/checkbox-group/checkbox-group.ts
@@ -1,0 +1,60 @@
+import { BooleanInput } from '@angular/cdk/coercion';
+import { booleanAttribute, Directive, input, output } from '@angular/core';
+import { SetterOptions } from 'ng-primitives/state';
+import { uniqueId } from 'ng-primitives/utils';
+import { ngpCheckboxGroup, provideCheckboxGroupState } from './checkbox-group-state';
+
+@Directive({
+  selector: '[ngpCheckboxGroup]',
+  exportAs: 'ngpCheckboxGroup',
+  // Each group owns its selection state; descendant checkboxes inherit it.
+  providers: [provideCheckboxGroupState({ inherit: false })],
+})
+export class NgpCheckboxGroup<T = string> {
+  readonly id = input<string>(uniqueId('ngp-checkbox-group'));
+  readonly value = input<T[] | undefined>(undefined, { alias: 'ngpCheckboxGroupValue' });
+  readonly defaultValue = input<T[]>([], { alias: 'ngpCheckboxGroupDefaultValue' });
+  readonly allValues = input<T[] | undefined>(undefined, { alias: 'ngpCheckboxGroupAllValues' });
+  readonly disabled = input<boolean, BooleanInput>(false, {
+    alias: 'ngpCheckboxGroupDisabled',
+    transform: booleanAttribute,
+  });
+  readonly compareWith = input<(a: T, b: T) => boolean>((a, b) => a === b, {
+    alias: 'ngpCheckboxGroupCompareWith',
+  });
+  readonly valueChange = output<T[]>({ alias: 'ngpCheckboxGroupValueChange' });
+
+  protected readonly state = ngpCheckboxGroup<T>({
+    id: this.id,
+    value: this.value,
+    defaultValue: this.defaultValue,
+    allValues: this.allValues,
+    disabled: this.disabled,
+    compareWith: this.compareWith,
+    onValueChange: value => this.valueChange.emit(value),
+  });
+
+  select(value: T): void {
+    this.state.select(value);
+  }
+
+  deselect(value: T): void {
+    this.state.deselect(value);
+  }
+
+  toggle(value: T): void {
+    this.state.toggle(value);
+  }
+
+  setValue(value: T[], options?: SetterOptions): void {
+    this.state.setValue(value, options);
+  }
+
+  setDefaultValue(value: T[]): void {
+    this.state.setDefaultValue(value);
+  }
+
+  setDisabled(value: boolean): void {
+    this.state.setDisabled(value);
+  }
+}

--- a/packages/ng-primitives/checkbox-group/src/index.ts
+++ b/packages/ng-primitives/checkbox-group/src/index.ts
@@ -1,0 +1,8 @@
+export { NgpCheckboxGroup } from './checkbox-group/checkbox-group';
+export {
+  injectCheckboxGroupState,
+  ngpCheckboxGroup,
+  NgpCheckboxGroupProps,
+  NgpCheckboxGroupState,
+  provideCheckboxGroupState,
+} from './checkbox-group/checkbox-group-state';

--- a/packages/ng-primitives/checkbox-group/src/tests/checkbox-group-forms.fixture.ts
+++ b/packages/ng-primitives/checkbox-group/src/tests/checkbox-group-forms.fixture.ts
@@ -1,0 +1,55 @@
+import { Component } from '@angular/core';
+import { ControlValueAccessor } from '@angular/forms';
+import { injectCheckboxGroupState, NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
+import {
+  ChangeFn,
+  provideValueAccessor,
+  safeTakeUntilDestroyed,
+  TouchedFn,
+} from 'ng-primitives/utils';
+
+@Component({
+  selector: 'app-checkbox-group',
+  hostDirectives: [
+    {
+      directive: NgpCheckboxGroup,
+      inputs: [
+        'ngpCheckboxGroupValue:value',
+        'ngpCheckboxGroupDefaultValue:defaultValue',
+        'ngpCheckboxGroupAllValues:allValues',
+        'ngpCheckboxGroupDisabled:disabled',
+      ],
+      outputs: ['ngpCheckboxGroupValueChange:valueChange'],
+    },
+  ],
+  providers: [provideValueAccessor(CheckboxGroupFixture)],
+  template: '<ng-content />',
+  host: { '(focusout)': 'onTouched?.()' },
+})
+export class CheckboxGroupFixture implements ControlValueAccessor {
+  private readonly state = injectCheckboxGroupState<string>();
+  private onChange?: ChangeFn<string[]>;
+  protected onTouched?: TouchedFn;
+
+  constructor() {
+    this.state()
+      .valueChange.pipe(safeTakeUntilDestroyed())
+      .subscribe(value => this.onChange?.(value));
+  }
+
+  writeValue(value: string[] | null): void {
+    this.state().setValue(value ?? [], { emit: false });
+  }
+
+  registerOnChange(onChange: ChangeFn<string[]>): void {
+    this.onChange = onChange;
+  }
+
+  registerOnTouched(onTouched: TouchedFn): void {
+    this.onTouched = onTouched;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.state().setDisabled(isDisabled);
+  }
+}

--- a/packages/ng-primitives/checkbox-group/src/tests/checkbox-group-forms.test.ts
+++ b/packages/ng-primitives/checkbox-group/src/tests/checkbox-group-forms.test.ts
@@ -1,0 +1,29 @@
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { fireEvent, render } from '@testing-library/angular';
+import { NgpCheckbox } from 'ng-primitives/checkbox';
+import { describe, expect, it } from 'vitest';
+import { CheckboxGroupFixture } from './checkbox-group-forms.fixture';
+
+describe('CheckboxGroup (reusable component) — reactive forms', () => {
+  it('reflects and updates a form control array', async () => {
+    const formControl = new FormControl<string[]>(['one']);
+    const { getByTestId, fixture } = await render(
+      `<app-checkbox-group [formControl]="formControl">
+        <div ngpCheckbox ngpCheckboxValue="one" data-testid="one"></div>
+        <div ngpCheckbox ngpCheckboxValue="two" data-testid="two"></div>
+      </app-checkbox-group>`,
+      {
+        imports: [CheckboxGroupFixture, NgpCheckbox, ReactiveFormsModule],
+        componentProperties: { formControl },
+      },
+    );
+
+    expect(getByTestId('one')).toHaveAttribute('aria-checked', 'true');
+    fireEvent.click(getByTestId('two'));
+    expect(formControl.value).toEqual(['one', 'two']);
+
+    formControl.setValue([]);
+    fixture.detectChanges();
+    expect(getByTestId('one')).toHaveAttribute('aria-checked', 'false');
+  });
+});

--- a/packages/ng-primitives/checkbox-group/src/tests/checkbox-group-primitive.test.ts
+++ b/packages/ng-primitives/checkbox-group/src/tests/checkbox-group-primitive.test.ts
@@ -1,0 +1,101 @@
+import { fireEvent, render } from '@testing-library/angular';
+import { NgpCheckbox } from 'ng-primitives/checkbox';
+import { NgpCheckboxGroup } from 'ng-primitives/checkbox-group';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('NgpCheckboxGroup', () => {
+  it('uses defaultValue to check matching checkbox values', async () => {
+    const { getAllByRole } = await render(
+      `<div ngpCheckboxGroup [ngpCheckboxGroupDefaultValue]="defaultValue">
+        <div ngpCheckbox ngpCheckboxValue="one"></div>
+        <div ngpCheckbox ngpCheckboxValue="two"></div>
+      </div>`,
+      { imports: [NgpCheckboxGroup, NgpCheckbox], componentProperties: { defaultValue: ['two'] } },
+    );
+
+    const checkboxes = getAllByRole('checkbox');
+    expect(checkboxes[0]).toHaveAttribute('aria-checked', 'false');
+    expect(checkboxes[1]).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('updates the group value when a child is toggled', async () => {
+    const valueChange = vi.fn();
+    const { getByRole } = await render(
+      `<div ngpCheckboxGroup (ngpCheckboxGroupValueChange)="valueChange($event)">
+        <div ngpCheckbox ngpCheckboxValue="one"></div>
+      </div>`,
+      { imports: [NgpCheckboxGroup, NgpCheckbox], componentProperties: { valueChange } },
+    );
+
+    const checkbox = getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+    expect(valueChange).toHaveBeenCalledWith(['one']);
+  });
+
+  it('supports a parent checkbox with checked and indeterminate state', async () => {
+    const { getAllByRole } = await render(
+      `<div ngpCheckboxGroup [ngpCheckboxGroupDefaultValue]="defaultValue" [ngpCheckboxGroupAllValues]="allValues">
+        <div ngpCheckbox ngpCheckboxParent></div>
+        <div ngpCheckbox ngpCheckboxValue="one"></div>
+        <div ngpCheckbox ngpCheckboxValue="two"></div>
+      </div>`,
+      {
+        imports: [NgpCheckboxGroup, NgpCheckbox],
+        componentProperties: { allValues: ['one', 'two'], defaultValue: ['one'] },
+      },
+    );
+
+    const checkboxes = getAllByRole('checkbox');
+    expect(checkboxes[0]).toHaveAttribute('aria-checked', 'mixed');
+    expect(checkboxes[1]).toHaveAttribute('aria-checked', 'true');
+    expect(checkboxes[2]).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(checkboxes[0]);
+    expect(checkboxes[0]).toHaveAttribute('aria-checked', 'true');
+    expect(checkboxes[2]).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('disables child interaction when the group is disabled', async () => {
+    const { getByRole } = await render(
+      `<div ngpCheckboxGroup ngpCheckboxGroupDisabled>
+        <div ngpCheckbox ngpCheckboxValue="one"></div>
+      </div>`,
+      { imports: [NgpCheckboxGroup, NgpCheckbox] },
+    );
+
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-disabled', 'true');
+    fireEvent.click(checkbox);
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('keeps nested group state isolated from the outer group', async () => {
+    const { getAllByRole } = await render(
+      `<div ngpCheckboxGroup [ngpCheckboxGroupAllValues]="outerValues">
+        <div ngpCheckbox ngpCheckboxValue="outer-one"></div>
+        <div ngpCheckboxGroup [ngpCheckboxGroupAllValues]="innerValues">
+          <div ngpCheckbox ngpCheckboxParent></div>
+          <div ngpCheckbox ngpCheckboxValue="inner-one"></div>
+          <div ngpCheckbox ngpCheckboxValue="inner-two"></div>
+        </div>
+      </div>`,
+      {
+        imports: [NgpCheckboxGroup, NgpCheckbox],
+        componentProperties: {
+          outerValues: ['outer-one'],
+          innerValues: ['inner-one', 'inner-two'],
+        },
+      },
+    );
+
+    const checkboxes = getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+
+    expect(checkboxes[0]).toHaveAttribute('aria-checked', 'false');
+    expect(checkboxes[1]).toHaveAttribute('aria-checked', 'true');
+    expect(checkboxes[2]).toHaveAttribute('aria-checked', 'true');
+    expect(checkboxes[3]).toHaveAttribute('aria-checked', 'true');
+  });
+});

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
@@ -1,4 +1,5 @@
 import { computed, Signal, signal, WritableSignal } from '@angular/core';
+import { injectCheckboxGroupState } from 'ng-primitives/checkbox-group';
 import { ngpFormControl } from 'ng-primitives/form-field';
 import { ngpInteractions } from 'ng-primitives/interactions';
 import { injectElementRef } from 'ng-primitives/internal';
@@ -83,6 +84,14 @@ export interface NgpCheckboxProps {
    */
   readonly defaultChecked?: Signal<boolean>;
   /**
+   * The value represented by the checkbox in a checkbox group.
+   */
+  readonly value?: Signal<unknown>;
+  /**
+   * Whether this checkbox controls all values in its checkbox group.
+   */
+  readonly parent?: Signal<boolean>;
+  /**
    * Whether the checkbox is indeterminate.
    */
   readonly indeterminate?: Signal<boolean>;
@@ -111,6 +120,8 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
       id = signal(uniqueId('ngp-checkbox')),
       checked: _checked = signal<boolean | undefined>(undefined),
       defaultChecked: _defaultChecked,
+      value: _value = signal<unknown>(undefined),
+      parent: _parent = signal(false),
       indeterminate: _indeterminate = signal(false),
       disabled: _disabled = signal(false),
       required: _required = signal(false),
@@ -118,14 +129,42 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
       onIndeterminateChange,
     }: NgpCheckboxProps): NgpCheckboxState => {
       const element = injectElementRef();
+      const checkboxGroup = injectCheckboxGroupState<unknown>({ optional: true });
       const defaultChecked = controlled(_defaultChecked, false);
-      const [checked, setChecked, checkedChange] = controlledState({
+      const [baseChecked, setBaseChecked, checkedChange] = controlledState({
         value: _checked,
         defaultValue: defaultChecked,
         onChange: onCheckedChange,
       });
-      const indeterminate = controlled(_indeterminate);
-      const disabled = controlled(_disabled);
+      const baseIndeterminate = controlled(_indeterminate);
+      const baseDisabled = controlled(_disabled);
+      const checked = computed(() => {
+        const group = checkboxGroup();
+        if (!group) {
+          return baseChecked();
+        }
+
+        if (_parent()) {
+          const allValues = group.allValues();
+          return !!allValues?.length && allValues.every(itemValue => group.isSelected(itemValue));
+        }
+
+        return _value() !== undefined && group.isSelected(_value());
+      });
+      const indeterminate = computed(() => {
+        const group = checkboxGroup();
+        if (!group || !_parent()) {
+          return baseIndeterminate();
+        }
+
+        const allValues = group.allValues();
+        const selectedCount =
+          allValues?.filter(itemValue => group.isSelected(itemValue)).length ?? 0;
+        return (
+          baseIndeterminate() || (selectedCount > 0 && selectedCount < (allValues?.length ?? 0))
+        );
+      });
+      const disabled = computed(() => baseDisabled() || !!checkboxGroup()?.disabled());
       const indeterminateChange = emitter<boolean>();
       const tabindex = computed(() => (disabled() ? -1 : 0));
 
@@ -146,6 +185,17 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
 
       // Event listeners
       listener(element, 'click', event => toggle(event));
+      const label = element.nativeElement.closest('label');
+      if (label) {
+        listener(label, 'click', event => {
+          // The checkbox listener already handles clicks on itself and its contents.
+          if (event.target instanceof Node && element.nativeElement.contains(event.target)) {
+            return;
+          }
+
+          toggle(event);
+        });
+      }
       listener(element, 'keydown', (event: KeyboardEvent) => {
         if (event.key === 'Enter') {
           // According to WAI ARIA, checkboxes don't activate on enter keypress
@@ -167,7 +217,21 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
         event?.preventDefault();
 
         const nextChecked = indeterminate() ? true : !checked();
-        setChecked(nextChecked);
+        const group = checkboxGroup();
+        if (group && _parent()) {
+          const allValues = group.allValues();
+          if (allValues) {
+            group.setValue(nextChecked ? [...allValues] : []);
+          }
+        } else if (group && _value() !== undefined) {
+          group.toggle(_value());
+        } else {
+          setBaseChecked(nextChecked);
+        }
+
+        if (group) {
+          onCheckedChange?.(nextChecked);
+        }
 
         // if the checkbox was indeterminate, it isn't anymore
         if (indeterminate()) {
@@ -176,20 +240,39 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
       }
 
       function setIndeterminate(value: boolean): void {
-        indeterminate.set(value);
+        baseIndeterminate.set(value);
         onIndeterminateChange?.(value);
         indeterminateChange.emit(value);
       }
 
       function setDisabled(value: boolean): void {
-        disabled.set(value);
+        baseDisabled.set(value);
+      }
+
+      function setChecked(value: boolean, options?: SetterOptions): void {
+        const group = checkboxGroup();
+        if (group && _parent() && group.allValues()) {
+          group.setValue(value ? [...group.allValues()!] : [], options);
+        } else if (group && _value() !== undefined) {
+          if (value) {
+            group.select(_value());
+          } else {
+            group.deselect(_value());
+          }
+        } else {
+          setBaseChecked(value, options);
+        }
       }
 
       return {
         id,
-        checked: deprecatedSetter(checked, 'setChecked', setChecked),
-        indeterminate: deprecatedSetter(indeterminate, 'setIndeterminate', setIndeterminate),
-        disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
+        checked: deprecatedSetter(checked as WritableSignal<boolean>, 'setChecked', setChecked),
+        indeterminate: deprecatedSetter(
+          indeterminate as WritableSignal<boolean>,
+          'setIndeterminate',
+          setIndeterminate,
+        ),
+        disabled: deprecatedSetter(disabled as WritableSignal<boolean>, 'setDisabled', setDisabled),
         checkedChange,
         indeterminateChange: indeterminateChange.asObservable(),
         toggle,

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
@@ -69,7 +69,7 @@ export interface NgpCheckboxState {
 /**
  * Inputs for configuring the Checkbox primitive.
  */
-export interface NgpCheckboxProps {
+export interface NgpCheckboxProps<T = string> {
   /**
    * The id of the checkbox.
    */
@@ -85,7 +85,7 @@ export interface NgpCheckboxProps {
   /**
    * The value represented by the checkbox in a checkbox group.
    */
-  readonly value?: Signal<unknown>;
+  readonly value?: Signal<T | undefined>;
   /**
    * Whether this checkbox controls all values in its checkbox group.
    */
@@ -115,20 +115,20 @@ export interface NgpCheckboxProps {
 export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCheckboxState] =
   createPrimitive(
     'NgpCheckbox',
-    ({
+    <T = string>({
       id = signal(uniqueId('ngp-checkbox')),
       checked: _checked = signal<boolean | undefined>(undefined),
       defaultChecked: _defaultChecked,
-      value: _value = signal<unknown>(undefined),
+      value: _value = signal<T | undefined>(undefined),
       parent: _parent = signal(false),
       indeterminate: _indeterminate = signal(false),
       disabled: _disabled = signal(false),
       required: _required = signal(false),
       onCheckedChange,
       onIndeterminateChange,
-    }: NgpCheckboxProps): NgpCheckboxState => {
+    }: NgpCheckboxProps<T>): NgpCheckboxState => {
       const element = injectElementRef();
-      const checkboxGroup = injectCheckboxGroupState<unknown>({ optional: true });
+      const checkboxGroup = injectCheckboxGroupState<T>({ optional: true });
       const defaultChecked = controlled(_defaultChecked, false);
       const [baseChecked, setBaseChecked, checkedChange] = controlledState({
         value: _checked,
@@ -148,7 +148,8 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
           return !!allValues?.length && allValues.every(itemValue => group.isSelected(itemValue));
         }
 
-        return _value() !== undefined && group.isSelected(_value());
+        const itemValue = _value();
+        return itemValue !== undefined && group.isSelected(itemValue);
       });
       const indeterminate = computed(() => {
         const group = checkboxGroup();
@@ -222,8 +223,11 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
           if (allValues) {
             group.setValue(nextChecked ? [...allValues] : []);
           }
-        } else if (group && _value() !== undefined) {
-          group.toggle(_value());
+        } else if (group) {
+          const itemValue = _value();
+          if (itemValue !== undefined) {
+            group.toggle(itemValue);
+          }
         } else {
           setBaseChecked(nextChecked);
         }
@@ -252,11 +256,14 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
         const group = checkboxGroup();
         if (group && _parent() && group.allValues()) {
           group.setValue(value ? [...group.allValues()!] : [], options);
-        } else if (group && _value() !== undefined) {
-          if (value) {
-            group.select(_value());
-          } else {
-            group.deselect(_value());
+        } else if (group) {
+          const itemValue = _value();
+          if (itemValue !== undefined) {
+            if (value) {
+              group.select(itemValue);
+            } else {
+              group.deselect(itemValue);
+            }
           }
         } else {
           setBaseChecked(value, options);

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
@@ -1,4 +1,4 @@
-import { computed, Signal, signal, WritableSignal } from '@angular/core';
+import { computed, Signal, signal } from '@angular/core';
 import { injectCheckboxGroupState } from 'ng-primitives/checkbox-group';
 import { ngpFormControl } from 'ng-primitives/form-field';
 import { ngpInteractions } from 'ng-primitives/interactions';
@@ -9,7 +9,6 @@ import {
   controlledState,
   createPrimitive,
   dataBinding,
-  deprecatedSetter,
   emitter,
   listener,
   SetterOptions,
@@ -28,15 +27,15 @@ export interface NgpCheckboxState {
   /**
    * Whether the checkbox is checked.
    */
-  readonly checked: WritableSignal<boolean>;
+  readonly checked: Signal<boolean>;
   /**
    * Whether the checkbox is indeterminate.
    */
-  readonly indeterminate: WritableSignal<boolean>;
+  readonly indeterminate: Signal<boolean>;
   /**
    * Whether the checkbox is disabled.
    */
-  readonly disabled: WritableSignal<boolean>;
+  readonly disabled: Signal<boolean>;
   /**
    * Emits when the checked state changes.
    */
@@ -266,13 +265,9 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
 
       return {
         id,
-        checked: deprecatedSetter(checked as WritableSignal<boolean>, 'setChecked', setChecked),
-        indeterminate: deprecatedSetter(
-          indeterminate as WritableSignal<boolean>,
-          'setIndeterminate',
-          setIndeterminate,
-        ),
-        disabled: deprecatedSetter(disabled as WritableSignal<boolean>, 'setDisabled', setDisabled),
+        checked,
+        indeterminate,
+        disabled,
         checkedChange,
         indeterminateChange: indeterminateChange.asObservable(),
         toggle,

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox-state.ts
@@ -1,4 +1,4 @@
-import { computed, Signal, signal } from '@angular/core';
+import { computed, Signal, signal, WritableSignal } from '@angular/core';
 import { injectCheckboxGroupState } from 'ng-primitives/checkbox-group';
 import { ngpFormControl } from 'ng-primitives/form-field';
 import { ngpInteractions } from 'ng-primitives/interactions';
@@ -9,6 +9,7 @@ import {
   controlledState,
   createPrimitive,
   dataBinding,
+  deprecatedSetter,
   emitter,
   listener,
   SetterOptions,
@@ -27,15 +28,15 @@ export interface NgpCheckboxState {
   /**
    * Whether the checkbox is checked.
    */
-  readonly checked: Signal<boolean>;
+  readonly checked: WritableSignal<boolean>;
   /**
    * Whether the checkbox is indeterminate.
    */
-  readonly indeterminate: Signal<boolean>;
+  readonly indeterminate: WritableSignal<boolean>;
   /**
    * Whether the checkbox is disabled.
    */
-  readonly disabled: Signal<boolean>;
+  readonly disabled: WritableSignal<boolean>;
   /**
    * Emits when the checked state changes.
    */
@@ -272,9 +273,13 @@ export const [NgpCheckboxStateToken, ngpCheckbox, injectCheckboxState, provideCh
 
       return {
         id,
-        checked,
-        indeterminate,
-        disabled,
+        checked: deprecatedSetter(checked as WritableSignal<boolean>, 'setChecked', setChecked),
+        indeterminate: deprecatedSetter(
+          indeterminate as WritableSignal<boolean>,
+          'setIndeterminate',
+          setIndeterminate,
+        ),
+        disabled: deprecatedSetter(disabled as WritableSignal<boolean>, 'setDisabled', setDisabled),
         checkedChange,
         indeterminateChange: indeterminateChange.asObservable(),
         toggle,

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox.ts
@@ -1,5 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { Directive, booleanAttribute, input, output } from '@angular/core';
+import { Directive, booleanAttribute, input, OnInit, output } from '@angular/core';
+import { injectCheckboxGroupState } from 'ng-primitives/checkbox-group';
 import { SetterOptions } from 'ng-primitives/state';
 import { coerceBooleanOrUndefined, uniqueId } from 'ng-primitives/utils';
 import { ngpCheckbox, provideCheckboxState } from './checkbox-state';
@@ -11,7 +12,7 @@ import { ngpCheckbox, provideCheckboxState } from './checkbox-state';
   selector: '[ngpCheckbox]',
   providers: [provideCheckboxState({ inherit: false })],
 })
-export class NgpCheckbox {
+export class NgpCheckbox<T = string> implements OnInit {
   /**
    * The id of the checkbox.
    * @internal
@@ -32,6 +33,19 @@ export class NgpCheckbox {
    */
   readonly defaultChecked = input<boolean, BooleanInput>(false, {
     alias: 'ngpCheckboxDefaultChecked',
+    transform: booleanAttribute,
+  });
+
+  /**
+   * The value represented by the checkbox when it belongs to a checkbox group.
+   */
+  readonly value = input<T | undefined>(undefined, { alias: 'ngpCheckboxValue' });
+
+  /**
+   * Whether the checkbox controls all values in its checkbox group.
+   */
+  readonly parent = input<boolean, BooleanInput>(false, {
+    alias: 'ngpCheckboxParent',
     transform: booleanAttribute,
   });
 
@@ -80,12 +94,22 @@ export class NgpCheckbox {
     id: this.id,
     checked: this.checked,
     defaultChecked: this.defaultChecked,
+    value: this.value,
+    parent: this.parent,
     indeterminate: this.indeterminate,
     disabled: this.disabled,
     required: this.required,
     onCheckedChange: value => this.checkedChange.emit(value),
     onIndeterminateChange: value => this.indeterminateChange.emit(value),
   });
+
+  private readonly group = injectCheckboxGroupState<T>({ optional: true });
+
+  ngOnInit(): void {
+    if (this.group() && !this.parent() && this.value() === undefined) {
+      throw new Error('The `ngpCheckboxValue` input is required for a checkbox in a group.');
+    }
+  }
 
   toggle(event?: Event): void {
     this.state.toggle(event);

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox.ts
@@ -91,7 +91,7 @@ export class NgpCheckbox<T = string> implements OnInit {
   /**
    * The state of the checkbox.
    */
-  readonly state = ngpCheckbox({
+  readonly state = ngpCheckbox<T>({
     id: this.id,
     checked: this.checked,
     defaultChecked: this.defaultChecked,

--- a/packages/ng-primitives/checkbox/src/checkbox/checkbox.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/checkbox.ts
@@ -10,6 +10,7 @@ import { ngpCheckbox, provideCheckboxState } from './checkbox-state';
  */
 @Directive({
   selector: '[ngpCheckbox]',
+  exportAs: 'ngpCheckbox',
   providers: [provideCheckboxState({ inherit: false })],
 })
 export class NgpCheckbox<T = string> implements OnInit {
@@ -90,7 +91,7 @@ export class NgpCheckbox<T = string> implements OnInit {
   /**
    * The state of the checkbox.
    */
-  protected readonly state = ngpCheckbox({
+  readonly state = ngpCheckbox({
     id: this.id,
     checked: this.checked,
     defaultChecked: this.defaultChecked,

--- a/packages/ng-primitives/checkbox/src/checkbox/tests/checkbox-primitive.test.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/tests/checkbox-primitive.test.ts
@@ -87,6 +87,16 @@ describe('NgpCheckbox', () => {
   });
 
   describe('toggle interaction', () => {
+    it('should toggle when the enclosing label is clicked', async () => {
+      const { getByRole, getByText } = await render(
+        `<label><div ngpCheckbox></div>Checkbox</label>`,
+        { imports: [NgpCheckbox] },
+      );
+
+      fireEvent.click(getByText('Checkbox'));
+      expect(getByRole('checkbox')).toHaveAttribute('aria-checked', 'true');
+    });
+
     it('should emit checkedChange when clicked', async () => {
       const checkedChange = vi.fn();
       const { getByRole } = await render(

--- a/packages/ng-primitives/schematics/ng-generate/templates/checkbox/checkbox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/checkbox/checkbox.__fileSuffix@dasherize__.ts.template
@@ -13,6 +13,8 @@ import { ChangeFn, provideValueAccessor, TouchedFn } from 'ng-primitives/utils';
       directive: NgpCheckbox,
       inputs: [
         'ngpCheckboxChecked:checked',
+        'ngpCheckboxValue:value',
+        'ngpCheckboxParent:parent',
         'ngpCheckboxIndeterminate:indeterminate',
         'ngpCheckboxDisabled:disabled',
       ],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -26,6 +26,7 @@
       "ng-primitives/breadcrumbs": ["packages/ng-primitives/breadcrumbs/src/index.ts"],
       "ng-primitives/button": ["packages/ng-primitives/button/src/index.ts"],
       "ng-primitives/checkbox": ["packages/ng-primitives/checkbox/src/index.ts"],
+      "ng-primitives/checkbox-group": ["packages/ng-primitives/checkbox-group/src/index.ts"],
       "ng-primitives/collapsible": ["packages/ng-primitives/collapsible/src/index.ts"],
       "ng-primitives/combobox": ["packages/ng-primitives/combobox/src/index.ts"],
       "ng-primitives/common": ["packages/ng-primitives/common/src/index.ts"],


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

## What does this PR implement/fix?

Adds a `ng-primitives/checkbox-group` entry point - following Base UI's Checkbox Group primitive.

### Checkbox

Add new `ngpCheckboxValue` and `ngpCheckboxParent` input to NgpCheckbox.
Export as `ngpCheckbox` to access the state for showing NgIcon.

Checkbox State injects the Checkbox Group State optionally and includes the group state for state changes too.

### Checkbox Group

Add new `NgpCheckboxGroup` primitive to create a group with default values, a group with a parent checkbox and nested parent checkboxes.

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Checkbox Group primitive to share and control an array of selected values across multiple checkboxes, including select-all parents and nested groups. Integrates with `ng-primitives/checkbox` for shared state and label-click toggling, and keeps writable-signal compatibility in checkbox state.

- **New Features**
  - Added `NgpCheckboxGroup` in `ng-primitives/checkbox-group` with controlled (`ngpCheckboxGroupValue`) and uncontrolled (`ngpCheckboxGroupDefaultValue`) modes, `ngpCheckboxGroupAllValues` for select-all, `ngpCheckboxGroupDisabled`, `ngpCheckboxGroupCompareWith`, and `ngpCheckboxGroupValueChange`; uses `role="group"` and isolates nested group state.
  - Extended `NgpCheckbox` with `ngpCheckboxValue` and `ngpCheckboxParent`; checkboxes inherit group `checked`, `indeterminate`, and `disabled` state and update the group on toggle; label clicks toggle; exported as `ngpCheckbox`.
  - Added docs, API/accessibility notes, and examples (basic, parent, nested + Tailwind); plus unit tests and a reactive-forms fixture.

- **Migration**
  - Inside a group, each checkbox must set `ngpCheckboxValue`; otherwise an error is thrown.
  - For a select-all checkbox, set `ngpCheckboxParent` on that checkbox and provide `ngpCheckboxGroupAllValues` on the group.

<sup>Written for commit a03404b733258f9e6d9de8122275daa128579260. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checkbox groups with controlled and uncontrolled selection, disabled states, parent and nested groups, and indeterminate indicators.
  * Added form-control integration and support for selecting, deselecting, and toggling options programmatically.
  * Checkboxes can now participate in groups and respond correctly to associated label clicks.

* **Documentation**
  * Added comprehensive checkbox-group guidance, API details, accessibility information, and interactive examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->