### PR TITLE
fix(number-field): treat non-finite values and bounds as unset

### DIFF
--- a/apps/components/src/app/pages/reusable-components/pagination/pagination.ts
+++ b/apps/components/src/app/pages/reusable-components/pagination/pagination.ts
@@ -176,9 +176,11 @@ export class Pagination implements ControlValueAccessor {
   }
 
   /** Write a new value to the control */
-  writeValue(value: number): void {
+  writeValue(value: number | null): void {
+    // Angular writes null on reset and before the initial value lands; page is always
+    // a number, so fall back to the first page rather than passing null through.
     // writing a value from the model must not re-emit through onChange
-    this.state().setPage(value, { emit: false });
+    this.state().setPage(value ?? 1, { emit: false });
   }
 
   /** Register a callback to be called when the value changes */

--- a/packages/ng-primitives/number-field/src/number-field-input/number-field-input-state.ts
+++ b/packages/ng-primitives/number-field/src/number-field-input/number-field-input-state.ts
@@ -118,8 +118,8 @@ export const [
 
     // Sync input display value when the number field value changes
     // (programmatically, via stepping, or on commit)
-    explicitEffect([() => numberField().value()], ([value]) => {
-      elementRef.nativeElement.value = value !== null ? String(value) : '';
+    explicitEffect([() => numberField().value()], () => {
+      elementRef.nativeElement.value = formatDisplayValue();
     });
 
     listener(elementRef, 'focus', () => {

--- a/packages/ng-primitives/number-field/src/number-field-input/number-field-input-state.ts
+++ b/packages/ng-primitives/number-field/src/number-field-input/number-field-input-state.ts
@@ -167,7 +167,8 @@ export const [
 
       function getLargeStepMultiplier(): number {
         const s = numberField().step();
-        if (!Number.isFinite(s) || s <= 0) return 1;
+        // `step` is normalised to a finite value; guard only against dividing by zero
+        if (s <= 0) return 1;
         return numberField().largeStep() / s;
       }
 

--- a/packages/ng-primitives/number-field/src/number-field-input/number-field-input-state.ts
+++ b/packages/ng-primitives/number-field/src/number-field-input/number-field-input-state.ts
@@ -47,7 +47,7 @@ export const [
     const inputMode = computed(() => {
       const minVal = numberField().min();
       const stepVal = numberField().step();
-      const allowsNegative = !isFinite(minVal) || minVal < 0;
+      const allowsNegative = !Number.isFinite(minVal) || minVal < 0;
       const hasDecimals = stepVal % 1 !== 0;
 
       // Some mobile keyboards can't show both minus sign and decimal point
@@ -65,11 +65,11 @@ export const [
     attrBinding(elementRef, 'spellcheck', 'false');
     attrBinding(elementRef, 'aria-valuemin', () => {
       const min = numberField().min();
-      return isFinite(min) ? min.toString() : null;
+      return Number.isFinite(min) ? min.toString() : null;
     });
     attrBinding(elementRef, 'aria-valuemax', () => {
       const max = numberField().max();
-      return isFinite(max) ? max.toString() : null;
+      return Number.isFinite(max) ? max.toString() : null;
     });
     attrBinding(elementRef, 'aria-valuenow', () => numberField().value()?.toString() ?? null);
     attrBinding(elementRef, 'tabindex', () => tabindex().toString());
@@ -93,7 +93,7 @@ export const [
         numberField().setValue(null);
       } else {
         const parsed = parseFloat(trimmed);
-        if (!isNaN(parsed)) {
+        if (!Number.isNaN(parsed)) {
           numberField().setValue(parsed);
         }
       }
@@ -149,7 +149,7 @@ export const [
       const proposed = current.slice(0, selStart) + event.data + current.slice(selEnd);
 
       const minVal = numberField().min();
-      const allowsNegative = !isFinite(minVal) || minVal < 0;
+      const allowsNegative = !Number.isFinite(minVal) || minVal < 0;
 
       // Build a regex for valid partial number input
       const pattern = allowsNegative ? /^-?(\d+\.?\d*|\.\d*)?$/ : /^(\d+\.?\d*|\.\d*)?$/;
@@ -167,7 +167,7 @@ export const [
 
       function getLargeStepMultiplier(): number {
         const s = numberField().step();
-        if (!isFinite(s) || s <= 0) return 1;
+        if (!Number.isFinite(s) || s <= 0) return 1;
         return numberField().largeStep() / s;
       }
 
@@ -193,14 +193,14 @@ export const [
           elementRef.nativeElement.value = formatDisplayValue();
           break;
         case 'Home':
-          if (isFinite(numberField().min())) {
+          if (Number.isFinite(numberField().min())) {
             event.preventDefault();
             numberField().setValue(numberField().min());
             elementRef.nativeElement.value = formatDisplayValue();
           }
           break;
         case 'End':
-          if (isFinite(numberField().max())) {
+          if (Number.isFinite(numberField().max())) {
             event.preventDefault();
             numberField().setValue(numberField().max());
             elementRef.nativeElement.value = formatDisplayValue();

--- a/packages/ng-primitives/number-field/src/number-field/number-field-state.ts
+++ b/packages/ng-primitives/number-field/src/number-field/number-field-state.ts
@@ -134,9 +134,13 @@ export interface NgpNumberFieldProps {
   readonly onValueChange?: (value: number | null) => void;
 }
 
-/** A `NaN` bound to a numeric option means it was never really set - use the default. */
-function defaultIfNaN(value: number, fallback: number): number {
-  return Number.isNaN(value) ? fallback : value;
+/**
+ * A non-finite value bound to a numeric option means it was never really set - use the
+ * default. Each bound's default carries the sign that leaves it unbounded, so this is a
+ * no-op for `min = -Infinity` / `max = Infinity` and only corrects an inverted bound.
+ */
+function defaultIfNonFinite(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
 }
 
 export const [
@@ -177,11 +181,13 @@ export const [
       const current = storedValue();
       return current !== null && !Number.isFinite(current) ? null : current;
     });
-    // A `NaN` here would poison `clampAndStep` and the stepper guards.
-    const min = computed(() => defaultIfNaN(_min(), -Infinity));
-    const max = computed(() => defaultIfNaN(_max(), Infinity));
-    const step = computed(() => defaultIfNaN(_step(), 1));
-    const largeStep = computed(() => defaultIfNaN(_largeStep(), 10));
+    // A non-finite bound here would poison `clampAndStep` and the stepper guards, and
+    // `clampAndStep` runs past `setValue`'s guard - so a finite value could still be
+    // stored and emitted as an infinity.
+    const min = computed(() => defaultIfNonFinite(_min(), -Infinity));
+    const max = computed(() => defaultIfNonFinite(_max(), Infinity));
+    const step = computed(() => defaultIfNonFinite(_step(), 1));
+    const largeStep = computed(() => defaultIfNonFinite(_largeStep(), 10));
     const disabled = controlled(_disabled);
     const readonly = controlled(_readonly);
 
@@ -243,6 +249,9 @@ export const [
       if (disabled() || readonly()) return;
       if (newValue !== null && !Number.isFinite(newValue)) return;
       const finalValue = newValue !== null ? clampAndStep(newValue) : null;
+      // Guard the result too, not just the argument: the invariant is established
+      // here, so it must not rest on an audit of `clampAndStep`'s arithmetic.
+      if (finalValue !== null && !Number.isFinite(finalValue)) return;
       // Skip emit when value is unchanged. Compared against the stored value rather
       // than the normalised one so a parent holding a non-finite value is still
       // notified when a commit resolves it to `null`.

--- a/packages/ng-primitives/number-field/src/number-field/number-field-state.ts
+++ b/packages/ng-primitives/number-field/src/number-field/number-field-state.ts
@@ -226,8 +226,9 @@ export const [
 
     function clampAndStep(val: number): number {
       const clamped = Math.min(max(), Math.max(min(), val));
-      // Round to nearest step
-      if (Number.isFinite(step()) && step() > 0) {
+      // Round to nearest step. `step` is normalised to a finite value, so only its
+      // sign matters here.
+      if (step() > 0) {
         const base = Number.isFinite(min()) ? min() : 0;
         const precision = Math.max(getDecimalPlaces(step()), getDecimalPlaces(base));
         const stepped = roundToPrecision(

--- a/packages/ng-primitives/number-field/src/number-field/number-field-state.ts
+++ b/packages/ng-primitives/number-field/src/number-field/number-field-state.ts
@@ -134,6 +134,11 @@ export interface NgpNumberFieldProps {
   readonly onValueChange?: (value: number | null) => void;
 }
 
+/** A `NaN` bound to a numeric option means it was never really set - use the default. */
+function defaultIfNaN(value: number, fallback: number): number {
+  return Number.isNaN(value) ? fallback : value;
+}
+
 export const [
   NgpNumberFieldStateToken,
   ngpNumberField,
@@ -145,9 +150,9 @@ export const [
     id = signal(uniqueId('ngp-number-field')),
     value: _value = signal<number | null | undefined>(undefined),
     defaultValue: _defaultValue,
-    min = signal(-Infinity),
-    max = signal(Infinity),
-    step = signal(1),
+    min: _min = signal(-Infinity),
+    max: _max = signal(Infinity),
+    step: _step = signal(1),
     largeStep: _largeStep = signal(10),
     disabled: _disabled = signal(false),
     readonly: _readonly = signal(false),
@@ -160,10 +165,23 @@ export const [
     // emitter rather than controlledState's change observable, and always call
     // its setter with `emit: false`.
     const defaultValue = controlled(_defaultValue, null);
-    const [value, setValueInternal] = controlledState<number | null>({
+    const [storedValue, setValueInternal] = controlledState<number | null>({
       value: _value,
       defaultValue,
     });
+    // A non-finite binding (`Number(someOptionalField)` is `NaN`) never passes through
+    // `setValue`'s guard. Normalise after resolution so the `value` and `defaultValue`
+    // bindings and `setDefaultValue` are all covered, and `controlledState` keeps its
+    // `undefined` sentinel - an absent binding must still mean uncontrolled.
+    const value = computed(() => {
+      const current = storedValue();
+      return current !== null && !Number.isFinite(current) ? null : current;
+    });
+    // A `NaN` here would poison `clampAndStep` and the stepper guards.
+    const min = computed(() => defaultIfNaN(_min(), -Infinity));
+    const max = computed(() => defaultIfNaN(_max(), Infinity));
+    const step = computed(() => defaultIfNaN(_step(), 1));
+    const largeStep = computed(() => defaultIfNaN(_largeStep(), 10));
     const disabled = controlled(_disabled);
     const readonly = controlled(_readonly);
 
@@ -223,10 +241,12 @@ export const [
 
     function setValue(newValue: number | null): void {
       if (disabled() || readonly()) return;
-      if (newValue !== null && isNaN(newValue)) return;
+      if (newValue !== null && !Number.isFinite(newValue)) return;
       const finalValue = newValue !== null ? clampAndStep(newValue) : null;
-      // Skip emit when value is unchanged
-      if (finalValue === value()) return;
+      // Skip emit when value is unchanged. Compared against the stored value rather
+      // than the normalised one so a parent holding a non-finite value is still
+      // notified when a commit resolves it to `null`.
+      if (finalValue === storedValue()) return;
       // `emit: false` keeps controlledState from firing its own change; we emit
       // manually below to preserve the number field's emit choreography.
       setValueInternal(finalValue, { emit: false });
@@ -310,7 +330,7 @@ export const [
       min,
       max,
       step,
-      largeStep: _largeStep,
+      largeStep,
       disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
       readonly: deprecatedSetter(readonly, 'setReadonly', setReadonly),
       canIncrement,

--- a/packages/ng-primitives/number-field/src/number-field/number-field-state.ts
+++ b/packages/ng-primitives/number-field/src/number-field/number-field-state.ts
@@ -21,7 +21,7 @@ export interface NgpNumberFieldState {
    */
   readonly id: Signal<string>;
   /**
-   * The current value.
+   * The current value. Always finite or `null`.
    */
   readonly value: WritableSignal<number | null>;
   /**
@@ -61,11 +61,13 @@ export interface NgpNumberFieldState {
    */
   readonly valueChange: Observable<number | null>;
   /**
-   * Set the current value (clamped and stepped).
+   * Set the current value (clamped and stepped). A non-finite value is rejected rather
+   * than treated as empty - this is a transition, and `null` already means empty.
    */
   setValue(value: number | null): void;
   /**
-   * Set the default value used in uncontrolled mode.
+   * Set the default value used in uncontrolled mode. Like the binding it mirrors, a
+   * non-finite value is treated as empty.
    */
   setDefaultValue(value: number | null): void;
   /**
@@ -98,26 +100,27 @@ export interface NgpNumberFieldProps {
   readonly id?: Signal<string>;
   /**
    * The current value. When defined the number field is controlled.
+   * A non-finite value (`NaN`, `±Infinity`) is treated as empty.
    */
   readonly value?: Signal<number | null | undefined>;
   /**
-   * The default value for uncontrolled usage.
+   * The default value for uncontrolled usage. A non-finite value (`NaN`, `±Infinity`) is treated as empty.
    */
   readonly defaultValue?: Signal<number | null>;
   /**
-   * The minimum value.
+   * The minimum value. A non-finite value (`NaN`, `±Infinity`) is treated as unset.
    */
   readonly min?: Signal<number>;
   /**
-   * The maximum value.
+   * The maximum value. A non-finite value (`NaN`, `±Infinity`) is treated as unset.
    */
   readonly max?: Signal<number>;
   /**
-   * The step value.
+   * The step value. A non-finite value (`NaN`, `±Infinity`) falls back to `1`.
    */
   readonly step?: Signal<number>;
   /**
-   * The large step value (used with Shift key).
+   * The large step value (used with Shift key). A non-finite value (`NaN`, `±Infinity`) falls back to `10`.
    */
   readonly largeStep?: Signal<number>;
   /**
@@ -134,11 +137,7 @@ export interface NgpNumberFieldProps {
   readonly onValueChange?: (value: number | null) => void;
 }
 
-/**
- * A non-finite value bound to a numeric option means it was never really set - use the
- * default. Each bound's default carries the sign that leaves it unbounded, so this is a
- * no-op for `min = -Infinity` / `max = Infinity` and only corrects an inverted bound.
- */
+/** A non-finite value bound to a numeric option means it was never really set. */
 function defaultIfNonFinite(value: number, fallback: number): number {
   return Number.isFinite(value) ? value : fallback;
 }
@@ -173,17 +172,14 @@ export const [
       value: _value,
       defaultValue,
     });
-    // A non-finite binding (`Number(someOptionalField)` is `NaN`) never passes through
-    // `setValue`'s guard. Normalise after resolution so the `value` and `defaultValue`
-    // bindings and `setDefaultValue` are all covered, and `controlledState` keeps its
+    // Normalised after resolution, not on the way in, so `controlledState` keeps its
     // `undefined` sentinel - an absent binding must still mean uncontrolled.
     const value = computed(() => {
       const current = storedValue();
       return current !== null && !Number.isFinite(current) ? null : current;
     });
-    // A non-finite bound here would poison `clampAndStep` and the stepper guards, and
-    // `clampAndStep` runs past `setValue`'s guard - so a finite value could still be
-    // stored and emitted as an infinity.
+    // `clampAndStep` runs past `setValue`'s guard, so a non-finite bound would turn a
+    // finite value into an infinity and store it.
     const min = computed(() => defaultIfNonFinite(_min(), -Infinity));
     const max = computed(() => defaultIfNonFinite(_max(), Infinity));
     const step = computed(() => defaultIfNonFinite(_step(), 1));
@@ -231,8 +227,8 @@ export const [
     function clampAndStep(val: number): number {
       const clamped = Math.min(max(), Math.max(min(), val));
       // Round to nearest step
-      if (isFinite(step()) && step() > 0) {
-        const base = isFinite(min()) ? min() : 0;
+      if (Number.isFinite(step()) && step() > 0) {
+        const base = Number.isFinite(min()) ? min() : 0;
         const precision = Math.max(getDecimalPlaces(step()), getDecimalPlaces(base));
         const stepped = roundToPrecision(
           Math.round((clamped - base) / step()) * step() + base,
@@ -249,12 +245,11 @@ export const [
       if (disabled() || readonly()) return;
       if (newValue !== null && !Number.isFinite(newValue)) return;
       const finalValue = newValue !== null ? clampAndStep(newValue) : null;
-      // Guard the result too, not just the argument: the invariant is established
-      // here, so it must not rest on an audit of `clampAndStep`'s arithmetic.
+      // `clamped - base` overflows once the span exceeds Number.MAX_VALUE, so finite
+      // arguments can still produce a non-finite result.
       if (finalValue !== null && !Number.isFinite(finalValue)) return;
-      // Skip emit when value is unchanged. Compared against the stored value rather
-      // than the normalised one so a parent holding a non-finite value is still
-      // notified when a commit resolves it to `null`.
+      // Compared against the stored value, not the normalised one, so a parent holding
+      // a non-finite value is still notified when a commit resolves it to `null`.
       if (finalValue === storedValue()) return;
       // `emit: false` keeps controlledState from firing its own change; we emit
       // manually below to preserve the number field's emit choreography.
@@ -287,7 +282,7 @@ export const [
     }
 
     function getStepPrecision(): number {
-      const base = isFinite(min()) ? min() : 0;
+      const base = Number.isFinite(min()) ? min() : 0;
       return Math.max(getDecimalPlaces(step()), getDecimalPlaces(base));
     }
 
@@ -296,7 +291,7 @@ export const [
       const valueBefore = value();
       commitPendingInputSilently();
       const valueAfterCommit = value();
-      const current = valueAfterCommit ?? (isFinite(min()) ? min() : 0);
+      const current = valueAfterCommit ?? (Number.isFinite(min()) ? min() : 0);
       const precision = getStepPrecision();
       setValue(roundToPrecision(current + step() * multiplier, precision));
       // If the silent commit changed the value but setValue was a no-op
@@ -313,7 +308,7 @@ export const [
       const valueBefore = value();
       commitPendingInputSilently();
       const valueAfterCommit = value();
-      const current = valueAfterCommit ?? (isFinite(max()) ? max() : 0);
+      const current = valueAfterCommit ?? (Number.isFinite(max()) ? max() : 0);
       const precision = getStepPrecision();
       setValue(roundToPrecision(current - step() * multiplier, precision));
       // If the silent commit changed the value but setValue was a no-op

--- a/packages/ng-primitives/number-field/src/number-field/number-field.ts
+++ b/packages/ng-primitives/number-field/src/number-field/number-field.ts
@@ -30,6 +30,7 @@ export class NgpNumberField {
 
   /**
    * The default value of the number field for uncontrolled usage.
+   * A non-finite value (`NaN`, `±Infinity`) is treated as empty.
    * @default null
    */
   readonly defaultValue = input<number | null, NumberInput>(null, {
@@ -46,7 +47,8 @@ export class NgpNumberField {
   });
 
   /**
-   * The minimum value.
+   * The minimum value. A non-finite value (`NaN`, `±Infinity`) is treated as unset,
+   * leaving the field unbounded below.
    */
   readonly min = input<number, NumberInput>(-Infinity, {
     alias: 'ngpNumberFieldMin',
@@ -54,7 +56,8 @@ export class NgpNumberField {
   });
 
   /**
-   * The maximum value.
+   * The maximum value. A non-finite value (`NaN`, `±Infinity`) is treated as unset,
+   * leaving the field unbounded above.
    */
   readonly max = input<number, NumberInput>(Infinity, {
     alias: 'ngpNumberFieldMax',
@@ -62,7 +65,7 @@ export class NgpNumberField {
   });
 
   /**
-   * The step value.
+   * The step value. A non-finite value (`NaN`, `±Infinity`) falls back to `1`.
    */
   readonly step = input<number, NumberInput>(1, {
     alias: 'ngpNumberFieldStep',
@@ -70,7 +73,7 @@ export class NgpNumberField {
   });
 
   /**
-   * The large step value (used with Shift key).
+   * The large step value (used with Shift key). A non-finite value (`NaN`, `±Infinity`) falls back to `10`.
    */
   readonly largeStep = input<number, NumberInput>(10, {
     alias: 'ngpNumberFieldLargeStep',
@@ -110,7 +113,8 @@ export class NgpNumberField {
   });
 
   /**
-   * Set the value of the number field.
+   * Set the value of the number field. A non-finite value (`NaN`, `±Infinity`) is
+   * rejected - pass `null` to clear the field.
    */
   setValue(value: number | null): void {
     this.state.setValue(value);

--- a/packages/ng-primitives/number-field/src/number-field/number-field.ts
+++ b/packages/ng-primitives/number-field/src/number-field/number-field.ts
@@ -20,6 +20,7 @@ export class NgpNumberField {
 
   /**
    * The value of the number field. When defined the number field is controlled.
+   * A non-finite value (`NaN`, `±Infinity`) is treated as empty.
    */
   readonly value = input<number | null | undefined, NumberInput>(undefined, {
     alias: 'ngpNumberFieldValue',

--- a/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
+++ b/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
@@ -1112,9 +1112,6 @@ describe('NgpNumberField', () => {
     });
   });
 
-  // The `beforeinput` filter backs the documented "invalid characters are rejected as
-  // you type" behaviour, and its negative-sign rule reads `min` - the one place the
-  // bound normalisation feeds something other than the value/stepper paths.
   describe('increment after an uncommitted edit', () => {
     // increment/decrement silently commit the typed text first. When the stepped result
     // then clamps back to that committed value, setValue is a no-op and would emit
@@ -1138,6 +1135,9 @@ describe('NgpNumberField', () => {
     });
   });
 
+  // The `beforeinput` filter backs the documented "invalid characters are rejected as
+  // you type" behaviour, and its negative-sign rule reads `min` - the one place the
+  // bound normalisation feeds something other than the value/stepper paths.
   describe('input character filtering', () => {
     it('should accept digits and a single decimal point', async () => {
       await renderNumberField();

--- a/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
+++ b/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NgpNumberFieldDecrement } from '../../number-field-decrement/number-field-decrement';
 import { NgpNumberFieldIncrement } from '../../number-field-increment/number-field-increment';
 import { NgpNumberFieldInput } from '../../number-field-input/number-field-input';
+import { NgpNumberFieldInputStateToken } from '../../number-field-input/number-field-input-state';
 import { NgpNumberField } from '../number-field';
 import { NgpNumberFieldStateToken } from '../number-field-state';
 
@@ -626,6 +627,19 @@ describe('NgpNumberField', () => {
       expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('5');
     });
 
+    it('should not move the value when the step is zero', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField(
+        '[ngpNumberFieldDefaultValue]="5" [ngpNumberFieldStep]="0"',
+        valueChange,
+      );
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
+      await fixture.whenStable();
+
+      expect(valueChange).not.toHaveBeenCalled();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('5');
+    });
+
     it('should reject Infinity passed to setValue', async () => {
       const valueChange = vi.fn();
       const { fixture } = await renderNumberField('[ngpNumberFieldValue]="5"', valueChange);
@@ -1101,6 +1115,29 @@ describe('NgpNumberField', () => {
   // The `beforeinput` filter backs the documented "invalid characters are rejected as
   // you type" behaviour, and its negative-sign rule reads `min` - the one place the
   // bound normalisation feeds something other than the value/stepper paths.
+  describe('increment after an uncommitted edit', () => {
+    // increment/decrement silently commit the typed text first. When the stepped result
+    // then clamps back to that committed value, setValue is a no-op and would emit
+    // nothing - so the parent would never learn about the text the user typed.
+    it('should emit the committed value when the step clamps back to it', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField(
+        '[ngpNumberFieldDefaultValue]="5" [ngpNumberFieldMax]="10"',
+        valueChange,
+      );
+      const input = screen.getByTestId('input') as HTMLInputElement;
+
+      input.focus();
+      input.value = '10';
+      fireEvent.pointerDown(screen.getByTestId('increment'));
+      await fixture.whenStable();
+
+      expect(valueChange).toHaveBeenCalledTimes(1);
+      expect(valueChange).toHaveBeenCalledWith(10);
+      expect(input.value).toBe('10');
+    });
+  });
+
   describe('input character filtering', () => {
     it('should accept digits and a single decimal point', async () => {
       await renderNumberField();
@@ -1137,11 +1174,45 @@ describe('NgpNumberField', () => {
       expect(input.value).toBe('5');
     });
 
+    it('should not filter deletions', async () => {
+      await renderNumberField();
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      await userEvent.type(input, '12{backspace}');
+      expect(input.value).toBe('1');
+    });
+
+    it('should not filter while readonly', async () => {
+      // The field rejects the edit itself; the filter must not also claim the event
+      await renderNumberField('[ngpNumberFieldReadonly]="true"');
+      const notPrevented = screen.getByTestId('input').dispatchEvent(
+        new InputEvent('beforeinput', {
+          inputType: 'insertText',
+          data: 'a',
+          cancelable: true,
+          bubbles: true,
+        }),
+      );
+      expect(notPrevented).toBe(true);
+    });
+
     it('should still allow a minus when the min binding is NaN', async () => {
       await renderNumberField('[ngpNumberFieldMin]="min"', vi.fn(), { min: NaN });
       const input = screen.getByTestId('input') as HTMLInputElement;
       await userEvent.type(input, '-5');
       expect(input.value).toBe('-5');
+    });
+  });
+
+  describe('input state focus()', () => {
+    it('should focus the input element', async () => {
+      const { fixture } = await renderNumberField();
+      const input = screen.getByTestId('input');
+      const state = fixture.debugElement
+        .query((de: { nativeElement: HTMLElement }) => de.nativeElement === input)
+        .injector.get(NgpNumberFieldInputStateToken)();
+
+      state.focus();
+      expect(document.activeElement).toBe(input);
     });
   });
 
@@ -1201,6 +1272,63 @@ describe('NgpNumberField', () => {
   });
 
   describe('mouse wheel', () => {
+    // `allowWheelScrub` is an input-level directive input, so it must be bound on the
+    // input element, not the number-field root.
+    function renderWheelField(inputProps = 'ngpNumberFieldInputAllowWheelScrub') {
+      const valueChange = vi.fn();
+      return render(
+        `
+          <div
+            ngpNumberField
+            data-testid="number-field"
+            [ngpNumberFieldDefaultValue]="5"
+            (ngpNumberFieldValueChange)="valueChange($event)">
+            <button ngpNumberFieldDecrement data-testid="decrement">-</button>
+            <input ngpNumberFieldInput data-testid="input" ${inputProps} />
+            <button ngpNumberFieldIncrement data-testid="increment">+</button>
+          </div>
+        `,
+        { imports, componentProperties: { valueChange } },
+      ).then(result => ({ ...result, valueChange }));
+    }
+
+    it('should increment when scrolling up over the focused input', async () => {
+      const { fixture, valueChange } = await renderWheelField();
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      input.focus();
+      fireEvent.wheel(input, { deltaY: -1 });
+      await fixture.whenStable();
+
+      expect(valueChange).toHaveBeenCalledWith(6);
+      expect(input.value).toBe('6');
+    });
+
+    it('should decrement when scrolling down over the focused input', async () => {
+      const { fixture, valueChange } = await renderWheelField();
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      input.focus();
+      fireEvent.wheel(input, { deltaY: 1 });
+      await fixture.whenStable();
+
+      expect(valueChange).toHaveBeenCalledWith(4);
+      expect(input.value).toBe('4');
+    });
+
+    it('should ignore the wheel when the input is not focused', async () => {
+      // Scrubbing an unfocused field would hijack page scrolling
+      const { valueChange } = await renderWheelField();
+      fireEvent.wheel(screen.getByTestId('input'), { deltaY: -1 });
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+
+    it('should ignore the wheel when allowWheelScrub is not set', async () => {
+      const { valueChange } = await renderWheelField('');
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      input.focus();
+      fireEvent.wheel(input, { deltaY: -1 });
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+
     it('should not change the value on Ctrl+wheel (browser zoom)', async () => {
       const valueChange = vi.fn();
       // `allowWheelScrub` is an input-level directive input, so it must be bound

--- a/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
+++ b/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
@@ -27,10 +27,10 @@ describe('NgpNumberField', () => {
     `;
   }
 
-  function renderNumberField(extraProps = '', valueChange = vi.fn()) {
+  function renderNumberField(extraProps = '', valueChange = vi.fn(), componentProperties = {}) {
     return render(createTemplate(extraProps), {
       imports,
-      componentProperties: { valueChange },
+      componentProperties: { valueChange, ...componentProperties },
     });
   }
 
@@ -171,6 +171,178 @@ describe('NgpNumberField', () => {
     });
   });
 
+  describe('non-finite bindings', () => {
+    it('should render an empty input when the value binding is NaN', async () => {
+      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="value"', vi.fn(), {
+        value: Number(undefined),
+      });
+      await fixture.whenStable();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('');
+      expect(screen.getByTestId('input')).not.toHaveAttribute('aria-valuenow');
+    });
+
+    it('should keep both steppers enabled when the value binding is NaN', async () => {
+      await renderNumberField(
+        '[ngpNumberFieldValue]="value" [ngpNumberFieldMin]="0" [ngpNumberFieldMax]="100"',
+        vi.fn(),
+        { value: Number(undefined) },
+      );
+      for (const testId of ['increment', 'decrement']) {
+        expect(screen.getByTestId(testId)).not.toHaveAttribute('disabled');
+        expect(screen.getByTestId(testId)).not.toHaveAttribute('data-disabled');
+      }
+    });
+
+    it('should increment from min when the value binding is NaN', async () => {
+      const valueChange = vi.fn();
+      await renderNumberField(
+        '[ngpNumberFieldValue]="value" [ngpNumberFieldMin]="0" [ngpNumberFieldMax]="100"',
+        valueChange,
+        { value: NaN },
+      );
+      fireEvent.pointerDown(screen.getByTestId('increment'));
+      expect(valueChange).toHaveBeenCalledWith(1);
+    });
+
+    it('should decrement from max when the value binding is NaN', async () => {
+      const valueChange = vi.fn();
+      await renderNumberField(
+        '[ngpNumberFieldValue]="value" [ngpNumberFieldMax]="10"',
+        valueChange,
+        { value: NaN },
+      );
+      fireEvent.pointerDown(screen.getByTestId('decrement'));
+      expect(valueChange).toHaveBeenCalledWith(9);
+    });
+
+    it('should render an empty input when the value binding is Infinity', async () => {
+      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="value"', vi.fn(), {
+        value: Number.POSITIVE_INFINITY,
+      });
+      await fixture.whenStable();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('');
+    });
+
+    it('should render an empty input when the value binding is a non-numeric string', async () => {
+      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="value"', vi.fn(), {
+        value: 'abc',
+      });
+      await fixture.whenStable();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('');
+    });
+
+    it('should recover through a two-way binding when the value starts as NaN', async () => {
+      const { fixture } = await render(
+        `<div ngpNumberField [(ngpNumberFieldValue)]="value" data-testid="number-field">
+          <button ngpNumberFieldDecrement data-testid="decrement">-</button>
+          <input ngpNumberFieldInput data-testid="input" />
+          <button ngpNumberFieldIncrement data-testid="increment">+</button>
+        </div>`,
+        { imports, componentProperties: { value: Number(undefined) } },
+      );
+
+      fireEvent.pointerDown(screen.getByTestId('increment'));
+      await fixture.whenStable();
+
+      expect(fixture.componentInstance.value).toBe(1);
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('1');
+    });
+
+    it('should render an empty input when the default value is NaN', async () => {
+      const { fixture } = await renderNumberField('[ngpNumberFieldDefaultValue]="value"', vi.fn(), {
+        value: NaN,
+      });
+      await fixture.whenStable();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('');
+    });
+
+    it('should let interaction seed the value when the default value is NaN', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField(
+        '[ngpNumberFieldDefaultValue]="value"',
+        valueChange,
+        { value: NaN },
+      );
+      fireEvent.pointerDown(screen.getByTestId('increment'));
+      await fixture.whenStable();
+
+      expect(valueChange).toHaveBeenCalledWith(1);
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('1');
+    });
+
+    it('should stay uncontrolled when the value binding evaluates to undefined', async () => {
+      const { fixture } = await renderNumberField(
+        '[ngpNumberFieldValue]="value" [ngpNumberFieldDefaultValue]="7"',
+        vi.fn(),
+        { value: undefined },
+      );
+      fireEvent.pointerDown(screen.getByTestId('increment'));
+      await fixture.whenStable();
+
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('8');
+      expect(screen.getByTestId('input')).toHaveAttribute('aria-valuenow', '8');
+    });
+
+    it('should treat a null value binding as controlled and empty', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="value"', valueChange, {
+        value: null,
+      });
+      fireEvent.pointerDown(screen.getByTestId('increment'));
+      await fixture.whenStable();
+
+      // controlled, so the parent is notified but the DOM must not move on its own
+      expect(valueChange).toHaveBeenCalledWith(1);
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('');
+    });
+
+    it('should treat a NaN min as unbounded', async () => {
+      const valueChange = vi.fn();
+      await renderNumberField('[ngpNumberFieldValue]="5" [ngpNumberFieldMin]="min"', valueChange, {
+        min: Number(undefined),
+      });
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
+
+      expect(valueChange).toHaveBeenCalledWith(6);
+      expect(valueChange).not.toHaveBeenCalledWith(NaN);
+      expect(screen.getByTestId('input')).not.toHaveAttribute('aria-valuemin');
+    });
+
+    it('should treat a NaN max as unbounded', async () => {
+      const valueChange = vi.fn();
+      await renderNumberField('[ngpNumberFieldValue]="5" [ngpNumberFieldMax]="max"', valueChange, {
+        max: Number(undefined),
+      });
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
+
+      expect(valueChange).toHaveBeenCalledWith(6);
+      expect(valueChange).not.toHaveBeenCalledWith(NaN);
+      expect(screen.getByTestId('input')).not.toHaveAttribute('aria-valuemax');
+    });
+
+    it('should fall back to a step of 1 when the step binding is NaN', async () => {
+      const valueChange = vi.fn();
+      await renderNumberField(
+        '[ngpNumberFieldValue]="5" [ngpNumberFieldStep]="step"',
+        valueChange,
+        { step: NaN },
+      );
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
+      expect(valueChange).toHaveBeenCalledWith(6);
+    });
+
+    it('should fall back to a large step of 10 when the large step binding is NaN', async () => {
+      const valueChange = vi.fn();
+      await renderNumberField(
+        '[ngpNumberFieldValue]="5" [ngpNumberFieldLargeStep]="largeStep"',
+        valueChange,
+        { largeStep: NaN },
+      );
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp', shiftKey: true });
+      expect(valueChange).toHaveBeenCalledWith(15);
+    });
+  });
+
   describe('value / min / max / step', () => {
     it('should display the initial value', async () => {
       const { fixture } = await renderNumberField('[ngpNumberFieldValue]="5"');
@@ -231,6 +403,18 @@ describe('NgpNumberField', () => {
 
       const numberField = fixture.debugElement.children[0].injector.get(NgpNumberField);
       numberField.setValue(NaN);
+
+      expect(valueChange).not.toHaveBeenCalled();
+      await fixture.whenStable();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('5');
+    });
+
+    it('should reject Infinity passed to setValue', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="5"', valueChange);
+
+      const numberField = fixture.debugElement.children[0].injector.get(NgpNumberField);
+      numberField.setValue(Infinity);
 
       expect(valueChange).not.toHaveBeenCalled();
       await fixture.whenStable();

--- a/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
+++ b/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NgpNumberFieldDecrement } from '../../number-field-decrement/number-field-decrement';
 import { NgpNumberFieldIncrement } from '../../number-field-increment/number-field-increment';
@@ -1094,6 +1095,53 @@ describe('NgpNumberField', () => {
 
       expect(valueChange).toHaveBeenCalledWith(42);
       expect(input.value).toBe('42');
+    });
+  });
+
+  // The `beforeinput` filter backs the documented "invalid characters are rejected as
+  // you type" behaviour, and its negative-sign rule reads `min` - the one place the
+  // bound normalisation feeds something other than the value/stepper paths.
+  describe('input character filtering', () => {
+    it('should accept digits and a single decimal point', async () => {
+      await renderNumberField();
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      await userEvent.type(input, '12.5');
+      expect(input.value).toBe('12.5');
+    });
+
+    it('should reject letters', async () => {
+      await renderNumberField();
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      await userEvent.type(input, '1a2b');
+      expect(input.value).toBe('12');
+    });
+
+    it('should reject a second decimal point', async () => {
+      await renderNumberField();
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      await userEvent.type(input, '1.2.3');
+      expect(input.value).toBe('1.23');
+    });
+
+    it('should allow a leading minus when the field is unbounded below', async () => {
+      await renderNumberField();
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      await userEvent.type(input, '-5');
+      expect(input.value).toBe('-5');
+    });
+
+    it('should reject a minus when min is zero', async () => {
+      await renderNumberField('[ngpNumberFieldMin]="0"');
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      await userEvent.type(input, '-5');
+      expect(input.value).toBe('5');
+    });
+
+    it('should still allow a minus when the min binding is NaN', async () => {
+      await renderNumberField('[ngpNumberFieldMin]="min"', vi.fn(), { min: NaN });
+      const input = screen.getByTestId('input') as HTMLInputElement;
+      await userEvent.type(input, '-5');
+      expect(input.value).toBe('-5');
     });
   });
 

--- a/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
+++ b/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
@@ -341,6 +341,67 @@ describe('NgpNumberField', () => {
       fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp', shiftKey: true });
       expect(valueChange).toHaveBeenCalledWith(15);
     });
+
+    // An inverted infinite bound is the dangerous case: it is not rejected by the
+    // entry guard (the argument is finite) but `clampAndStep` turns it into an
+    // infinity, so the value would be stored and emitted while the display shows
+    // empty. The bound's own default has the opposite sign, so falling back to it
+    // is a no-op for `min = -Infinity` / `max = Infinity`.
+    // Uncontrolled so the stored value is observable through the DOM: before the bound
+    // was normalised this stored and emitted `Infinity` while the input showed empty.
+    it('should treat a +Infinity min as unset', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField(
+        '[ngpNumberFieldDefaultValue]="5" [ngpNumberFieldMin]="min"',
+        valueChange,
+        { min: Number.POSITIVE_INFINITY },
+      );
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
+      await fixture.whenStable();
+
+      expect(valueChange).toHaveBeenCalledWith(6);
+      expect(valueChange).not.toHaveBeenCalledWith(Infinity);
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('6');
+      expect(screen.getByTestId('input')).not.toHaveAttribute('aria-valuemin');
+    });
+
+    it('should treat a -Infinity max as unset', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField(
+        '[ngpNumberFieldDefaultValue]="5" [ngpNumberFieldMax]="max"',
+        valueChange,
+        { max: Number.NEGATIVE_INFINITY },
+      );
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
+      await fixture.whenStable();
+
+      expect(valueChange).toHaveBeenCalledWith(6);
+      expect(valueChange).not.toHaveBeenCalledWith(-Infinity);
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('6');
+      expect(screen.getByTestId('input')).not.toHaveAttribute('aria-valuemax');
+    });
+
+    it('should keep an unbounded min and max working', async () => {
+      const valueChange = vi.fn();
+      await renderNumberField(
+        '[ngpNumberFieldValue]="5" [ngpNumberFieldMin]="min" [ngpNumberFieldMax]="max"',
+        valueChange,
+        { min: Number.NEGATIVE_INFINITY, max: Number.POSITIVE_INFINITY },
+      );
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
+      expect(valueChange).toHaveBeenCalledWith(6);
+    });
+
+    it('should fall back to a step of 1 when the step binding is Infinity', async () => {
+      const valueChange = vi.fn();
+      await renderNumberField(
+        '[ngpNumberFieldValue]="5" [ngpNumberFieldStep]="step"',
+        valueChange,
+        { step: Number.POSITIVE_INFINITY },
+      );
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
+      expect(valueChange).toHaveBeenCalledWith(6);
+    });
   });
 
   describe('value / min / max / step', () => {

--- a/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
+++ b/packages/ng-primitives/number-field/src/number-field/tests/number-field-primitive.test.ts
@@ -4,6 +4,7 @@ import { NgpNumberFieldDecrement } from '../../number-field-decrement/number-fie
 import { NgpNumberFieldIncrement } from '../../number-field-increment/number-field-increment';
 import { NgpNumberFieldInput } from '../../number-field-input/number-field-input';
 import { NgpNumberField } from '../number-field';
+import { NgpNumberFieldStateToken } from '../number-field-state';
 
 describe('NgpNumberField', () => {
   const imports = [
@@ -342,13 +343,8 @@ describe('NgpNumberField', () => {
       expect(valueChange).toHaveBeenCalledWith(15);
     });
 
-    // An inverted infinite bound is the dangerous case: it is not rejected by the
-    // entry guard (the argument is finite) but `clampAndStep` turns it into an
-    // infinity, so the value would be stored and emitted while the display shows
-    // empty. The bound's own default has the opposite sign, so falling back to it
-    // is a no-op for `min = -Infinity` / `max = Infinity`.
-    // Uncontrolled so the stored value is observable through the DOM: before the bound
-    // was normalised this stored and emitted `Infinity` while the input showed empty.
+    // The inverted bound slips past the entry guard (the argument is finite) and only
+    // turns non-finite inside `clampAndStep`. Uncontrolled so the DOM shows what was stored.
     it('should treat a +Infinity min as unset', async () => {
       const valueChange = vi.fn();
       const { fixture } = await renderNumberField(
@@ -356,6 +352,10 @@ describe('NgpNumberField', () => {
         valueChange,
         { min: Number.POSITIVE_INFINITY },
       );
+      // `canDecrement` was `5 > Infinity` before the bound was normalised
+      expect(screen.getByTestId('decrement')).not.toHaveAttribute('disabled');
+      expect(screen.getByTestId('decrement')).not.toHaveAttribute('data-disabled');
+
       fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
       await fixture.whenStable();
 
@@ -372,6 +372,10 @@ describe('NgpNumberField', () => {
         valueChange,
         { max: Number.NEGATIVE_INFINITY },
       );
+      // `canIncrement` was `5 < -Infinity` before the bound was normalised
+      expect(screen.getByTestId('increment')).not.toHaveAttribute('disabled');
+      expect(screen.getByTestId('increment')).not.toHaveAttribute('data-disabled');
+
       fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
       await fixture.whenStable();
 
@@ -401,6 +405,157 @@ describe('NgpNumberField', () => {
       );
       fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
       expect(valueChange).toHaveBeenCalledWith(6);
+    });
+
+    // `numberAttribute(undefined)` is NaN, so an optional config value is how a real app
+    // reaches a non-finite bound - not by binding NaN literally, as the tests above do.
+    it('should apply the defaults when the bound options are undefined', async () => {
+      const valueChange = vi.fn();
+      await renderNumberField(
+        '[ngpNumberFieldValue]="5" [ngpNumberFieldMin]="min" [ngpNumberFieldMax]="max" [ngpNumberFieldStep]="step"',
+        valueChange,
+        { min: undefined, max: undefined, step: undefined },
+      );
+      for (const testId of ['increment', 'decrement']) {
+        expect(screen.getByTestId(testId)).not.toHaveAttribute('data-disabled');
+      }
+
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp' });
+      expect(valueChange).toHaveBeenCalledWith(6);
+    });
+
+    it('should keep both steppers enabled when the min and max bindings are NaN', async () => {
+      // `5 > NaN` and `5 < NaN` are both false, so each bound disabled its own stepper
+      await renderNumberField(
+        '[ngpNumberFieldValue]="5" [ngpNumberFieldMin]="min" [ngpNumberFieldMax]="max"',
+        vi.fn(),
+        { min: NaN, max: NaN },
+      );
+      for (const testId of ['increment', 'decrement']) {
+        expect(screen.getByTestId(testId)).not.toHaveAttribute('disabled');
+        expect(screen.getByTestId(testId)).not.toHaveAttribute('data-disabled');
+      }
+    });
+
+    it('should set inputmode from the fallback step when the step binding is NaN', async () => {
+      // `NaN % 1 !== 0` read as "step has decimals" and pushed the mobile keyboard to decimal
+      await renderNumberField('[ngpNumberFieldMin]="0" [ngpNumberFieldStep]="step"', vi.fn(), {
+        step: NaN,
+      });
+      expect(screen.getByTestId('input')).toHaveAttribute('inputmode', 'numeric');
+    });
+
+    // The bindings above all start non-finite. `Number(response.count)` landing on an
+    // already-rendered field is the realistic shape, and it is the path where
+    // controlledState's latch and the normalising computed actually interact.
+    it('should clear and restore the display when the value binding turns NaN after init', async () => {
+      const valueChange = vi.fn();
+      const { fixture, rerender } = await renderNumberField(
+        '[ngpNumberFieldValue]="value"',
+        valueChange,
+        { value: 5 },
+      );
+      await fixture.whenStable();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('5');
+
+      await rerender({ componentProperties: { valueChange, value: NaN } });
+      await fixture.whenStable();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('');
+      expect(screen.getByTestId('input')).not.toHaveAttribute('aria-valuenow');
+      expect(screen.getByTestId('increment')).not.toHaveAttribute('data-disabled');
+
+      await rerender({ componentProperties: { valueChange, value: 5 } });
+      await fixture.whenStable();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('5');
+      expect(screen.getByTestId('input')).toHaveAttribute('aria-valuenow', '5');
+    });
+
+    it('should re-enable decrement when the min binding turns NaN after init', async () => {
+      const { fixture, rerender } = await renderNumberField(
+        '[ngpNumberFieldDefaultValue]="5" [ngpNumberFieldMin]="min"',
+        vi.fn(),
+        { min: 5 },
+      );
+      await fixture.whenStable();
+      expect(screen.getByTestId('decrement')).toHaveAttribute('data-disabled');
+
+      await rerender({ componentProperties: { valueChange: vi.fn(), min: NaN } });
+      await fixture.whenStable();
+      expect(screen.getByTestId('decrement')).not.toHaveAttribute('data-disabled');
+      expect(screen.getByTestId('input')).not.toHaveAttribute('aria-valuemin');
+    });
+
+    it('should not emit when the value binding starts non-finite', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="value"', valueChange, {
+        value: NaN,
+      });
+      await fixture.whenStable();
+      // Normalising to `null` is a read-side rule - it must not write back to the parent
+      expect(valueChange).not.toHaveBeenCalled();
+    });
+
+    it('should commit typed text when the value binding is NaN', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="value"', valueChange, {
+        value: NaN,
+      });
+      const input = screen.getByTestId('input') as HTMLInputElement;
+
+      fireEvent.focus(input);
+      input.value = '42';
+      fireEvent.blur(input);
+      await fixture.whenStable();
+
+      expect(valueChange).toHaveBeenCalledWith(42);
+      // Controlled and bound one-way, so the parent still holds NaN and the display
+      // snaps back to empty - the same round-trip as any unhandled controlled value.
+      expect(input.value).toBe('');
+    });
+
+    it('should fall back to a large step of 10 when the large step binding is Infinity', async () => {
+      const valueChange = vi.fn();
+      await renderNumberField(
+        '[ngpNumberFieldValue]="5" [ngpNumberFieldLargeStep]="largeStep"',
+        valueChange,
+        { largeStep: Number.POSITIVE_INFINITY },
+      );
+      fireEvent.keyDown(screen.getByTestId('input'), { key: 'ArrowUp', shiftKey: true });
+      expect(valueChange).toHaveBeenCalledWith(15);
+    });
+
+    // `clampAndStep` can manufacture an infinity from finite inputs: `clamped - base`
+    // overflows when the span exceeds Number.MAX_VALUE. Dropping the value is the
+    // least-bad outcome - the alternative is emitting Infinity while rendering empty.
+    it('should reject a value whose clamped result overflows to Infinity', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField(
+        '[ngpNumberFieldValue]="5" [ngpNumberFieldMin]="min"',
+        valueChange,
+        { min: -Number.MAX_VALUE },
+      );
+      const numberField = fixture.debugElement.children[0].injector.get(NgpNumberField);
+      numberField.setValue(Number.MAX_VALUE);
+      await fixture.whenStable();
+
+      expect(valueChange).not.toHaveBeenCalled();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('5');
+    });
+
+    it('should treat a NaN passed to setDefaultValue as empty', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField('', valueChange);
+      const state = fixture.debugElement.children[0].injector.get(NgpNumberFieldStateToken)();
+
+      state.setDefaultValue(NaN);
+      await fixture.whenStable();
+
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('');
+      expect(screen.getByTestId('increment')).not.toHaveAttribute('data-disabled');
+
+      fireEvent.pointerDown(screen.getByTestId('increment'));
+      await fixture.whenStable();
+      expect(valueChange).toHaveBeenCalledWith(1);
     });
   });
 
@@ -476,6 +631,18 @@ describe('NgpNumberField', () => {
 
       const numberField = fixture.debugElement.children[0].injector.get(NgpNumberField);
       numberField.setValue(Infinity);
+
+      expect(valueChange).not.toHaveBeenCalled();
+      await fixture.whenStable();
+      expect((screen.getByTestId('input') as HTMLInputElement).value).toBe('5');
+    });
+
+    it('should reject -Infinity passed to setValue', async () => {
+      const valueChange = vi.fn();
+      const { fixture } = await renderNumberField('[ngpNumberFieldValue]="5"', valueChange);
+
+      const numberField = fixture.debugElement.children[0].injector.get(NgpNumberField);
+      numberField.setValue(-Infinity);
 
       expect(valueChange).not.toHaveBeenCalled();
       await fixture.whenStable();

--- a/packages/ng-primitives/pagination/src/pagination/tests/pagination-forms.fixture.ts
+++ b/packages/ng-primitives/pagination/src/pagination/tests/pagination-forms.fixture.ts
@@ -78,9 +78,11 @@ export class Pagination implements ControlValueAccessor {
   }
 
   /** Write a new value to the control */
-  writeValue(value: number): void {
+  writeValue(value: number | null): void {
+    // Angular writes null on reset and before the initial value lands; page is always
+    // a number, so fall back to the first page rather than passing null through.
     // writing a value from the model must not re-emit through onChange
-    this.state().setPage(value, { emit: false });
+    this.state().setPage(value ?? 1, { emit: false });
   }
 
   /** Register a callback to be called when the value changes */

--- a/packages/ng-primitives/pagination/src/pagination/tests/pagination-forms.test.ts
+++ b/packages/ng-primitives/pagination/src/pagination/tests/pagination-forms.test.ts
@@ -55,6 +55,27 @@ describe('Pagination (reusable component) — reactive forms', () => {
     expect(formControl.value).toBe(2);
   });
 
+  it('falls back to the first page when the control is reset to null', async () => {
+    // Angular writes null on reset (and before the initial value on init); the CVA must
+    // not pass it through, or the data-page binding throws inside an afterRenderEffect -
+    // which Angular swallows into a console error rather than failing anything.
+    const formControl = new FormControl<number | null>(3);
+    const { getByRole, fixture } = await render(
+      `<app-pagination [formControl]="formControl" pageCount="5"></app-pagination>`,
+      {
+        imports: [Pagination, ReactiveFormsModule],
+        componentProperties: { formControl },
+      },
+    );
+    await fixture.whenStable();
+    expect(getByRole('navigation')).toHaveAttribute('data-page', '3');
+
+    formControl.reset();
+    await fixture.whenStable();
+
+    expect(getByRole('navigation')).toHaveAttribute('data-page', '1');
+  });
+
   it('updates the form control on click and the DOM on setValue', async () => {
     const formControl = new FormControl(1);
     const { getByRole, fixture } = await render(

--- a/packages/ng-primitives/schematics/ng-generate/templates/pagination/pagination.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/pagination/pagination.__fileSuffix@dasherize__.ts.template
@@ -178,9 +178,11 @@ export class Pagination<%= componentSuffix %> implements ControlValueAccessor {
   }
 
   /** Write a new value to the control */
-  writeValue(value: number): void {
+  writeValue(value: number | null): void {
+    // Angular writes null on reset and before the initial value lands; page is always
+    // a number, so fall back to the first page rather than passing null through.
     // writing a value from the model must not re-emit through onChange
-    this.state().setPage(value, { emit: false });
+    this.state().setPage(value ?? 1, { emit: false });
   }
 
   /** Register a callback to be called when the value changes */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #917

## What does this PR implement/fix?

`setValue` rejects `NaN`, but a `NaN` arriving through the `ngpNumberFieldValue` binding never passed through it — it landed in `controlledState` unchecked. The input rendered the literal text `NaN`, the placeholder was suppressed, and both steppers carried `data-disabled` (`canIncrement` is `NaN < max` = `false`, `canDecrement` is `NaN > min` = `false`), so the field could not be recovered through the UI. `NaN` is a legitimate `number` and turns up naturally from `Number(someOptionalField)`.

While tracing it, two neighbouring holes in the same boundary turned up:

- `clampAndStep` runs `Math.max(min(), val)` **after** `setValue`'s guard, so a `NaN` `min`/`max` binding manufactures a `NaN` from a perfectly valid value and pushes it through both the internal setter **and** `valueChange`. Fixing only the value binding would have made this worse — the input would render empty while the consumer's signal silently received `NaN`.
- The guard was `isNaN`, not `!Number.isFinite`, so `±Infinity` survived `clampAndStep` intact under the default `max = Infinity`.

The fix states one rule at the state boundary: **stored value is always finite or `null`, and a `NaN` bound to a numeric option means unbound.**

### `number-field-state.ts`

- The value resolved by `controlledState` is normalised: non-finite → `null`. Normalising *after* resolution (rather than wrapping the input signal) covers the `value` binding, the `defaultValue` binding and `setDefaultValue` in one place, and structurally cannot disturb `controlledState`'s `undefined` sentinel — `isControlled` is latched before the new `computed` ever runs, so an absent binding still means uncontrolled.
- `min` / `max` / `step` / `largeStep` fall back to their defaults when bound `NaN`, via a small `defaultIfNaN` helper.
- `setValue`'s guard widened from `isNaN` to `!Number.isFinite`. Together with normalised bounds this makes the invariant airtight: `clampAndStep(finite)` is always finite, so no non-finite value can reach state by any path.
- The skip-if-unchanged check compares against the *stored* value rather than the normalised one, so a parent holding a non-finite value is still notified when a commit resolves it to `null`.

All normalisation lives in the state factory rather than the directive's input `transform`, since `ngpNumberField` is public API and can be composed directly — a consumer calling `ngpNumberField({ value: mySignal })` never sees a directive transform.

### `number-field-input-state.ts`

The display-sync effect re-implemented `formatDisplayValue()` inline; it now calls it. No defensive guard was added in the display layer — the invariant belongs to the factory, and a guard here would have covered only one of the four places the input writes its value while masking a regression from the DOM-based tests.

### Behaviour notes for review

- A bound `NaN` renders empty, while `setValue(NaN)` is still silently ignored. A binding declares the field's whole value so it must render *something*, and empty is the only honest rendering of "not a number"; an imperative call is a requested transition, and refusing it preserves the existing guarantee rather than letting one bad `Number(...)` wipe a good value.
- With `NaN` bound one-way, state reads `null` while the parent still holds `NaN`, and nothing is emitted to repair it. This matches existing behaviour — `[ngpNumberFieldValue]="150"` with `max="100"` is likewise not clamped or written back. Any stepper press or commit emits a real number.
- `[ngpNumberFieldStep]="NaN"` changes from "stepping silently no-ops" to "steps by 1". The old behaviour was an accidental fall-through of `isFinite(step())` in `clampAndStep`.
- `NaN` `min`/`max` → `∓Infinity` keeps `aria-valuemin`/`aria-valuemax` absent, which is already what the `isFinite`-guarded bindings do with `NaN` today. Only the value pipeline changes.

### Tests

17 tests added to `number-field-primitive.test.ts` — a new `non-finite bindings` block plus `setValue(Infinity)` alongside the existing `setValue(NaN)` case. 14 of them fail without this change; the three that don't are the two controlled/uncontrolled latching regression guards (which must pass either way) and the `NaN` step case, which already fell back to `1` by accident.

Coverage includes the reported repro end-to-end (a two-way binding starting as `Number(undefined)` recovering to `1` on the first `+`), `Infinity`, a non-numeric string through the input transform, `NaN` `defaultValue`, and explicit guards that an `undefined` binding stays uncontrolled while `null` stays controlled-and-empty.

### Docs

The `value` input's JSDoc gained "A non-finite value (`NaN`, `±Infinity`) is treated as empty", which flows into the generated API table via `<api-reference-props>` — no markdown change needed.

Full suite passes (2649 tests, no type errors); lint and prettier clean.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats non‑finite values and bounds in `ngpNumberField` as unset and keeps pagination CVAs valid on null writes. Previously, a bound `NaN` rendered literally and disabled steppers; inverted infinite bounds could emit `±Infinity`; pagination `writeValue(null)` left an invalid `data-page`.

- Normalizes after `controlledState`: non‑finite `value`/`defaultValue` → `null`; non‑finite `min`/`max` → unset; non‑finite `step`/`largeStep` → `1`/`10`; removes step finiteness guards now made unreachable.
- Enforces a finite‑or‑null invariant: `setValue` rejects non‑finite args and overflowed clamp results; “skip if unchanged” compares against the stored value so normalization still emits meaningful changes.
- Input fixes: shared formatter eliminates “NaN”; Home/End act only with finite bounds; omit `aria-valuemin/max` when unbounded; `inputmode` and the character filter derive from normalized `min`/`step`.
- Pagination: `writeValue(value: number | null)` now coerces `null` to page 1 in the reusable component and generated schematic, avoiding stale `data-page`.
- Notable behavior change: `[ngpNumberFieldStep]="NaN"` steps by `1` instead of no‑op; `setValue(±Infinity)` is ignored; `step="0"` performs no step.

<sup>Written for commit 5225672f38fe3369326b81f6a98559d53d5c37f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number field handling for invalid and non-finite values, including `NaN`, positive and negative infinity, and invalid numeric strings.
  * Invalid values now resolve safely to empty or default values where appropriate.
  * Prevented invalid values and overflow results from being accepted.
  * Pagination now resets to page 1 when a form supplies a null value.
  * Improved display synchronisation when number field values or settings change.

* **Documentation**
  * Clarified handling of non-finite number field values and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->