### PR TITLE
chore: review changed code for performance at scale

### DIFF
--- a/.claude/skills/ngp-code-review/SKILL.md
+++ b/.claude/skills/ngp-code-review/SKILL.md
@@ -22,6 +22,8 @@ Use this skill when reviewing changes on a branch or PR in this repo. The goal i
 
 **Filter speculative findings.** Drop any finding whose justification only kicks in under hypothetical future changes ("if someone later adds X…", "if this describe block grows…", "if this primitive ever supports Y…"). Only raise issues that affect the code **as it stands today** — i.e. there is a concrete current call site, test, or usage that demonstrates the problem. If a future-proofing concern is genuinely important, reframe it as a concrete present-day risk or drop it. This rule supersedes anything else in the checklist.
 
+**Scale is not speculation.** The one exception: §7 asks what the changed code costs per instance and per event. That is a property of the code as written, not a hypothetical future change — a headless library ships into pages its authors never see, so you may reason about cost × N without pointing at a call site that already does it. The escape hatch is bounded by §7's own "what not to flag" list; it does not license micro-optimisation findings.
+
 ## Checklist
 
 ### 0. Scope of the change
@@ -110,7 +112,65 @@ Accessibility is first-class per `CONTRIBUTING.md`. Flag:
 - Focus-trap interactions that don't account for `NgpOverlayRegistry` — if a new overlay/portal primitive lets focus move outside a host element, verify focus-trap will treat it as an allowed external target.
 - Hardcoded `tabindex` values that conflict with `FocusMonitor` / focus-trap logic.
 
-### 7. Documentation & examples
+### 7. Performance at scale
+
+A headless library ships into pages its authors never see. Review the diff through one question: **what does this cost when the primitive is on the page a thousand times, or when its handler fires sixty times a second?** Work that is invisible on one instance is a hung tab on a dense page.
+
+Three axes. Ask each of the changed code:
+
+- **Per instance × N** — what runs for every instance, whether or not the user ever interacts with it.
+- **Per event × frequency** — what runs inside a `pointermove` / `scroll` / `wheel` / `input` / `keydown` handler.
+- **Per notification, superlinear** — work whose cost grows with the number of _siblings_, so adding one child re-does work for all of them.
+
+#### What to flag
+
+**Forced synchronous layout.** Grep the diff first — this is mechanical, so do it before reading:
+
+```bash
+git diff next...HEAD | grep -nE '^\+.*\b(getBoundingClientRect|getClientRects|getComputedStyle|scrollIntoView|offset(Width|Height|Top|Left|Parent)|client(Width|Height|Top|Left)|scroll(Width|Height|Top|Left))\b'
+```
+
+Every hit is a layout read. It costs nothing on its own; it costs a full reflow when layout is dirty. So judge each by **what writes DOM before it**:
+
+- **In a state factory body, a directive constructor, or anything running while Angular creates elements.** Angular is writing DOM in the same pass, so each read forces its own reflow — N instances cost N reflows, each growing with the document. Defer to `queueMicrotask` (still ahead of paint, so nothing is a frame staler, and the whole creation pass shares one flush) or to the `earlyRead` phase of `afterRenderEffect`. `fromResizeEvent` (`internal/src/utilities/resize.ts`) is the worked example.
+- **Interleaved with writes in one `afterRenderEffect`.** Plain `afterRenderEffect(fn)` is the mixed-read-write phase: a callback that measures and then writes styles or attributes dirties layout for every instance that follows it. Use the phased form so all reads land before any write.
+
+  ```ts
+  afterRenderEffect({
+    earlyRead: () => element.nativeElement.scrollHeight,
+    write: height => element.nativeElement.style.setProperty(heightVar, `${height()}px`),
+  });
+  ```
+
+- **Inside a subscriber to a batched producer.** `fromResizeEvent` and `fromMutationObserver` batch their own reads into one microtask checkpoint; a synchronous DOM write in any subscriber breaks that batch for every instance after it.
+- **Inside a high-frequency handler** without caching. A `pointermove` handler that re-reads the track's rect on every move is a reflow per frame per active pointer — read once on `pointerdown`, or on resize.
+
+**DOM traversal per instance or per event.** `closest()`, `querySelector`/`querySelectorAll`, `matches()` in a loop, and hand-rolled `parentElement` walks are all O(depth) or O(document). Flag them in a factory body or a hot handler; hoist to the parent state and share the result, or cache the resolved element. An ancestor walk that runs on every scroll event, once per overlay, is the shape to watch (`portal/src/scroll-strategy.ts`).
+
+**Superlinear parent/child registration.** Container primitives collect children (`roving-focus`, `listbox`, `select`, `menu`, `tree`, `toolbar`) and these are exactly the primitives that appear in the thousands. Registration must be O(1) amortised. Flag a `register`/`unregister` that scans, sorts, re-indexes, or compares document position across the whole collection on each call — N children then cost O(N²) to mount, which is the difference between a 200-row listbox and a 5,000-row one. The same applies to a parent `computed` that rebuilds an array every time any child changes while every child reads it.
+
+**Per-instance observers, listeners and timers.** For each one added:
+
+- **Lazy?** A `ResizeObserver` / `MutationObserver` / `IntersectionObserver` created for a feature that is switched off wastes an observer per instance. Gate it on a `disabled` signal.
+- **Torn down?** Disconnected on destroy _and_ when the feature is disabled — and any effect that could rebuild it destroyed alongside the subscription, or it rebuilds observers nobody listens to.
+- **Hoisted or scoped?** A `document`/`window` listener held for the lifetime of an instance is a HIGH finding. Either hoist it into a root-level singleton (`NgpOverlayRegistry`, `hover-interaction`) or attach it only for the duration of a gesture (pointerdown → pointerup), as the slider and colour thumbs do. Scroll/wheel/touch listeners need `{ passive: true }` unless they call `preventDefault`.
+
+**Eager work in the factory.** Everything in a state factory body runs once per instance at construction, before any interaction. Flag anything heavier than a field assignment that isn't needed until the user acts: building an `Intl` formatter, compiling a regex, cloning config, materialising a list, subscribing to a stream for an off-by-default feature, or an `effect`/`explicitEffect` created unconditionally for a feature the inputs disabled. `computed()` is lazy and cached — prefer it to an eager `const`, and prefer one `computed` to an `effect` that writes a signal.
+
+#### What not to flag
+
+This section is about cost that scales. Constant-factor micro-optimisation is noise and will bury the findings that matter:
+
+- Don't flag `map`/`filter`/spread over a small fixed collection, an extra object allocation, or a string concatenation.
+- Don't propose memoising something that runs once per instance and is already cheap.
+- Don't flag a cost that is genuinely bounded — a single overlay's positioning work is bounded by "one overlay is open", however expensive it looks.
+- Severity follows the axis, not the instinct: **HIGH** for forced layout in a creation/render path, a superlinear registration, or a permanent global listener per instance; **MEDIUM** for a constant per-instance overhead that is real but not layout-forcing; below that, drop it.
+
+#### Testing a scale fix
+
+When the change is about cost rather than behaviour, the test has to assert the cost. Reject wall-clock assertions (`expect(elapsed).toBeLessThan(...)`) — on a slow CI box they either flake or are set so loose they catch nothing. Instead render N instances and **count operations**: patch the layout-reading accessors, or spy on the method whose call count is the invariant, and assert the count stays sub-linear in N (`tooltip/src/tooltip-trigger/tests/tooltip-overflow-scale.test.ts`). Check the counter actually covers the work: a counter restored before a deferred microtask flushes never sees the deferred reads at all.
+
+### 8. Documentation & examples
 
 PR template requires docs updates for features and bug fixes. For new public behaviour:
 
@@ -132,13 +192,13 @@ If the diff touches files under `apps/documentation/src/app/examples/`, check th
 - **Typography/radii off-scale** (500/600 weights instead of 510/590, no negative tracking, dark panels using `bg-black` / `gray-700` instead of `zinc-950` / `zinc-800`).
 - **Dialog overlay** missing `z-index: 1000` / `z-[1000]` (backdrop renders under the navbar).
 
-### 8. Commits & PR template
+### 9. Commits & PR template
 
 - Conventional Commits required: `feat(scope): …`, `fix(scope): …`, `docs(scope): …`, `chore(scope): …`. Scope is usually the primitive name (`combobox`, `focus-trap`, `tooltip`).
 - Flag malformed commit messages before suggesting merge.
 - PR template checklist: tests added, docs updated, issue linked (`Closes #...`), breaking change disclosed.
 
-### 9. Formatting
+### 10. Formatting
 
 Formatting is enforced by `.prettierrc` plus the Prettier plugins (`@trivago/prettier-plugin-sort-imports`, `prettier-plugin-organize-attributes`, `prettier-plugin-tailwindcss`). If something looks off, suggest `pnpm format` rather than nitpicking line-by-line.
 
@@ -170,7 +230,7 @@ Each finding is its own block. Group blocks under the file they belong to, order
 
 Always prefix the severity tag with its emoji so the reader can scan the review visually:
 
-- 🔴 **HIGH** — correctness bug, lint-rule violation, public API regression, accessibility regression, broken test, missing required test for a behaviour change. The PR should not merge without addressing it.
+- 🔴 **HIGH** — correctness bug, lint-rule violation, public API regression, accessibility regression, a performance cost that scales with instance count or event frequency (§7), broken test, missing required test for a behaviour change. The PR should not merge without addressing it.
 - 🟡 **MEDIUM** — clarity, maintainability, type-safety, or a convention miss that isn't lint-enforced. Worth fixing in this PR but not a blocker.
 - 🟢 **LOW** — style or naming nits, usually auto-fixable by `pnpm format`. Mention briefly or omit.
 

--- a/.claude/skills/ngp-code-review/SKILL.md
+++ b/.claude/skills/ngp-code-review/SKILL.md
@@ -164,11 +164,11 @@ This section is about cost that scales. Constant-factor micro-optimisation is no
 - Don't flag `map`/`filter`/spread over a small fixed collection, an extra object allocation, or a string concatenation.
 - Don't propose memoising something that runs once per instance and is already cheap.
 - Don't flag a cost that is genuinely bounded — a single overlay's positioning work is bounded by "one overlay is open", however expensive it looks.
-- Severity follows the axis, not the instinct: **HIGH** for forced layout in a creation/render path, a superlinear registration, or a permanent global listener per instance; **MEDIUM** for a constant per-instance overhead that is real but not layout-forcing; below that, drop it.
+- Severity follows the axis, not the instinct (this mapping takes precedence over the general severity guidance below for performance findings): **HIGH** for forced layout in a creation/render path, a superlinear registration, or a permanent global listener per instance; **MEDIUM** for a constant per-instance overhead that is real but not layout-forcing; below that, drop it.
 
 #### Testing a scale fix
 
-When the change is about cost rather than behaviour, the test has to assert the cost. Reject wall-clock assertions (`expect(elapsed).toBeLessThan(...)`) — on a slow CI box they either flake or are set so loose they catch nothing. Instead render N instances and **count operations**: patch the layout-reading accessors, or spy on the method whose call count is the invariant, and assert the count stays sub-linear in N (`tooltip/src/tooltip-trigger/tests/tooltip-overflow-scale.test.ts`). Check the counter actually covers the work: a counter restored before a deferred microtask flushes never sees the deferred reads at all.
+When the change is about cost rather than behaviour, the test has to assert the cost. Reject wall-clock assertions (`expect(elapsed).toBeLessThan(...)`) — on a slow CI box they either flake or are set so loose they catch nothing. Instead render N instances and **count operations**: patch the layout-reading accessors, or spy on the method whose call count is the invariant, and assert the count matches the intended complexity for that code path (`tooltip/src/tooltip-trigger/tests/tooltip-overflow-scale.test.ts`). O(N) total work is expected and correct when N independent instances each require constant setup; reject O(N²) or unnecessary repeated/duplicated work per instance (e.g., superlinear registration that re-scans all children on each hookup). Check the counter actually covers the work: a counter restored before a deferred microtask flushes never sees the deferred reads at all.
 
 ### 8. Documentation & examples
 
@@ -230,7 +230,7 @@ Each finding is its own block. Group blocks under the file they belong to, order
 
 Always prefix the severity tag with its emoji so the reader can scan the review visually:
 
-- 🔴 **HIGH** — correctness bug, lint-rule violation, public API regression, accessibility regression, a performance cost that scales with instance count or event frequency (§7), broken test, missing required test for a behaviour change. The PR should not merge without addressing it.
+- 🔴 **HIGH** — correctness bug, lint-rule violation, public API regression, accessibility regression, a performance finding that §7 maps to HIGH (forced layout in a creation/render path, superlinear registration, or a permanent global listener per instance — see §7's severity mapping, which takes precedence for performance findings), broken test, missing required test for a behaviour change. The PR should not merge without addressing it.
 - 🟡 **MEDIUM** — clarity, maintainability, type-safety, or a convention miss that isn't lint-enforced. Worth fixing in this PR but not a blocker.
 - 🟢 **LOW** — style or naming nits, usually auto-fixable by `pnpm format`. Mention briefly or omit.
 

--- a/.claude/skills/ngp-code-review/SKILL.md
+++ b/.claude/skills/ngp-code-review/SKILL.md
@@ -130,7 +130,7 @@ Three axes. Ask each of the changed code:
 git diff next...HEAD | grep -nE '^\+.*\b(getBoundingClientRect|getClientRects|getComputedStyle|scrollIntoView|offset(Width|Height|Top|Left|Parent)|client(Width|Height|Top|Left)|scroll(Width|Height|Top|Left))\b'
 ```
 
-Every hit is a layout read. It costs nothing on its own; it costs a full reflow when layout is dirty. So judge each by **what writes DOM before it**:
+Every hit except `scrollIntoView` is a layout read. A read costs nothing on its own; it costs a full reflow when layout is dirty. `scrollIntoView` differs: it always scrolls the element into view (forcing layout to compute the destination), so it is a side effect, not a read. Judge each hit by what runs around it — and for a read, by **what writes DOM before it**:
 
 - **In a state factory body, a directive constructor, or anything running while Angular creates elements.** Angular is writing DOM in the same pass, so each read forces its own reflow — N instances cost N reflows, each growing with the document. Defer to `queueMicrotask` (still ahead of paint, so nothing is a frame staler, and the whole creation pass shares one flush) or to the `earlyRead` phase of `afterRenderEffect`. `fromResizeEvent` (`internal/src/utilities/resize.ts`) is the worked example.
 - **Interleaved with writes in one `afterRenderEffect`.** Plain `afterRenderEffect(fn)` is the mixed-read-write phase: a callback that measures and then writes styles or attributes dirties layout for every instance that follows it. Use the phased form so all reads land before any write.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features) — n/a, no library code changes
- [ ] Docs have been added / updated (for bug fixes / features) — n/a, this change *is* internal contributor documentation

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [x] Other... Please describe: repository tooling — adds a section to the `ngp-code-review` skill

## Issue

Closes #

No linked issue. Follow-up to #895, where a synchronous layout read in `fromResizeEvent` took a page with thousands of `showOnOverflow` tooltips from milliseconds to tens of seconds of blocked main thread. Nothing in the review checklist would have caught it.

## What does this PR implement/fix?

Adds **§7 Performance at scale** to `.claude/skills/ngp-code-review/SKILL.md` (sections 7–9 renumbered to 8–10).

The skill had no performance dimension at all, so a change whose cost only shows up once a primitive is on the page in bulk passed review on its correctness alone. A headless library ships into pages its authors never see, so per-instance cost is worth a section of its own.

The section is framed around three axes rather than a single symptom:

- **per instance × N** — what runs for every instance whether or not the user interacts with it
- **per event × frequency** — what runs inside a `pointermove` / `scroll` / `wheel` handler
- **per notification, superlinear** — work whose cost grows with the number of siblings

What it asks the reviewer to flag:

- **Forced synchronous layout**, judged by what writes DOM *before* the read: in a state factory body while Angular is still creating elements, interleaved with writes in a plain (mixed-phase) `afterRenderEffect`, inside a subscriber to a batched producer, or uncached inside a high-frequency handler. Opens with a grep so the mechanical part happens before the reading.
- **DOM traversal** per instance or per event — `closest`, `querySelectorAll`, hand-rolled ancestor walks.
- **Superlinear parent/child registration** — a `register`/`unregister` that scans, sorts or re-indexes the whole collection makes N children cost O(N²) to mount. This is the axis that matters most for `roving-focus`, `listbox`, `select`, `menu` and `tree`, which are exactly the primitives that appear in the thousands.
- **Per-instance observers, listeners and timers** — lazy, torn down on both destroy and disable, and global listeners hoisted to a singleton or scoped to a gesture.
- **Eager work in state factories** — `Intl` formatters, regexes, cloned config, effects created for a feature the inputs disabled.

It also says explicitly **what not to flag**. Constant-factor micro-optimisation would bury the findings that matter, so the section carries its own exclusion list and maps severity to the axis rather than to instinct: HIGH for forced layout in a render path, a superlinear registration, or a permanent global listener per instance; MEDIUM for real-but-bounded per-instance overhead; below that, drop it.

Two supporting edits:

- The existing "filter speculative findings" rule gets a carve-out, or it would suppress the new section on sight — cost per instance is a property of the code as written, not a hypothetical future change, so it does not need a call site that already renders a thousand of them. The carve-out is explicitly bounded by §7's exclusion list.
- The HIGH severity definition now names cost that scales with instance count or event frequency.

Finally, a note on testing a scale fix: assert operation counts, not wall clock, since a timing assertion on CI either flakes or is set so loose it catches nothing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “Performance at scale” checklist to `ngp-code-review` so reviewers catch per‑instance, high‑frequency, and superlinear costs before they ship. Also adds a “Scale is not speculation” carve‑out and updates severity to treat scaling costs as first‑class, with clear testing guidance.

- **New Features**
  - Adds §7 framed around three axes (per instance, per event, superlinear) with a grep for layout reads and phased `afterRenderEffect` guidance; notes `scrollIntoView` is a side effect, not a read.
  - Flags hot‑path DOM traversal, superlinear parent/child registration (keep registration O(1)), and per‑instance observers/listeners/timers (lazy, torn down, hoisted/scoped, use `{ passive: true }` when applicable).
  - Calls out eager factory work; prefer lazy `computed` over unconditional `effect`.
  - Introduces “Scale is not speculation” and a performance‑specific severity map (HIGH for forced layout in creation/render paths, superlinear registration, or permanent global listeners per instance); renumbers §§8–10.
  - Testing guidance: assert operation counts instead of wall‑clock time, and ensure counters observe deferred microtasks.

- **Bug Fixes**
  - Minor wording/formatting fixes in `SKILL.md`.

<sup>Written for commit 39f581c67d39b923edac0012639ec65c66f722f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for reviewing performance at scale, including layout reads, DOM traversal, observers, event listeners, timers and eager processing.
  * Added scale-oriented operation-count testing guidance and clarified severity mapping for high-impact performance findings.
  * Updated section numbering and refined wording and placement for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->