### PR TITLE
fix(ng-primitives): allow TypeScript 6 by bumping tsquery to 6.2.0

### DIFF
--- a/packages/ng-primitives/package.json
+++ b/packages/ng-primitives/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/sponsors/ng-primitives"
   },
   "dependencies": {
-    "@phenomnomnominal/tsquery": "6.1.3"
+    "@phenomnomnominal/tsquery": "6.2.0"
   },
   "peerDependencies": {
     "@angular/core": "^21.0.0 || ^22.0.0",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features) — n/a, this is a dependency range change with no testable code path
- [ ] Docs have been added / updated (for bug fixes / features) — n/a

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

No existing issue — I searched open and closed issues and PRs for `tsquery` and for `typescript 6` and found nothing. Happy to open one to track this if you'd prefer.

## What does this PR implement/fix?

`packages/ng-primitives/package.json` pins `@phenomnomnominal/tsquery` to the exact version `6.1.3`. That version declares:

```json
"peerDependencies": { "typescript": "^3 || ^4 || ^5" }
```

Because the pin is exact, every consumer on TypeScript 6 resolves a tsquery whose peer range excludes their TypeScript:

```
└─┬ ng-primitives 0.128.7
  └─┬ @phenomnomnominal/tsquery 6.1.3
    └── ✕ unmet peer typescript@"^3 || ^4 || ^5": found 6.0.3
```

Under default pnpm settings that is a warning; under `--strict-peer-dependencies` the install fails outright with `ERR_PNPM_PEER_DEP_ISSUES`. Consumers cannot work around it in a way that reaches their own users — a pnpm `overrides` entry only applies to the workspace that declares it and is not inherited by anyone installing their published package — so the bump has to happen here.

tsquery `6.2.0` relaxes the range to `"typescript": ">3.0.0"`, which is all that is needed. `6.1.4` still carried the old range, so `6.2.0` is the first version that fixes it.

### Compatibility

I diffed the two published tarballs rather than assume a minor bump was safe. The file lists are identical and the entry point (`dist/src/index.js`) is unchanged. There is one public API change: `6.2.0` drops the exported `remove()` helper. This repository imports only `query` and `tsquery` — in `packages/tools/src/generators/{example,reusable-component,templates}` and `packages/ng-primitives/schematics/ng-generate` — and never `remove` or `map`, so it is unaffected. The only other change is in `match`, where `parse.ensure(selector)` was hoisted out of the traversal callback; that is a performance refactor with identical behaviour.

As a check, I ran the ten selectors this repository actually passes to tsquery through both versions — 6.1.3 on TypeScript 5.9.3 and 6.2.0 on TypeScript 6.0.3 — and compared the matched nodes. They were identical apart from `remove` no longer appearing in the module's exports.

Two notes on scope:

- `6.2.0` is already in `pnpm-lock.yaml` as a transitive dependency of Nx, so this also dedupes the tree.
- The root `package.json` devDependency is already `^6.1.3`, which admits `6.2.0`, so it needs no change. `packages/ng-primitives/package.json` is not a pnpm workspace importer, so the lockfile is untouched and `pnpm install --frozen-lockfile` is unaffected.

Unrelated but noticed while checking the call sites: `apps/documentation/src/typings.d.ts` still declares a module for `https://esm.sh/@phenomnomnominal/tsquery@6.1.3`, but nothing imports that URL (unlike the neighbouring `prettier` declarations). I left it alone to keep this PR to one line — flagging it in case you want it cleaned up separately.

### On the pinning style

I kept the exact pin so as not to change your pinning convention unilaterally. A caret (`^6.2.0`) would additionally let consumers pick up future patch releases, and would reduce the chance of a duplicate install for consumers who also depend on tsquery themselves. The trade-off is the usual one — less control over exactly what consumers resolve. Happy to switch it to a caret if you'd prefer.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow TypeScript 6 by bumping `@phenomnomnominal/tsquery` from 6.1.3 to 6.2.0, which relaxes its `typescript` peer range to `>3.0.0`.
This removes `pnpm --strict-peer-dependencies` install errors for consumers; no APIs we use changed (only `remove()` was dropped, which we don’t import).

<sup>Written for commit 6650f1b3cc3f49440aa329de898c2dfa49858723. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

