### PR TITLE
fix(menu): stop the trigger-group hover flickering between siblings

### DIFF
--- a/apps/documentation/src/app/examples/menu/menu-trigger-group.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-trigger-group.example.ts
@@ -115,7 +115,6 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
       font-weight: 510;
       letter-spacing: -0.006em;
       color: var(--ngp-text-primary);
-      transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
       outline: none;
     }
 
@@ -124,6 +123,11 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
       --ng-icon__size: 1.125rem;
     }
 
+    /*
+     * Deliberately not transitioned: the highlight marks which menu is open, and
+     * within the cooldown that swaps in a single frame. Fading it leaves the row
+     * you came from lit underneath the menu you moved to.
+     */
     .sidebar-item[data-hover],
     .sidebar-item[data-open] {
       background-color: var(--ngp-background-hover);

--- a/apps/documentation/src/app/examples/menu/menu-trigger-group.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-trigger-group.example.ts
@@ -166,7 +166,8 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
     }
 
     /* Swapping menus within the cooldown is one movement, not two animations. */
-    [ngpMenu][data-instant] {
+    [ngpMenu][data-instant][data-enter],
+    [ngpMenu][data-instant][data-exit] {
       animation: none;
     }
 

--- a/apps/documentation/src/app/examples/menu/menu-trigger-group.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-trigger-group.example.ts
@@ -166,8 +166,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
     }
 
     /* Swapping menus within the cooldown is one movement, not two animations. */
-    [ngpMenu][data-instant][data-enter],
-    [ngpMenu][data-instant][data-exit] {
+    [ngpMenu][data-instant][data-enter] {
       animation: none;
     }
 

--- a/apps/documentation/src/app/examples/menu/menu-trigger-group.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-trigger-group.example.ts
@@ -17,6 +17,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
           class="sidebar-item"
           [ngpMenuTrigger]="teamMenu"
           [ngpMenuTriggerOpenTriggers]="['hover']"
+          [ngpMenuTriggerCooldown]="300"
           ngpButton
           ngpMenuTriggerPlacement="right-start"
         >
@@ -27,6 +28,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
           class="sidebar-item"
           [ngpMenuTrigger]="projectsMenu"
           [ngpMenuTriggerOpenTriggers]="['hover']"
+          [ngpMenuTriggerCooldown]="300"
           ngpButton
           ngpMenuTriggerPlacement="right-start"
         >
@@ -37,6 +39,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
           class="sidebar-item"
           [ngpMenuTrigger]="reportsMenu"
           [ngpMenuTriggerOpenTriggers]="['hover']"
+          [ngpMenuTriggerCooldown]="300"
           ngpButton
           ngpMenuTriggerPlacement="right-start"
         >
@@ -156,6 +159,11 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
     [ngpMenu][data-exit] {
       animation: menu-hide 0.2s ease-out;
+    }
+
+    /* Swapping menus within the cooldown is one movement, not two animations. */
+    [ngpMenu][data-instant] {
+      animation: none;
     }
 
     [ngpMenuItem] {

--- a/apps/documentation/src/app/examples/menu/menu-trigger-group.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-trigger-group.tailwind.example.ts
@@ -70,23 +70,23 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
     <ng-template #teamMenu>
       <div
-        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:animate-none dark:border-zinc-800 dark:bg-zinc-950"
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:data-enter:animate-none data-instant:data-exit:animate-none dark:border-zinc-800 dark:bg-zinc-950"
         ngpMenu
       >
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Members
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Roles
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Invitations
@@ -96,23 +96,23 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
     <ng-template #projectsMenu>
       <div
-        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:animate-none dark:border-zinc-800 dark:bg-zinc-950"
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:data-enter:animate-none data-instant:data-exit:animate-none dark:border-zinc-800 dark:bg-zinc-950"
         ngpMenu
       >
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Active
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Archived
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Templates
@@ -122,23 +122,23 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
     <ng-template #reportsMenu>
       <div
-        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:animate-none dark:border-zinc-800 dark:bg-zinc-950"
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:data-enter:animate-none data-instant:data-exit:animate-none dark:border-zinc-800 dark:bg-zinc-950"
         ngpMenu
       >
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Overview
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Usage
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Billing

--- a/apps/documentation/src/app/examples/menu/menu-trigger-group.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-trigger-group.tailwind.example.ts
@@ -70,7 +70,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
     <ng-template #teamMenu>
       <div
-        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:data-enter:animate-none data-instant:data-exit:animate-none dark:border-zinc-800 dark:bg-zinc-950"
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:data-enter:animate-none dark:border-zinc-800 dark:bg-zinc-950"
         ngpMenu
       >
         <button
@@ -96,7 +96,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
     <ng-template #projectsMenu>
       <div
-        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:data-enter:animate-none data-instant:data-exit:animate-none dark:border-zinc-800 dark:bg-zinc-950"
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:data-enter:animate-none dark:border-zinc-800 dark:bg-zinc-950"
         ngpMenu
       >
         <button
@@ -122,7 +122,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
     <ng-template #reportsMenu>
       <div
-        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:data-enter:animate-none data-instant:data-exit:animate-none dark:border-zinc-800 dark:bg-zinc-950"
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:data-enter:animate-none dark:border-zinc-800 dark:bg-zinc-950"
         ngpMenu
       >
         <button

--- a/apps/documentation/src/app/examples/menu/menu-trigger-group.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-trigger-group.tailwind.example.ts
@@ -24,6 +24,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
           class="flex h-[2.125rem] cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:shadow-[0_0_0_2px_var(--ngp-focus-ring)] active:bg-gray-200 data-open:bg-gray-100 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20 dark:data-open:bg-white/10"
           [ngpMenuTrigger]="teamMenu"
           [ngpMenuTriggerOpenTriggers]="['hover']"
+          [ngpMenuTriggerCooldown]="300"
           ngpButton
           ngpMenuTriggerPlacement="right-start"
         >
@@ -38,6 +39,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
           class="flex h-[2.125rem] cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:shadow-[0_0_0_2px_var(--ngp-focus-ring)] active:bg-gray-200 data-open:bg-gray-100 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20 dark:data-open:bg-white/10"
           [ngpMenuTrigger]="projectsMenu"
           [ngpMenuTriggerOpenTriggers]="['hover']"
+          [ngpMenuTriggerCooldown]="300"
           ngpButton
           ngpMenuTriggerPlacement="right-start"
         >
@@ -52,6 +54,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
           class="flex h-[2.125rem] cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:shadow-[0_0_0_2px_var(--ngp-focus-ring)] active:bg-gray-200 data-open:bg-gray-100 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20 dark:data-open:bg-white/10"
           [ngpMenuTrigger]="reportsMenu"
           [ngpMenuTriggerOpenTriggers]="['hover']"
+          [ngpMenuTriggerCooldown]="300"
           ngpButton
           ngpMenuTriggerPlacement="right-start"
         >
@@ -67,7 +70,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
     <ng-template #teamMenu>
       <div
-        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none dark:border-zinc-800 dark:bg-zinc-950"
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:animate-none dark:border-zinc-800 dark:bg-zinc-950"
         ngpMenu
       >
         <button
@@ -93,7 +96,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
     <ng-template #projectsMenu>
       <div
-        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none dark:border-zinc-800 dark:bg-zinc-950"
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:animate-none dark:border-zinc-800 dark:bg-zinc-950"
         ngpMenu
       >
         <button
@@ -119,7 +122,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
     <ng-template #reportsMenu>
       <div
-        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none dark:border-zinc-800 dark:bg-zinc-950"
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none data-instant:animate-none dark:border-zinc-800 dark:bg-zinc-950"
         ngpMenu
       >
         <button

--- a/apps/documentation/src/app/examples/menu/menu-trigger-group.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-trigger-group.tailwind.example.ts
@@ -21,7 +21,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
 
       <div class="flex flex-col gap-1 px-2 pb-2">
         <button
-          class="flex h-[2.125rem] cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:shadow-[0_0_0_2px_var(--ngp-focus-ring)] active:bg-gray-200 data-open:bg-gray-100 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20 dark:data-open:bg-white/10"
+          class="flex h-[2.125rem] cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:shadow-[0_0_0_2px_var(--ngp-focus-ring)] active:bg-gray-200 data-open:bg-gray-100 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20 dark:data-open:bg-white/10"
           [ngpMenuTrigger]="teamMenu"
           [ngpMenuTriggerOpenTriggers]="['hover']"
           [ngpMenuTriggerCooldown]="300"
@@ -36,7 +36,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
           Team
         </button>
         <button
-          class="flex h-[2.125rem] cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:shadow-[0_0_0_2px_var(--ngp-focus-ring)] active:bg-gray-200 data-open:bg-gray-100 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20 dark:data-open:bg-white/10"
+          class="flex h-[2.125rem] cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:shadow-[0_0_0_2px_var(--ngp-focus-ring)] active:bg-gray-200 data-open:bg-gray-100 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20 dark:data-open:bg-white/10"
           [ngpMenuTrigger]="projectsMenu"
           [ngpMenuTriggerOpenTriggers]="['hover']"
           [ngpMenuTriggerCooldown]="300"
@@ -51,7 +51,7 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
           Projects
         </button>
         <button
-          class="flex h-[2.125rem] cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:shadow-[0_0_0_2px_var(--ngp-focus-ring)] active:bg-gray-200 data-open:bg-gray-100 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20 dark:data-open:bg-white/10"
+          class="flex h-[2.125rem] cursor-pointer items-center gap-2.5 rounded-lg border-none bg-transparent px-2.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:shadow-[0_0_0_2px_var(--ngp-focus-ring)] active:bg-gray-200 data-open:bg-gray-100 dark:text-gray-100 dark:hover:bg-white/10 dark:active:bg-white/20 dark:data-open:bg-white/10"
           [ngpMenuTrigger]="reportsMenu"
           [ngpMenuTriggerOpenTriggers]="['hover']"
           [ngpMenuTriggerCooldown]="300"
@@ -74,19 +74,19 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
         ngpMenu
       >
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Members
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Roles
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Invitations
@@ -100,19 +100,19 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
         ngpMenu
       >
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Active
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Archived
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Templates
@@ -126,19 +126,19 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-pr
         ngpMenu
       >
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Overview
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Usage
         </button>
         <button
-          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          class="flex min-w-[140px] cursor-pointer items-center rounded-md border-none bg-transparent py-[0.4375rem] pr-2 pl-3 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
           ngpMenuItem
         >
           Billing

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -214,7 +214,7 @@ Nested `NgpSubmenuTrigger`s inside an already-open menu are protected from this 
 
 <docs-example name="menu-trigger-group"></docs-example>
 
-Moving between siblings closes one menu and opens another in quick succession, so the example also sets `ngpMenuTriggerCooldown`. Within that window the swap is treated as a single movement: the outgoing menu is dropped rather than animating out behind its replacement, and the incoming one is marked `data-instant` so its own animation can be skipped.
+Moving between siblings closes one menu and opens another in quick succession, so the example also sets `ngpMenuTriggerCooldown`. Within that window, the swap is treated as a single movement: the outgoing menu is dropped rather than animating out behind its replacement, and the incoming one is marked `data-instant` so its own animation can be skipped.
 
 The coordination only earns its keep while the siblings actually sit between a trigger and its menu. In a collapsible navigation, that stops being true once the rail collapses to icons - the pointer reaches the panel without crossing anything, so all the group does is hold the siblings inert a moment longer than they need to be. Bind `ngpMenuTriggerGroupSiblingTracking` to turn it off for as long as that is the case:
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -214,6 +214,8 @@ Nested `NgpSubmenuTrigger`s inside an already-open menu are protected from this 
 
 <docs-example name="menu-trigger-group"></docs-example>
 
+Moving between siblings closes one menu and opens another in quick succession, so the example also sets `ngpMenuTriggerCooldown`. Within that window the swap is treated as a single movement: the outgoing menu is dropped rather than animating out behind its replacement, and the incoming one is marked `data-instant` so its own animation can be skipped.
+
 The coordination only earns its keep while the siblings actually sit between a trigger and its menu. In a collapsible navigation, that stops being true once the rail collapses to icons - the pointer reaches the panel without crossing anything, so all the group does is hold the siblings inert a moment longer than they need to be. Bind `ngpMenuTriggerGroupSiblingTracking` to turn it off for as long as that is the case:
 
 ```html

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -351,11 +351,12 @@ The `ngpMenu` will also add the `data-enter` and `data-exit` attributes to the e
 When using the `cooldown` option to allow quick switching between menus, the `data-instant` attribute is applied. Use this to skip animations for instant transitions:
 
 ```css
-:host[data-instant][data-enter],
-:host[data-instant][data-exit] {
+:host[data-instant][data-enter] {
   animation: none;
 }
 ```
+
+`data-instant` comes off as the menu switches to its exit state, so the rule only ever needs the enter state - the exit animation is never suppressed by it.
 
 ## Global Configuration
 

--- a/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
@@ -41,6 +41,8 @@ export interface NgpExitAnimationRef {
   exit: () => Promise<void>;
   /** Cancel an in-progress exit animation and transition back to enter state. */
   cancel: () => void;
+  /** End an in-progress exit animation now, leaving the element on its way out. */
+  finish: () => void;
 }
 
 /**
@@ -169,6 +171,30 @@ export function setupExitAnimation({
         // element is removed mid-animation) resolve exactly like success.
         Promise.allSettled(animations.map(anim => anim.finished)).then(settle);
       });
+    },
+    finish: () => {
+      if (state !== 'exit') {
+        return;
+      }
+
+      clearExitTimeout();
+
+      // Jump to the animation's end state rather than cancelling: the element is
+      // leaving, and cancel() would snap it back to how it looked before the
+      // exit began for however long it takes the caller to remove it. Infinite
+      // animations are skipped - `finish()` throws on them, and `exit()` never
+      // waited on them in the first place.
+      const animations = canAnimate ? element.getAnimations() : [];
+      for (const animation of animations) {
+        if (!isInfinite(animation)) {
+          animation.finish();
+        }
+      }
+
+      if (exitResolve) {
+        exitResolve();
+        exitResolve = null;
+      }
     },
     cancel: () => {
       if (state === 'exit') {

--- a/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
@@ -186,8 +186,16 @@ export function setupExitAnimation({
       // waited on them in the first place.
       const animations = canAnimate ? element.getAnimations() : [];
       for (const animation of animations) {
-        if (!isInfinite(animation)) {
+        if (isInfinite(animation)) {
+          continue;
+        }
+        try {
           animation.finish();
+        } catch {
+          // `finish()` also throws on a paused-at-rate-zero animation, which
+          // nothing here creates but a consumer can. Resolving the exit matters
+          // more than the frame it ends on - throwing past the resolve below
+          // would strand the detach this exists to unstick.
         }
       }
 

--- a/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
@@ -210,4 +210,35 @@ describe('setupExitAnimation', () => {
     expect(element).toHaveAttribute('data-enter');
     expect(element).not.toHaveAttribute('data-exit');
   });
+
+  it('finish() ends a pending exit without returning to the enter state', async () => {
+    const element = document.createElement('div');
+    const finished: string[] = [];
+    const { animation } = finiteAnimation();
+    (animation as unknown as { finish: () => void }).finish = () => finished.push('animation');
+    element.getAnimations = () => [animation];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+    const exit = ref.exit();
+
+    ref.finish();
+
+    // The element is on its way out, so it jumps to the animation's end state
+    // rather than snapping back to how it looked before the exit began.
+    await expect(exit).resolves.toBeUndefined();
+    expect(finished).toEqual(['animation']);
+    expect(element).toHaveAttribute('data-exit');
+    expect(element).not.toHaveAttribute('data-enter');
+  });
+
+  it('finish() does nothing when no exit is in progress', async () => {
+    const element = document.createElement('div');
+    element.getAnimations = () => [];
+
+    const ref = setupExitAnimation({ element, immediate: true });
+    ref.finish();
+
+    expect(element).toHaveAttribute('data-enter');
+    expect(element).not.toHaveAttribute('data-exit');
+  });
 });

--- a/packages/ng-primitives/internal/src/hover-bridge/hover-bridge-controller.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/hover-bridge-controller.ts
@@ -366,12 +366,17 @@ export function createHoverBridge({
    * counts as occupied space is whatever shares the trigger's row box - a
    * sibling trigger, a plain menu item, a wrapper around either. Called at most
    * once per corridor, the first time the pointer is over the container.
+   *
+   * Deliberately does not consult `siblingContainer()`: the caller has already
+   * placed the pointer inside the container the corridor captured, and re-asking
+   * the live accessor would return null - and drop the rows - if tracking were
+   * switched off mid-corridor, while every other rect stayed as captured.
    */
   function readSiblingItemBounds(): DOMRect[] {
     const self = trigger?.nativeElement;
     const parent = self?.parentElement;
 
-    if (!self || !parent || !siblingContainer?.()) {
+    if (!self || !parent) {
       return [];
     }
 

--- a/packages/ng-primitives/internal/src/hover-bridge/hover-bridge-controller.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/hover-bridge-controller.ts
@@ -110,7 +110,10 @@ export function createHoverBridge({
   // and reading them back would force layout on every pointermove.
   let siblingBounds: DOMRect | null = null;
   let triggerBounds: DOMRect | null = null;
-  let siblingItemBounds: DOMRect[] = [];
+  // Measured on first use, not with the rects above: a pointer heading straight
+  // for the panel never touches the container's own space, and these are every
+  // row the container lays out - for a submenu, every item in the parent menu.
+  let siblingItemBounds: DOMRect[] | null = null;
   let previousTriggerPointerEvents = '';
   let removePressGuards: (() => void) | undefined = undefined;
 
@@ -344,20 +347,25 @@ export function createHoverBridge({
    * a pointer parked out there closes on the usual timers.
    */
   function isOverContainerDeadSpace(point: HoverBridgePoint): boolean {
-    if (!isOverSibling(point) || siblingItemBounds.some(rect => isWithin(rect, point))) {
+    if (!isOverSibling(point)) {
       return false;
     }
 
-    return [triggerBounds, ...siblingItemBounds].some(rect =>
-      isWithin(rect, point, HOVER_BRIDGE_ROW_GRACE_PX),
-    );
+    const rows = (siblingItemBounds ??= readSiblingItemBounds());
+
+    if (rows.some(rect => isWithin(rect, point))) {
+      return false;
+    }
+
+    return [triggerBounds, ...rows].some(rect => isWithin(rect, point, HOVER_BRIDGE_ROW_GRACE_PX));
   }
 
   /**
    * The rows the container lays out around this trigger. Read from the
    * trigger's own DOM siblings rather than the container's descendants: what
    * counts as occupied space is whatever shares the trigger's row box - a
-   * sibling trigger, a plain menu item, a wrapper around either.
+   * sibling trigger, a plain menu item, a wrapper around either. Called at most
+   * once per corridor, the first time the pointer is over the container.
    */
   function readSiblingItemBounds(): DOMRect[] {
     const self = trigger?.nativeElement;
@@ -471,7 +479,7 @@ export function createHoverBridge({
     lastPointer = exitPoint;
     siblingBounds = siblingContainer?.()?.getBoundingClientRect() ?? null;
     triggerBounds = trigger?.nativeElement.getBoundingClientRect() ?? null;
-    siblingItemBounds = readSiblingItemBounds();
+    siblingItemBounds = null;
     registerPointerMoveListener();
     // Deliberately the full window, whatever the exit point sits over: the gap
     // between two stacked triggers belongs to the container, so leaving one and
@@ -488,7 +496,7 @@ export function createHoverBridge({
     lastPointer = null;
     siblingBounds = null;
     triggerBounds = null;
-    siblingItemBounds = [];
+    siblingItemBounds = null;
     clearTimeout(fallbackTimeoutId);
     fallbackTimeoutId = undefined;
     removePointerMoveListener?.();

--- a/packages/ng-primitives/internal/src/hover-bridge/hover-bridge-controller.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/hover-bridge-controller.ts
@@ -4,6 +4,7 @@ import {
   createHoverBridgePolygon,
   getHoverBridgeDirection,
   HOVER_BRIDGE_DIRECTION_TOLERANCE_PX,
+  HOVER_BRIDGE_ROW_GRACE_PX,
   HOVER_BRIDGE_SIBLING_TIMEOUT_MS,
   HOVER_BRIDGE_TIMEOUT_MS,
   HoverBridgeDirection,
@@ -109,6 +110,7 @@ export function createHoverBridge({
   // and reading them back would force layout on every pointermove.
   let siblingBounds: DOMRect | null = null;
   let triggerBounds: DOMRect | null = null;
+  let siblingItemBounds: DOMRect[] = [];
   let previousTriggerPointerEvents = '';
   let removePressGuards: (() => void) | undefined = undefined;
 
@@ -252,6 +254,46 @@ export function createHoverBridge({
     }
   }
 
+  /**
+   * Deliver the enter the browser withheld. Hit-testing is redone on pointer
+   * movement, not when pointer-events changes back, so a pointer that came to
+   * rest on a sibling while the container was inert is never announced to it -
+   * the overlay closes and the sibling the pointer is sitting on never opens.
+   * This is the boundary event a single pixel of movement would have produced.
+   */
+  function announcePointerToRestoredContainer(
+    container: HTMLElement,
+    point: HoverBridgePoint,
+  ): void {
+    const hit = document.elementFromPoint(point.x, point.y);
+
+    // Nothing to announce when the pointer left the container behind, or when
+    // it is over the trigger, which stayed hit-testable throughout.
+    if (!hit || !container.contains(hit) || trigger?.nativeElement.contains(hit)) {
+      return;
+    }
+
+    // pointerenter does not bubble: the browser fires it on each element from
+    // the container down to the target, and so do we.
+    const chain: Element[] = [];
+    for (let element: Element | null = hit; element; element = element.parentElement) {
+      chain.unshift(element);
+      if (element === container) {
+        break;
+      }
+    }
+
+    for (const element of chain) {
+      element.dispatchEvent(
+        new PointerEvent('pointerenter', {
+          clientX: point.x,
+          clientY: point.y,
+          pointerType: 'mouse',
+        }),
+      );
+    }
+  }
+
   function isMovingAway(point: HoverBridgePoint): boolean {
     if (!requireForwardMovement || !direction || !lastPointer) {
       return false;
@@ -262,16 +304,72 @@ export function createHoverBridge({
   }
 
   /**
+   * Half-open, the way the browser's own hit-testing treats a box: a point
+   * exactly on the right or bottom edge belongs to whatever is laid out next,
+   * not to this rect. Element edges land on fractional pixels, so a closed test
+   * disagrees with the browser about which row a resting pointer is on - and a
+   * hand-over to a row the browser has not put the pointer on closes the
+   * overlay with nothing to take its place.
+   */
+  function isWithin(rect: DOMRect | null, { x, y }: HoverBridgePoint, margin = 0): boolean {
+    return (
+      !!rect &&
+      x >= rect.left - margin &&
+      x < rect.right + margin &&
+      y >= rect.top - margin &&
+      y < rect.bottom + margin
+    );
+  }
+
+  /**
    * Whether the pointer is over one of the trigger's siblings rather than the
    * open gap. This never rejects the point - the corridor deliberately covers
    * that ground, because a diagonal approach to the panel has to cross it. It
    * only shortens how long a pointer that has *stopped* there is waited on.
    */
-  function isOverSibling({ x, y }: HoverBridgePoint): boolean {
-    const within = (rect: DOMRect | null): boolean =>
-      !!rect && x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+  function isOverSibling(point: HoverBridgePoint): boolean {
+    return isWithin(siblingBounds, point) && !isWithin(triggerBounds, point);
+  }
 
-    return within(siblingBounds) && !within(triggerBounds);
+  /**
+   * Whether the pointer is on the few pixels of layout the container puts
+   * between its rows - the gap between two triggers, the padding around
+   * them - rather than on a row itself. A hand cannot hold a mouse inside a 4px
+   * gap, so treating that strip as "left" closes the menu and reopens it on the
+   * next drift back; a pointer resting there is still among the rows, and the
+   * menu stays as it is until a sibling takes the hover or the pointer leaves.
+   *
+   * Deliberately bounded to the rows' immediate surroundings: the empty middle
+   * of a sidebar with rows at its top and bottom is open ground, not a gap, and
+   * a pointer parked out there closes on the usual timers.
+   */
+  function isOverContainerDeadSpace(point: HoverBridgePoint): boolean {
+    if (!isOverSibling(point) || siblingItemBounds.some(rect => isWithin(rect, point))) {
+      return false;
+    }
+
+    return [triggerBounds, ...siblingItemBounds].some(rect =>
+      isWithin(rect, point, HOVER_BRIDGE_ROW_GRACE_PX),
+    );
+  }
+
+  /**
+   * The rows the container lays out around this trigger. Read from the
+   * trigger's own DOM siblings rather than the container's descendants: what
+   * counts as occupied space is whatever shares the trigger's row box - a
+   * sibling trigger, a plain menu item, a wrapper around either.
+   */
+  function readSiblingItemBounds(): DOMRect[] {
+    const self = trigger?.nativeElement;
+    const parent = self?.parentElement;
+
+    if (!self || !parent || !siblingContainer?.()) {
+      return [];
+    }
+
+    return Array.from(parent.children)
+      .filter(child => child !== self)
+      .map(child => child.getBoundingClientRect());
   }
 
   /** (Re)start the idle timer - reset on valid movement so it only fires when idle. */
@@ -285,15 +383,30 @@ export function createHoverBridge({
         return;
       }
 
+      // A pointer resting on the container's inert space hasn't gone anywhere.
+      // The corridor stays live with no timer pending: only movement can change
+      // where the pointer is, and movement reschedules this.
+      if (lastPointer && isOverContainerDeadSpace(lastPointer)) {
+        return;
+      }
+
       // Always tear the corridor down, whether or not the overlay should close
       // with it. Leaving it live because the pointer happens to be in the safe
       // area would strand the container suppressed with no timer pending and
       // nothing but a future pointermove to rescue it.
       const shouldClose = !isPointerInAnchor();
+      // Where the pointer came to rest. Only sound on this path: the timer
+      // fires precisely because nothing has moved since.
+      const restingPoint = lastPointer;
+      const restoredContainer = suppressedElement;
       clear();
 
       if (shouldClose) {
         close();
+      }
+
+      if (restingPoint && restoredContainer) {
+        announcePointerToRestoredContainer(restoredContainer, restingPoint);
       }
     }, delay);
   }
@@ -313,11 +426,17 @@ export function createHoverBridge({
         }
 
         const point: HoverBridgePoint = { x: event.clientX, y: event.clientY };
-        const inside = isPointInHoverBridgePolygon(point, polygon()!);
         const away = isMovingAway(point);
         lastPointer = point;
 
-        if (!inside || away) {
+        // The corridor's geometry doesn't apply over the container's inert
+        // space: the pointer is parked among the rows, so the corridor just
+        // keeps watching for it to leave.
+        if (isOverContainerDeadSpace(point)) {
+          return;
+        }
+
+        if (!isPointInHoverBridgePolygon(point, polygon()!) || away) {
           clear();
           close();
           return;
@@ -352,6 +471,7 @@ export function createHoverBridge({
     lastPointer = exitPoint;
     siblingBounds = siblingContainer?.()?.getBoundingClientRect() ?? null;
     triggerBounds = trigger?.nativeElement.getBoundingClientRect() ?? null;
+    siblingItemBounds = readSiblingItemBounds();
     registerPointerMoveListener();
     // Deliberately the full window, whatever the exit point sits over: the gap
     // between two stacked triggers belongs to the container, so leaving one and
@@ -368,6 +488,7 @@ export function createHoverBridge({
     lastPointer = null;
     siblingBounds = null;
     triggerBounds = null;
+    siblingItemBounds = [];
     clearTimeout(fallbackTimeoutId);
     fallbackTimeoutId = undefined;
     removePointerMoveListener?.();

--- a/packages/ng-primitives/internal/src/hover-bridge/hover-bridge.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/hover-bridge.ts
@@ -20,6 +20,16 @@ export const HOVER_BRIDGE_DIRECTION_TOLERANCE_PX = 2;
  */
 export const HOVER_BRIDGE_SIBLING_TIMEOUT_MS = 80;
 
+/**
+ * The band around a row a hand can cross without meaning to - a thin gap
+ * between two of them, the padding they sit in. Space that close to a row is
+ * treated as the row's surroundings rather than as leaving. Kept deliberately
+ * small: past it the pointer is on open ground the user can see they are on
+ * (the empty middle of a rail with rows at its top and bottom), and resting
+ * there closes on the usual timers.
+ */
+export const HOVER_BRIDGE_ROW_GRACE_PX = 8;
+
 export interface HoverBridgePoint {
   x: number;
   y: number;

--- a/packages/ng-primitives/internal/src/hover-bridge/tests/hover-bridge-controller.test.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/tests/hover-bridge-controller.test.ts
@@ -169,6 +169,21 @@ describe('createHoverBridge - idling over a sibling', () => {
     expect(bridge.isActive()).toBe(true);
   });
 
+  it('reads a point on a row boundary the way the browser hit-tests it', () => {
+    const { close } = trackOverGroup();
+
+    // Exactly on the sibling row's bottom edge. Boxes are half-open, so the
+    // browser puts a point there on whatever is laid out next - this is the
+    // strip between rows, not the row. Counting it as the row hands the hover
+    // to something the browser has not put the pointer on, which closes the
+    // overlay with nothing to take its place.
+    movePointer({ x: 160, y: 120 });
+
+    vi.advanceTimersByTime(HOVER_BRIDGE_TIMEOUT_MS * 4);
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
   it('closes when the pointer rests on open ground well clear of the rows', () => {
     const { close } = trackOverGroup();
 

--- a/packages/ng-primitives/internal/src/hover-bridge/tests/hover-bridge-controller.test.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/tests/hover-bridge-controller.test.ts
@@ -172,11 +172,11 @@ describe('createHoverBridge - idling over a sibling', () => {
   it('reads a point on a row boundary the way the browser hit-tests it', () => {
     const { close } = trackOverGroup();
 
-    // Exactly on the sibling row's bottom edge. Boxes are half-open, so the
-    // browser puts a point there on whatever is laid out next - this is the
-    // strip between rows, not the row. Counting it as the row hands the hover
-    // to something the browser has not put the pointer on, which closes the
-    // overlay with nothing to take its place.
+    // Exactly on the sibling row's bottom edge. Boxes are half-open, so that
+    // point is not *in* the row - it is the inert strip past it, still inside
+    // the row's grace margin. Reading the edge as the row instead hands the
+    // hover to a row the browser has not put the pointer on, and closes the
+    // overlay on the shorter sibling timeout with nothing to take its place.
     movePointer({ x: 160, y: 120 });
 
     vi.advanceTimersByTime(HOVER_BRIDGE_TIMEOUT_MS * 4);

--- a/packages/ng-primitives/internal/src/hover-bridge/tests/hover-bridge-controller.test.ts
+++ b/packages/ng-primitives/internal/src/hover-bridge/tests/hover-bridge-controller.test.ts
@@ -1,5 +1,6 @@
 import {
   createEnvironmentInjector,
+  ElementRef,
   EnvironmentInjector,
   runInInjectionContext,
 } from '@angular/core';
@@ -36,8 +37,11 @@ afterEach(() => {
   activeEnvironments.splice(0).forEach(env => env.destroy());
 });
 
-function setup(options: Partial<HoverBridgeOptions> = {}) {
-  const env = createEnvironmentInjector([], TestBed.inject(EnvironmentInjector));
+function setup(options: Partial<HoverBridgeOptions> = {}, element?: HTMLElement) {
+  const env = createEnvironmentInjector(
+    element ? [{ provide: ElementRef, useValue: new ElementRef(element) }] : [],
+    TestBed.inject(EnvironmentInjector),
+  );
   activeEnvironments.push(env);
   const close = vi.fn();
   const isPointerInAnchor = vi.fn(() => false);
@@ -76,13 +80,27 @@ describe('createHoverBridge - idling over a sibling', () => {
   };
   const OVER_SIBLING = { x: 160, y: 60 };
   const IN_THE_GAP = { x: 202, y: 60 };
+  const BETWEEN_SIBLINGS = { x: 100, y: 36 };
+  const OPEN_GROUND = { x: 190, y: 190 };
 
   let container: HTMLElement;
+  let triggerElement: HTMLElement;
 
   beforeEach(() => {
     vi.useFakeTimers();
     container = document.createElement('div');
-    container.style.cssText = 'position:fixed;left:0;top:0;width:200px;height:120px';
+    container.style.cssText = 'position:fixed;left:0;top:0;width:200px;height:260px';
+    // A sidebar's shape, laid out to match GROUP_OPTIONS: the trigger, a
+    // sibling row 8px below it, and a row pinned to the bottom - so a point can
+    // be over a row, on the strip between two of them, or out on the open
+    // ground the container leaves in between.
+    triggerElement = document.createElement('div');
+    triggerElement.style.cssText = 'position:absolute;left:0;top:0;width:200px;height:32px';
+    const sibling = document.createElement('div');
+    sibling.style.cssText = 'position:absolute;left:0;top:40px;width:200px;height:80px';
+    const bottomRow = document.createElement('div');
+    bottomRow.style.cssText = 'position:absolute;left:0;bottom:0;width:200px;height:32px';
+    container.append(triggerElement, sibling, bottomRow);
     document.body.appendChild(container);
   });
 
@@ -92,7 +110,7 @@ describe('createHoverBridge - idling over a sibling', () => {
   });
 
   function trackOverGroup(options = {}) {
-    const harness = setup({ siblingContainer: () => container, ...options });
+    const harness = setup({ siblingContainer: () => container, ...options }, triggerElement);
     harness.bridge.track(GROUP_OPTIONS);
     return harness;
   }
@@ -135,6 +153,69 @@ describe('createHoverBridge - idling over a sibling', () => {
 
     vi.advanceTimersByTime(HOVER_BRIDGE_TIMEOUT_MS - HOVER_BRIDGE_SIBLING_TIMEOUT_MS);
     expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('never closes while the pointer rests on the container between two siblings', () => {
+    const { bridge, close } = trackOverGroup();
+
+    movePointer(BETWEEN_SIBLINGS);
+
+    // The strip between two rows is a few pixels of inert layout, not the way
+    // out - a hand drifting across it must not close and reopen the overlay.
+    vi.advanceTimersByTime(HOVER_BRIDGE_TIMEOUT_MS * 10);
+
+    expect(close).not.toHaveBeenCalled();
+    // Still tracking, so leaving the container is still noticed.
+    expect(bridge.isActive()).toBe(true);
+  });
+
+  it('closes when the pointer rests on open ground well clear of the rows', () => {
+    const { close } = trackOverGroup();
+
+    // A sidebar with rows at its top and bottom leaves a lot of container in
+    // between. That is not a gap between rows - the pointer has left them.
+    movePointer(OPEN_GROUND);
+
+    vi.advanceTimersByTime(HOVER_BRIDGE_SIBLING_TIMEOUT_MS);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes once the pointer moves off the inert strip and out of the corridor', () => {
+    const { close } = trackOverGroup();
+
+    movePointer(BETWEEN_SIBLINGS);
+    vi.advanceTimersByTime(HOVER_BRIDGE_TIMEOUT_MS);
+    movePointer({ x: 100, y: 400 });
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('announces the pointer to the sibling it came to rest on once suppression lifts', () => {
+    const sibling = container.children[1] as HTMLElement;
+    const enters: Event[] = [];
+    sibling.addEventListener('pointerenter', event => enters.push(event));
+
+    trackOverGroup();
+    movePointer(OVER_SIBLING);
+    expect(document.elementFromPoint(OVER_SIBLING.x, OVER_SIBLING.y)).not.toBe(sibling);
+
+    vi.advanceTimersByTime(HOVER_BRIDGE_SIBLING_TIMEOUT_MS);
+
+    // The browser withheld the enter while the container was inert and will not
+    // re-hit-test without movement, so the sibling would never learn the
+    // pointer is sitting on it.
+    expect(enters).toHaveLength(1);
+  });
+
+  it('announces nothing to the trigger, which was hit-testable throughout', () => {
+    const enters: Event[] = [];
+    triggerElement.addEventListener('pointerenter', event => enters.push(event));
+
+    trackOverGroup();
+    movePointer({ x: 100, y: 16 });
+    vi.advanceTimersByTime(HOVER_BRIDGE_TIMEOUT_MS);
+
+    expect(enters).toHaveLength(0);
   });
 
   it('never shortens past a caller that configured a tighter timeout', () => {

--- a/packages/ng-primitives/internal/src/index.ts
+++ b/packages/ng-primitives/internal/src/index.ts
@@ -12,7 +12,6 @@ export {
   createHoverBridgePolygon,
   getHoverBridgeDirection,
   HOVER_BRIDGE_DIRECTION_TOLERANCE_PX,
-  HOVER_BRIDGE_ROW_GRACE_PX,
   HOVER_BRIDGE_SIBLING_TIMEOUT_MS,
   HOVER_BRIDGE_TIMEOUT_MS,
   HoverBridgeDirection,

--- a/packages/ng-primitives/internal/src/index.ts
+++ b/packages/ng-primitives/internal/src/index.ts
@@ -12,6 +12,7 @@ export {
   createHoverBridgePolygon,
   getHoverBridgeDirection,
   HOVER_BRIDGE_DIRECTION_TOLERANCE_PX,
+  HOVER_BRIDGE_ROW_GRACE_PX,
   HOVER_BRIDGE_SIBLING_TIMEOUT_MS,
   HOVER_BRIDGE_TIMEOUT_MS,
   HoverBridgeDirection,

--- a/packages/ng-primitives/menu/src/menu-trigger-group/tests/menu-trigger-group-cooldown.test.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger-group/tests/menu-trigger-group-cooldown.test.ts
@@ -1,0 +1,193 @@
+import { Component, TemplateRef, viewChild } from '@angular/core';
+import { render, waitFor } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
+import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpMenuTriggerGroup } from 'ng-primitives/menu';
+import { afterEach, describe, expect, it } from 'vitest';
+import { leavePointerAt, movePointerTo } from '../../tests/hover-bridge-pointer.fixture';
+
+/**
+ * Grouped hover triggers, each opening a panel to the side. The corridor closes
+ * the menu you are leaving before the one you are heading to opens, so the
+ * outgoing panel is already playing its exit animation when its replacement
+ * arrives - the ordering a same-type swap has to cope with.
+ */
+@Component({
+  template: `
+    <div
+      ngpMenuTriggerGroup
+      style="display: flex; flex-direction: column; gap: 4px; position: relative;"
+    >
+      <button
+        [ngpMenuTrigger]="menuA"
+        [ngpMenuTriggerOpenTriggers]="['hover']"
+        [ngpMenuTriggerCooldown]="cooldown"
+        [ngpMenuTriggerPlacement]="'right-start'"
+        data-testid="cooldown-trigger-a"
+        style="height: 32px; padding: 0; margin: 0;"
+      >
+        Trigger A
+      </button>
+      <button
+        [ngpMenuTrigger]="menuB"
+        [ngpMenuTriggerOpenTriggers]="['hover']"
+        [ngpMenuTriggerCooldown]="cooldown"
+        [ngpMenuTriggerPlacement]="'right-start'"
+        data-testid="cooldown-trigger-b"
+        style="height: 32px; padding: 0; margin: 0;"
+      >
+        Trigger B
+      </button>
+    </div>
+
+    <ng-template #menuA>
+      <div ngpMenu data-testid="cooldown-menu-a" style="width: 140px; height: 80px;">
+        <button ngpMenuItem>A Item 1</button>
+      </div>
+    </ng-template>
+
+    <ng-template #menuB>
+      <div ngpMenu data-testid="cooldown-menu-b" style="width: 140px; height: 80px;">
+        <button ngpMenuItem>B Item 1</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem, NgpMenuTriggerGroup],
+})
+class CooldownGroupComponent {
+  readonly menuA = viewChild<TemplateRef<unknown>>('menuA');
+  readonly menuB = viewChild<TemplateRef<unknown>>('menuB');
+  cooldown = 300;
+}
+
+/**
+ * A CSS exit animation the test can hold open. This environment does not
+ * materialise real CSS animations synchronously, so `getAnimations` is stubbed
+ * the same way the exit-animation unit tests do it: the panel stays on screen
+ * mid-exit until something ends the animation, which is exactly the window a
+ * same-type swap lands in.
+ */
+function holdExitAnimationOpen(element: HTMLElement): void {
+  const animation = {
+    finished: new Promise<void>(() => undefined),
+    cancel: () => undefined,
+    finish: () => undefined,
+    effect: { getComputedTiming: () => ({ iterations: 1, endTime: 100_000 }) },
+  } as unknown as Animation;
+
+  element.getAnimations = () => [animation];
+}
+
+/** Open menu A and leave it mid-exit, with the pointer clear of the group. */
+async function openThenExitMenuA(): Promise<void> {
+  const triggerA = document.querySelector('[data-testid="cooldown-trigger-a"]') as HTMLElement;
+
+  await userEvent.pointer({ target: triggerA, coords: { x: 10, y: 16 } });
+  await waitFor(() =>
+    expect(document.querySelector('[data-testid="cooldown-menu-a"]')).toBeInTheDocument(),
+  );
+
+  holdExitAnimationOpen(document.querySelector('[data-testid="cooldown-menu-a"]') as HTMLElement);
+
+  const farPoint = { x: 5, y: 600 };
+  leavePointerAt(triggerA, farPoint);
+  movePointerTo(farPoint);
+
+  await waitFor(() =>
+    expect(document.querySelector('[data-testid="cooldown-menu-a"]')).toHaveAttribute('data-exit'),
+  );
+}
+
+/** Hover trigger B, which opens its menu while menu A is still exiting. */
+async function openMenuB(): Promise<void> {
+  const triggerB = document.querySelector('[data-testid="cooldown-trigger-b"]') as HTMLElement;
+
+  await userEvent.pointer({ target: triggerB, coords: { x: 10, y: 16 } });
+  await waitFor(() =>
+    expect(document.querySelector('[data-testid="cooldown-menu-b"]')).toBeInTheDocument(),
+  );
+}
+
+/**
+ * Every animation state the element passes through, in order. The documented
+ * way to opt out of an instant transition is
+ * `[data-instant][data-enter] { animation: none }`, so any state that still
+ * carries `data-enter` after `data-instant` has gone re-arms the entrance
+ * animation - the panel blinks back to its "from" frame before it exits.
+ */
+function recordAnimationStates(element: HTMLElement): string[] {
+  const states: string[] = [];
+  const snapshot = () =>
+    ['data-enter', 'data-exit', 'data-instant']
+      .filter(name => element.hasAttribute(name))
+      .join(' ');
+
+  states.push(snapshot());
+  new MutationObserver(() => {
+    const current = snapshot();
+    if (current !== states[states.length - 1]) {
+      states.push(current);
+    }
+  }).observe(element, { attributes: true });
+
+  return states;
+}
+
+describe('NgpMenuTriggerGroup cooldown', () => {
+  afterEach(() => {
+    document.querySelectorAll('[data-overlay]').forEach(el => el.remove());
+  });
+
+  it('drops the exiting menu when its replacement opens within the cooldown', async () => {
+    await render(CooldownGroupComponent);
+    await openThenExitMenuA();
+    await openMenuB();
+
+    // The point of the cooldown: the swap reads as one movement, not as a panel
+    // fading out behind the panel that replaced it.
+    expect(document.querySelector('[data-testid="cooldown-menu-a"]')).not.toBeInTheDocument();
+  });
+
+  it('marks the incoming menu as an instant transition', async () => {
+    await render(CooldownGroupComponent);
+    await openThenExitMenuA();
+    await openMenuB();
+
+    expect(document.querySelector('[data-testid="cooldown-menu-b"]')).toHaveAttribute(
+      'data-instant',
+    );
+  });
+
+  it('keeps an instantly-shown menu instant until it is actually exiting', async () => {
+    await render(CooldownGroupComponent);
+    await openThenExitMenuA();
+    await openMenuB();
+
+    const menuB = document.querySelector('[data-testid="cooldown-menu-b"]') as HTMLElement;
+    expect(menuB).toHaveAttribute('data-instant');
+    const states = recordAnimationStates(menuB);
+
+    // Leave the trigger without heading for the menu, so it closes normally.
+    const triggerB = document.querySelector('[data-testid="cooldown-trigger-b"]') as HTMLElement;
+    const farPoint = { x: 5, y: 600 };
+    leavePointerAt(triggerB, farPoint);
+    movePointerTo(farPoint);
+
+    await waitFor(() => expect(menuB).toHaveAttribute('data-exit'));
+
+    // The instant flag may only be dropped once the element is exiting. Losing
+    // it a moment early re-arms the entrance animation, so the panel blinks
+    // back to its opening frame and then fades out from full opacity.
+    expect(
+      states.filter(state => state.includes('data-enter') && !state.includes('data-instant')),
+    ).toEqual([]);
+  });
+
+  it('leaves the exiting menu to finish when no cooldown is configured', async () => {
+    // The menu default - opting out has to keep today's behaviour.
+    await render(CooldownGroupComponent, { componentProperties: { cooldown: 0 } });
+    await openThenExitMenuA();
+    await openMenuB();
+
+    expect(document.querySelector('[data-testid="cooldown-menu-a"]')).toBeInTheDocument();
+  });
+});

--- a/packages/ng-primitives/menu/src/menu-trigger-group/tests/menu-trigger-group.test.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger-group/tests/menu-trigger-group.test.ts
@@ -152,6 +152,67 @@ class UntrackedRootTriggersComponent {
   readonly menuB = viewChild<TemplateRef<unknown>>('menuB');
 }
 
+/**
+ * The docs sidebar's shape: the triggers sit in a padded row wrapper inside the
+ * group, separated by a 4px gap - the inert space a hand inevitably drifts
+ * across when moving between two items.
+ */
+@Component({
+  template: `
+    <nav
+      ngpMenuTriggerGroup
+      data-testid="trigger-group"
+      style="display: flex; flex-direction: column; width: 120px; position: relative;"
+    >
+      <div data-testid="header" style="height: 20px;">Workspace</div>
+      <div style="display: flex; flex-direction: column; gap: 4px; padding: 0 8px 8px;">
+        <button
+          [ngpMenuTrigger]="menuA"
+          [ngpMenuTriggerOpenTriggers]="['hover']"
+          [ngpMenuTriggerPlacement]="'right-start'"
+          data-testid="trigger-a"
+          style="height: 32px; padding: 0; margin: 0;"
+        >
+          Trigger A
+        </button>
+        <button
+          [ngpMenuTrigger]="menuB"
+          [ngpMenuTriggerOpenTriggers]="['hover']"
+          [ngpMenuTriggerPlacement]="'right-start'"
+          data-testid="trigger-b"
+          style="height: 32px; padding: 0; margin: 0;"
+        >
+          Trigger B
+        </button>
+      </div>
+      <!-- Rows pinned to the bottom of the rail leave open ground in between. -->
+      <div data-testid="spacer" style="height: 200px;"></div>
+      <div style="padding: 0 8px 8px;">
+        <button data-testid="settings" style="height: 32px; padding: 0; margin: 0;">
+          Settings
+        </button>
+      </div>
+    </nav>
+
+    <ng-template #menuA>
+      <div ngpMenu data-testid="menu-a" style="width: 140px; height: 80px;">
+        <button ngpMenuItem data-testid="menu-a-item-1">A Item 1</button>
+      </div>
+    </ng-template>
+
+    <ng-template #menuB>
+      <div ngpMenu data-testid="menu-b" style="width: 140px; height: 80px;">
+        <button ngpMenuItem data-testid="menu-b-item-1">B Item 1</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem, NgpMenuTriggerGroup],
+})
+class GappedRootTriggersComponent {
+  readonly menuA = viewChild<TemplateRef<unknown>>('menuA');
+  readonly menuB = viewChild<TemplateRef<unknown>>('menuB');
+}
+
 describe('NgpMenuTriggerGroup sibling suppression - real layout, real pointer movement', () => {
   afterEach(() => {
     document.querySelectorAll('[data-overlay]').forEach(el => el.remove());
@@ -411,5 +472,145 @@ describe('NgpMenuTriggerGroup sibling suppression - real layout, real pointer mo
     await waitFor(() =>
       expect(document.querySelector('[data-testid="menu-b"]')).toBeInTheDocument(),
     );
+  });
+
+  describe('inert space between siblings', () => {
+    async function openTriggerB(): Promise<{ gap: { x: number; y: number }; onB: DOMRect }> {
+      await render(GappedRootTriggersComponent);
+      const triggerA = document.querySelector('[data-testid="trigger-a"]') as HTMLElement;
+      const triggerB = document.querySelector('[data-testid="trigger-b"]') as HTMLElement;
+
+      // Item 1, then item 2, as a pointer travelling down the nav does.
+      await userEvent.pointer({ target: triggerA, coords: { x: 10, y: 16 } });
+      await waitFor(() =>
+        expect(document.querySelector('[data-testid="menu-a"]')).toBeInTheDocument(),
+      );
+      await userEvent.pointer({ target: triggerB, coords: { x: 10, y: 16 } });
+      await waitFor(() =>
+        expect(document.querySelector('[data-testid="menu-b"]')).toBeInTheDocument(),
+      );
+
+      const rectA = triggerA.getBoundingClientRect();
+      const rectB = triggerB.getBoundingClientRect();
+
+      return {
+        gap: { x: rectB.left + 10, y: (rectA.bottom + rectB.top) / 2 },
+        onB: rectB,
+      };
+    }
+
+    it('keeps the menu open while the pointer rests in the gap between two siblings', async () => {
+      const { gap } = await openTriggerB();
+      const triggerB = document.querySelector('[data-testid="trigger-b"]') as HTMLElement;
+
+      leavePointerAt(triggerB, gap);
+      movePointerTo(gap);
+
+      // The gap is inert layout space inside the group, not the way out: a
+      // pointer resting there is still in the nav, so the menu it just opened
+      // must stay put rather than close and reopen as the hand drifts.
+      await new Promise(resolve => setTimeout(resolve, 400));
+
+      expect(document.querySelector('[data-testid="menu-b"]')).toBeInTheDocument();
+    });
+
+    it('does not flicker as the pointer drifts across the gap boundary', async () => {
+      const { gap, onB } = await openTriggerB();
+      const triggerB = document.querySelector('[data-testid="trigger-b"]') as HTMLElement;
+
+      let closures = 0;
+      for (let i = 0; i < 6; i++) {
+        leavePointerAt(triggerB, gap);
+        movePointerTo(gap);
+        await new Promise(resolve => setTimeout(resolve, 120));
+        if (!document.querySelector('[data-testid="menu-b"]')) {
+          closures++;
+        }
+
+        movePointerTo({ x: onB.left + 10, y: onB.top + 16 });
+        await new Promise(resolve => setTimeout(resolve, 120));
+      }
+
+      expect(closures).toBe(0);
+    });
+
+    it('closes when the pointer parks on the rail well below the items', async () => {
+      const { gap } = await openTriggerB();
+      const triggerB = document.querySelector('[data-testid="trigger-b"]') as HTMLElement;
+      const spacer = document.querySelector('[data-testid="spacer"]') as HTMLElement;
+      const rectSpacer = spacer.getBoundingClientRect();
+      const openGround = { x: gap.x, y: rectSpacer.top + rectSpacer.height / 2 };
+
+      leavePointerAt(triggerB, openGround);
+      movePointerTo(openGround);
+
+      // Sparing the gap between two items must not spare the whole rail: a
+      // sidebar with items top and bottom is mostly empty space, and a pointer
+      // parked out there has left the items behind.
+      await waitFor(() =>
+        expect(document.querySelector('[data-testid="menu-b"]')).not.toBeInTheDocument(),
+      );
+    });
+
+    it('opens the sibling the pointer came to rest on while the corridor held it inert', async () => {
+      await openTriggerB();
+      const triggerA = document.querySelector('[data-testid="trigger-a"]') as HTMLElement;
+      const triggerB = document.querySelector('[data-testid="trigger-b"]') as HTMLElement;
+      const rectA = triggerA.getBoundingClientRect();
+      const onA = { x: rectA.left + 20, y: rectA.bottom - 2 };
+
+      // The corridor makes trigger-a inert before the pointer arrives, so the
+      // browser withholds its enter entirely - and it re-hit-tests on movement,
+      // not when pointer-events changes back. Nothing would ever tell trigger-a
+      // the pointer is sitting on it, leaving the group with nothing open.
+      leavePointerAt(triggerB, onA);
+      movePointerTo(onA);
+      expect(document.elementFromPoint(onA.x, onA.y)).not.toBe(triggerA);
+
+      await waitFor(() =>
+        expect(document.querySelector('[data-testid="menu-a"]')).toBeInTheDocument(),
+      );
+    });
+
+    it('announces nothing when the corridor ends with the pointer outside the group', async () => {
+      const { onB } = await openTriggerB();
+      const triggerB = document.querySelector('[data-testid="trigger-b"]') as HTMLElement;
+      const farPoint = { x: onB.left, y: onB.bottom + 400 };
+
+      leavePointerAt(triggerB, farPoint);
+      movePointerTo(farPoint);
+
+      await waitFor(() =>
+        expect(document.querySelector('[data-testid="menu-b"]')).not.toBeInTheDocument(),
+      );
+
+      // Restoring the container must not hand a hover to a trigger the pointer
+      // is nowhere near.
+      await new Promise(resolve => setTimeout(resolve, 200));
+      expect(document.querySelector('[ngpmenu]')).toBeNull();
+    });
+
+    it('still hands the hover over when the pointer settles on the sibling itself', async () => {
+      await render(GappedRootTriggersComponent);
+      const triggerA = document.querySelector('[data-testid="trigger-a"]') as HTMLElement;
+      const triggerB = document.querySelector('[data-testid="trigger-b"]') as HTMLElement;
+
+      await userEvent.pointer({ target: triggerA, coords: { x: 10, y: 16 } });
+      await waitFor(() =>
+        expect(document.querySelector('[data-testid="menu-a"]')).toBeInTheDocument(),
+      );
+
+      const rectB = triggerB.getBoundingClientRect();
+      const ontoB = { clientX: rectB.left + 50, clientY: rectB.top + 16, pointerType: 'mouse' };
+
+      // Sparing the gap must not spare the sibling row: a pointer that has
+      // genuinely landed on trigger-b still gets trigger-b's menu.
+      fireEvent.pointerLeave(triggerA, ontoB);
+      fireEvent.pointerEnter(triggerB, ontoB);
+
+      await waitFor(() =>
+        expect(document.querySelector('[data-testid="menu-b"]')).toBeInTheDocument(),
+      );
+    });
   });
 });

--- a/packages/ng-primitives/menu/src/menu/tests/menu-hover-bridge.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-hover-bridge.test.ts
@@ -382,15 +382,11 @@ describe('NgpMenuTrigger safe-polygon hover bridge', () => {
 
     const submenu = document.querySelector('[data-testid="submenu"]') as HTMLElement;
     const rootMenu = document.querySelector('[data-testid="root-menu"]') as HTMLElement;
-    const siblingRow = document.querySelector('[data-testid="item-1"]') as HTMLElement;
     vi.spyOn(submenuTrigger, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 200, 32));
     vi.spyOn(submenu, 'getBoundingClientRect').mockReturnValue(new DOMRect(204, 0, 180, 240));
     // The sibling container the corridor suppresses, and the ground a diagonal
-    // approach to a lower row of the submenu has to cross. The sibling row is
-    // placed below the trigger, leaving the bottom of the panel as its own
-    // inert space.
+    // approach to a lower row of the submenu has to cross.
     vi.spyOn(rootMenu, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 200, 120));
-    vi.spyOn(siblingRow, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 32, 200, 40));
 
     vi.useFakeTimers();
     fireEvent.pointerLeave(submenuTrigger, { pointerType: 'mouse', clientX: 100, clientY: 32 });
@@ -399,38 +395,16 @@ describe('NgpMenuTrigger safe-polygon hover bridge', () => {
   it('closes the submenu once the pointer settles over a sibling row', async () => {
     await leaveSubmenuTriggerDownward();
 
-    // Still inside the corridor, and over the sibling row - which a real
+    // Still inside the corridor, and over the sibling rows - which a real
     // approach crosses - so it is the pointer settling there, not the position,
     // that ends the corridor.
-    fireEvent.pointerMove(document, { clientX: 140, clientY: 50 });
+    fireEvent.pointerMove(document, { clientX: 140, clientY: 90 });
 
     await vi.advanceTimersByTimeAsync(HOVER_BRIDGE_SIBLING_TIMEOUT_MS - 1);
     expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
 
     // Well short of the gap timeout, so it is the sibling window that ended it.
     await vi.advanceTimersByTimeAsync(20);
-    expect(document.querySelector('[data-testid="submenu"]')).not.toBeInTheDocument();
-  });
-
-  it('keeps the submenu open while the pointer rests on the padding beside a row', async () => {
-    await leaveSubmenuTriggerDownward();
-
-    // The panel's own padding under the last row: inert space the pointer is
-    // resting on, not a sibling waiting to take the hover over.
-    fireEvent.pointerMove(document, { clientX: 140, clientY: 76 });
-
-    await vi.advanceTimersByTimeAsync(HOVER_BRIDGE_TIMEOUT_MS * 4);
-    expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
-  });
-
-  it('closes once the pointer parks on the panel well clear of its rows', async () => {
-    await leaveSubmenuTriggerDownward();
-
-    // Far enough past the rows to be open ground rather than the gap between
-    // them - the grace around a row is a few pixels, not the whole container.
-    fireEvent.pointerMove(document, { clientX: 140, clientY: 110 });
-
-    await vi.advanceTimersByTimeAsync(HOVER_BRIDGE_TIMEOUT_MS);
     expect(document.querySelector('[data-testid="submenu"]')).not.toBeInTheDocument();
   });
 
@@ -444,5 +418,40 @@ describe('NgpMenuTrigger safe-polygon hover bridge', () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
+  });
+
+  /**
+   * The panel lays its rows out with padding around them, so a submenu's
+   * corridor has to tell the strip beside a row apart from the open panel
+   * beyond it. Placing the sibling row explicitly is what makes "beside" and
+   * "well clear of" mean something in these coordinates.
+   */
+  function placeSiblingRow(): void {
+    const siblingRow = document.querySelector('[data-testid="item-1"]') as HTMLElement;
+    vi.spyOn(siblingRow, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 32, 200, 40));
+  }
+
+  it('keeps the submenu open while the pointer rests on the padding beside a row', async () => {
+    await leaveSubmenuTriggerDownward();
+    placeSiblingRow();
+
+    // The panel's own padding under the last row: inert space the pointer is
+    // resting on, not a sibling waiting to take the hover over.
+    fireEvent.pointerMove(document, { clientX: 140, clientY: 76 });
+
+    await vi.advanceTimersByTimeAsync(HOVER_BRIDGE_TIMEOUT_MS * 4);
+    expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
+  });
+
+  it('closes once the pointer parks on the panel well clear of its rows', async () => {
+    await leaveSubmenuTriggerDownward();
+    placeSiblingRow();
+
+    // Far enough past the rows to be open ground rather than the gap between
+    // them - the grace around a row is a few pixels, not the whole container.
+    fireEvent.pointerMove(document, { clientX: 140, clientY: 110 });
+
+    await vi.advanceTimersByTimeAsync(HOVER_BRIDGE_TIMEOUT_MS);
+    expect(document.querySelector('[data-testid="submenu"]')).not.toBeInTheDocument();
   });
 });

--- a/packages/ng-primitives/menu/src/menu/tests/menu-hover-bridge.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-hover-bridge.test.ts
@@ -1,6 +1,6 @@
 import { Component, TemplateRef, viewChild } from '@angular/core';
 import { fireEvent, render, waitFor } from '@testing-library/angular';
-import { HOVER_BRIDGE_SIBLING_TIMEOUT_MS } from 'ng-primitives/internal';
+import { HOVER_BRIDGE_SIBLING_TIMEOUT_MS, HOVER_BRIDGE_TIMEOUT_MS } from 'ng-primitives/internal';
 import { NgpMenu, NgpMenuItem, NgpMenuTrigger, NgpSubmenuTrigger } from 'ng-primitives/menu';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -382,11 +382,15 @@ describe('NgpMenuTrigger safe-polygon hover bridge', () => {
 
     const submenu = document.querySelector('[data-testid="submenu"]') as HTMLElement;
     const rootMenu = document.querySelector('[data-testid="root-menu"]') as HTMLElement;
+    const siblingRow = document.querySelector('[data-testid="item-1"]') as HTMLElement;
     vi.spyOn(submenuTrigger, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 200, 32));
     vi.spyOn(submenu, 'getBoundingClientRect').mockReturnValue(new DOMRect(204, 0, 180, 240));
     // The sibling container the corridor suppresses, and the ground a diagonal
-    // approach to a lower row of the submenu has to cross.
+    // approach to a lower row of the submenu has to cross. The sibling row is
+    // placed below the trigger, leaving the bottom of the panel as its own
+    // inert space.
     vi.spyOn(rootMenu, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 200, 120));
+    vi.spyOn(siblingRow, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 32, 200, 40));
 
     vi.useFakeTimers();
     fireEvent.pointerLeave(submenuTrigger, { pointerType: 'mouse', clientX: 100, clientY: 32 });
@@ -395,16 +399,38 @@ describe('NgpMenuTrigger safe-polygon hover bridge', () => {
   it('closes the submenu once the pointer settles over a sibling row', async () => {
     await leaveSubmenuTriggerDownward();
 
-    // Still inside the corridor, and over the sibling rows - which a real
+    // Still inside the corridor, and over the sibling row - which a real
     // approach crosses - so it is the pointer settling there, not the position,
     // that ends the corridor.
-    fireEvent.pointerMove(document, { clientX: 140, clientY: 90 });
+    fireEvent.pointerMove(document, { clientX: 140, clientY: 50 });
 
     await vi.advanceTimersByTimeAsync(HOVER_BRIDGE_SIBLING_TIMEOUT_MS - 1);
     expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
 
     // Well short of the gap timeout, so it is the sibling window that ended it.
     await vi.advanceTimersByTimeAsync(20);
+    expect(document.querySelector('[data-testid="submenu"]')).not.toBeInTheDocument();
+  });
+
+  it('keeps the submenu open while the pointer rests on the padding beside a row', async () => {
+    await leaveSubmenuTriggerDownward();
+
+    // The panel's own padding under the last row: inert space the pointer is
+    // resting on, not a sibling waiting to take the hover over.
+    fireEvent.pointerMove(document, { clientX: 140, clientY: 76 });
+
+    await vi.advanceTimersByTimeAsync(HOVER_BRIDGE_TIMEOUT_MS * 4);
+    expect(document.querySelector('[data-testid="submenu"]')).toBeInTheDocument();
+  });
+
+  it('closes once the pointer parks on the panel well clear of its rows', async () => {
+    await leaveSubmenuTriggerDownward();
+
+    // Far enough past the rows to be open ground rather than the gap between
+    // them - the grace around a row is a few pixels, not the whole container.
+    fireEvent.pointerMove(document, { clientX: 140, clientY: 110 });
+
+    await vi.advanceTimersByTimeAsync(HOVER_BRIDGE_TIMEOUT_MS);
     expect(document.querySelector('[data-testid="submenu"]')).not.toBeInTheDocument();
   });
 

--- a/packages/ng-primitives/portal/src/overlay-cooldown.ts
+++ b/packages/ng-primitives/portal/src/overlay-cooldown.ts
@@ -2,7 +2,7 @@ import { Injectable, WritableSignal } from '@angular/core';
 
 /** Interface for overlays that can be closed immediately */
 export interface CooldownOverlay {
-  hideImmediate(): void;
+  hideImmediate(options?: { skipExitAnimation?: boolean }): void;
   /** Optional signal to mark the transition as instant due to cooldown */
   instantTransition?: WritableSignal<boolean>;
   /**
@@ -90,11 +90,15 @@ export class NgpOverlayCooldownManager {
         return;
       }
       stack.pop();
-      // Enable instant transition only if cooldown is active
-      if (cooldown > 0) {
+      // Enable instant transition only if cooldown is active. The same condition
+      // decides whether an overlay already animating out is cut short: within a
+      // cooldown the swap should read as one movement, without one the outgoing
+      // overlay keeps the exit animation it was given.
+      const isInstant = cooldown > 0;
+      if (isInstant) {
         top.instantTransition?.set(true);
       }
-      top.hideImmediate();
+      top.hideImmediate({ skipExitAnimation: isInstant });
     }
 
     // Push as the topmost active overlay, avoiding a duplicate entry if it is

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -1206,6 +1206,11 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     const reusableContent =
       !forceDestroy && (this.config.keepMounted?.() ?? false) ? this.renderedContent : null;
 
+    // Captured up front for the same reason: `updateConfig()` can replace the
+    // config while the exit animation runs, and unregistering under a new type
+    // would leave this overlay registered under its old one forever.
+    const overlayType = this.config.overlayType;
+
     // Synchronous with the switch to the exit state below, so the element never
     // renders a frame in its enter state without it.
     this.clearInstantAttribute(portal);
@@ -1239,8 +1244,8 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       // leaves it on screen for a while yet, and a same-type overlay opening in
       // that window has to be able to replace it rather than fade in over it.
       // Skipped when destruction was cancelled - it is live again.
-      if (this.config.overlayType) {
-        this.cooldownManager.unregisterActive(this.config.overlayType, this);
+      if (overlayType) {
+        this.cooldownManager.unregisterActive(overlayType, this);
       }
 
       this.renderedContent = null;

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -626,12 +626,10 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       // Reset instant transition for normal closes so exit animations can play.
       // When being replaced by another overlay during cooldown, hideImmediate()
       // is called instead (which doesn't come through here), and registerActive
-      // sets instantTransition to true before that call.
+      // sets instantTransition to true before that call. The `data-instant`
+      // attribute itself is dropped later, as the element switches to its exit
+      // state - see clearInstantAttribute().
       this.instantTransition.set(false);
-      // Remove data-instant attribute so CSS exit animations can play
-      for (const element of this.getElements()) {
-        element.removeAttribute('data-instant');
-      }
       this.closeTimeout = this.disposables.setTimeout(dispose, delay);
     }
   }
@@ -701,6 +699,14 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    * @param options Optional hide configuration
    */
   hideImmediate(options?: OverlayHideImmediateOptions): void {
+    // An exit already under way owns the portal - `portal()` is nulled the
+    // moment destroyOverlay starts - so ending it is the only way an immediate
+    // hide reaches an overlay that has begun animating out. Opt-in, because a
+    // plain close still owes the caller the exit animation it asked for.
+    if (options?.skipExitAnimation) {
+      this.destroyingPortal?.finishDetach();
+    }
+
     // Cancel any pending operations
     if (this.openTimeout) {
       this.openTimeout();
@@ -1178,11 +1184,6 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     // Deregister from the overlay registry
     this.registry.deregister(this.id());
 
-    // Unregister from active overlays
-    if (this.config.overlayType) {
-      this.cooldownManager.unregisterActive(this.config.overlayType, this);
-    }
-
     // Clear portal reference to prevent double destruction
     this.portal.set(null);
 
@@ -1204,6 +1205,10 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     // one acted on after the await.
     const reusableContent =
       !forceDestroy && (this.config.keepMounted?.() ?? false) ? this.renderedContent : null;
+
+    // Synchronous with the switch to the exit state below, so the element never
+    // renders a frame in its enter state without it.
+    this.clearInstantAttribute(portal);
 
     // Detach the portal (waits for exit animations unless immediate).
     // During this await, cancelDestruction() may be called if the user
@@ -1230,10 +1235,35 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
         }
       }
 
+      // Unregister only once the overlay is really gone. An exit animation
+      // leaves it on screen for a while yet, and a same-type overlay opening in
+      // that window has to be able to replace it rather than fade in over it.
+      // Skipped when destruction was cancelled - it is live again.
+      if (this.config.overlayType) {
+        this.cooldownManager.unregisterActive(this.config.overlayType, this);
+      }
+
       this.renderedContent = null;
       this.isOpen.set(false);
       this.finalPlacement.set(undefined);
       this.instantTransition.set(false);
+    }
+  }
+
+  /**
+   * Drop `data-instant` as the element goes into its exit state, so a normal
+   * close still animates out.
+   *
+   * The timing is the whole point. Consumers opt out of instant transitions with
+   * `[data-instant][data-enter] { animation: none }`, so an element left in its
+   * enter state without the attribute matches its entrance rule again and
+   * replays that animation from its opening frame - the panel blinks out and
+   * back before it exits. Removing it here keeps that window closed: the exit
+   * state is applied synchronously by the `detach()` that follows.
+   */
+  private clearInstantAttribute(portal: NgpPortal): void {
+    for (const element of portal.getElements()) {
+      element.removeAttribute('data-instant');
     }
   }
 
@@ -1345,6 +1375,12 @@ export interface OverlayHideImmediateOptions {
    * overlay itself is being torn down (see `destroy()`), not just hidden.
    */
   forceDestroy?: boolean;
+  /**
+   * When true, end an exit animation that is already running instead of letting it play out.
+   * Used when another overlay of the same type is replacing this one during its cooldown, so
+   * the swap reads as one movement rather than a cross-fade.
+   */
+  skipExitAnimation?: boolean;
 }
 
 interface OverlayDestroyOptions extends OverlayHideImmediateOptions {

--- a/packages/ng-primitives/portal/src/portal.ts
+++ b/packages/ng-primitives/portal/src/portal.ts
@@ -82,8 +82,14 @@ export abstract class NgpPortal {
   /**
    * End an in-progress detach now, skipping the rest of any exit animation, so
    * the pending `detach()` resolves and tears the view down.
+   *
+   * Concrete rather than abstract: `NgpPortal` is exported, so an abstract
+   * member added here would stop any subclass outside this repo compiling.
+   * Doing nothing is the honest default for a portal that doesn't animate.
    */
-  abstract finishDetach(): void;
+  finishDetach(): void {
+    // no-op
+  }
 
   /**
    * Re-insert a previously detached-but-kept-mounted portal's root nodes into a container.
@@ -185,7 +191,7 @@ export class NgpComponentPortal<T> extends NgpPortal {
   /**
    * End an in-progress detach now, skipping the rest of any exit animation.
    */
-  finishDetach(): void {
+  override finishDetach(): void {
     if (this.isDestroying) {
       this.exitAnimationRef?.finish();
     }
@@ -332,7 +338,7 @@ export class NgpTemplatePortal<T> extends NgpPortal {
   /**
    * End an in-progress detach now, skipping the rest of any exit animation.
    */
-  finishDetach(): void {
+  override finishDetach(): void {
     if (this.isDestroying) {
       for (const ref of this.exitAnimationRefs) {
         ref.finish();

--- a/packages/ng-primitives/portal/src/portal.ts
+++ b/packages/ng-primitives/portal/src/portal.ts
@@ -80,6 +80,12 @@ export abstract class NgpPortal {
   abstract cancelDetach(): void;
 
   /**
+   * End an in-progress detach now, skipping the rest of any exit animation, so
+   * the pending `detach()` resolves and tears the view down.
+   */
+  abstract finishDetach(): void;
+
+  /**
    * Re-insert a previously detached-but-kept-mounted portal's root nodes into a container.
    * Only valid after a `detach({ keepMounted: true })` call that left the underlying view alive.
    * @param container The DOM element to reattach the portal to.
@@ -173,6 +179,15 @@ export class NgpComponentPortal<T> extends NgpPortal {
       this.detachCancelled = true;
       this.exitAnimationRef?.cancel();
       this.isDestroying = false;
+    }
+  }
+
+  /**
+   * End an in-progress detach now, skipping the rest of any exit animation.
+   */
+  finishDetach(): void {
+    if (this.isDestroying) {
+      this.exitAnimationRef?.finish();
     }
   }
 
@@ -311,6 +326,17 @@ export class NgpTemplatePortal<T> extends NgpPortal {
         ref.cancel();
       }
       this.isDestroying = false;
+    }
+  }
+
+  /**
+   * End an in-progress detach now, skipping the rest of any exit animation.
+   */
+  finishDetach(): void {
+    if (this.isDestroying) {
+      for (const ref of this.exitAnimationRefs) {
+        ref.finish();
+      }
     }
   }
 

--- a/packages/ng-primitives/portal/src/tests/portal.test.ts
+++ b/packages/ng-primitives/portal/src/tests/portal.test.ts
@@ -1,0 +1,64 @@
+import { Component, Injector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NgpComponentPortal } from '../portal';
+
+@Component({
+  selector: 'ngp-portal-test',
+  template: 'content',
+})
+class PortalContent {}
+
+describe('NgpComponentPortal', () => {
+  let container: HTMLElement;
+
+  afterEach(() => container?.remove());
+
+  /**
+   * A fake animation that never settles on its own, so a detach waiting on it
+   * stays pending until something ends it. `endTime` feeds the defensive
+   * fallback timeout and is large enough never to fire during a test.
+   */
+  function pendingAnimation(): { animation: Animation; finished: () => boolean } {
+    let didFinish = false;
+    const animation = {
+      finished: new Promise<void>(() => undefined),
+      cancel: () => undefined,
+      finish: () => (didFinish = true),
+      effect: { getComputedTiming: () => ({ iterations: 1, endTime: 100_000 }) },
+    } as unknown as Animation;
+    return { animation, finished: () => didFinish };
+  }
+
+  function attachPortal() {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    const portal = new NgpComponentPortal(PortalContent, null, TestBed.inject(Injector));
+    portal.attach(container);
+    return portal;
+  }
+
+  it('finishDetach() ends an exit animation still in flight', async () => {
+    const portal = attachPortal();
+    const { animation, finished } = pendingAnimation();
+    portal.getElements()[0].getAnimations = () => [animation];
+
+    const detach = portal.detach();
+    portal.finishDetach();
+
+    await expect(detach).resolves.toBeUndefined();
+    expect(finished()).toBe(true);
+    expect(portal.getAttached()).toBe(false);
+  });
+
+  it('finishDetach() does nothing when no detach is in progress', () => {
+    const portal = attachPortal();
+    const { finished } = pendingAnimation();
+
+    portal.finishDetach();
+
+    expect(finished()).toBe(false);
+    expect(portal.getAttached()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/portal/src/tests/portal.test.ts
+++ b/packages/ng-primitives/portal/src/tests/portal.test.ts
@@ -11,8 +11,15 @@ class PortalContent {}
 
 describe('NgpComponentPortal', () => {
   let container: HTMLElement;
+  let attached: NgpComponentPortal<PortalContent> | undefined;
 
-  afterEach(() => container?.remove());
+  // The view is attached to the root ApplicationRef, not to a fixture, so
+  // removing the container alone leaves it live for the rest of the run.
+  afterEach(() => {
+    attached?.destroyView();
+    attached = undefined;
+    container?.remove();
+  });
 
   /**
    * A fake animation that never settles on its own, so a detach waiting on it
@@ -36,6 +43,7 @@ describe('NgpComponentPortal', () => {
 
     const portal = new NgpComponentPortal(PortalContent, null, TestBed.inject(Injector));
     portal.attach(container);
+    attached = portal;
     return portal;
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

_No linked issue - found while working on `NgpMenuTriggerGroup`._

## What does this PR implement/fix?

Moving the pointer between two triggers in an `NgpMenuTriggerGroup` and coming to rest in the gap between them closed the open menu, and the next drift back across the row boundary reopened it: a fade out/in cycle every ~160ms while the hand hovers a 4px band it cannot hold a mouse inside. Fixing that surfaced two more problems on the same path.

**The hover corridor treats a container's inert space as somewhere the pointer still is.** Neither its geometry nor its idle timer closes there, and it keeps tracking so leaving the group is still noticed. Bounded to the band around the rows (`HOVER_BRIDGE_ROW_GRACE_PX`), so the empty middle of a rail with items at its top and bottom stays open ground and closes on the usual timers. Rect containment is now half-open in both axes to match the browser's own hit-testing - element edges land on fractional pixels, and a closed test disagreed with the browser about which row a resting pointer was on, handing the hover to a row it had not been put on and leaving the group with nothing open.

**A pointer that comes to rest on a sibling while the container is inert is now announced to it.** The browser re-hit-tests on movement, not when `pointer-events` changes back, so the menu closed and the row the pointer was sitting on never opened. The idle path delivers the `pointerenter` chain the movement would have, once the container is live again.

**Cooldown never reached a grouped menu.** The eviction that makes a same-type swap instant only fires while the outgoing overlay is still active, but a group's hover corridor closes the menu you are leaving before the one you are heading to opens - and an overlay unregistered itself the moment teardown began, so by the time the sibling opened there was nothing left to evict and the old panel faded out behind it. An overlay now stays registered until its destruction actually completes, and `hideImmediate` can end an exit already in flight. Both are gated on a configured cooldown: without one the outgoing overlay keeps the exit animation it was given. `NgpExitAnimationRef.finish()` and `NgpPortal.finishDetach()` carry this, mirroring the existing `cancel()`/`cancelDetach()` pair, and jump animations to their end state rather than cancelling so nothing snaps back to how it looked before the exit.

Separately, a normal close dropped `data-instant` a task before the element switched to its exit state. Consumers opt out of instant transitions with `[data-instant][data-enter] { animation: none }`, so that window left the panel matching its entrance rule again: it blinked back to its opening frame and then faded out from full opacity. The attribute now comes off as the exit state is applied.

Also included: the corridor's sibling rows are measured lazily, the first time the pointer is actually over the container, rather than up front - for a submenu those rows are every item in the parent menu, one `getBoundingClientRect` each on every hover-out that never consulted them.

### Docs

The trigger-group example sets a cooldown and the documented `data-instant` opt-out, since moving between siblings is exactly the swap this covers, and its highlight now keeps up with the menu instead of fading over 150ms and leaving two rows lit mid-handover. The menu page documents the cooldown behaviour for groups.

### Tests

New coverage for the gap/dead-space rule, half-open row boundaries, open ground, the withheld `pointerenter`, the cooldown swap, and `finish()`/`finishDetach()`. The existing submenu corridor tests pass untouched, which is the useful signal - a standard menu's submenu corridor behaves exactly as it did.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hover flicker when moving between triggers in `NgpMenuTriggerGroup`, makes sibling swaps instant within cooldown, and correctly unregisters overlays under their original type during teardown.

- **Bug Fixes**
  - Treats the small gap/padding between rows as inert; menus stay open while the pointer rests there and still close on open ground. Bounded to a narrow band around rows.
  - Hit-testing matches the browser (half-open rects), and sibling item bounds are measured lazily once instead of mid-corridor.
  - When suppression lifts, a pointer that was resting on a sibling is announced via a synthetic `pointerenter` chain so the correct menu opens.
  - Cooldown now applies to grouped menus: outgoing overlays stay registered until destruction completes and can be evicted; `hideImmediate({ skipExitAnimation: true })` can end an in-flight exit; new `finish()` and `finishDetach()` end exit animations without snapping back, with `NgpPortal.finishDetach()` provided as a concrete no-op base for non-animating portals.
  - `data-instant` is removed as the exit state is applied; examples set cooldown and use `[data-instant][data-enter]` to skip instant enters, and the sidebar row highlight no longer transitions.
  - Fix: a closing overlay now unregisters using the overlay type it registered with, avoiding stale registrations if the config changes mid-exit.

<sup>Written for commit b2aa008e8ed20ead20c0ce9b03bdfd25f8d86c55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a 300 ms cooldown for rapid sibling menu changes, with instant transitions for incoming menus.
  - Improved hover navigation across menu gaps and row boundaries, reducing flicker and unintended closures.
- **Bug Fixes**
  - Menus remain open in nearby padding and close reliably when the pointer moves away.
  - Exit animations can complete immediately during menu and overlay transitions.
- **Documentation**
  - Documented menu-trigger cooldown and instant-transition behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->