### PR TITLE
feat(date-picker): allow set start and end date on range picker

### DIFF
--- a/packages/ng-primitives/date-picker/src/date-range-picker/date-range-picker-state.ts
+++ b/packages/ng-primitives/date-picker/src/date-range-picker/date-range-picker-state.ts
@@ -36,11 +36,11 @@ export interface NgpDateRangePickerState<T> extends NgpDateControllerState<T> {
   /**
    * Set the start date.
    */
-  setStart(value: T | undefined, options: SetterOptions): void;
+  setStart(value: T | undefined, options?: SetterOptions): void;
   /**
    * Set the end date.
    */
-  setEnd(value: T | undefined, options: SetterOptions): void;
+  setEnd(value: T | undefined, options?: SetterOptions): void;
   /**
    * Set the default (uncontrolled) start date.
    */

--- a/packages/ng-primitives/date-picker/src/date-range-picker/date-range-picker-state.ts
+++ b/packages/ng-primitives/date-picker/src/date-range-picker/date-range-picker-state.ts
@@ -34,6 +34,14 @@ export interface NgpDateRangePickerState<T> extends NgpDateControllerState<T> {
    */
   readonly endDateChange: Observable<T | undefined>;
   /**
+   * Set the start date.
+   */
+  setStart(value: T | undefined, options: SetterOptions): void;
+  /**
+   * Set the end date.
+   */
+  setEnd(value: T | undefined, options: SetterOptions): void;
+  /**
    * Set the default (uncontrolled) start date.
    */
   setDefaultStartDate(value: T | undefined): void;
@@ -359,6 +367,8 @@ export const [
       endDate,
       startDateChange,
       endDateChange,
+      setStart,
+      setEnd,
       setFocusedDate,
       select,
       setDisabled,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

Allow users to set the `startDate` and `endDate` in date range picker

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add programmatic setters for the date range picker so apps can set the start and end dates directly. Improves controlled usage and form integration; no breaking changes.

- **New Features**
  - Added `setStart(value: T | undefined, options?: SetterOptions)` and `setEnd(value: T | undefined, options?: SetterOptions)` to `NgpDateRangePickerState<T>`, and exposed them from `date-range-picker-state`.

<sup>Written for commit 871d6e318110719c87ea5b1840545cce4c67e827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added public controls for setting or clearing the start and end dates in date-range pickers.
  - Exposed optional setter options for managing date-range updates in controlled usage.
  - Date-range values can now be updated independently, providing greater flexibility when coordinating picker state and responding to application interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->