### PR TITLE
fix(slider): set data-disabled on the range slider host when disabled from the start

### DIFF
--- a/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider-state.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/range-slider-state.ts
@@ -243,7 +243,7 @@ export const [
     // Host bindings
     attrBinding(element, 'id', id);
     dataBinding(element, 'data-orientation', orientation);
-    dataBinding(element, 'data-disabled', status().disabled);
+    dataBinding(element, 'data-disabled', () => status().disabled);
 
     function setLowValue(value: number, options?: SetterOptions): void {
       const clampedValue = Math.max(min(), Math.min(value, high()));

--- a/packages/ng-primitives/slider/src/range-slider/range-slider/tests/range-slider-primitive.test.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/tests/range-slider-primitive.test.ts
@@ -578,6 +578,32 @@ describe('NgpRangeSlider', () => {
   });
 
   describe('disabled', () => {
+    it('should set data-disabled on the host when disabled from the first render', async () => {
+      await render(TestComponent, { componentProperties: { disabled: signal(true) } });
+
+      expect(screen.getByTestId('range-slider')).toHaveAttribute('data-disabled', '');
+    });
+
+    it('should set and remove data-disabled on the host when disabled changes', async () => {
+      const { fixture } = await render(TestComponent);
+      const component = fixture.componentInstance;
+      const slider = screen.getByTestId('range-slider');
+
+      expect(slider).not.toHaveAttribute('data-disabled');
+
+      component.disabled.set(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(slider).toHaveAttribute('data-disabled', '');
+
+      component.disabled.set(false);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(slider).not.toHaveAttribute('data-disabled');
+    });
+
     it('should respect disabled state', async () => {
       const { fixture } = await render(TestComponent);
       const component = fixture.componentInstance;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #913

## What does this PR implement/fix?

A range slider that is disabled from its first render never got `data-disabled` on the host element. The host binding in `range-slider-state.ts` evaluated the form control status once at primitive construction, before inputs were bound, and passed a plain boolean rather than a reactive function:

```ts
dataBinding(element, 'data-disabled', status().disabled);
```

It now passes a function, matching the single-thumb slider in `slider-state.ts`:

```ts
dataBinding(element, 'data-disabled', () => status().disabled);
```

Thumbs, track and range were already reactive and unaffected, and the disabled behaviour itself (pointer/keyboard inert, `tabindex="-1"`) always worked - only the host attribute was missing.

Two tests were added to `range-slider-primitive.test.ts`: one for disabled from the first render (fails without the fix), one covering the attribute appearing and being removed as `disabled` toggles.

No docs change - this restores documented behaviour rather than altering it.

I also swept every `attrBinding` / `dataBinding` / `styleBinding` / `classBinding` call in the package for the same shape. The only other eagerly evaluated value is `progress-label-state.ts`, where `for` reads `state().id?.()` once, so the attribute goes stale if a bound progress id changes. Initial render is correct there, so it's left for a separate PR. The other matches (`collapsible`, `accordion-content`, `search-clear`) resolve the injected parent state once but pass the inner signal through unevaluated, so they stay reactive.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where the range slider didn’t set `data-disabled` on the host when disabled from the first render. The host now binds `data-disabled` reactively, so the attribute appears and updates correctly.

- **Bug Fixes**
  - In `range-slider-state.ts`, pass a function to `dataBinding` for `data-disabled` (`() => status().disabled`), matching the single-thumb slider.
  - Added tests to cover initial disabled state and toggling.
  - No behavior, docs, or breaking changes.

<sup>Written for commit d84aba9d400b6d736a2614e87ada45651d7fbff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the range slider so its disabled state is correctly reflected with the `data-disabled` attribute.
  * The attribute now updates reliably when the slider is disabled or re-enabled.

* **Tests**
  * Added coverage for initially disabled sliders and dynamic disabled-state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->