### PR TITLE
docs(date-picker): add an example using popover and input display

### DIFF
--- a/apps/documentation/src/app/examples/date-picker/date-picker-with-popover.example.ts
+++ b/apps/documentation/src/app/examples/date-picker/date-picker-with-popover.example.ts
@@ -1,0 +1,257 @@
+import { DatePipe } from '@angular/common';
+import { Component, computed, signal } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronLeftMini, heroChevronRightMini } from '@ng-icons/heroicons/mini';
+import {
+  NgpDatePicker,
+  NgpDatePickerCell,
+  NgpDatePickerCellRender,
+  NgpDatePickerDateButton,
+  NgpDatePickerGrid,
+  NgpDatePickerLabel,
+  NgpDatePickerNextMonth,
+  NgpDatePickerPreviousMonth,
+  NgpDatePickerRowRender,
+} from 'ng-primitives/date-picker';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+
+@Component({
+  selector: 'app-date-picker-with-popover',
+  imports: [
+    NgIcon,
+    NgpDatePicker,
+    NgpDatePickerLabel,
+    NgpDatePickerNextMonth,
+    NgpDatePickerPreviousMonth,
+    NgpDatePickerGrid,
+    NgpDatePickerCell,
+    NgpDatePickerRowRender,
+    NgpDatePickerCellRender,
+    NgpDatePickerDateButton,
+    NgpPopoverTrigger,
+    NgpPopover,
+    DatePipe,
+  ],
+  providers: [provideIcons({ heroChevronRightMini, heroChevronLeftMini })],
+  template: `
+    <input
+      [ngpPopoverTrigger]="datePickerPopover"
+      [value]="date() | date: 'longDate'"
+      ngpFormControl
+      readonly
+      placeholder="Select a date"
+    />
+
+    <ng-template #datePickerPopover let-ctx>
+      <div ngpPopover>
+        <div [(ngpDatePickerDate)]="date" [(ngpDatePickerFocusedDate)]="focused" ngpDatePicker>
+          <div class="date-picker-header">
+            <button ngpDatePickerPreviousMonth aria-label="previous month">
+              <ng-icon name="heroChevronLeftMini" />
+            </button>
+            <h2 ngpDatePickerLabel>{{ label() }}</h2>
+            <button ngpDatePickerNextMonth aria-label="next month">
+              <ng-icon name="heroChevronRightMini" />
+            </button>
+          </div>
+          <table ngpDatePickerGrid>
+            <thead>
+              <tr>
+                <th scope="col" abbr="Sunday">S</th>
+                <th scope="col" abbr="Monday">M</th>
+                <th scope="col" abbr="Tuesday">T</th>
+                <th scope="col" abbr="Wednesday">W</th>
+                <th scope="col" abbr="Thursday">T</th>
+                <th scope="col" abbr="Friday">F</th>
+                <th scope="col" abbr="Saturday">S</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngpDatePickerRowRender>
+                <td *ngpDatePickerCellRender="let date" ngpDatePickerCell>
+                  <button ngpDatePickerDateButton>{{ date.getDate() }}</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    [ngpDatePicker] {
+      display: inline-block;
+      background-color: var(--ngp-background);
+      border-radius: 12px;
+      padding: 16px;
+    }
+
+    .date-picker-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      height: 36px;
+      margin-bottom: 16px;
+    }
+
+    th {
+      font-size: 14px;
+      font-weight: 500;
+      width: 40px;
+      height: 40px;
+      text-align: center;
+      color: var(--ngp-text-secondary);
+    }
+
+    [ngpDatePickerLabel] {
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--ngp-text-primary);
+    }
+
+    [ngpDatePickerPreviousMonth],
+    [ngpDatePickerNextMonth] {
+      all: unset;
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      font-size: 20px;
+      border: 1px solid var(--ngp-border);
+      cursor: pointer;
+    }
+
+    [ngpDatePickerPreviousMonth][data-hover],
+    [ngpDatePickerNextMonth][data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpDatePickerPreviousMonth][data-focus-visible],
+    [ngpDatePickerNextMonth][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+    }
+
+    [ngpDatePickerPreviousMonth][data-press],
+    [ngpDatePickerNextMonth][data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpDatePickerPreviousMonth][data-disabled],
+    [ngpDatePickerNextMonth][data-disabled] {
+      cursor: not-allowed;
+      color: var(--ngp-text-disabled);
+    }
+
+    [ngpDatePickerDateButton] {
+      all: unset;
+      width: 40px;
+      height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      cursor: pointer;
+    }
+
+    [ngpDatePickerDateButton][data-today] {
+      color: var(--ngp-primary);
+    }
+
+    [ngpDatePickerDateButton][data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpDatePickerDateButton][data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    [ngpDatePickerDateButton][data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    [ngpDatePickerDateButton][data-outside-month] {
+      color: var(--ngp-text-disabled);
+    }
+
+    [ngpDatePickerDateButton][data-selected] {
+      background-color: var(--ngp-primary);
+      color: var(--ngp-primary-text);
+    }
+
+    [ngpDatePickerDateButton][data-selected][data-outside-month] {
+      background-color: var(--ngp-background-disabled);
+      color: var(--ngp-text-disabled);
+    }
+
+    [ngpDatePickerDateButton][data-disabled] {
+      cursor: not-allowed;
+      color: var(--ngp-text-disabled);
+    }
+
+    [ngpPopover] {
+      position: absolute;
+      display: flex;
+      flex-direction: column;
+      row-gap: 4px;
+      max-width: max-content;
+      border-radius: 0.75rem;
+      background: var(--ngp-background);
+      padding: 0.75rem 1rem;
+      box-shadow: var(--ngp-shadow);
+      border: 1px solid var(--ngp-border);
+      outline: none;
+      animation: popover-show 0.1s ease-out;
+      transform-origin: var(--ngp-popover-transform-origin);
+    }
+
+    [ngpPopover][data-exit] {
+      animation: popover-hide 0.1s ease-out;
+    }
+
+    [ngpFormControl] {
+      height: 2.125rem;
+      width: 100%;
+      border-radius: 0.5rem;
+      padding: 0 16px;
+      border: none;
+      box-shadow: var(--ngp-input-shadow);
+      background-color: var(--ngp-background);
+      color: var(--ngp-text-primary);
+      font-size: 0.875rem;
+      letter-spacing: -0.006em;
+      outline: none;
+    }
+
+    [ngpFormControl]:focus {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    [ngpFormControl]::placeholder {
+      color: var(--ngp-text-placeholder);
+    }
+  `,
+})
+export default class DatePickerWithPopoverExample {
+  /**
+   * The selected date.
+   */
+  readonly date = signal<Date | null>(null);
+
+  /**
+   * Store the current focused date.
+   */
+  readonly focused = signal<Date>(new Date());
+
+  /**
+   * Get the current focused date in string format.
+   * @returns The focused date in "February 2024" format.
+   */
+  readonly label = computed(
+    () =>
+      `${this.focused().toLocaleString('default', { month: 'long' })} ${this.focused().getFullYear()}`,
+  );
+}

--- a/apps/documentation/src/app/examples/date-picker/date-picker-with-popover.example.ts
+++ b/apps/documentation/src/app/examples/date-picker/date-picker-with-popover.example.ts
@@ -13,6 +13,7 @@ import {
   NgpDatePickerPreviousMonth,
   NgpDatePickerRowRender,
 } from 'ng-primitives/date-picker';
+import { NgpFormControl } from 'ng-primitives/form-field';
 import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
 
 @Component({
@@ -30,6 +31,7 @@ import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
     NgpDatePickerDateButton,
     NgpPopoverTrigger,
     NgpPopover,
+    NgpFormControl,
     DatePipe,
   ],
   providers: [provideIcons({ heroChevronRightMini, heroChevronLeftMini })],
@@ -37,12 +39,13 @@ import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
     <input
       [ngpPopoverTrigger]="datePickerPopover"
       [value]="date() | date: 'longDate'"
+      aria-label="Select a date"
       ngpFormControl
       readonly
       placeholder="Select a date"
     />
 
-    <ng-template #datePickerPopover let-ctx>
+    <ng-template #datePickerPopover>
       <div ngpPopover>
         <div [(ngpDatePickerDate)]="date" [(ngpDatePickerFocusedDate)]="focused" ngpDatePicker>
           <div class="date-picker-header">
@@ -232,6 +235,28 @@ import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
 
     [ngpFormControl]::placeholder {
       color: var(--ngp-text-placeholder);
+    }
+
+    @keyframes popover-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes popover-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
     }
   `,
 })

--- a/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
@@ -93,7 +93,7 @@ The date range picker allows users to select a range of dates by selecting the s
 
 ### Date Picker inside a Popover
 
-When using forms, it can be useful to use a popover to select a date and let a separate component displays the value.
+When using forms, it can be useful to use a popover to select a date and let a separate component display the value.
 
 <docs-example name="date-picker-with-popover"></docs-example>
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/date-picker.md
@@ -91,6 +91,12 @@ The date range picker allows users to select a range of dates by selecting the s
 
 <docs-example name="date-range-picker"></docs-example>
 
+### Date Picker inside a Popover
+
+When using forms, it can be useful to use a popover to select a date and let a separate component displays the value.
+
+<docs-example name="date-picker-with-popover"></docs-example>
+
 ## API Reference
 
 By default, the date picker uses the native JavaScript `Date` object, however the date picker is designed to work with any date library. To use a date library, such as Luxon, you need to specify the appropriate date adapter. The date adapter is an abstraction layer that allows components to use date objects from any date library, ensuring compatibility and easy integration. To learn more about the date adapter, see the [Date Adapter](/utilities/date-adapter) documentation.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #492 

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a docs example showing the Date Picker inside a Popover with a read-only input that displays the selected date. Improves form UX with accessible controls and clean styles.

- **New Features**
  - Added `date-picker-with-popover` example combining `ng-primitives/popover`, `ng-primitives/date-picker`, and `ng-primitives/form-field`, with a formatted read-only input bound to the selected date.
  - Polished the demo with month navigation controls, ARIA labels, focus-visible states, and clear styles; updated docs with a “Date Picker inside a Popover” section and live demo.

<sup>Written for commit 85df616b3e68ef1754ed8c8df35f9f9bfbdcde22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a date picker example displayed within a popover.
  * Supports date selection, focused-date navigation, month labels, formatted input values, navigation controls, and interaction styling.

* **Documentation**
  * Added guidance for using the date picker with a popover, including form-related usage.
  * Added the new date-picker-with-popover example to the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->