### PR TITLE
feat(form-field): allow form field without direct DOM ng control

### DIFF
--- a/apps/documentation/src/app/examples/form-field/outer-form-field.example.ts
+++ b/apps/documentation/src/app/examples/form-field/outer-form-field.example.ts
@@ -1,0 +1,178 @@
+import { Component, signal } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { form, FormField, required } from '@angular/forms/signals';
+import { NgpDescription, NgpError, NgpFormField, NgpLabel } from 'ng-primitives/form-field';
+import { NgpInput } from 'ng-primitives/input';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+
+@Component({
+  imports: [
+    NgpInput,
+    NgpLabel,
+    NgpDescription,
+    NgpError,
+    NgpFormField,
+    NgpPopoverTrigger,
+    NgpPopover,
+    ReactiveFormsModule,
+    FormField,
+  ],
+  template: `
+    <div class="form">
+      <div [ngpFormFieldSource]="reactiveForm.controls.name" ngpFormField>
+        <label ngpLabel>Name</label>
+        <p ngpDescription>Please provide your name.</p>
+        <input
+          [ngpPopoverTrigger]="reactiveFormPopover"
+          [value]="reactiveForm.controls.name.value"
+          ngpInput
+          readonly
+        />
+        <p ngpError ngpErrorValidator="required">This field is required</p>
+      </div>
+
+      <div [ngpFormFieldSource]="signalForm.name" ngpFormField>
+        <label ngpLabel>Name</label>
+        <p ngpDescription>Please provide your name.</p>
+        <input
+          [ngpPopoverTrigger]="signalFormPopover"
+          [value]="signalForm.name().value()"
+          ngpInput
+          readonly
+        />
+        <p ngpError ngpErrorValidator="required">This field is required</p>
+      </div>
+    </div>
+
+    <ng-template #reactiveFormPopover>
+      <div ngpPopover>
+        <input [formControl]="reactiveForm.controls.name" ngpInput placeholder="What's your name" />
+      </div>
+    </ng-template>
+
+    <ng-template #signalFormPopover>
+      <div ngpPopover>
+        <input [formField]="signalForm.name" ngpInput placeholder="What's your name" />
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    :host {
+      display: contents;
+    }
+
+    .form {
+      display: flex;
+      flex-direction: column;
+      gap: 2rem;
+    }
+
+    [ngpFormField] {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      width: 300px;
+    }
+
+    [ngpInput] {
+      height: 2.125rem;
+      width: 100%;
+      border-radius: 0.5rem;
+      padding: 0 16px;
+      border: none;
+      box-shadow: var(--ngp-input-shadow);
+      background-color: var(--ngp-background);
+      color: var(--ngp-text-primary);
+      font-size: 0.875rem;
+      letter-spacing: -0.006em;
+      outline: none;
+    }
+
+    [ngpInput]:focus {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 2px;
+    }
+
+    [ngpInput]::placeholder {
+      color: var(--ngp-text-placeholder);
+    }
+
+    [ngpLabel] {
+      color: var(--ngp-text-primary);
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      font-weight: 510;
+      margin: 0;
+    }
+
+    [ngpDescription] {
+      color: var(--ngp-text-secondary);
+      font-size: 0.75rem;
+      line-height: 1rem;
+      margin: 0 0 4px;
+    }
+
+    [ngpError] {
+      display: none;
+      color: var(--ngp-primary);
+      font-size: 0.75rem;
+      line-height: 1rem;
+      margin: 0;
+    }
+
+    [ngpError][data-validator='fail'][data-dirty] {
+      display: block;
+    }
+
+    [ngpPopover] {
+      position: absolute;
+      display: flex;
+      flex-direction: column;
+      row-gap: 4px;
+      max-width: max-content;
+      border-radius: 0.75rem;
+      background: var(--ngp-background);
+      padding: 0.75rem 1rem;
+      box-shadow: var(--ngp-shadow);
+      border: 1px solid var(--ngp-border);
+      outline: none;
+      animation: popover-show 0.1s ease-out;
+      transform-origin: var(--ngp-popover-transform-origin);
+    }
+
+    [ngpPopover][data-exit] {
+      animation: popover-hide 0.1s ease-out;
+    }
+
+    @keyframes popover-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes popover-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+  `,
+})
+export default class OuterFormFieldExample {
+  readonly reactiveForm = new FormGroup({
+    name: new FormControl('', [Validators.required]),
+  });
+
+  readonly signalForm = form(signal({ name: '' }), schema => {
+    required(schema.name);
+  });
+}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
@@ -59,6 +59,12 @@ ng g ng-primitives:primitive form-field
 - `styles`: How component styles should be generated. `css` (default) includes the full example styles; `unstyled` omits them entirely so you can style the component yourself.
 - `example-styles` (deprecated): still supported for compatibility - `true` maps to `styles: css`, `false` maps to `styles: unstyled`.
 
+### Outer FormField
+
+This example demonstrates form-field with a form source input. Works both with ReactiveForms and SignalForms.
+
+<docs-example name="outer-form-field"></docs-example>
+
 ## API Reference
 
 The following directives are available to import from the `ng-primitives/form-field` package:

--- a/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/form-field.md
@@ -61,7 +61,17 @@ ng g ng-primitives:primitive form-field
 
 ### Outer FormField
 
-This example demonstrates form-field with a form source input. Works both with ReactiveForms and SignalForms.
+By default, a form field discovers the form control contained within its own DOM. Sometimes
+the control lives elsewhere—for example, inside a popover, dialog, or another component. In
+that case, associate it with the form field using the `ngpFormFieldSource` input.
+Both Reactive Forms and Signal Forms are supported:
+
+- **Reactive Forms**: pass an `AbstractControl`, typically bound with `[formControl]`.
+- **Signal Forms**: pass a `FieldTree`, typically bound with `[formField]`.
+
+The form field then tracks the source's status (valid, touched, dirty, and so on) and exposes it
+through the `data-*` attributes on the form field and its `ngpError`, `ngpLabel`, and `ngpDescription`
+elements, exactly as it would for a control inside its own DOM.
 
 <docs-example name="outer-form-field"></docs-example>
 

--- a/packages/ng-primitives/form-field/src/form-field/form-field-state.ts
+++ b/packages/ng-primitives/form-field/src/form-field/form-field-state.ts
@@ -2,7 +2,7 @@ import { Signal, computed, signal } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { injectElementRef } from 'ng-primitives/internal';
 import { createPrimitive, dataBinding } from 'ng-primitives/state';
-import { controlStatus, FormFieldSource, sourceStatus } from 'ng-primitives/utils';
+import { controlStatus, FormFieldSource } from 'ng-primitives/utils';
 
 /**
  * The state interface for the FormField primitive.
@@ -96,10 +96,11 @@ export const [NgpFormFieldStateToken, ngpFormField, injectFormFieldState, provid
   createPrimitive('NgpFormField', ({ ngControl, formFieldSource }: NgpFormFieldProps) => {
     const element = injectElementRef();
 
-    const formFieldStatus = sourceStatus(formFieldSource);
-
     // Access the form control status.
-    const status = controlStatus(ngControl);
+    const status = controlStatus({
+      source: formFieldSource,
+      control: ngControl,
+    });
 
     // Store the form labels
     const labels = signal<string[]>([]);
@@ -111,16 +112,16 @@ export const [NgpFormFieldStateToken, ngpFormField, injectFormFieldState, provid
     const formControl = signal<string | null>(null);
 
     // Store the validation error messages
-    const errors = computed<string[]>(() => formFieldStatus().errors ?? status().errors ?? []);
+    const errors = computed<string[]>(() => status().errors ?? []);
 
     // Form control state signals
-    const pristine = computed<boolean | null>(() => formFieldStatus().pristine ?? status().pristine);
-    const touched = computed<boolean | null>(() => formFieldStatus().touched ?? status().touched);
-    const dirty = computed<boolean | null>(() => formFieldStatus().dirty ?? status().dirty);
-    const valid = computed<boolean | null>(() => formFieldStatus().valid ?? status().valid);
-    const invalid = computed<boolean | null>(() => formFieldStatus().invalid ?? status().invalid);
-    const pending = computed<boolean | null>(() => formFieldStatus().pending ?? status().pending);
-    const disabled = computed<boolean | null>(() => formFieldStatus().disabled ?? status().disabled);
+    const pristine = computed<boolean | null>(() => status().pristine);
+    const touched = computed<boolean | null>(() => status().touched);
+    const dirty = computed<boolean | null>(() => status().dirty);
+    const valid = computed<boolean | null>(() => status().valid);
+    const invalid = computed<boolean | null>(() => status().invalid);
+    const pending = computed<boolean | null>(() => status().pending);
+    const disabled = computed<boolean | null>(() => status().disabled);
 
     // Host bindings
     dataBinding(element, 'data-invalid', invalid);

--- a/packages/ng-primitives/form-field/src/form-field/form-field-state.ts
+++ b/packages/ng-primitives/form-field/src/form-field/form-field-state.ts
@@ -1,9 +1,8 @@
-import { Injector, Signal, effect, inject, signal, untracked } from '@angular/core';
+import { Signal, computed, signal } from '@angular/core';
 import { NgControl } from '@angular/forms';
 import { injectElementRef } from 'ng-primitives/internal';
-import { createPrimitive, dataBinding, onDestroy } from 'ng-primitives/state';
-import { onChange } from 'ng-primitives/utils';
-import { Subscription } from 'rxjs';
+import { createPrimitive, dataBinding } from 'ng-primitives/state';
+import { controlStatus, FormFieldSource, sourceStatus } from 'ng-primitives/utils';
 
 /**
  * The state interface for the FormField primitive.
@@ -87,12 +86,20 @@ export interface NgpFormFieldProps {
    * Find any NgControl within the form field.
    */
   readonly ngControl: Signal<NgControl | undefined>;
+  /**
+   * Provide any AbstractControl or FieldTree if no NgControl is inside its DOM.
+   */
+  readonly formFieldSource: Signal<FormFieldSource | undefined>;
 }
 
 export const [NgpFormFieldStateToken, ngpFormField, injectFormFieldState, provideFormFieldState] =
-  createPrimitive('NgpFormField', ({ ngControl }: NgpFormFieldProps) => {
+  createPrimitive('NgpFormField', ({ ngControl, formFieldSource }: NgpFormFieldProps) => {
     const element = injectElementRef();
-    const injector = inject(Injector);
+
+    const formFieldStatus = sourceStatus(formFieldSource);
+
+    // Access the form control status.
+    const status = controlStatus(ngControl);
 
     // Store the form labels
     const labels = signal<string[]>([]);
@@ -104,19 +111,16 @@ export const [NgpFormFieldStateToken, ngpFormField, injectFormFieldState, provid
     const formControl = signal<string | null>(null);
 
     // Store the validation error messages
-    const errors = signal<string[]>([]);
+    const errors = computed<string[]>(() => formFieldStatus().errors ?? status().errors ?? []);
 
     // Form control state signals
-    const pristine = signal<boolean | null>(null);
-    const touched = signal<boolean | null>(null);
-    const dirty = signal<boolean | null>(null);
-    const valid = signal<boolean | null>(null);
-    const invalid = signal<boolean | null>(null);
-    const pending = signal<boolean | null>(null);
-    const disabled = signal<boolean | null>(null);
-
-    // Store the current status subscription
-    let subscription: Subscription | undefined;
+    const pristine = computed<boolean | null>(() => formFieldStatus().pristine ?? status().pristine);
+    const touched = computed<boolean | null>(() => formFieldStatus().touched ?? status().touched);
+    const dirty = computed<boolean | null>(() => formFieldStatus().dirty ?? status().dirty);
+    const valid = computed<boolean | null>(() => formFieldStatus().valid ?? status().valid);
+    const invalid = computed<boolean | null>(() => formFieldStatus().invalid ?? status().invalid);
+    const pending = computed<boolean | null>(() => formFieldStatus().pending ?? status().pending);
+    const disabled = computed<boolean | null>(() => formFieldStatus().disabled ?? status().disabled);
 
     // Host bindings
     dataBinding(element, 'data-invalid', invalid);
@@ -126,73 +130,6 @@ export const [NgpFormFieldStateToken, ngpFormField, injectFormFieldState, provid
     dataBinding(element, 'data-dirty', dirty);
     dataBinding(element, 'data-pending', pending);
     dataBinding(element, 'data-disabled', disabled);
-
-    function updateStatus(): void {
-      const control = ngControl();
-
-      if (!control) {
-        return;
-      }
-
-      // Wrap in try-catch to handle signal-forms interop controls where
-      // the `field` input may not be available yet (throws NG0950).
-      // Reading the signal still establishes a dependency, so the effect
-      // will re-run when the input becomes available.
-      try {
-        const controlPristine = control.pristine;
-        const controlTouched = control.touched;
-        const controlDirty = control.dirty;
-        const controlValid = control.valid;
-        const controlInvalid = control.invalid;
-        const controlPending = control.pending;
-        const controlDisabled = control.disabled;
-        const controlErrors = control.errors;
-
-        untracked(() => {
-          pristine.set(controlPristine);
-          touched.set(controlTouched);
-          dirty.set(controlDirty);
-          valid.set(controlValid);
-          invalid.set(controlInvalid);
-          pending.set(controlPending);
-          disabled.set(controlDisabled);
-          errors.set(controlErrors ? Object.keys(controlErrors) : []);
-        });
-      } catch {
-        // NG0950: Required input not available yet. The effect will re-run
-        // when the signal input becomes available.
-      }
-    }
-
-    function setupSubscriptions(control: NgControl | null | undefined): void {
-      // Unsubscribe from the previous subscriptions.
-      subscription?.unsubscribe();
-
-      if (!control) {
-        return;
-      }
-
-      // For signal-forms interop controls, use an effect to reactively track status.
-      // For classic controls, also use an effect but additionally subscribe to events.
-      effect(
-        () => {
-          updateStatus();
-        },
-        { injector },
-      );
-
-      // Classic controls also have an events observable we can subscribe to.
-      const underlyingControl = control?.control;
-      if (underlyingControl?.events) {
-        subscription = underlyingControl.events.subscribe(() => updateStatus());
-      }
-    }
-
-    // Setup subscriptions when ngControl changes
-    onChange(ngControl, setupSubscriptions);
-
-    // Cleanup subscription on destroy
-    onDestroy(() => subscription?.unsubscribe());
 
     // Methods
     function setFormControl(id: string): void {

--- a/packages/ng-primitives/form-field/src/form-field/form-field-state.ts
+++ b/packages/ng-primitives/form-field/src/form-field/form-field-state.ts
@@ -87,7 +87,15 @@ export interface NgpFormFieldProps {
    */
   readonly ngControl: Signal<NgControl | undefined>;
   /**
-   * Provide any AbstractControl or FieldTree if no NgControl is inside its DOM.
+   * The form control associated with the form field, used when the control is not
+   * located within the form field's own DOM.
+   *
+   * Accepts either a Reactive Forms `AbstractControl`, typically bound with
+   * `[formControl]`, or a Signal Forms `FieldTree`, typically bound with `[formField]`.
+   *
+   * When omitted, the form field automatically looks up the `NgControl` contained
+   * within its own DOM. This input is only necessary when the control lives outside
+   * the form field.
    */
   readonly formFieldSource: Signal<FormFieldSource | undefined>;
 }

--- a/packages/ng-primitives/form-field/src/form-field/form-field.ts
+++ b/packages/ng-primitives/form-field/src/form-field/form-field.ts
@@ -1,5 +1,6 @@
-import { Directive, contentChild } from '@angular/core';
+import { Directive, contentChild, input } from '@angular/core';
 import { NgControl } from '@angular/forms';
+import { FormFieldSource } from 'packages/ng-primitives/utils/src/forms/types';
 import { ngpFormField, provideFormFieldState } from './form-field-state';
 
 /**
@@ -15,12 +16,20 @@ export class NgpFormField {
    * Find any NgControl within the form field.
    * @internal
    */
-  private readonly ngControl = contentChild(NgControl);
+  private readonly ngControlChild = contentChild(NgControl);
+
+  /**
+   * Provide any AbstractControl or FieldTree if no NgControl is inside its DOM.
+   */
+  readonly formFieldSource = input<FormFieldSource | undefined>(undefined, {
+    alias: 'ngpFormFieldSource',
+  });
 
   /**
    * The form field state.
    */
-  constructor() {
-    ngpFormField({ ngControl: this.ngControl });
-  }
+  protected readonly state = ngpFormField({
+    ngControl: this.ngControlChild,
+    formFieldSource: this.formFieldSource,
+  });
 }

--- a/packages/ng-primitives/form-field/src/form-field/form-field.ts
+++ b/packages/ng-primitives/form-field/src/form-field/form-field.ts
@@ -19,7 +19,15 @@ export class NgpFormField {
   private readonly ngControlChild = contentChild(NgControl);
 
   /**
-   * Provide any AbstractControl or FieldTree if no NgControl is inside its DOM.
+   * The form control associated with the form field, used when the control is not
+   * located within the form field's own DOM.
+   *
+   * Accepts either a Reactive Forms `AbstractControl`, typically bound with
+   * `[formControl]`, or a Signal Forms `FieldTree`, typically bound with `[formField]`.
+   *
+   * When omitted, the form field automatically looks up the `NgControl` contained
+   * within its own DOM. This input is only necessary when the control lives outside
+   * the form field.
    */
   readonly formFieldSource = input<FormFieldSource | undefined>(undefined, {
     alias: 'ngpFormFieldSource',

--- a/packages/ng-primitives/form-field/src/form-field/form-field.ts
+++ b/packages/ng-primitives/form-field/src/form-field/form-field.ts
@@ -1,6 +1,6 @@
 import { Directive, contentChild, input } from '@angular/core';
 import { NgControl } from '@angular/forms';
-import { FormFieldSource } from 'packages/ng-primitives/utils/src/forms/types';
+import { FormFieldSource } from 'ng-primitives/utils';
 import { ngpFormField, provideFormFieldState } from './form-field-state';
 
 /**

--- a/packages/ng-primitives/form-field/src/form-field/tests/form-field-source.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/form-field-source.test.ts
@@ -1,0 +1,143 @@
+import { Component, signal } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { form, FormField, required } from '@angular/forms/signals';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpError, NgpFormField, NgpLabel } from 'ng-primitives/form-field';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+import { afterEach, describe, expect, it } from 'vitest';
+
+/**
+ * Inline fixture mirroring `apps/documentation/src/app/examples/form-field/outer-form-field.example.ts`.
+ * The actual `[formControl]` / `[formField]` input lives inside a popover, so the form field
+ * can only discover the control through the `ngpFormFieldSource` input.
+ */
+@Component({
+  template: `
+    <div id="reactive" [ngpFormFieldSource]="reactiveForm.controls.name" ngpFormField>
+      <label ngpLabel>Name</label>
+      <input id="reactive-display" [value]="reactiveForm.controls.name.value" readonly />
+      <p id="reactive-error" ngpError ngpErrorValidator="required">This field is required</p>
+    </div>
+
+    <div id="signal" [ngpFormFieldSource]="signalForm.name" ngpFormField>
+      <label ngpLabel>Name</label>
+      <input id="signal-display" [value]="signalForm.name().value()" readonly />
+      <p id="signal-error" ngpError ngpErrorValidator="required">This field is required</p>
+    </div>
+
+    <button [ngpPopoverTrigger]="reactivePopover">Edit reactive</button>
+    <button [ngpPopoverTrigger]="signalPopover">Edit signal</button>
+
+    <ng-template #reactivePopover>
+      <div ngpPopover>
+        <input [formControl]="reactiveForm.controls.name" placeholder="What's your name" />
+      </div>
+    </ng-template>
+
+    <ng-template #signalPopover>
+      <div ngpPopover>
+        <input [formField]="signalForm.name" placeholder="What's your name" />
+      </div>
+    </ng-template>
+  `,
+  imports: [
+    NgpFormField,
+    NgpLabel,
+    NgpError,
+    NgpPopoverTrigger,
+    NgpPopover,
+    ReactiveFormsModule,
+    FormField,
+  ],
+})
+class HostComponent {
+  readonly reactiveForm = new FormGroup({
+    name: new FormControl('', [Validators.required]),
+  });
+
+  readonly signalForm = form(signal({ name: '' }), schema => {
+    required(schema.name);
+  });
+}
+
+describe('NgpFormField with a source control living in a popover', () => {
+  afterEach(() => {
+    // The popover content is portalled to the body, so remove any leftover overlays.
+    document.querySelectorAll('[ngpPopover]').forEach(el => el.remove());
+  });
+
+  it('tracks the required error state while editing a Reactive Forms source', async () => {
+    const { container, getByRole } = await render(HostComponent);
+    const formField = container.querySelector('#reactive')!;
+    const display = container.querySelector<HTMLInputElement>('#reactive-display')!;
+    const error = container.querySelector('#reactive-error')!;
+
+    fireEvent.click(getByRole('button', { name: 'Edit reactive' }));
+    const input = await waitFor(() => {
+      const el = document.querySelector<HTMLInputElement>('[ngpPopover] input');
+      expect(el).toBeTruthy();
+      return el!;
+    });
+
+    // The source control is required, so the field starts invalid but pristine.
+    expect(formField).toHaveAttribute('data-invalid');
+    expect(formField).toHaveAttribute('data-pristine');
+    expect(error).toHaveAttribute('data-validator', 'fail');
+    expect(error).not.toHaveAttribute('data-dirty');
+
+    // Typing satisfies the required validator and marks the control dirty.
+    fireEvent.input(input, { target: { value: 'Ada' } });
+    await waitFor(() => expect(formField).toHaveAttribute('data-dirty'));
+    expect(formField).not.toHaveAttribute('data-invalid');
+    expect(error).toHaveAttribute('data-validator', 'pass');
+    expect(display.value).toBe('Ada');
+
+    // Clearing the control makes it dirty AND invalid again, so the error must
+    // surface: the example only shows the message once `[data-dirty]` is set.
+    fireEvent.input(input, { target: { value: '' } });
+    await waitFor(() => expect(error).toHaveAttribute('data-validator', 'fail'));
+    expect(error).toHaveAttribute('data-dirty');
+    expect(formField).toHaveAttribute('data-dirty');
+    expect(formField).toHaveAttribute('data-invalid');
+
+    fireEvent.blur(input);
+    await waitFor(() => expect(formField).toHaveAttribute('data-touched'));
+  });
+
+  it('tracks the required error state while editing a Signal Forms source', async () => {
+    const { container, getByRole } = await render(HostComponent);
+    const formField = container.querySelector('#signal')!;
+    const display = container.querySelector<HTMLInputElement>('#signal-display')!;
+    const error = container.querySelector('#signal-error')!;
+
+    fireEvent.click(getByRole('button', { name: 'Edit signal' }));
+    const input = await waitFor(() => {
+      const el = document.querySelector<HTMLInputElement>('[ngpPopover] input');
+      expect(el).toBeTruthy();
+      return el!;
+    });
+
+    // The source field is required, so the form field starts invalid but pristine.
+    expect(formField).toHaveAttribute('data-invalid');
+    expect(formField).toHaveAttribute('data-pristine');
+    expect(error).toHaveAttribute('data-validator', 'fail');
+    expect(error).not.toHaveAttribute('data-dirty');
+
+    // Typing satisfies the required validator and marks the field dirty.
+    fireEvent.input(input, { target: { value: 'Ada' } });
+    await waitFor(() => expect(formField).toHaveAttribute('data-dirty'));
+    expect(formField).not.toHaveAttribute('data-invalid');
+    expect(error).toHaveAttribute('data-validator', 'pass');
+    expect(display.value).toBe('Ada');
+
+    // Clearing the field makes it dirty AND invalid again.
+    fireEvent.input(input, { target: { value: '' } });
+    await waitFor(() => expect(error).toHaveAttribute('data-validator', 'fail'));
+    expect(error).toHaveAttribute('data-dirty');
+    expect(formField).toHaveAttribute('data-dirty');
+    expect(formField).toHaveAttribute('data-invalid');
+
+    fireEvent.blur(input);
+    await waitFor(() => expect(formField).toHaveAttribute('data-touched'));
+  });
+});

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -37,6 +37,21 @@ const initialStatus: NgpControlStatus = {
   errors: null,
 };
 
+/**
+ * Create a reactive signal that tracks the status of an Angular form control.
+ *
+ * The control can be provided as a signal-based source (`FormFieldSource`, such as a
+ * signal `FieldTree` or interop control) or as a `NgControl`/classic `AbstractControl`.
+ *
+ * - Signal-based controls are read directly through their signal getters.
+ * - Classic controls are derived from the control and re-synced on `control.events`.
+ *
+ * If neither `source` nor `control` is provided, the nearest injected `NgControl` is used.
+ * @param options The options for the status.
+ * @param options.source A signal resolving to a `FormFieldSource` (signal-based control) or `NgControl`.
+ * @param options.control A signal resolving to a `NgControl`, used when no `source` is provided.
+ * @returns A reactive signal of the control's current status.
+ */
 export function controlStatus(options?: {
   source?: Signal<FormFieldSource | null | undefined>;
   control?: Signal<NgControl | null | undefined>;
@@ -53,19 +68,20 @@ export function controlStatus(options?: {
   return status;
 }
 
+/**
+ * Set up the status for a signal-based control by reading its signal getters.
+ * @internal
+ */
 function setupForSignal(
   source: Signal<FormFieldSource | NgControl | null | undefined>,
   status: WritableSignal<NgpControlStatus>,
   injector: Injector,
 ): void {
-  let canReset = true;
-
   effect(
     () => {
       const s = source();
 
       if (!s || typeof s !== 'function') {
-        canReset = false;
         return;
       }
 
@@ -83,32 +99,30 @@ function setupForSignal(
             .map(x => x.kind),
           disabled: s().disabled(),
         });
-      } else if (canReset) {
-        status.set(initialStatus);
       }
     },
     { injector },
   );
 }
 
+/**
+ * Set up the status for a `NgControl` or classic `AbstractControl`, re-syncing on
+ * `control.events`. Falls back to the injected `NgControl` when no source is provided.
+ * @internal
+ */
 function setupForObservable(
   source: WritableSignal<FormFieldSource | NgControl | null | undefined>,
   status: WritableSignal<NgpControlStatus>,
   destroyRef: DestroyRef,
   injector: Injector,
 ) {
-  let canReset = true;
-  let canUnsubscribe = true;
   let subscription: Subscription | undefined;
   const control = linkedSignal<AbstractControl | null>(() => {
     const s = source();
 
     if (!s || typeof s === 'function') {
-      canReset = false;
       return null;
     }
-
-    canUnsubscribe = false;
 
     if ('control' in s) {
       return s.control;
@@ -164,15 +178,11 @@ function setupForObservable(
     () => {
       const c = control();
 
-      if (canUnsubscribe) {
-        subscription?.unsubscribe();
-      }
+      subscription?.unsubscribe();
 
       if (c) {
         setup(c);
         updateStatus(c);
-      } else if (canReset) {
-        untracked(() => status.set(initialStatus));
       }
     },
     { injector },

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -7,10 +7,8 @@ import {
   inject,
   linkedSignal,
   signal,
-  untracked,
 } from '@angular/core';
 import { AbstractControl, NgControl } from '@angular/forms';
-import { FieldTree } from '@angular/forms/signals';
 import { onDestroy, onMount } from 'ng-primitives/state';
 import { Subscription } from 'rxjs';
 import { safeTakeUntilDestroyed } from '../observables/take-until-destroyed';
@@ -27,59 +25,11 @@ export interface NgpControlStatus {
   disabled: boolean | null;
 }
 
-function buildFromAbstractControl<T>(
-  control: AbstractControl<T>,
-  status: WritableSignal<NgpControlStatus>,
-  destroyRef: DestroyRef,
-) {
-  const buildStatus = (): NgpControlStatus => {
-    return {
-      valid: control.valid,
-      invalid: control.invalid,
-      pristine: control.pristine,
-      dirty: control.dirty,
-      touched: control.touched,
-      pending: control.pending,
-      errors: Object.keys(control.errors ?? []),
-      disabled: control.disabled,
-    };
-  };
-
-  status.set(buildStatus());
-
-  // If any events is raised, we recalculate the status
-  control.events
-    .pipe(safeTakeUntilDestroyed(destroyRef))
-    .subscribe(() => status.set(buildStatus()));
-}
-
-function buildFromFieldTree<T>(control: FieldTree<T>, status: WritableSignal<NgpControlStatus>) {
-  // No need to subscribe to anything since everything is signal based
-  status.set({
-    valid: control().valid(),
-    invalid: control().invalid(),
-    pristine: !control().dirty(),
-    dirty: control().dirty(),
-    touched: control().touched(),
-    pending: control().pending(),
-    errors: control()
-      .errors()
-      .map(x => x.kind),
-    disabled: control().disabled(),
-  });
-}
-
-function isFieldTree<T>(value: unknown): value is FieldTree<T> {
-  return !!value && typeof value === 'function';
-}
-
-function isAbstractControl<T>(value: unknown): value is AbstractControl<T> {
-  return !!value && value instanceof AbstractControl;
-}
-
-export function sourceStatus<T>(
-  source: Signal<FormFieldSource | null | undefined>,
-): Signal<NgpControlStatus> {
+export function controlStatus(options?: {
+  source?: Signal<FormFieldSource | null | undefined>;
+  control?: Signal<NgControl | null | undefined>;
+}): Signal<NgpControlStatus> {
+  const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
   const initialStatus: NgpControlStatus = {
     valid: null,
@@ -91,51 +41,88 @@ export function sourceStatus<T>(
     disabled: null,
     errors: null,
   };
-
   const status = signal(initialStatus);
 
-  const buildStatus = () => {
-    if (isFieldTree(source())) {
-      buildFromFieldTree<T>(source() as FieldTree<T>, status);
-    } else if (isAbstractControl(source())) {
-      buildFromAbstractControl(source() as AbstractControl<T>, status, destroyRef);
-    }
-  };
+  const source = linkedSignal(() => options?.source?.() ?? options?.control?.());
 
-  effect(() => {
-    const s = source();
-
-    if (s) {
-      buildStatus();
-    } else {
-      status.set(initialStatus);
-    }
-  });
+  setupForSignal(source, status, injector, initialStatus);
+  setupForObservable(source, status, destroyRef, injector, initialStatus);
 
   return status;
 }
 
-/**
- * Detects an Angular signal-forms interop control without importing any of the new
- * signal-form types. Interop controls expose a `field()` method which returns the
- * underlying FieldState.
- */
-function isInteropControl(control: NgControl | null | undefined): boolean {
-  return !!control && typeof (control as any).field === 'function';
+function setupForSignal(
+  source: Signal<FormFieldSource | NgControl | null | undefined>,
+  status: WritableSignal<NgpControlStatus>,
+  injector: Injector,
+  initialStatus: NgpControlStatus,
+): void {
+  let canReset = true;
+
+  effect(
+    () => {
+      const s = source();
+
+      if (!s || typeof s !== 'function') {
+        canReset = false;
+        return;
+      }
+
+      if (s) {
+        // No need to subscribe to anything since everything is signal based
+        status.set({
+          valid: s().valid(),
+          invalid: s().invalid(),
+          pristine: !s().dirty(),
+          dirty: s().dirty(),
+          touched: s().touched(),
+          pending: s().pending(),
+          errors: s()
+            .errors()
+            .map(x => x.kind),
+          disabled: s().disabled(),
+        });
+      } else if (canReset) {
+        status.set(initialStatus);
+      }
+    },
+    { injector },
+  );
 }
 
-/**
- * Reads status from a control and updates the status signal.
- * Wrapped in try-catch to handle signal-forms interop controls where
- * the `field` input may not be available yet (throws NG0950).
- */
-function updateStatus(control: NgControl, status: WritableSignal<NgpControlStatus>): void {
-  try {
+function setupForObservable(
+  source: Signal<FormFieldSource | NgControl | null | undefined>,
+  status: WritableSignal<NgpControlStatus>,
+  destroyRef: DestroyRef,
+  injector: Injector,
+  initialStatus: NgpControlStatus,
+) {
+  let canReset = true;
+  let canUnsubscribe = true;
+  const subscription = new Subscription();
+  const control = linkedSignal<AbstractControl | null>(() => {
+    const s = source();
+
+    if (!s || typeof s === 'function') {
+      canReset = false;
+      return null;
+    }
+
+    canUnsubscribe = false;
+
+    if ('control' in s) {
+      return s.control;
+    }
+
+    return s;
+  });
+
+  function updateStatus(control: AbstractControl) {
     // For interop controls, read directly from the control (which has signal getters).
     // For classic controls, read from the underlying AbstractControl.
     const source = isInteropControl(control) ? control : ((control as any).control ?? control);
 
-    const newStatus: NgpControlStatus = {
+    status.set({
       valid: source.valid ?? null,
       invalid: source.invalid ?? null,
       pristine: source.pristine ?? null,
@@ -143,103 +130,48 @@ function updateStatus(control: NgControl, status: WritableSignal<NgpControlStatu
       touched: source.touched ?? null,
       pending: source.pending ?? null,
       disabled: source.disabled ?? null,
-      errors: source.errors ? Object.keys(source.errors) : null,
-    };
-
-    untracked(() => status.set(newStatus));
-  } catch {
-    // NG0950: Required input not available yet. The effect will re-run
-    // when the signal input becomes available.
-  }
-}
-
-/**
- * A utility function to get the status of an Angular form control as a reactive signal.
- * This function injects the NgControl and returns a signal that reflects the control's status.
- * It supports both classic reactive forms controls and signal-forms interop controls.
- * @internal
- */
-/**
- * Sets up event subscription for a given NgControl.
- * Only sets up the subscription - does not call updateStatus.
- */
-function setupEventSubscription(
-  ngControl: NgControl,
-  status: WritableSignal<NgpControlStatus>,
-  destroyRef: DestroyRef,
-): Subscription | undefined {
-  // For classic controls, also subscribe to the events observable.
-  const underlyingControl = (ngControl as any).control;
-  if (underlyingControl?.events) {
-    return underlyingControl.events
-      .pipe(safeTakeUntilDestroyed(destroyRef))
-      .subscribe(() => updateStatus(ngControl, status));
-  }
-
-  return undefined;
-}
-
-export function controlStatus(
-  ngControl?: Signal<NgControl | null | undefined>,
-): Signal<NgpControlStatus> {
-  const injector = inject(Injector);
-  const destroyRef = inject(DestroyRef);
-
-  const initialStatus: NgpControlStatus = {
-    valid: null,
-    invalid: null,
-    pristine: null,
-    dirty: null,
-    touched: null,
-    pending: null,
-    disabled: null,
-    errors: null,
-  };
-
-  const status = signal<NgpControlStatus>(initialStatus);
-  let eventSubscription: Subscription | undefined = undefined;
-
-  const control = linkedSignal<NgControl | null>(() => ngControl?.() ?? null);
-
-  function cleanup(): void {
-    eventSubscription?.unsubscribe();
-  }
-
-  function setup(ngControl: NgControl): void {
-    // Set up event subscription for reactive updates
-    eventSubscription = setupEventSubscription(ngControl, status, destroyRef);
+      errors: source.errors ? Object.keys(source.errors!) : null,
+    });
   }
 
   onMount(() => {
     if (!control()) {
-      // Try to inject NgControl immediately for initial state
-      control.set(inject(NgControl, { optional: true }));
+      const ngControl = inject(NgControl, { optional: true });
+      control.set(ngControl?.control ?? null);
     }
   });
 
   onDestroy(() => {
-    cleanup();
+    subscription.unsubscribe();
   });
 
-  // Use an effect to reactively track status changes.
-  // For signal-forms interop controls, the status properties are signals.
-  // For classic controls, this will read the current values and establish
-  // no signal dependencies, but we also subscribe to events below.
   effect(
     () => {
       const c = control();
 
-      cleanup();
+      if (canUnsubscribe) {
+        subscription.unsubscribe();
+      }
 
       if (c) {
-        setup(c);
-        updateStatus(c, status);
-      } else {
-        untracked(() => status.set(initialStatus));
+        subscription.add(
+          c.events.pipe(safeTakeUntilDestroyed(destroyRef)).subscribe(() => updateStatus(c)),
+        );
+
+        updateStatus(c);
+      } else if (canReset) {
+        status.set(initialStatus);
       }
     },
     { injector },
   );
+}
 
-  return status;
+/**
+ * Detects an Angular signal-forms interop control without importing any of the new
+ * signal-form types. Interop controls expose a `field()` method which returns the
+ * underlying FieldState.
+ */
+function isInteropControl(control: unknown | null | undefined): boolean {
+  return !!control && typeof (control as any).field === 'function';
 }

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -5,12 +5,16 @@ import {
   WritableSignal,
   effect,
   inject,
+  linkedSignal,
   signal,
   untracked,
 } from '@angular/core';
-import { NgControl } from '@angular/forms';
-import { onMount } from 'ng-primitives/state';
+import { AbstractControl, NgControl } from '@angular/forms';
+import { FieldTree } from '@angular/forms/signals';
+import { onDestroy, onMount } from 'ng-primitives/state';
+import { Subscription } from 'rxjs';
 import { safeTakeUntilDestroyed } from '../observables/take-until-destroyed';
+import { FormFieldSource } from './types';
 
 export interface NgpControlStatus {
   valid: boolean | null;
@@ -19,7 +23,96 @@ export interface NgpControlStatus {
   dirty: boolean | null;
   touched: boolean | null;
   pending: boolean | null;
+  errors: string[] | null;
   disabled: boolean | null;
+}
+
+function buildFromAbstractControl<T>(
+  control: AbstractControl<T>,
+  status: WritableSignal<NgpControlStatus>,
+  destroyRef: DestroyRef,
+) {
+  const buildStatus = (): NgpControlStatus => {
+    return {
+      valid: control.valid,
+      invalid: control.invalid,
+      pristine: control.pristine,
+      dirty: control.dirty,
+      touched: control.touched,
+      pending: control.pending,
+      errors: Object.keys(control.errors ?? []),
+      disabled: control.disabled,
+    };
+  };
+
+  status.set(buildStatus());
+
+  // If any events is raised, we recalculate the status
+  control.events
+    .pipe(safeTakeUntilDestroyed(destroyRef))
+    .subscribe(() => status.set(buildStatus()));
+}
+
+function buildFromFieldTree<T>(control: FieldTree<T>, status: WritableSignal<NgpControlStatus>) {
+  // No need to subscribe to anything since everything is signal based
+  status.set({
+    valid: control().valid(),
+    invalid: control().invalid(),
+    pristine: !control().dirty(),
+    dirty: control().dirty(),
+    touched: control().touched(),
+    pending: control().pending(),
+    errors: control()
+      .errors()
+      .map(x => x.kind),
+    disabled: control().disabled(),
+  });
+}
+
+function isFieldTree<T>(value: unknown): value is FieldTree<T> {
+  return !!value && typeof value === 'function';
+}
+
+function isAbstractControl<T>(value: unknown): value is AbstractControl<T> {
+  return !!value && value instanceof AbstractControl;
+}
+
+export function sourceStatus<T>(
+  source: Signal<FormFieldSource | null | undefined>,
+): Signal<NgpControlStatus> {
+  const destroyRef = inject(DestroyRef);
+  const initialStatus: NgpControlStatus = {
+    valid: null,
+    invalid: null,
+    pristine: null,
+    dirty: null,
+    touched: null,
+    pending: null,
+    disabled: null,
+    errors: null,
+  };
+
+  const status = signal(initialStatus);
+
+  const buildStatus = () => {
+    if (isFieldTree(source())) {
+      buildFromFieldTree<T>(source() as FieldTree<T>, status);
+    } else if (isAbstractControl(source())) {
+      buildFromAbstractControl(source() as AbstractControl<T>, status, destroyRef);
+    }
+  };
+
+  effect(() => {
+    const s = source();
+
+    if (s) {
+      buildStatus();
+    } else {
+      status.set(initialStatus);
+    }
+  });
+
+  return status;
 }
 
 /**
@@ -50,6 +143,7 @@ function updateStatus(control: NgControl, status: WritableSignal<NgpControlStatu
       touched: source.touched ?? null,
       pending: source.pending ?? null,
       disabled: source.disabled ?? null,
+      errors: source.errors ? Object.keys(source.errors) : null,
     };
 
     untracked(() => status.set(newStatus));
@@ -73,21 +167,25 @@ function setupEventSubscription(
   ngControl: NgControl,
   status: WritableSignal<NgpControlStatus>,
   destroyRef: DestroyRef,
-): void {
+): Subscription | undefined {
   // For classic controls, also subscribe to the events observable.
   const underlyingControl = (ngControl as any).control;
   if (underlyingControl?.events) {
-    underlyingControl.events
+    return underlyingControl.events
       .pipe(safeTakeUntilDestroyed(destroyRef))
       .subscribe(() => updateStatus(ngControl, status));
   }
+
+  return undefined;
 }
 
-export function controlStatus(): Signal<NgpControlStatus> {
+export function controlStatus(
+  ngControl?: Signal<NgControl | null | undefined>,
+): Signal<NgpControlStatus> {
   const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
 
-  const status = signal<NgpControlStatus>({
+  const initialStatus: NgpControlStatus = {
     valid: null,
     invalid: null,
     pristine: null,
@@ -95,36 +193,32 @@ export function controlStatus(): Signal<NgpControlStatus> {
     touched: null,
     pending: null,
     disabled: null,
-  });
+    errors: null,
+  };
 
-  const control = signal<NgControl | null>(null);
+  const status = signal<NgpControlStatus>(initialStatus);
+  let eventSubscription: Subscription | undefined = undefined;
+
+  const control = linkedSignal<NgControl | null>(() => ngControl?.() ?? null);
+
+  function cleanup(): void {
+    eventSubscription?.unsubscribe();
+  }
+
+  function setup(ngControl: NgControl): void {
+    // Set up event subscription for reactive updates
+    eventSubscription = setupEventSubscription(ngControl, status, destroyRef);
+  }
 
   onMount(() => {
-    // Try to inject NgControl immediately for initial state
-    control.set(inject(NgControl, { optional: true }));
-
-    // If we have a control immediately, update initial status
-    if (control()) {
-      updateStatus(control()!, status);
-    }
-
-    // Get the control (either from initial injection or from mount)
-    const mountControl = control() || inject(NgControl, { optional: true });
-
-    if (!mountControl) {
-      return;
-    }
-
-    // Update control signal if it wasn't set before
     if (!control()) {
-      control.set(mountControl);
+      // Try to inject NgControl immediately for initial state
+      control.set(inject(NgControl, { optional: true }));
     }
+  });
 
-    // Update status to ensure latest values
-    updateStatus(mountControl, status);
-
-    // Set up event subscription for reactive updates
-    setupEventSubscription(mountControl, status, destroyRef);
+  onDestroy(() => {
+    cleanup();
   });
 
   // Use an effect to reactively track status changes.
@@ -134,8 +228,14 @@ export function controlStatus(): Signal<NgpControlStatus> {
   effect(
     () => {
       const c = control();
+
+      cleanup();
+
       if (c) {
+        setup(c);
         updateStatus(c, status);
+      } else {
+        untracked(() => status.set(initialStatus));
       }
     },
     { injector },

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -90,21 +90,19 @@ function setupForSignal(
         return;
       }
 
-      if (s) {
-        // No need to subscribe to anything since everything is signal based
-        status.set({
-          valid: s().valid(),
-          invalid: s().invalid(),
-          pristine: !s().dirty(),
-          dirty: s().dirty(),
-          touched: s().touched(),
-          pending: s().pending(),
-          errors: s()
-            .errors()
-            .map(x => x.kind),
-          disabled: s().disabled(),
-        });
-      }
+      // No need to subscribe to anything since everything is signal based
+      status.set({
+        valid: s().valid(),
+        invalid: s().invalid(),
+        pristine: !s().dirty(),
+        dirty: s().dirty(),
+        touched: s().touched(),
+        pending: s().pending(),
+        errors: s()
+          .errors()
+          .map(x => x.kind),
+        disabled: s().disabled(),
+      });
     },
     { injector },
   );

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -7,6 +7,7 @@ import {
   inject,
   linkedSignal,
   signal,
+  untracked,
 } from '@angular/core';
 import { AbstractControl, NgControl } from '@angular/forms';
 import { onDestroy, onMount } from 'ng-primitives/state';
@@ -25,28 +26,29 @@ export interface NgpControlStatus {
   disabled: boolean | null;
 }
 
+const initialStatus: NgpControlStatus = {
+  valid: null,
+  invalid: null,
+  pristine: null,
+  dirty: null,
+  touched: null,
+  pending: null,
+  disabled: null,
+  errors: null,
+};
+
 export function controlStatus(options?: {
   source?: Signal<FormFieldSource | null | undefined>;
   control?: Signal<NgControl | null | undefined>;
 }): Signal<NgpControlStatus> {
   const injector = inject(Injector);
   const destroyRef = inject(DestroyRef);
-  const initialStatus: NgpControlStatus = {
-    valid: null,
-    invalid: null,
-    pristine: null,
-    dirty: null,
-    touched: null,
-    pending: null,
-    disabled: null,
-    errors: null,
-  };
   const status = signal(initialStatus);
 
-  const source = linkedSignal(() => options?.source?.() ?? options?.control?.());
+  const optionSource = linkedSignal(() => options?.source?.() ?? options?.control?.());
 
-  setupForSignal(source, status, injector, initialStatus);
-  setupForObservable(source, status, destroyRef, injector, initialStatus);
+  setupForSignal(optionSource, status, injector);
+  setupForObservable(optionSource, status, destroyRef, injector);
 
   return status;
 }
@@ -55,7 +57,6 @@ function setupForSignal(
   source: Signal<FormFieldSource | NgControl | null | undefined>,
   status: WritableSignal<NgpControlStatus>,
   injector: Injector,
-  initialStatus: NgpControlStatus,
 ): void {
   let canReset = true;
 
@@ -91,15 +92,14 @@ function setupForSignal(
 }
 
 function setupForObservable(
-  source: Signal<FormFieldSource | NgControl | null | undefined>,
+  source: WritableSignal<FormFieldSource | NgControl | null | undefined>,
   status: WritableSignal<NgpControlStatus>,
   destroyRef: DestroyRef,
   injector: Injector,
-  initialStatus: NgpControlStatus,
 ) {
   let canReset = true;
   let canUnsubscribe = true;
-  const subscription = new Subscription();
+  let subscription: Subscription | undefined;
   const control = linkedSignal<AbstractControl | null>(() => {
     const s = source();
 
@@ -122,27 +122,42 @@ function setupForObservable(
     // For classic controls, read from the underlying AbstractControl.
     const source = isInteropControl(control) ? control : ((control as any).control ?? control);
 
-    status.set({
-      valid: source.valid ?? null,
-      invalid: source.invalid ?? null,
-      pristine: source.pristine ?? null,
-      dirty: source.dirty ?? null,
-      touched: source.touched ?? null,
-      pending: source.pending ?? null,
-      disabled: source.disabled ?? null,
-      errors: source.errors ? Object.keys(source.errors!) : null,
-    });
+    try {
+      untracked(() =>
+        status.set({
+          valid: source.valid ?? null,
+          invalid: source.invalid ?? null,
+          pristine: source.pristine ?? null,
+          dirty: source.dirty ?? null,
+          touched: source.touched ?? null,
+          pending: source.pending ?? null,
+          disabled: source.disabled ?? null,
+          errors: source.errors ? Object.keys(source.errors!) : null,
+        }),
+      );
+    } catch {
+      // NG0950: Required input not available yet. The effect will re-run
+      // when the signal input becomes available.
+    }
   }
 
-  onMount(() => {
-    if (!control()) {
-      const ngControl = inject(NgControl, { optional: true });
-      control.set(ngControl?.control ?? null);
+  function setup(control: AbstractControl) {
+    if (control.events) {
+      subscription = control.events
+        .pipe(safeTakeUntilDestroyed(destroyRef))
+        .subscribe(() => updateStatus(control));
     }
-  });
+  }
 
   onDestroy(() => {
-    subscription.unsubscribe();
+    subscription?.unsubscribe();
+  });
+
+  onMount(() => {
+    if (!source()) {
+      const ngControl = inject(NgControl, { optional: true });
+      source.set(ngControl?.control ?? null);
+    }
   });
 
   effect(
@@ -150,17 +165,14 @@ function setupForObservable(
       const c = control();
 
       if (canUnsubscribe) {
-        subscription.unsubscribe();
+        subscription?.unsubscribe();
       }
 
       if (c) {
-        subscription.add(
-          c.events.pipe(safeTakeUntilDestroyed(destroyRef)).subscribe(() => updateStatus(c)),
-        );
-
+        setup(c);
         updateStatus(c);
       } else if (canReset) {
-        status.set(initialStatus);
+        untracked(() => status.set(initialStatus));
       }
     },
     { injector },

--- a/packages/ng-primitives/utils/src/forms/status.ts
+++ b/packages/ng-primitives/utils/src/forms/status.ts
@@ -81,7 +81,12 @@ function setupForSignal(
     () => {
       const s = source();
 
-      if (!s || typeof s !== 'function') {
+      if (!s) {
+        status.set(initialStatus);
+        return;
+      }
+
+      if (typeof s !== 'function') {
         return;
       }
 

--- a/packages/ng-primitives/utils/src/forms/types.ts
+++ b/packages/ng-primitives/utils/src/forms/types.ts
@@ -1,3 +1,6 @@
+import { AbstractControl } from '@angular/forms';
+import { FieldState, FieldTree } from '@angular/forms/signals';
+
 /**
  * A utility type for Angular's onChange function.
  */
@@ -7,3 +10,8 @@ export type ChangeFn<T> = (value: T) => void;
  * A utility type for Angular's onTouched function.
  */
 export type TouchedFn = () => void;
+
+/**
+ * The handled form types
+ */
+export type FormFieldSource<T = unknown> = AbstractControl<T> | FieldTree<T>;

--- a/packages/ng-primitives/utils/src/forms/types.ts
+++ b/packages/ng-primitives/utils/src/forms/types.ts
@@ -1,5 +1,5 @@
 import { AbstractControl } from '@angular/forms';
-import { FieldState, FieldTree } from '@angular/forms/signals';
+import { FieldTree } from '@angular/forms/signals';
 
 /**
  * A utility type for Angular's onChange function.

--- a/packages/ng-primitives/utils/src/index.ts
+++ b/packages/ng-primitives/utils/src/index.ts
@@ -1,6 +1,6 @@
 export { provideValueAccessor } from './forms/providers';
-export { controlStatus, NgpControlStatus } from './forms/status';
-export { ChangeFn, TouchedFn } from './forms/types';
+export { controlStatus, NgpControlStatus, sourceStatus } from './forms/status';
+export { ChangeFn, TouchedFn, FormFieldSource } from './forms/types';
 export { booleanAttributeBinding } from './helpers/attributes';
 export { coerceBooleanOrUndefined, coerceNumberOrUndefined } from './helpers/coercion';
 export { injectDisposables } from './helpers/disposables';

--- a/packages/ng-primitives/utils/src/index.ts
+++ b/packages/ng-primitives/utils/src/index.ts
@@ -1,5 +1,5 @@
 export { provideValueAccessor } from './forms/providers';
-export { controlStatus, NgpControlStatus, sourceStatus } from './forms/status';
+export { controlStatus, NgpControlStatus } from './forms/status';
 export { ChangeFn, TouchedFn, FormFieldSource } from './forms/types';
 export { booleanAttributeBinding } from './helpers/attributes';
 export { coerceBooleanOrUndefined, coerceNumberOrUndefined } from './helpers/coercion';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #

## What does this PR implement/fix?

<!-- Please describe the changes in this PR. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow a form field to bind to a control outside its DOM via the new `ngpFormFieldSource` input. Fixes stale validation so status and errors stay current for Reactive Forms, Signal Forms, and `NgModel`, including controls rendered in popovers.

- **New Features**
  - `ng-primitives/form-field`: add `ngpFormFieldSource` on `NgpFormField` to link an external control; accepts `AbstractControl` (`[formControl]`) or `FieldTree` (`[formField]`), works with `NgModel`.
  - Status and errors propagate to `data-*` attrs and `ngpError`/`ngpLabel`/`ngpDescription`.
  - Docs: added “Outer FormField” section and example.
  - `ng-primitives/utils`: expanded `controlStatus` to accept a `source` or use the injected `NgControl`, unify `AbstractControl`/`FieldTree`, include `errors`, and handle signal-based and classic controls; exported `FormFieldSource`.

- **Bug Fixes**
  - Prevented stale validation by syncing to classic control events and reacting to source changes; added non-regression tests for popover-hosted controls.

<sup>Written for commit 4916c8254216cca259f8ff30b8ed485dd120f232. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Form fields can now connect to external Reactive Forms and Signal Forms controls.
  * Validation status, errors, and related field attributes update automatically.
  * Added support for form fields used with editable popovers, including value and validation state updates.
  * Added an example demonstrating labels, descriptions, required validation, and read-only values.

* **Documentation**
  * Added guidance and examples for associating external controls with form fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->