### PR TITLE
feat(menu): support positioning the menu against a separate anchor element

### DIFF
--- a/apps/documentation/src/app/examples/menu/menu-custom-anchor.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-custom-anchor.example.ts
@@ -1,0 +1,165 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronUpDownMini } from '@ng-icons/heroicons/mini';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from 'ng-primitives/menu';
+
+@Component({
+  selector: 'app-menu-custom-anchor',
+  imports: [NgpButton, NgpMenu, NgpMenuTrigger, NgpMenuItem, NgIcon],
+  providers: [provideIcons({ heroChevronUpDownMini })],
+  template: `
+    <button
+      class="row"
+      [ngpMenuTrigger]="menu"
+      [ngpMenuTriggerAnchor]="chevron"
+      ngpMenuTriggerPlacement="bottom-end"
+      ngpMenuTriggerOffset="12"
+      ngpButton
+    >
+      <span class="row-label">Sort by</span>
+      <span class="row-value">
+        Recently updated
+        <span class="chevron" #chevron>
+          <ng-icon name="heroChevronUpDownMini" size="16" />
+        </span>
+      </span>
+    </button>
+
+    <ng-template #menu>
+      <div ngpMenu>
+        <button ngpMenuItem>Recently updated</button>
+        <button ngpMenuItem>Name</button>
+        <button ngpMenuItem>Date created</button>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    :host {
+      display: contents;
+    }
+
+    .row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      width: 100%;
+      max-width: 20rem;
+      height: 2.125rem;
+      padding: 0 0.625rem;
+      border: none;
+      border-radius: 0.625rem;
+      background-color: var(--ngp-background);
+      box-shadow:
+        inset 0 0 0 1px var(--ngp-border),
+        0 1px 2px 0 rgb(0 0 0 / 0.04);
+      transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+      outline: none;
+    }
+
+    .row[data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    .row[data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    .row[data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 1px;
+    }
+
+    .row-label {
+      font-size: 0.875rem;
+      font-weight: 510;
+      letter-spacing: -0.006em;
+      color: var(--ngp-text-primary);
+    }
+
+    .row-value {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.875rem;
+      letter-spacing: -0.006em;
+      color: var(--ngp-text-secondary);
+    }
+
+    .chevron {
+      display: inline-flex;
+      color: var(--ngp-text-tertiary);
+    }
+
+    [ngpMenu] {
+      position: fixed;
+      display: flex;
+      flex-direction: column;
+      width: max-content;
+      background: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      box-shadow: var(--ngp-shadow-lg);
+      border-radius: 0.625rem;
+      padding: 0.25rem;
+      outline: none;
+      transform-origin: var(--ngp-menu-transform-origin);
+    }
+
+    [ngpMenu][data-enter] {
+      animation: menu-show 0.1s ease-out;
+    }
+
+    [ngpMenu][data-exit] {
+      animation: menu-hide 0.1s ease-out;
+    }
+
+    [ngpMenuItem] {
+      padding: 0.4375rem 0.75rem;
+      border: none;
+      background: none;
+      cursor: pointer;
+      transition: background-color 0.15s ease;
+      border-radius: 0.375rem;
+      min-width: 140px;
+      text-align: start;
+      outline: none;
+      font-size: 0.875rem;
+      font-weight: 510;
+      letter-spacing: -0.006em;
+      color: var(--ngp-text-primary);
+    }
+
+    [ngpMenuItem][data-hover],
+    [ngpMenuItem][data-focus-visible] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpMenuItem][data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    @keyframes menu-show {
+      0% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+      100% {
+        opacity: 1;
+        transform: scale(1);
+      }
+    }
+
+    @keyframes menu-hide {
+      0% {
+        opacity: 1;
+        transform: scale(1);
+      }
+      100% {
+        opacity: 0;
+        transform: scale(0.9);
+      }
+    }
+  `,
+})
+export default class MenuCustomAnchorExample {}

--- a/apps/documentation/src/app/examples/menu/menu-custom-anchor.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-custom-anchor.tailwind.example.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroChevronUpDownMini } from '@ng-icons/heroicons/mini';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from 'ng-primitives/menu';
+
+@Component({
+  selector: 'app-menu-custom-anchor-tailwind',
+  imports: [NgpButton, NgpMenu, NgpMenuTrigger, NgpMenuItem, NgIcon],
+  providers: [provideIcons({ heroChevronUpDownMini })],
+  template: `
+    <button
+      class="flex h-[2.125rem] w-full max-w-80 items-center justify-between gap-4 rounded-[0.625rem] border-none bg-white px-2.5 shadow-sm ring-1 ring-black/5 outline-hidden transition-colors duration-150 data-focus-visible:outline-2 data-focus-visible:outline-offset-1 data-focus-visible:outline-blue-500 data-hover:bg-gray-100 data-press:bg-gray-200 dark:bg-transparent dark:ring-white/10 dark:data-focus-visible:outline-blue-400 dark:data-hover:bg-white/10 dark:data-press:bg-white/20"
+      [ngpMenuTrigger]="menu"
+      [ngpMenuTriggerAnchor]="chevron"
+      ngpMenuTriggerPlacement="bottom-end"
+      ngpMenuTriggerOffset="12"
+      ngpButton
+    >
+      <span class="text-sm font-[510] tracking-[-0.006em] text-gray-900 dark:text-gray-100">
+        Sort by
+      </span>
+      <span
+        class="inline-flex items-center gap-1 text-sm tracking-[-0.006em] text-gray-600 dark:text-gray-400"
+      >
+        Recently updated
+        <span class="inline-flex text-gray-400 dark:text-gray-500" #chevron>
+          <ng-icon name="heroChevronUpDownMini" size="16" />
+        </span>
+      </span>
+    </button>
+
+    <ng-template #menu>
+      <div
+        class="animate-in fade-in-0 zoom-in-95 fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none dark:border-zinc-800 dark:bg-zinc-950"
+        ngpMenu
+      >
+        <button
+          class="min-w-[140px] cursor-pointer rounded-md border-none bg-transparent px-3 py-1.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          ngpMenuItem
+        >
+          Recently updated
+        </button>
+        <button
+          class="min-w-[140px] cursor-pointer rounded-md border-none bg-transparent px-3 py-1.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          ngpMenuItem
+        >
+          Name
+        </button>
+        <button
+          class="min-w-[140px] cursor-pointer rounded-md border-none bg-transparent px-3 py-1.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors hover:bg-gray-100 focus-visible:bg-gray-100 active:bg-gray-200 dark:text-gray-100 dark:hover:bg-white/10 dark:focus-visible:bg-white/10 dark:active:bg-white/20"
+          ngpMenuItem
+        >
+          Date created
+        </button>
+      </div>
+    </ng-template>
+  `,
+})
+export default class MenuCustomAnchorTailwindExample {}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -164,12 +164,9 @@ The `--ngp-menu-available-width` and `--ngp-menu-available-height` custom proper
 
 You can provide a separate anchor element using `ngpMenuTriggerAnchor` to control where the menu appears while keeping the full trigger area interactive. Clicks on the anchor are treated as inside the menu, so they do not dismiss it.
 
-```html
-<div class="field" #anchor>
-  <input type="text" />
-  <button [ngpMenuTrigger]="menu" [ngpMenuTriggerAnchor]="anchor">Options</button>
-</div>
-```
+<docs-example name="menu-custom-anchor"></docs-example>
+
+The anchor also becomes the element `--ngp-menu-trigger-width` measures, so a menu sized to that property matches the anchor - which is rarely what you want when the anchor is a small icon.
 
 The anchor is captured once, when the menu overlay is created on the first open. Changing the binding afterwards has no effect - not even on a later open - so bind an element that stays where it is rather than one you intend to swap.
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -171,7 +171,7 @@ You can provide a separate anchor element using `ngpMenuTriggerAnchor` to contro
 </div>
 ```
 
-The anchor is captured when the menu overlay is created - that is, the first time the menu opens. Changing the binding afterwards does not move a menu that has already been opened.
+The anchor is captured once, when the menu overlay is created on the first open. Changing the binding afterwards has no effect - not even on a later open - so bind an element that stays where it is rather than one you intend to swap.
 
 ### Keyboard Triggers
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -160,6 +160,19 @@ By default, the menu is kept within the viewport and its clipping ancestors. Pas
 
 The `--ngp-menu-available-width` and `--ngp-menu-available-height` custom properties are measured against the flip boundary, or the shift boundary when flip does not set one.
 
+### Custom Anchor
+
+You can provide a separate anchor element using `ngpMenuTriggerAnchor` to control where the menu appears while keeping the full trigger area interactive. Clicks on the anchor are treated as inside the menu, so they do not dismiss it.
+
+```html
+<div class="field" #anchor>
+  <input type="text" />
+  <button [ngpMenuTrigger]="menu" [ngpMenuTriggerAnchor]="anchor">Options</button>
+</div>
+```
+
+The anchor is captured when the menu overlay is created - that is, the first time the menu opens. Changing the binding afterwards does not move a menu that has already been opened.
+
 ### Keyboard Triggers
 
 Enable keyboard triggers to allow users to open menus using Enter or arrow keys:

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -78,6 +78,12 @@ export interface NgpMenuTriggerState<T = unknown> {
   readonly context: WritableSignal<T>;
 
   /**
+   * Define an anchor element for positioning the menu.
+   * If provided, the menu will be positioned relative to this element instead of the trigger.
+   */
+  readonly anchor: WritableSignal<HTMLElement | null>;
+
+  /**
    * The focus origin that was used to open the menu.
    * @internal
    */
@@ -112,6 +118,13 @@ export interface NgpMenuTriggerState<T = unknown> {
    * @param context - The new context
    */
   setContext(context: T): void;
+
+  /**
+   * Set the anchor element the menu is positioned against. Takes effect the next
+   * time the menu is opened; it does not move a menu that is already open.
+   * @param anchor - The new anchor element
+   */
+  setAnchor(anchor: HTMLElement | null): void;
 
   /**
    * Set the container in which the menu should be attached. Takes effect the
@@ -190,6 +203,12 @@ export interface NgpMenuTriggerProps<T = unknown> {
    * Context to provide to the menu.
    */
   readonly context?: Signal<T>;
+
+  /**
+   * Define an anchor element for positioning the menu.
+   * If provided, the menu will be positioned relative to this element instead of the trigger.
+   */
+  readonly anchor?: Signal<HTMLElement | null>;
   /**
    * Cooldown duration in milliseconds.
    */
@@ -226,6 +245,7 @@ export const [
     flip: _flip = signal(true),
     shift: _shift = signal(undefined),
     context: _context = signal<T>(undefined as T),
+    anchor: _anchor,
     container: _container,
     scrollBehavior,
     cooldown,
@@ -247,6 +267,7 @@ export const [
     const shift = controlled(_shift);
     const offset = controlled(_offset);
     const context = controlled(_context);
+    const anchor = controlled<HTMLElement | null>(_anchor, null);
     const container = controlled(_container, 'body');
 
     // Internal state
@@ -544,6 +565,7 @@ export const [
       const config: NgpOverlayConfig<T> = {
         content: menu,
         triggerElement: element.nativeElement,
+        anchorElement: anchor(),
         viewContainerRef,
         injector,
         context,
@@ -594,6 +616,10 @@ export const [
       context.set(newContext);
     }
 
+    function setAnchor(newAnchor: HTMLElement | null): void {
+      anchor.set(newAnchor);
+    }
+
     function setContainer(newContainer: HTMLElement | string | null): void {
       container.set(newContainer);
     }
@@ -628,6 +654,7 @@ export const [
       offset: deprecatedSetter(offset, 'setOffset', setOffset),
       disabled: deprecatedSetter(disabled, 'setDisabled', setDisabled),
       context: deprecatedSetter(context, 'setContext', setContext),
+      anchor: deprecatedSetter(anchor, 'setAnchor', setAnchor),
       open,
       openOrigin,
       show,
@@ -639,6 +666,7 @@ export const [
       setPlacement,
       setOffset,
       setContext,
+      setAnchor,
       setContainer,
       setPointerOverContent,
       flip,

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -204,7 +204,6 @@ export interface NgpMenuTriggerProps<T = unknown> {
    * Context to provide to the menu.
    */
   readonly context?: Signal<T>;
-
   /**
    * Define an anchor element for positioning the menu.
    * If provided, the menu will be positioned relative to this element instead of the trigger.

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -120,8 +120,9 @@ export interface NgpMenuTriggerState<T = unknown> {
   setContext(context: T): void;
 
   /**
-   * Set the anchor element the menu is positioned against. Takes effect the next
-   * time the menu is opened; it does not move a menu that is already open.
+   * Set the anchor element the menu is positioned against. The anchor is captured
+   * when the overlay is created, on the first open, so a later change does not
+   * reposition the menu - not even when it is closed and opened again.
    * @param anchor - The new anchor element
    */
   setAnchor(anchor: HTMLElement | null): void;

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
@@ -120,6 +120,14 @@ export class NgpMenuTrigger<T = unknown> {
   });
 
   /**
+   * Define an anchor element for positioning the menu.
+   * If provided, the menu will be positioned relative to this element instead of the trigger.
+   */
+  readonly anchor = input<HTMLElement | null>(null, {
+    alias: 'ngpMenuTriggerAnchor',
+  });
+
+  /**
    * Define which trigger types are enabled for the menu.
    * @default ['click']
    */
@@ -159,6 +167,7 @@ export class NgpMenuTrigger<T = unknown> {
     scrollBehavior: this.scrollBehavior,
     cooldown: this.cooldown,
     context: this.context as Signal<T>,
+    anchor: this.anchor,
     triggers: this.triggers,
     showDelay: this.showDelay,
     hideDelay: this.hideDelay,

--- a/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
@@ -1,0 +1,132 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from 'ng-primitives/menu';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The anchor sits well above the trigger, so which of the two the menu is
+ * placed against is unambiguous on the vertical axis. Horizontal placement is
+ * clamped by the shift middleware near the viewport edge, so the assertions
+ * lead with the vertical axis.
+ */
+@Component({
+  template: `
+    <div
+      #anchor
+      data-testid="anchor"
+      style="position: absolute; top: 100px; left: 200px; width: 50px; height: 30px;"
+    >
+      Anchor Element
+    </div>
+    <button
+      [ngpMenuTrigger]="menu"
+      [ngpMenuTriggerAnchor]="useAnchor ? anchor : null"
+      data-testid="trigger"
+      style="position: absolute; top: 300px; left: 400px;"
+    >
+      Open Menu
+    </button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu" style="position: absolute; width: 120px;">
+        <button ngpMenuItem>Item 1</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem],
+})
+class AnchoredMenuComponent {
+  useAnchor = true;
+}
+
+describe('Menu anchor element', () => {
+  it('should position the menu against the anchor element when provided', async () => {
+    const { getByTestId } = await renderMenu(true);
+    await openMenu(getByTestId('trigger'));
+
+    const menuRect = menuElement().getBoundingClientRect();
+    const anchorRect = getByTestId('anchor').getBoundingClientRect();
+    const triggerRect = getByTestId('trigger').getBoundingClientRect();
+
+    // bottom-start places the menu just below its positioning reference and
+    // aligns their left edges.
+    expect(menuRect.top).toBeGreaterThanOrEqual(anchorRect.bottom);
+    expect(menuRect.left).toBeCloseTo(anchorRect.left, 0);
+
+    // It is the anchor, not the trigger, that the menu followed.
+    expect(menuRect.top).toBeLessThan(triggerRect.top);
+  });
+
+  it('should fall back to the trigger element when the anchor is null', async () => {
+    const { getByTestId } = await renderMenu(false);
+    await openMenu(getByTestId('trigger'));
+
+    const menuRect = menuElement().getBoundingClientRect();
+    const triggerRect = getByTestId('trigger').getBoundingClientRect();
+
+    expect(menuRect.top).toBeGreaterThanOrEqual(triggerRect.bottom);
+  });
+
+  it('should not dismiss the menu when the anchor element is clicked', async () => {
+    const { getByTestId } = await renderMenu(true);
+    const trigger = getByTestId('trigger');
+    await openMenu(trigger);
+
+    // The anchor is not the trigger, so unless the overlay registry treats it
+    // as inside, this counts as an outside press and dismisses the menu.
+    fireEvent.mouseUp(getByTestId('anchor'));
+    await settle();
+
+    expect(document.querySelector('[data-testid="menu"]')).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('data-open');
+  });
+
+  it('should still dismiss the menu when an unrelated element is clicked', async () => {
+    const { getByTestId } = await renderMenu(true);
+    const trigger = getByTestId('trigger');
+    await openMenu(trigger);
+
+    fireEvent.mouseUp(document.body);
+    await settle();
+
+    expect(document.querySelector('[data-testid="menu"]')).not.toBeInTheDocument();
+    expect(trigger).not.toHaveAttribute('data-open');
+  });
+});
+
+async function renderMenu(useAnchor: boolean) {
+  const result = await render(AnchoredMenuComponent);
+  result.fixture.componentInstance.useAnchor = useAnchor;
+  result.fixture.autoDetectChanges(true);
+  return result;
+}
+
+/**
+ * Waits for data-placement, which is only set once Floating UI has resolved a
+ * position - before that the menu is in the DOM but still sitting at 0,0.
+ */
+async function openMenu(trigger: HTMLElement): Promise<void> {
+  fireEvent.click(trigger);
+
+  await waitFor(() => {
+    TestBed.flushEffects();
+    expect(menuElement()).toBeInTheDocument();
+    expect(menuElement()).toHaveAttribute('data-placement');
+  });
+}
+
+/**
+ * Outside-press dismissal is not observable by waiting for it to happen, so the
+ * two dismissal tests share a fixed settle instead. The dismissing case uses the
+ * same settle, which is what keeps the non-dismissing assertions honest rather
+ * than merely early.
+ */
+async function settle(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 100));
+  TestBed.flushEffects();
+}
+
+function menuElement(): HTMLElement {
+  return document.querySelector('[data-testid="menu"]') as HTMLElement;
+}

--- a/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
@@ -5,10 +5,10 @@ import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from 'ng-primitives/menu';
 import { describe, expect, it } from 'vitest';
 
 /**
- * The anchor sits well above the trigger, so which of the two the menu is
- * placed against is unambiguous on the vertical axis. Horizontal placement is
- * clamped by the shift middleware near the viewport edge, so the assertions
- * lead with the vertical axis.
+ * The anchor sits well above and to the left of the trigger, so the two are
+ * separable on both axes. `menuRect.top >= anchorRect.bottom` holds either way
+ * and only checks the placement is below - it is the left-edge alignment and
+ * `menuRect.top < triggerRect.top` that say which element was followed.
  */
 @Component({
   template: `


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

No linked issue — @ashley-hunter pre-approved this approach ahead of the PR.

## What does this PR implement/fix?

Adds an `ngpMenuTriggerAnchor` input to `NgpMenuTrigger`, so a menu can be positioned against an element other than its trigger.

This mirrors the existing `ngpTooltipTriggerAnchor` and `ngpPopoverTriggerAnchor` inputs exactly — same input name and type (`HTMLElement | null`, default `null`), same `anchor` state property, `setAnchor` setter and `deprecatedSetter` wiring, and the same `anchorElement: anchor()` key on the overlay config. No new shape is introduced.

The overlay layer already supports this end to end, so the change is confined to forwarding it from the menu primitive. `config.anchorElement || config.triggerElement` is already honoured in `packages/ng-primitives/portal/src/overlay.ts` for:

- the element whose resize is observed,
- the `CloseScrollStrategy` target,
- the `autoUpdate` positioning reference,
- `getPositionReference()`.

`NgpOverlay.createOverlay()` also already passes `anchorElement` into `NgpOverlayRegistry.register()`, and `isClickOutsideEntry` already treats the anchor as "inside" — so clicks on the anchor do not dismiss the menu, with no extra threading needed.

### Motivation

Rendering one `NgpMenuTrigger` per interactive token is too much machinery when the tokens number in the hundreds — for example a virtualized JSON tree where every key and value can open a menu, also rendered as a grid cell renderer across many rows. The workaround is a single menu with a zero-size `position: fixed` trigger element that gets moved onto whichever token was clicked, which exists only because the trigger is currently the sole positioning reference. Binding the clicked element as the anchor removes the need for it.

### Tests

Four tests in `packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts`:

- positions the menu against the anchor rather than the trigger,
- falls back to the trigger when the anchor is `null`,
- a click on the anchor does not dismiss the menu,
- a click on an unrelated element still does (control).

Reverting the source change fails the first and third; the other two are controls that pass either way.

### Note on a moving anchor

`anchorElement` is read once, when the overlay instance is created on first open — it is a plain value on `NgpOverlayConfig`, unlike `content`, `placement`, `position` and `context`, which are signals. So this input covers a *static* anchor, matching how tooltip and popover already behave, and the docs say so explicitly.

Making the anchor track a target that moves between opens is a portal-layer change (a live `anchorElement`, rebinding the `autoUpdate` reference and resize observer, and a registry entry that follows it — `register()` currently no-ops on a duplicate id, so an open overlay's entry is fixed). That is deliberately left out of this PR and can follow separately if you're happy with the direction.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Purely additive: a new optional input defaulting to `null`, which preserves the current behaviour of positioning against the trigger.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Positions menus against a separate anchor element via `ngpMenuTriggerAnchor` on `NgpMenuTrigger`. Previously menus were positioned relative to the trigger only; now they use the anchor when provided and fall back to the trigger. Anchor clicks are treated as inside; when an anchor is set, `--ngp-menu-trigger-width` measures the anchor.

- Mirrors `ngpTooltipTriggerAnchor`/`ngpPopoverTriggerAnchor` (input: `HTMLElement | null`, default `null`); no breaking changes.
- Forwards `anchorElement` to the overlay, which already handles positioning, resize/scroll tracking, close-on-scroll, and outside-press.
- Captures the anchor on first open; changing it later has no effect, even after closing and reopening (docs corrected to reflect this).
- Adds a runnable docs example (and Tailwind variant) showing an anchor inside a larger trigger, and notes the `--ngp-menu-trigger-width` side effect.
- Tests cover anchor vs. trigger fallback and outside-press behavior.

<sup>Written for commit 21ba67a803c7d73d94b6dfae30bb1e43ca9c5ae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for positioning menus relative to a custom anchor element.
  * Menus fall back to the trigger element when no custom anchor is provided.
  * Clicking the custom anchor keeps the menu open, while clicking elsewhere dismisses it.
  * Added documentation and examples covering custom menu anchors and dismissal behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->