### PR TITLE
Feat/add required flag on form primitives

### DIFF
--- a/packages/ng-primitives/form-field/src/description/description-state.ts
+++ b/packages/ng-primitives/form-field/src/description/description-state.ts
@@ -44,6 +44,7 @@ export const [
     dataBinding(element, 'data-dirty', () => (formField()?.dirty() ? '' : null));
     dataBinding(element, 'data-pending', () => (formField()?.pending() ? '' : null));
     dataBinding(element, 'data-disabled', () => (formField()?.disabled() ? '' : null));
+    dataBinding(element, 'data-required', () => (formField()?.required() ? '' : null));
 
     // Register with form field and cleanup on destroy
     formField()?.addDescription(id());

--- a/packages/ng-primitives/form-field/src/error/error-state.ts
+++ b/packages/ng-primitives/form-field/src/error/error-state.ts
@@ -62,6 +62,7 @@ export const [NgpErrorStateToken, ngpError, injectErrorState, provideErrorState]
     dataBinding(element, 'data-dirty', () => (formField()?.dirty() ? '' : null));
     dataBinding(element, 'data-pending', () => (formField()?.pending() ? '' : null));
     dataBinding(element, 'data-disabled', () => (formField()?.disabled() ? '' : null));
+    dataBinding(element, 'data-required', () => (formField()?.required() ? '' : null));
     dataBinding(element, 'data-validator', state);
 
     let currentId = id();

--- a/packages/ng-primitives/form-field/src/form-control/form-control-state.ts
+++ b/packages/ng-primitives/form-field/src/form-control/form-control-state.ts
@@ -60,6 +60,7 @@ export function ngpFormControl({
   dataBinding(elementRef, 'data-pristine', () => status().pristine);
   dataBinding(elementRef, 'data-dirty', () => status().dirty);
   dataBinding(elementRef, 'data-pending', () => status().pending);
+  dataBinding(elementRef, 'data-required', () => status().required);
   dataBinding(elementRef, 'data-disabled', () => disabled() || status().disabled);
 
   return computed(() => ({ ...status(), disabled: status().disabled || disabled() }));

--- a/packages/ng-primitives/form-field/src/form-field/form-field-state.ts
+++ b/packages/ng-primitives/form-field/src/form-field/form-field-state.ts
@@ -1,9 +1,8 @@
-import { Injector, Signal, effect, inject, signal, untracked } from '@angular/core';
+import { Signal, computed, signal } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { injectElementRef } from 'ng-primitives/internal';
-import { createPrimitive, dataBinding, onDestroy } from 'ng-primitives/state';
-import { onChange } from 'ng-primitives/utils';
-import { Subscription } from 'rxjs';
+import { createPrimitive, dataBinding } from 'ng-primitives/state';
+import { controlStatus } from 'ng-primitives/utils';
 
 /**
  * The state interface for the FormField primitive.
@@ -54,6 +53,10 @@ export interface NgpFormFieldState {
    */
   readonly disabled: Signal<boolean | null>;
   /**
+   * Whether the control is required.
+   */
+  readonly required: Signal<boolean | null>;
+  /**
    * Register the id of the associated form control.
    */
   setFormControl(id: string): void;
@@ -92,7 +95,9 @@ export interface NgpFormFieldProps {
 export const [NgpFormFieldStateToken, ngpFormField, injectFormFieldState, provideFormFieldState] =
   createPrimitive('NgpFormField', ({ ngControl }: NgpFormFieldProps) => {
     const element = injectElementRef();
-    const injector = inject(Injector);
+
+    // Access the form control status.
+    const status = controlStatus(ngControl);
 
     // Store the form labels
     const labels = signal<string[]>([]);
@@ -104,19 +109,17 @@ export const [NgpFormFieldStateToken, ngpFormField, injectFormFieldState, provid
     const formControl = signal<string | null>(null);
 
     // Store the validation error messages
-    const errors = signal<string[]>([]);
+    const errors = computed<string[]>(() => status().errors ?? []);
 
     // Form control state signals
-    const pristine = signal<boolean | null>(null);
-    const touched = signal<boolean | null>(null);
-    const dirty = signal<boolean | null>(null);
-    const valid = signal<boolean | null>(null);
-    const invalid = signal<boolean | null>(null);
-    const pending = signal<boolean | null>(null);
-    const disabled = signal<boolean | null>(null);
-
-    // Store the current status subscription
-    let subscription: Subscription | undefined;
+    const pristine = computed<boolean | null>(() => status().pristine);
+    const touched = computed<boolean | null>(() => status().touched);
+    const dirty = computed<boolean | null>(() => status().dirty);
+    const valid = computed<boolean | null>(() => status().valid);
+    const invalid = computed<boolean | null>(() => status().invalid);
+    const pending = computed<boolean | null>(() => status().pending);
+    const disabled = computed<boolean | null>(() => status().disabled);
+    const required = computed<boolean | null>(() => status().required);
 
     // Host bindings
     dataBinding(element, 'data-invalid', invalid);
@@ -126,73 +129,7 @@ export const [NgpFormFieldStateToken, ngpFormField, injectFormFieldState, provid
     dataBinding(element, 'data-dirty', dirty);
     dataBinding(element, 'data-pending', pending);
     dataBinding(element, 'data-disabled', disabled);
-
-    function updateStatus(): void {
-      const control = ngControl();
-
-      if (!control) {
-        return;
-      }
-
-      // Wrap in try-catch to handle signal-forms interop controls where
-      // the `field` input may not be available yet (throws NG0950).
-      // Reading the signal still establishes a dependency, so the effect
-      // will re-run when the input becomes available.
-      try {
-        const controlPristine = control.pristine;
-        const controlTouched = control.touched;
-        const controlDirty = control.dirty;
-        const controlValid = control.valid;
-        const controlInvalid = control.invalid;
-        const controlPending = control.pending;
-        const controlDisabled = control.disabled;
-        const controlErrors = control.errors;
-
-        untracked(() => {
-          pristine.set(controlPristine);
-          touched.set(controlTouched);
-          dirty.set(controlDirty);
-          valid.set(controlValid);
-          invalid.set(controlInvalid);
-          pending.set(controlPending);
-          disabled.set(controlDisabled);
-          errors.set(controlErrors ? Object.keys(controlErrors) : []);
-        });
-      } catch {
-        // NG0950: Required input not available yet. The effect will re-run
-        // when the signal input becomes available.
-      }
-    }
-
-    function setupSubscriptions(control: NgControl | null | undefined): void {
-      // Unsubscribe from the previous subscriptions.
-      subscription?.unsubscribe();
-
-      if (!control) {
-        return;
-      }
-
-      // For signal-forms interop controls, use an effect to reactively track status.
-      // For classic controls, also use an effect but additionally subscribe to events.
-      effect(
-        () => {
-          updateStatus();
-        },
-        { injector },
-      );
-
-      // Classic controls also have an events observable we can subscribe to.
-      const underlyingControl = control?.control;
-      if (underlyingControl?.events) {
-        subscription = underlyingControl.events.subscribe(() => updateStatus());
-      }
-    }
-
-    // Setup subscriptions when ngControl changes
-    onChange(ngControl, setupSubscriptions);
-
-    // Cleanup subscription on destroy
-    onDestroy(() => subscription?.unsubscribe());
+    dataBinding(element, 'data-required', required);
 
     // Methods
     function setFormControl(id: string): void {
@@ -241,6 +178,7 @@ export const [NgpFormFieldStateToken, ngpFormField, injectFormFieldState, provid
       invalid,
       pending,
       disabled,
+      required,
       setFormControl,
       addLabel,
       addDescription,

--- a/packages/ng-primitives/form-field/src/form-field/tests/form-field-component.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/form-field-component.test.ts
@@ -136,9 +136,17 @@ describe('FormField (reusable component) — standalone', () => {
           <label ngpLabel>Username</label>
           <input [formControl]="formControl" ngpFormControl />
           <div ngpDescription>Hint</div>
+          <div ngpError ngpErrorValidator="required">Required</div>
         </app-form-field>`,
       {
-        imports: [FormField, NgpLabel, NgpFormControl, NgpDescription, ReactiveFormsModule],
+        imports: [
+          FormField,
+          NgpLabel,
+          NgpError,
+          NgpFormControl,
+          NgpDescription,
+          ReactiveFormsModule,
+        ],
         componentProperties: { formControl },
       },
     );
@@ -147,6 +155,7 @@ describe('FormField (reusable component) — standalone', () => {
     expect(container.querySelector('label')).not.toHaveAttribute('data-required');
     expect(container.querySelector('input')).not.toHaveAttribute('data-required');
     expect(container.querySelector('[ngpDescription]')).not.toHaveAttribute('data-required');
+    expect(container.querySelector('[ngpError]')).not.toHaveAttribute('data-required');
 
     formControl.addValidators(Validators.required);
     fixture.detectChanges();
@@ -156,5 +165,6 @@ describe('FormField (reusable component) — standalone', () => {
     expect(container.querySelector('label')).toHaveAttribute('data-required');
     expect(container.querySelector('input')).toHaveAttribute('data-required');
     expect(container.querySelector('[ngpDescription]')).toHaveAttribute('data-required');
+    expect(container.querySelector('[ngpError]')).toHaveAttribute('data-required');
   });
 });

--- a/packages/ng-primitives/form-field/src/form-field/tests/form-field-component.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/form-field-component.test.ts
@@ -128,4 +128,33 @@ describe('FormField (reusable component) — standalone', () => {
     expect(container.querySelector('input')).toHaveAttribute('data-disabled');
     expect(container.querySelector('[ngpDescription]')).toHaveAttribute('data-disabled');
   });
+
+  it('reflects the required state onto the wrapper and projected parts', async () => {
+    const formControl = new FormControl('');
+    const { container, fixture } = await render(
+      `<app-form-field>
+          <label ngpLabel>Username</label>
+          <input [formControl]="formControl" ngpFormControl />
+          <div ngpDescription>Hint</div>
+        </app-form-field>`,
+      {
+        imports: [FormField, NgpLabel, NgpFormControl, NgpDescription, ReactiveFormsModule],
+        componentProperties: { formControl },
+      },
+    );
+
+    expect(container.querySelector('app-form-field')).not.toHaveAttribute('data-required');
+    expect(container.querySelector('label')).not.toHaveAttribute('data-required');
+    expect(container.querySelector('input')).not.toHaveAttribute('data-required');
+    expect(container.querySelector('[ngpDescription]')).not.toHaveAttribute('data-required');
+
+    formControl.addValidators(Validators.required);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(container.querySelector('app-form-field')).toHaveAttribute('data-required');
+    expect(container.querySelector('label')).toHaveAttribute('data-required');
+    expect(container.querySelector('input')).toHaveAttribute('data-required');
+    expect(container.querySelector('[ngpDescription]')).toHaveAttribute('data-required');
+  });
 });

--- a/packages/ng-primitives/form-field/src/label/label-state.ts
+++ b/packages/ng-primitives/form-field/src/label/label-state.ts
@@ -56,6 +56,7 @@ export const [NgpLabelStateToken, ngpLabel, injectLabelState, provideLabelState]
     dataBinding(element, 'data-dirty', () => (formField()?.dirty() ? '' : null));
     dataBinding(element, 'data-pending', () => (formField()?.pending() ? '' : null));
     dataBinding(element, 'data-disabled', () => (formField()?.disabled() ? '' : null));
+    dataBinding(element, 'data-required', () => (formField()?.required() ? '' : null));
 
     function onClick(event: MouseEvent): void {
       // by default a label will perform a click on the associated form control, however

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -16,7 +16,7 @@ import { safeTakeUntilDestroyed } from '../observables/take-until-destroyed';
 
 // Avoid multiple patch from different `controlStatus` on the same NgControl
 interface PatchState {
-  consumers: { ngControl: NgControl; status: WritableSignal<NgpControlStatus> }[];
+  consumers: { status: WritableSignal<NgpControlStatus> }[];
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
   originalMethods: Record<string, Function>;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
@@ -117,7 +117,7 @@ function setupEventSubscription(
  * A global `WeakMap` tracks patch state per `AbstractControl`. It stores:
  * - the original validator methods
  * - the patched methods
- * - a list of consumers (each with its `NgControl` and `status` signal)
+ * - a list of consumers (each with its `status` signal)
  *
  * On the first consumer: the original methods are saved, patched versions are
  * installed on the control, and the consumer is registered.
@@ -182,10 +182,10 @@ function setupValidatorChangeSubscription(
       underlyingControl[method] = patchedMethods[method];
     }
 
-    state = { consumers: [{ ngControl, status }], originalMethods, patchedMethods };
+    state = { consumers: [{ status }], originalMethods, patchedMethods };
     patchRegistry.set(underlyingControl, state);
   } else {
-    state.consumers.push({ ngControl, status });
+    state.consumers.push({ status });
   }
 
   return () => {
@@ -195,9 +195,9 @@ function setupValidatorChangeSubscription(
       return;
     }
 
-    currentState.consumers = currentState.consumers.filter(
-      x => x.ngControl !== ngControl && x.status() !== status(),
-    );
+    // We check by reference of signal, not value
+    // eslint-disable-next-line @angular-eslint/no-uncalled-signals
+    currentState.consumers = currentState.consumers.filter(x => x.status !== status);
 
     // If no consumers remain, restore original methods and delete the WeakMap entry
     if (currentState.consumers.length === 0) {

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -54,7 +54,10 @@ function updateStatus(control: NgControl, status: WritableSignal<NgpControlStatu
       pending: source.pending ?? null,
       disabled: source.disabled ?? null,
       errors: source.errors ? Object.keys(source.errors) : null,
-      required: source.hasValidator(Validators.required) ?? null,
+      required:
+        (source.hasValidator(Validators.required) ||
+          source.hasValidator(Validators.requiredTrue)) ??
+        null,
     };
 
     untracked(() => status.set(newStatus));
@@ -113,7 +116,12 @@ function setupValidatorChangeSubscription(
   // `setValidators`/`setAsyncValidators` are the primitives that every other
   // mutator (`addValidators`, `removeValidators`, `addAsyncValidators`,
   // `removeAsyncValidators`) delegates to on `AbstractControl`.
-  for (const method of ['setValidators', 'setAsyncValidators'] as const) {
+  for (const method of [
+    'setValidators',
+    'setAsyncValidators',
+    'clearValidators',
+    'clearAsyncValidators',
+  ] as const) {
     const original = underlyingControl[method].bind(underlyingControl);
 
     underlyingControl[method] = (...args: unknown[]) => {

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -5,6 +5,7 @@ import {
   WritableSignal,
   effect,
   inject,
+  linkedSignal,
   signal,
   untracked,
 } from '@angular/core';
@@ -20,6 +21,7 @@ export interface NgpControlStatus {
   touched: boolean | null;
   pending: boolean | null;
   disabled: boolean | null;
+  errors: string[] | null;
   required: boolean | null;
 }
 
@@ -51,6 +53,7 @@ function updateStatus(control: NgControl, status: WritableSignal<NgpControlStatu
       touched: source.touched ?? null,
       pending: source.pending ?? null,
       disabled: source.disabled ?? null,
+      errors: source.errors ? Object.keys(source.errors) : null,
       required: source.hasValidator(Validators.required) ?? null,
     };
 
@@ -121,7 +124,9 @@ function setupValidatorChangeSubscription(
   }
 }
 
-export function controlStatus(): Signal<NgpControlStatus> {
+export function controlStatus(
+  ngControl?: Signal<NgControl | null | undefined>,
+): Signal<NgpControlStatus> {
   const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
 
@@ -133,14 +138,17 @@ export function controlStatus(): Signal<NgpControlStatus> {
     touched: null,
     pending: null,
     disabled: null,
+    errors: null,
     required: null,
   });
 
-  const control = signal<NgControl | null>(null);
+  const control = linkedSignal<NgControl | null>(() => ngControl?.() ?? null);
 
   onMount(() => {
-    // Try to inject NgControl immediately for initial state
-    control.set(inject(NgControl, { optional: true }));
+    if (!control()) {
+      // Try to inject NgControl immediately for initial state
+      control.set(inject(NgControl, { optional: true }));
+    }
 
     // If we have a control immediately, update initial status
     if (control()) {

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -8,7 +8,7 @@ import {
   signal,
   untracked,
 } from '@angular/core';
-import { NgControl } from '@angular/forms';
+import { NgControl, Validators } from '@angular/forms';
 import { onMount } from 'ng-primitives/state';
 import { safeTakeUntilDestroyed } from '../observables/take-until-destroyed';
 
@@ -20,6 +20,7 @@ export interface NgpControlStatus {
   touched: boolean | null;
   pending: boolean | null;
   disabled: boolean | null;
+  required: boolean | null;
 }
 
 /**
@@ -50,6 +51,7 @@ function updateStatus(control: NgControl, status: WritableSignal<NgpControlStatu
       touched: source.touched ?? null,
       pending: source.pending ?? null,
       disabled: source.disabled ?? null,
+      required: source.hasValidator(Validators.required) ?? null,
     };
 
     untracked(() => status.set(newStatus));
@@ -83,6 +85,42 @@ function setupEventSubscription(
   }
 }
 
+/**
+ * Patches the underlying control's validator mutators so that adding/removing
+ * validators re-reads the control status. Classic `AbstractControl` mutators
+ * (`setValidators`, `addValidators`, `removeValidators`, ...) do not emit any
+ * events, so without this the `required` state (derived from `hasValidator`)
+ * would stay stale until an unrelated value/status change.
+ * @internal
+ */
+function setupValidatorChangeSubscription(
+  ngControl: NgControl,
+  status: WritableSignal<NgpControlStatus>,
+): void {
+  // For classic controls, also subscribe to the events observable.
+  const underlyingControl = (ngControl as any).control;
+
+  // Signal-forms interop controls don't expose `setValidators` — skip them.
+  // They're already reactive: `hasValidator(Validators.required)` reads
+  // `field().required()`, a signal tracked by the effect below.
+  if (!underlyingControl || typeof underlyingControl.setValidators !== 'function') {
+    return;
+  }
+
+  // `setValidators`/`setAsyncValidators` are the primitives that every other
+  // mutator (`addValidators`, `removeValidators`, `addAsyncValidators`,
+  // `removeAsyncValidators`) delegates to on `AbstractControl`.
+  for (const method of ['setValidators', 'setAsyncValidators'] as const) {
+    const original = underlyingControl[method].bind(underlyingControl);
+
+    underlyingControl[method] = (...args: unknown[]) => {
+      original(...args);
+      // Re-read the status so `required` reflects the new validators.
+      updateStatus(ngControl, status);
+    };
+  }
+}
+
 export function controlStatus(): Signal<NgpControlStatus> {
   const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
@@ -95,6 +133,7 @@ export function controlStatus(): Signal<NgpControlStatus> {
     touched: null,
     pending: null,
     disabled: null,
+    required: null,
   });
 
   const control = signal<NgControl | null>(null);
@@ -125,6 +164,9 @@ export function controlStatus(): Signal<NgpControlStatus> {
 
     // Set up event subscription for reactive updates
     setupEventSubscription(mountControl, status, destroyRef);
+
+    // Set up validator "subscription" for reactive updates
+    setupValidatorChangeSubscription(mountControl, status);
   });
 
   // Use an effect to reactively track status changes.

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -195,7 +195,9 @@ function setupValidatorChangeSubscription(
       return;
     }
 
-    currentState.consumers.filter(x => x.ngControl !== ngControl && x.status() !== status());
+    currentState.consumers = currentState.consumers.filter(
+      x => x.ngControl !== ngControl && x.status() !== status(),
+    );
 
     // If no consumers remain, restore original methods and delete the WeakMap entry
     if (currentState.consumers.length === 0) {

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -256,7 +256,6 @@ export function controlStatus(
     }
 
     if (control()) {
-      setup(control()!);
       updateStatus(control()!, status);
     }
   });

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -10,8 +10,20 @@ import {
   untracked,
 } from '@angular/core';
 import { NgControl, Validators } from '@angular/forms';
-import { onMount } from 'ng-primitives/state';
+import { onDestroy, onMount } from 'ng-primitives/state';
+import { Subscription } from 'rxjs';
 import { safeTakeUntilDestroyed } from '../observables/take-until-destroyed';
+
+// Avoid multiple patch from different `controlStatus` on the same NgControl
+interface PatchState {
+  consumers: { ngControl: NgControl; status: WritableSignal<NgpControlStatus> }[];
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  originalMethods: Record<string, Function>;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+  patchedMethods: Record<string, Function>;
+}
+
+const patchRegistry = new WeakMap<NgControl, PatchState>();
 
 export interface NgpControlStatus {
   valid: boolean | null;
@@ -81,14 +93,16 @@ function setupEventSubscription(
   ngControl: NgControl,
   status: WritableSignal<NgpControlStatus>,
   destroyRef: DestroyRef,
-): void {
+): Subscription | undefined {
   // For classic controls, also subscribe to the events observable.
   const underlyingControl = (ngControl as any).control;
   if (underlyingControl?.events) {
-    underlyingControl.events
+    return underlyingControl.events
       .pipe(safeTakeUntilDestroyed(destroyRef))
       .subscribe(() => updateStatus(ngControl, status));
   }
+
+  return undefined;
 }
 
 /**
@@ -97,12 +111,31 @@ function setupEventSubscription(
  * (`setValidators`, `addValidators`, `removeValidators`, ...) do not emit any
  * events, so without this the `required` state (derived from `hasValidator`)
  * would stay stale until an unrelated value/status change.
+ *
+ * Implementation details:
+ *
+ * A global `WeakMap` tracks patch state per `AbstractControl`. It stores:
+ * - the original validator methods
+ * - the patched methods
+ * - a list of consumers (each with its `NgControl` and `status` signal)
+ *
+ * On the first consumer: the original methods are saved, patched versions are
+ * installed on the control, and the consumer is registered.
+ *
+ * On subsequent consumers: they are added to the consumer list without
+ * re-patching the control.
+ *
+ * When validators change: the patched method notifies all registered consumers
+ * by calling `updateStatus` with their respective status signals.
+ *
+ * On cleanup: the consumer is removed from the list. If no consumers remain,
+ * the original methods are restored and the `WeakMap` entry is deleted.
  * @internal
  */
 function setupValidatorChangeSubscription(
   ngControl: NgControl,
   status: WritableSignal<NgpControlStatus>,
-): void {
+): () => void {
   // For classic controls, also subscribe to the events observable.
   const underlyingControl = (ngControl as any).control;
 
@@ -110,26 +143,69 @@ function setupValidatorChangeSubscription(
   // They're already reactive: `hasValidator(Validators.required)` reads
   // `field().required()`, a signal tracked by the effect below.
   if (!underlyingControl || typeof underlyingControl.setValidators !== 'function') {
-    return;
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {}; // no-op unpatch
   }
 
-  // `setValidators`/`setAsyncValidators` are the primitives that every other
-  // mutator (`addValidators`, `removeValidators`, `addAsyncValidators`,
-  // `removeAsyncValidators`) delegates to on `AbstractControl`.
-  for (const method of [
-    'setValidators',
-    'setAsyncValidators',
-    'clearValidators',
-    'clearAsyncValidators',
-  ] as const) {
-    const original = underlyingControl[method].bind(underlyingControl);
+  let state = patchRegistry.get(underlyingControl);
 
-    underlyingControl[method] = (...args: unknown[]) => {
-      original(...args);
-      // Re-read the status so `required` reflects the new validators.
-      updateStatus(ngControl, status);
-    };
+  if (!state) {
+    // First consumer: save true originals, create patched versions
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    const originalMethods: Record<string, Function> = {};
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+    const patchedMethods: Record<string, Function> = {};
+
+    // `setValidators`/`setAsyncValidators` are the primitives that every other
+    // mutator (`addValidators`, `removeValidators`, `addAsyncValidators`,
+    // `removeAsyncValidators`) delegates to on `AbstractControl`.
+    for (const method of [
+      'setValidators',
+      'setAsyncValidators',
+      'clearValidators',
+      'clearAsyncValidators',
+    ] as const) {
+      const original = underlyingControl[method].bind(underlyingControl);
+
+      originalMethods[method] = original;
+
+      patchedMethods[method] = (...args: unknown[]) => {
+        original(...args);
+
+        // state is guaranteed non-null here: the patched method only runs after
+        // the first consumer creates the PatchState entry (which includes itself).
+        for (const consumer of state!.consumers) {
+          updateStatus(ngControl, consumer.status);
+        }
+      };
+
+      underlyingControl[method] = patchedMethods[method];
+    }
+
+    state = { consumers: [{ ngControl, status }], originalMethods, patchedMethods };
+    patchRegistry.set(underlyingControl, state);
+  } else {
+    state.consumers.push({ ngControl, status });
   }
+
+  return () => {
+    const currentState = patchRegistry.get(underlyingControl);
+
+    if (!currentState) {
+      return;
+    }
+
+    currentState.consumers.filter(x => x.ngControl !== ngControl && x.status() !== status());
+
+    // If no consumers remain, restore original methods and delete the WeakMap entry
+    if (currentState.consumers.length === 0) {
+      for (const [method, original] of Object.entries(currentState.originalMethods)) {
+        underlyingControl[method] = original;
+      }
+
+      patchRegistry.delete(underlyingControl);
+    }
+  };
 }
 
 export function controlStatus(
@@ -152,37 +228,39 @@ export function controlStatus(
 
   const control = linkedSignal<NgControl | null>(() => ngControl?.() ?? null);
 
+  let currentCleanup: {
+    eventSubscription?: Subscription;
+    unpatch?: () => void;
+  } = {};
+
+  function cleanup(): void {
+    currentCleanup.eventSubscription?.unsubscribe();
+    currentCleanup.unpatch?.();
+    currentCleanup = {};
+  }
+
+  function setup(ngControl: NgControl): void {
+    // Set up event subscription for reactive updates
+    currentCleanup.eventSubscription = setupEventSubscription(ngControl, status, destroyRef);
+
+    // Set up validator "subscription" for reactive updates
+    currentCleanup.unpatch = setupValidatorChangeSubscription(ngControl, status);
+  }
+
   onMount(() => {
     if (!control()) {
       // Try to inject NgControl immediately for initial state
       control.set(inject(NgControl, { optional: true }));
     }
 
-    // If we have a control immediately, update initial status
     if (control()) {
+      setup(control()!);
       updateStatus(control()!, status);
     }
+  });
 
-    // Get the control (either from initial injection or from mount)
-    const mountControl = control() || inject(NgControl, { optional: true });
-
-    if (!mountControl) {
-      return;
-    }
-
-    // Update control signal if it wasn't set before
-    if (!control()) {
-      control.set(mountControl);
-    }
-
-    // Update status to ensure latest values
-    updateStatus(mountControl, status);
-
-    // Set up event subscription for reactive updates
-    setupEventSubscription(mountControl, status, destroyRef);
-
-    // Set up validator "subscription" for reactive updates
-    setupValidatorChangeSubscription(mountControl, status);
+  onDestroy(() => {
+    cleanup();
   });
 
   // Use an effect to reactively track status changes.
@@ -192,7 +270,11 @@ export function controlStatus(
   effect(
     () => {
       const c = control();
+
+      cleanup();
+
       if (c) {
+        setup(c);
         updateStatus(c, status);
       }
     },


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #902 

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->
Add `data-required` flag in form related components based on the `NgControl` validators state.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `data-required` flag across form-field primitives and makes required state reactive to validator changes (including `clearValidators`/`clearAsyncValidators`). Refactors form-field state to use `controlStatus` and avoids duplicate patches/subscriptions per `NgControl`.

- **New Features**
  - Added `data-required` on the form-field wrapper, `ngpFormControl`, `ngpLabel`, `ngpDescription`, and `ngpError`.
  - `controlStatus` now exposes `required` and `errors`, and reacts to validator changes and clears.

- **Bug Fixes**
  - Prevent multiple `controlStatus` setups on the same control with a WeakMap registry; hardened consumer filtering and cleanup to remove stale subscriptions and keep state consistent.

<sup>Written for commit 7c9d65c353e8a0b8ef75973c252641d76678c706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Form fields now expose required-state information through a `data-required` attribute.
  - Required status is reflected consistently across form-field wrappers, labels, controls, descriptions and errors.
  - Required status updates automatically when validators are added or changed.
  - Form control status now includes detected validation errors and required-state information.

- **Tests**
  - Added coverage for required-state propagation and dynamic validator updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->