### PR TITLE
fix(portal): overlay with a multi-root content template can never close

### DIFF
--- a/packages/ng-primitives/portal/src/portal.ts
+++ b/packages/ng-primitives/portal/src/portal.ts
@@ -281,9 +281,13 @@ export class NgpTemplatePortal<T> extends NgpPortal {
 
   /**
    * Get the root elements of the portal.
+   *
+   * Root nodes are not all elements: a nested `<ng-template>` renders as a comment.
    */
   getElements(): HTMLElement[] {
-    return this.viewRef ? this.viewRef.rootNodes : [];
+    return this.viewRef
+      ? this.viewRef.rootNodes.filter(rootNode => rootNode instanceof HTMLElement)
+      : [];
   }
 
   /**

--- a/packages/ng-primitives/portal/src/tests/overlay-multi-root-content.test.ts
+++ b/packages/ng-primitives/portal/src/tests/overlay-multi-root-content.test.ts
@@ -1,0 +1,43 @@
+import { Component } from '@angular/core';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
+ * `hide()` strips `data-instant` from the portal's root nodes before scheduling the
+ * dispose timeout, so a non-element root node throws there and the overlay is never
+ * disposed — it stays open forever.
+ */
+@Component({
+  template: `
+    <button [ngpPopoverTrigger]="content" data-testid="trigger">Open</button>
+
+    <ng-template #content>
+      <div ngpPopover data-testid="popover">Popover content</div>
+
+      <!-- A second root node, which Angular renders as a comment. -->
+      <ng-template #nested><span>Nested</span></ng-template>
+    </ng-template>
+  `,
+  imports: [NgpPopoverTrigger, NgpPopover],
+})
+class MultiRootContentComponent {}
+
+describe('overlay with multi-root content', () => {
+  afterEach(() => {
+    // The overlay portals onto `body`, so a failure would leak it into the next test.
+    document.querySelectorAll('[ngpPopover]').forEach(element => element.remove());
+  });
+
+  it('should close an overlay whose content template has a non-element root node', async () => {
+    const { getByTestId } = await render(MultiRootContentComponent);
+    const trigger = getByTestId('trigger');
+
+    fireEvent.click(trigger);
+    await waitFor(() => expect(document.querySelector('[data-testid="popover"]')).not.toBeNull());
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => expect(document.querySelector('[data-testid="popover"]')).toBeNull());
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — N/A, no public API or behaviour is documented differently

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

No issue filed — happy to open one separately if you'd rather track the report on its own.

## What does this PR implement/fix?

An overlay whose content template has more than one root node can never be closed.

### Reproduction

```html
<ng-template #content>
  <div ngpPopover>Popover content</div>
  <ng-template #nested>…</ng-template>
</ng-template>
```

Open it, then close it: the overlay stays in the DOM permanently, and the console shows
`TypeError: element.removeAttribute is not a function`.

### Cause

`NgpTemplatePortal.getElements()` returns `viewRef.rootNodes` unfiltered. Angular renders a
nested `<ng-template>` as a **comment** node (and stray text as a text node), so the array
isn't all elements — but the method is declared `HTMLElement[]`:

```ts
// packages/ng-primitives/portal/src/portal.ts
abstract getElements(): HTMLElement[];                              // NgpPortal
getElements(): HTMLElement[] { return this.viewRef ? this.viewRef.rootNodes : []; }  // NgpTemplatePortal
```

It type-checks because Angular declares `EmbeddedViewRef.rootNodes` as `any[]`. And because
the sibling `NgpComponentPortal.getElements()` returns `[viewRef.location.nativeElement]` —
genuinely always an element — callers reasonably treat the contract as `Element[]`. Three
then call element-only methods on it, in `packages/ng-primitives/portal/src/overlay.ts`:

| Line | Call | Effect |
| --- | --- | --- |
| `:633` `hide()` | `removeAttribute('data-instant')` | **Throws**, and it runs *before* `this.closeTimeout = setTimeout(dispose, delay)` — so dispose is never scheduled and the overlay is stuck open. The throw also escapes whatever called `hide()`. |
| `:970` attach | `setAttribute('data-instant', '')` | Same crash, only reachable when `instantTransition()` is true. |
| `:812` `findOutletElement()` | `hasAttribute('data-overlay')` | Throws on a comment before reaching a later real match; `elements[0]` can also hand back a comment as the outlet. Masked wherever `registerOutletElement` is used. |

### Fix

Filter in `getElements()` rather than at each call site, so the declared `HTMLElement[]`
contract holds for every caller. `NgpTemplatePortal.attach()` already guards its own
`rootNodes` walk with `rootNode instanceof HTMLElement`, so this makes the two consistent:

```ts
getElements(): HTMLElement[] {
  return this.viewRef
    ? this.viewRef.rootNodes.filter(rootNode => rootNode instanceof HTMLElement)
    : [];
}
```

Multi-root content templates now work rather than failing, which seems preferable to
rejecting them — but if you'd rather they were an explicit dev-mode error instead, happy to
switch the approach.

### Tests

Added `packages/ng-primitives/portal/src/tests/overlay-multi-root-content.test.ts` — opens a
popover whose content template has a nested `<ng-template>`, closes it, and asserts it leaves
the DOM. Fails on `main` (`expected <div ngppopover …> to be null`), passes with the fix.

Popover is just the smallest primitive that shows it; nothing here is popover-specific. I hit
it on a 3-level menu, where a submenu's content template is naturally declared alongside the
menu it belongs to — that made the parent menu permanently un-closable, and because the throw
escapes `Subject.next()` on the parent menu's `closeSubmenus` subject, sibling submenu
triggers stopped receiving their close notifications too.

Full suite run locally on `main` + this change: **2602 passed, 0 failed**.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`getElements()` is documented as returning `HTMLElement[]`, and this makes it do that. A
caller relying on comment or text nodes coming back would be relying on the type being wrong.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overlays that never close when the content template has multiple root nodes (e.g., a nested `ng-template`). `NgpTemplatePortal.getElements()` now filters out non-element nodes so callers get `HTMLElement[]` and attribute calls on comments/text no longer throw.

<sup>Written for commit 75b9e9df90f4bb60b145e2fbb237ece982186049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

