### PR TITLE
feat(portal): let an open overlay follow a changing anchor

### DIFF
--- a/apps/documentation/src/app/examples/menu/menu-dynamic-anchor.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-dynamic-anchor.example.ts
@@ -1,0 +1,189 @@
+import { Component, signal } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from 'ng-primitives/menu';
+
+@Component({
+  selector: 'app-menu-dynamic-anchor',
+  imports: [NgpButton, NgpMenu, NgpMenuTrigger, NgpMenuItem],
+  template: `
+    <div class="stack">
+      <div class="tokens">
+        @for (token of tokens; track token) {
+          <button
+            class="token"
+            #element
+            [class.selected]="anchor() === element"
+            (click)="claim(trigger, element)"
+            (pointerdown)="claim(trigger, element)"
+            type="button"
+          >
+            {{ token }}
+          </button>
+        }
+      </div>
+
+      <!-- Below the tokens, so the menu it opens never covers the row it moves across. -->
+      <button
+        class="open"
+        #trigger="ngpMenuTrigger"
+        [ngpMenuTrigger]="menu"
+        ngpMenuTriggerPlacement="bottom-start"
+        ngpMenuTriggerOffset="8"
+        ngpButton
+      >
+        Format value
+      </button>
+    </div>
+
+    <ng-template #menu>
+      <div ngpMenu>
+        <button ngpMenuItem>Copy</button>
+        <button ngpMenuItem>Copy path</button>
+        <button ngpMenuItem>Filter on value</button>
+      </div>
+    </ng-template>
+  `,
+  styles: `
+    :host {
+      display: contents;
+    }
+
+    .stack {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      align-items: flex-start;
+    }
+
+    .tokens {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+
+    .open {
+      height: 2.125rem;
+      padding: 0 0.625rem;
+      border: none;
+      border-radius: 0.625rem;
+      background-color: var(--ngp-background);
+      box-shadow:
+        inset 0 0 0 1px var(--ngp-border),
+        0 1px 2px 0 rgb(0 0 0 / 0.04);
+      font-size: 0.875rem;
+      font-weight: 510;
+      letter-spacing: -0.006em;
+      color: var(--ngp-text-primary);
+      transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
+      outline: none;
+    }
+
+    .open[data-hover] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    .open[data-press] {
+      background-color: var(--ngp-background-active);
+    }
+
+    .open[data-focus-visible] {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 1px;
+    }
+
+    .token {
+      height: 2.125rem;
+      padding: 0 0.625rem;
+      border: none;
+      border-radius: 0.5rem;
+      background-color: var(--ngp-background);
+      box-shadow: inset 0 0 0 1px var(--ngp-border);
+      font-family: ui-monospace, monospace;
+      font-size: 0.8125rem;
+      letter-spacing: -0.006em;
+      color: var(--ngp-text-secondary);
+      cursor: pointer;
+      transition:
+        background-color 150ms cubic-bezier(0.4, 0, 0.2, 1),
+        box-shadow 150ms cubic-bezier(0.4, 0, 0.2, 1);
+      outline: none;
+    }
+
+    .token:hover {
+      background-color: var(--ngp-background-hover);
+    }
+
+    .token:active {
+      background-color: var(--ngp-background-active);
+    }
+
+    .token:focus-visible {
+      outline: 2px solid var(--ngp-focus-ring);
+      outline-offset: 1px;
+    }
+
+    .token.selected {
+      box-shadow: inset 0 0 0 1.5px var(--ngp-primary);
+      color: var(--ngp-text-primary);
+      font-weight: 510;
+    }
+
+    [ngpMenu] {
+      position: fixed;
+      display: flex;
+      flex-direction: column;
+      width: max-content;
+      background: var(--ngp-background);
+      border: 1px solid var(--ngp-border);
+      box-shadow: var(--ngp-shadow-lg);
+      border-radius: 0.625rem;
+      padding: 0.25rem;
+      outline: none;
+      transform-origin: var(--ngp-menu-transform-origin);
+    }
+
+    [ngpMenuItem] {
+      padding: 0.4375rem 0.75rem;
+      border: none;
+      background: none;
+      cursor: pointer;
+      transition: background-color 0.15s ease;
+      border-radius: 0.375rem;
+      min-width: 140px;
+      text-align: start;
+      outline: none;
+      font-size: 0.875rem;
+      font-weight: 510;
+      letter-spacing: -0.006em;
+      color: var(--ngp-text-primary);
+    }
+
+    [ngpMenuItem][data-hover],
+    [ngpMenuItem][data-focus-visible] {
+      background-color: var(--ngp-background-hover);
+    }
+
+    [ngpMenuItem][data-press] {
+      background-color: var(--ngp-background-active);
+    }
+  `,
+})
+export default class MenuDynamicAnchorExample {
+  /** Drives the highlight only - the menu is re-anchored through `setAnchor`. */
+  readonly anchor = signal<HTMLElement | null>(null);
+
+  readonly tokens = ['"id"', '"name"', '"createdAt"', '"tags"'];
+
+  /**
+   * Called on `pointerdown` so the anchor is claimed before the capture-phase `mouseup`
+   * that decides whether the press landed outside - on `click` alone the press would
+   * dismiss the menu instead of moving it. `setAnchor` rather than the input, because an
+   * input only reaches the trigger on the next change detection pass and a fast tap can
+   * outrun it. The `click` binding keeps the targets usable without a pointer, where it
+   * claims the anchor for the next open rather than moving a menu already on screen.
+   */
+  claim(trigger: NgpMenuTrigger, element: HTMLElement): void {
+    trigger.setAnchor(element);
+    this.anchor.set(element);
+  }
+}

--- a/apps/documentation/src/app/examples/menu/menu-dynamic-anchor.tailwind.example.ts
+++ b/apps/documentation/src/app/examples/menu/menu-dynamic-anchor.tailwind.example.ts
@@ -1,0 +1,87 @@
+import { Component, signal } from '@angular/core';
+import { NgpButton } from 'ng-primitives/button';
+import { NgpMenu, NgpMenuItem, NgpMenuTrigger } from 'ng-primitives/menu';
+
+@Component({
+  selector: 'app-menu-dynamic-anchor-tailwind',
+  imports: [NgpButton, NgpMenu, NgpMenuTrigger, NgpMenuItem],
+  template: `
+    <div class="flex flex-col items-start gap-4">
+      <div class="flex flex-wrap gap-2">
+        @for (token of tokens; track token) {
+          <button
+            class="h-[2.125rem] cursor-pointer rounded-lg border-none bg-white px-2.5 font-mono text-[0.8125rem] tracking-[-0.006em] text-gray-600 outline-hidden transition-colors duration-150 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-blue-500 active:bg-gray-200 dark:bg-transparent dark:text-gray-400 dark:hover:bg-white/10 dark:focus-visible:outline-blue-400 dark:active:bg-white/20"
+            #element
+            [class]="
+              anchor() === element
+                ? 'font-[510] text-gray-900 ring-2 ring-[#f01e2b] dark:text-gray-100 dark:ring-[#ff4651]'
+                : 'ring-1 ring-black/5 dark:ring-white/10'
+            "
+            (click)="claim(trigger, element)"
+            (pointerdown)="claim(trigger, element)"
+            type="button"
+          >
+            {{ token }}
+          </button>
+        }
+      </div>
+
+      <!-- Below the tokens, so the menu it opens never covers the row it moves across. -->
+      <button
+        class="h-[2.125rem] rounded-[0.625rem] border-none bg-white px-2.5 text-sm font-[510] tracking-[-0.006em] text-gray-900 shadow-sm ring-1 ring-black/5 outline-hidden transition-colors duration-150 data-focus-visible:outline-2 data-focus-visible:outline-offset-1 data-focus-visible:outline-blue-500 data-hover:bg-gray-100 data-press:bg-gray-200 dark:bg-transparent dark:text-gray-100 dark:ring-white/10 dark:data-focus-visible:outline-blue-400 dark:data-hover:bg-white/10 dark:data-press:bg-white/20"
+        #trigger="ngpMenuTrigger"
+        [ngpMenuTrigger]="menu"
+        ngpMenuTriggerPlacement="bottom-start"
+        ngpMenuTriggerOffset="8"
+        ngpButton
+      >
+        Format value
+      </button>
+    </div>
+
+    <ng-template #menu>
+      <div
+        class="fixed flex w-max origin-(--ngp-menu-transform-origin) flex-col rounded-[0.625rem] border border-gray-200 bg-white p-1 shadow-lg outline-none dark:border-zinc-800 dark:bg-zinc-950"
+        ngpMenu
+      >
+        <button
+          class="min-w-[140px] cursor-pointer rounded-md border-none bg-transparent px-3 py-1.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors data-focus-visible:bg-gray-100 data-hover:bg-gray-100 data-press:bg-gray-200 dark:text-gray-100 dark:data-focus-visible:bg-white/10 dark:data-hover:bg-white/10 dark:data-press:bg-white/20"
+          ngpMenuItem
+        >
+          Copy
+        </button>
+        <button
+          class="min-w-[140px] cursor-pointer rounded-md border-none bg-transparent px-3 py-1.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors data-focus-visible:bg-gray-100 data-hover:bg-gray-100 data-press:bg-gray-200 dark:text-gray-100 dark:data-focus-visible:bg-white/10 dark:data-hover:bg-white/10 dark:data-press:bg-white/20"
+          ngpMenuItem
+        >
+          Copy path
+        </button>
+        <button
+          class="min-w-[140px] cursor-pointer rounded-md border-none bg-transparent px-3 py-1.5 text-left text-sm font-[510] tracking-[-0.006em] text-gray-900 outline-hidden transition-colors data-focus-visible:bg-gray-100 data-hover:bg-gray-100 data-press:bg-gray-200 dark:text-gray-100 dark:data-focus-visible:bg-white/10 dark:data-hover:bg-white/10 dark:data-press:bg-white/20"
+          ngpMenuItem
+        >
+          Filter on value
+        </button>
+      </div>
+    </ng-template>
+  `,
+})
+export default class MenuDynamicAnchorExample {
+  /** Drives the highlight only - the menu is re-anchored through `setAnchor`. */
+  readonly anchor = signal<HTMLElement | null>(null);
+
+  readonly tokens = ['"id"', '"name"', '"createdAt"', '"tags"'];
+
+  /**
+   * Called on `pointerdown` so the anchor is claimed before the capture-phase `mouseup`
+   * that decides whether the press landed outside - on `click` alone the press would
+   * dismiss the menu instead of moving it. `setAnchor` rather than the input, because an
+   * input only reaches the trigger on the next change detection pass and a fast tap can
+   * outrun it. The `click` binding keeps the targets usable without a pointer, where it
+   * claims the anchor for the next open rather than moving a menu already on screen.
+   */
+  claim(trigger: NgpMenuTrigger, element: HTMLElement): void {
+    trigger.setAnchor(element);
+    this.anchor.set(element);
+  }
+}

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -170,7 +170,9 @@ The anchor also becomes the element `--ngp-menu-trigger-width` measures, so a me
 
 The anchor is live: rebinding it moves an already-open menu to the new element, and the new element is the one that counts as inside for dismissal. A single menu can therefore be pointed at whichever of many elements was interacted with, instead of giving each one its own trigger.
 
-When the new anchor comes from a press, claim it on `mousedown` rather than `click`. Outside-press dismissal is decided on a capture-phase `mouseup`, which runs before a bubbling `click`, so an anchor set there arrives after the decision has been made - the element still counts as outside and the press that was meant to move the menu dismisses it instead:
+#### Serving many targets from one menu
+
+When one menu serves many targets, set the anchor on `mousedown`, not on `click`. Outside-press dismissal is decided on a capture-phase `mouseup`, which runs before a bubbling `click` - so an anchor set on click is set too late, and pressing a new target dismisses the menu you were about to move:
 
 ```html
 <span (mousedown)="anchor = token" [class.selected]="anchor === token">{{ token }}</span>

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -172,17 +172,35 @@ The anchor is live: rebinding it moves an already-open menu to the new element, 
 
 #### Serving many targets from one menu
 
-When one menu serves many targets, set the anchor on `mousedown`, not on `click`. Outside-press dismissal is decided on a capture-phase `mouseup`, which runs before a bubbling `click` - so an anchor set on click is set too late, and pressing a new target dismisses the menu you were about to move:
+When one menu serves many targets, re-anchor it with `setAnchor` on `pointerdown` rather than by rebinding `ngpMenuTriggerAnchor`:
+
+<docs-example name="menu-dynamic-anchor"></docs-example>
 
 ```html
-<button #token type="button" (mousedown)="anchor = token" (click)="anchor = token">
+<button #trigger="ngpMenuTrigger" [ngpMenuTrigger]="menu">Actions</button>
+
+<button
+  #token
+  type="button"
+  (pointerdown)="trigger.setAnchor(token)"
+  (click)="trigger.setAnchor(token)"
+>
   {{ label }}
 </button>
 ```
 
-Keep the `click` handler as well: keyboard activation raises `click` without a preceding `mousedown`, and there is no outside press to lose that race against, so it is the binding that makes the interaction reachable without a pointer. Targets have to be focusable for that to mean anything, so use a native `button` rather than a `span`.
+Two things have to line up, and the input binding only gives you the first:
+
+- **Order.** Outside-press dismissal is decided on a capture-phase `mouseup`, which runs before a bubbling `click`, so an anchor claimed on `click` is claimed too late and the press dismisses the menu you meant to move. `pointerdown` is early enough, and covers mouse, pen and touch alike - `mousedown` works too.
+- **Timing.** `ngpMenuTriggerAnchor` is an input, so a new value only reaches the trigger on the next change detection pass. A press held for a few milliseconds gets one; a fast tap, or a frame the browser is busy rendering hundreds of targets, does not - and the dismissal check then still sees the old anchor. `setAnchor` writes the value the check reads, so there is no pass to wait for.
+
+Keep the `click` handler as well, so the targets work without a pointer: keyboard activation raises `click` with no preceding `pointerdown`. Note that it claims the anchor rather than moving an open menu - activating anything outside an open menu closes it - so from the keyboard the interaction is two steps, claim then open. Targets have to be focusable for any of this to mean anything, so use a native `button` rather than a `span`.
+
+Rebinding `ngpMenuTriggerAnchor` remains the right choice when the anchor changes outside a press - from a selection, a route, or a resize - where nothing is racing the binding.
 
 Guard the re-anchor if pressing the current anchor again should close the menu, since setting it to the element it already points at leaves the menu open.
+
+An anchor that is removed from the DOM closes the menu, so a target recycled out of a virtualized list does not leave the menu stranded at a stale position.
 
 ### Keyboard Triggers
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -170,6 +170,14 @@ The anchor also becomes the element `--ngp-menu-trigger-width` measures, so a me
 
 The anchor is live: rebinding it moves an already-open menu to the new element, and the new element is the one that counts as inside for dismissal. A single menu can therefore be pointed at whichever of many elements was interacted with, instead of giving each one its own trigger.
 
+When the new anchor comes from a press, claim it on `mousedown` rather than `click`. Outside-press dismissal is decided on a capture-phase `mouseup`, which runs before a bubbling `click`, so an anchor set there arrives after the decision has been made - the element still counts as outside and the press that was meant to move the menu dismisses it instead:
+
+```html
+<span (mousedown)="anchor = token" [class.selected]="anchor === token">{{ token }}</span>
+```
+
+Guard the re-anchor if pressing the current anchor again should close the menu, since setting it to the element it already points at leaves the menu open.
+
 ### Keyboard Triggers
 
 Enable keyboard triggers to allow users to open menus using Enter or arrow keys:

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -168,7 +168,7 @@ You can provide a separate anchor element using `ngpMenuTriggerAnchor` to contro
 
 The anchor also becomes the element `--ngp-menu-trigger-width` measures, so a menu sized to that property matches the anchor - which is rarely what you want when the anchor is a small icon.
 
-The anchor is captured once, when the menu overlay is created on the first open. Changing the binding afterwards has no effect - not even on a later open - so bind an element that stays where it is rather than one you intend to swap.
+The anchor is live: rebinding it moves an already-open menu to the new element, and the new element is the one that counts as inside for dismissal. A single menu can therefore be pointed at whichever of many elements was interacted with, instead of giving each one its own trigger.
 
 ### Keyboard Triggers
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/menu.md
@@ -175,8 +175,12 @@ The anchor is live: rebinding it moves an already-open menu to the new element, 
 When one menu serves many targets, set the anchor on `mousedown`, not on `click`. Outside-press dismissal is decided on a capture-phase `mouseup`, which runs before a bubbling `click` - so an anchor set on click is set too late, and pressing a new target dismisses the menu you were about to move:
 
 ```html
-<span (mousedown)="anchor = token" [class.selected]="anchor === token">{{ token }}</span>
+<button #token type="button" (mousedown)="anchor = token" (click)="anchor = token">
+  {{ label }}
+</button>
 ```
+
+Keep the `click` handler as well: keyboard activation raises `click` without a preceding `mousedown`, and there is no outside press to lose that race against, so it is the binding that makes the interaction reachable without a pointer. Targets have to be focusable for that to mean anything, so use a native `button` rather than a `span`.
 
 Guard the re-anchor if pressing the current anchor again should close the menu, since setting it to the element it already points at leaves the menu open.
 

--- a/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/popover.md
@@ -138,6 +138,8 @@ The popover can be anchored to a different element than the trigger.
 
 <docs-example name="popover-anchor"></docs-example>
 
+The anchor is live - rebinding it moves an already-open popover to the new element, and it is the new element that counts as inside for dismissal.
+
 ### Dismiss Guard
 
 Use dismiss guards to prevent a popover from closing when there are unsaved changes. The `closeOnOutsideClick` and `closeOnEscape` options accept a guard function that returns a boolean or a `Promise<boolean>`.

--- a/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/tooltip.md
@@ -90,6 +90,8 @@ You can provide a separate anchor element using `ngpTooltipTriggerAnchor` to con
 
 <docs-example name="tooltip-custom-anchor"></docs-example>
 
+The anchor is live - rebinding it moves a tooltip that is already showing to the new element.
+
 ### Custom Shift
 
 You can customize the shift behavior to control how the tooltip stays within the viewport:

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -120,9 +120,8 @@ export interface NgpMenuTriggerState<T = unknown> {
   setContext(context: T): void;
 
   /**
-   * Set the anchor element the menu is positioned against. The anchor is captured
-   * when the overlay is created, on the first open, so a later change does not
-   * reposition the menu - not even when it is closed and opened again.
+   * Set the anchor element the menu is positioned against. An open menu moves to the
+   * new anchor.
    * @param anchor - The new anchor element
    */
   setAnchor(anchor: HTMLElement | null): void;
@@ -565,7 +564,7 @@ export const [
       const config: NgpOverlayConfig<T> = {
         content: menu,
         triggerElement: element.nativeElement,
-        anchorElement: anchor(),
+        anchorElement: anchor,
         viewContainerRef,
         injector,
         context,

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -122,6 +122,11 @@ export interface NgpMenuTriggerState<T = unknown> {
   /**
    * Set the anchor element the menu is positioned against. An open menu moves to the
    * new anchor.
+   *
+   * When re-anchoring in response to a press, do it on `mousedown` rather than `click`:
+   * outside-press dismissal is decided on a capture-phase `mouseup`, which runs before
+   * a bubbling `click`, so an anchor claimed there arrives too late and the press that
+   * was meant to move the menu dismisses it instead.
    * @param anchor - The new anchor element
    */
   setAnchor(anchor: HTMLElement | null): void;

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger-state.ts
@@ -123,7 +123,7 @@ export interface NgpMenuTriggerState<T = unknown> {
    * Set the anchor element the menu is positioned against. An open menu moves to the
    * new anchor.
    *
-   * When re-anchoring in response to a press, do it on `mousedown` rather than `click`:
+   * When re-anchoring in response to a press, do it on `pointerdown` rather than `click`:
    * outside-press dismissal is decided on a capture-phase `mouseup`, which runs before
    * a bubbling `click`, so an anchor claimed there arrives too late and the press that
    * was meant to move the menu dismisses it instead.

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
@@ -123,9 +123,10 @@ export class NgpMenuTrigger<T = unknown> {
    * Define an anchor element for positioning the menu.
    * If provided, the menu will be positioned relative to this element instead of the trigger.
    *
-   * The anchor is live, so rebinding it moves an open menu. When the new anchor comes from
-   * a press, bind it on `mousedown` rather than `click` - outside-press dismissal is decided
-   * on a capture-phase `mouseup`, so an anchor arriving with `click` arrives too late.
+   * The anchor is live, so rebinding it moves an open menu.
+   *
+   * An input only reaches this directive on the next change detection pass, which a press
+   * can outrun - use `setAnchor()` instead when the anchor is claimed during one.
    */
   readonly anchor = input<HTMLElement | null>(null, {
     alias: 'ngpMenuTriggerAnchor',
@@ -199,6 +200,21 @@ export class NgpMenuTrigger<T = unknown> {
    */
   toggle(event: MouseEvent): void {
     this.state.toggle(event);
+  }
+
+  /**
+   * Set the anchor the menu is positioned against, taking effect immediately rather than
+   * on the next change detection pass.
+   *
+   * Reach for this over `ngpMenuTriggerAnchor` when the anchor is claimed during a press.
+   * Outside-press dismissal is decided on a capture-phase `mouseup`, which a fast tap can
+   * deliver in the same frame as the `pointerdown` that claimed the anchor - before the
+   * binding has reached this directive, so the press dismisses the menu instead of moving
+   * it. Writing the anchor here is visible to that check straight away.
+   * @param anchor - The new anchor element
+   */
+  setAnchor(anchor: HTMLElement | null): void {
+    this.state.setAnchor(anchor);
   }
 }
 

--- a/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
+++ b/packages/ng-primitives/menu/src/menu-trigger/menu-trigger.ts
@@ -122,6 +122,10 @@ export class NgpMenuTrigger<T = unknown> {
   /**
    * Define an anchor element for positioning the menu.
    * If provided, the menu will be positioned relative to this element instead of the trigger.
+   *
+   * The anchor is live, so rebinding it moves an open menu. When the new anchor comes from
+   * a press, bind it on `mousedown` rather than `click` - outside-press dismissal is decided
+   * on a capture-phase `mouseup`, so an anchor arriving with `click` arrives too late.
    */
   readonly anchor = input<HTMLElement | null>(null, {
     alias: 'ngpMenuTriggerAnchor',

--- a/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
@@ -40,6 +40,103 @@ class AnchoredMenuComponent {
   useAnchor = true;
 }
 
+/**
+ * Two anchors at different heights, so which one the menu followed is decided on
+ * the vertical axis alone. `anchor` selects between them, or unsets the anchor.
+ */
+@Component({
+  template: `
+    <div
+      #anchorA
+      data-testid="anchor-a"
+      style="position: absolute; top: 100px; left: 200px; width: 50px; height: 30px;"
+    >
+      Anchor A
+    </div>
+    <div
+      #anchorB
+      data-testid="anchor-b"
+      style="position: absolute; top: 260px; left: 200px; width: 50px; height: 30px;"
+    >
+      Anchor B
+    </div>
+    <button
+      [ngpMenuTrigger]="menu"
+      [ngpMenuTriggerAnchor]="anchor === 'a' ? anchorA : anchor === 'b' ? anchorB : null"
+      data-testid="trigger"
+      style="position: absolute; top: 400px; left: 400px;"
+    >
+      Open Menu
+    </button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu" style="position: absolute; width: 120px;">
+        <button ngpMenuItem>Item 1</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem],
+})
+class MovingAnchorMenuComponent {
+  anchor: 'a' | 'b' | null = 'a';
+}
+
+describe('Menu moving anchor', () => {
+  it('should move an open menu to the new anchor', async () => {
+    const { fixture, getByTestId } = await renderMovingMenu();
+    await openMenu(getByTestId('trigger'));
+    expectAnchoredTo(getByTestId('anchor-a'), getByTestId('anchor-b'));
+
+    await repoint(fixture, 'b');
+
+    // The menu moved without closing.
+    expect(getByTestId('trigger')).toHaveAttribute('data-open');
+    expectAnchoredTo(getByTestId('anchor-b'), getByTestId('anchor-a'));
+  });
+
+  it('should treat the new anchor as inside once it is bound', async () => {
+    const { fixture, getByTestId } = await renderMovingMenu();
+    await openMenu(getByTestId('trigger'));
+    await repoint(fixture, 'b');
+
+    fireEvent.mouseUp(getByTestId('anchor-b'));
+    await settle();
+
+    expect(document.querySelector('[data-testid="menu"]')).toBeInTheDocument();
+    expect(getByTestId('trigger')).toHaveAttribute('data-open');
+  });
+
+  it('should treat the previous anchor as outside once the anchor moves', async () => {
+    const { fixture, getByTestId } = await renderMovingMenu();
+    await openMenu(getByTestId('trigger'));
+
+    // Inside while it is the anchor...
+    fireEvent.mouseUp(getByTestId('anchor-a'));
+    await settle();
+    expect(document.querySelector('[data-testid="menu"]')).toBeInTheDocument();
+
+    // ...and outside once the anchor has moved on, so exactly one element is
+    // inside at a time and re-clicking the old one dismisses.
+    await repoint(fixture, 'b');
+    fireEvent.mouseUp(getByTestId('anchor-a'));
+    await settle();
+
+    expect(document.querySelector('[data-testid="menu"]')).not.toBeInTheDocument();
+    expect(getByTestId('trigger')).not.toHaveAttribute('data-open');
+  });
+
+  it('should fall back to the trigger when the anchor is unset while open', async () => {
+    const { fixture, getByTestId } = await renderMovingMenu();
+    await openMenu(getByTestId('trigger'));
+
+    await repoint(fixture, null);
+
+    const menuRect = menuElement().getBoundingClientRect();
+    const triggerRect = getByTestId('trigger').getBoundingClientRect();
+    expect(menuRect.top).toBeGreaterThanOrEqual(triggerRect.bottom);
+  });
+});
+
 describe('Menu anchor element', () => {
   it('should position the menu against the anchor element when provided', async () => {
     const { getByTestId } = await renderMenu(true);
@@ -94,6 +191,44 @@ describe('Menu anchor element', () => {
     expect(trigger).not.toHaveAttribute('data-open');
   });
 });
+
+async function renderMovingMenu() {
+  const result = await render(MovingAnchorMenuComponent);
+  result.fixture.autoDetectChanges(true);
+  return result;
+}
+
+/**
+ * Rebind the anchor and wait for floating-ui to settle on a new position.
+ */
+async function repoint(
+  fixture: { componentInstance: MovingAnchorMenuComponent; detectChanges: () => void },
+  anchor: 'a' | 'b' | null,
+): Promise<void> {
+  const before = menuElement().getBoundingClientRect().top;
+
+  fixture.componentInstance.anchor = anchor;
+  fixture.detectChanges();
+
+  await waitFor(() => {
+    TestBed.flushEffects();
+    expect(menuElement().getBoundingClientRect().top).not.toBeCloseTo(before, 0);
+  });
+}
+
+/**
+ * bottom-start puts the menu just below its reference. Asserting against both
+ * candidates keeps this honest - "close to A" alone would also hold if the menu
+ * had never moved and A happened to be nearby.
+ */
+function expectAnchoredTo(anchor: HTMLElement, other: HTMLElement): void {
+  const menuTop = menuElement().getBoundingClientRect().top;
+  const tolerance = 12;
+
+  expect(menuTop - anchor.getBoundingClientRect().bottom).toBeGreaterThanOrEqual(0);
+  expect(menuTop - anchor.getBoundingClientRect().bottom).toBeLessThan(tolerance);
+  expect(Math.abs(menuTop - other.getBoundingClientRect().bottom)).toBeGreaterThan(tolerance);
+}
 
 async function renderMenu(useAnchor: boolean) {
   const result = await render(AnchoredMenuComponent);

--- a/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
@@ -81,6 +81,94 @@ class MovingAnchorMenuComponent {
   anchor: 'a' | 'b' | null = 'a';
 }
 
+/**
+ * One menu re-anchored onto whichever element was pressed - the shape a consumer
+ * reaches for instead of a trigger per element. `claimOn` chooses the event the
+ * new anchor is claimed in, which is the whole point of these two tests.
+ */
+@Component({
+  template: `
+    <div
+      #anchorA
+      data-testid="anchor-a"
+      style="position: absolute; top: 100px; left: 200px; width: 50px; height: 30px;"
+    >
+      Anchor A
+    </div>
+    <div
+      #anchorB
+      (mousedown)="claim('mousedown', anchorB)"
+      (click)="claim('click', anchorB)"
+      data-testid="anchor-b"
+      style="position: absolute; top: 260px; left: 200px; width: 50px; height: 30px;"
+    >
+      Anchor B
+    </div>
+    <button
+      [ngpMenuTrigger]="menu"
+      [ngpMenuTriggerAnchor]="anchor"
+      data-testid="trigger"
+      style="position: absolute; top: 400px; left: 400px;"
+    >
+      Open Menu
+    </button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu" style="position: absolute; width: 120px;">
+        <button ngpMenuItem>Item 1</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem],
+})
+class ClaimedAnchorMenuComponent {
+  anchor: HTMLElement | null = null;
+  claimOn: 'mousedown' | 'click' = 'mousedown';
+
+  claim(event: 'mousedown' | 'click', element: HTMLElement): void {
+    if (this.claimOn === event) {
+      this.anchor = element;
+    }
+  }
+}
+
+/**
+ * Outside-press dismissal is decided on a capture-phase `mouseup`, so a consumer
+ * re-anchoring one menu across many elements has to claim the new anchor before
+ * that runs. These two tests pin the ordering down from both sides.
+ */
+describe('Menu anchor claimed during a press', () => {
+  it('should keep the menu open when the anchor is claimed on mousedown', async () => {
+    const { fixture, getByTestId } = await renderClaimedMenu('mousedown');
+    await openMenu(getByTestId('trigger'));
+
+    await pressSequence(getByTestId('anchor-b'), fixture);
+    await settle();
+
+    // The capture-phase mouseup saw the new anchor, so the press that moved the
+    // menu did not also dismiss it.
+    expect(document.querySelector('[data-testid="menu"]')).toBeInTheDocument();
+    expect(getByTestId('trigger')).toHaveAttribute('data-open');
+
+    await waitFor(() => {
+      TestBed.flushEffects();
+      expectAnchoredTo(getByTestId('anchor-b'), getByTestId('anchor-a'));
+    });
+  });
+
+  it('should dismiss the menu when the anchor is only claimed on click', async () => {
+    const { fixture, getByTestId } = await renderClaimedMenu('click');
+    await openMenu(getByTestId('trigger'));
+
+    await pressSequence(getByTestId('anchor-b'), fixture);
+    await settle();
+
+    // `click` bubbles after the capture-phase mouseup has already decided, so the
+    // element is still outside when dismissal is evaluated.
+    expect(document.querySelector('[data-testid="menu"]')).not.toBeInTheDocument();
+  });
+});
+
 describe('Menu moving anchor', () => {
   it('should move an open menu to the new anchor', async () => {
     const { fixture, getByTestId } = await renderMovingMenu();
@@ -191,6 +279,35 @@ describe('Menu anchor element', () => {
     expect(trigger).not.toHaveAttribute('data-open');
   });
 });
+
+async function renderClaimedMenu(claimOn: 'mousedown' | 'click') {
+  const result = await render(ClaimedAnchorMenuComponent);
+  result.fixture.componentInstance.claimOn = claimOn;
+  result.fixture.autoDetectChanges(true);
+  return result;
+}
+
+/**
+ * A full press. `userEvent.click` collapses the ordering these tests are about, so
+ * the events are dispatched individually - and the button phases are separated by a
+ * change detection pass, because a real press delivers them in separate tasks and an
+ * anchor bound in the template only reaches the directive on the next pass.
+ */
+async function pressSequence(
+  target: HTMLElement,
+  fixture: { detectChanges: () => void },
+): Promise<void> {
+  const init = { bubbles: true, composed: true, button: 0 };
+
+  target.dispatchEvent(new PointerEvent('pointerdown', init));
+  target.dispatchEvent(new MouseEvent('mousedown', init));
+
+  fixture.detectChanges();
+  await Promise.resolve();
+
+  target.dispatchEvent(new MouseEvent('mouseup', init));
+  target.dispatchEvent(new MouseEvent('click', init));
+}
 
 async function renderMovingMenu() {
   const result = await render(MovingAnchorMenuComponent);

--- a/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
@@ -97,8 +97,9 @@ class MovingAnchorMenuComponent {
     </div>
     <button
       #anchorB
-      (mousedown)="claim('mousedown', anchorB)"
       (click)="claim('click', anchorB)"
+      (mousedown)="claim('mousedown', anchorB)"
+      (pointerdown)="claim('pointerdown', anchorB)"
       data-testid="anchor-b"
       type="button"
       style="position: absolute; top: 260px; left: 200px; width: 50px; height: 30px;"
@@ -124,14 +125,47 @@ class MovingAnchorMenuComponent {
 })
 class ClaimedAnchorMenuComponent {
   anchor: HTMLElement | null = null;
-  claimOn: 'mousedown' | 'click' = 'mousedown';
+  claimOn: ClaimEvent = 'pointerdown';
 
-  claim(event: 'mousedown' | 'click', element: HTMLElement): void {
+  claim(event: ClaimEvent, element: HTMLElement): void {
     if (this.claimOn === event) {
       this.anchor = element;
     }
   }
 }
+
+type ClaimEvent = 'pointerdown' | 'mousedown' | 'click';
+
+/** The same shape, but claiming the anchor through `setAnchor` rather than the input. */
+@Component({
+  template: `
+    <button
+      #anchorB
+      (pointerdown)="trigger.setAnchor(anchorB)"
+      data-testid="anchor-b"
+      type="button"
+      style="position: absolute; top: 260px; left: 200px; width: 50px; height: 30px;"
+    >
+      Anchor B
+    </button>
+    <button
+      #trigger="ngpMenuTrigger"
+      [ngpMenuTrigger]="menu"
+      data-testid="trigger"
+      style="position: absolute; top: 400px; left: 400px;"
+    >
+      Open Menu
+    </button>
+
+    <ng-template #menu>
+      <div ngpMenu data-testid="menu" style="position: absolute; width: 120px;">
+        <button ngpMenuItem>Item 1</button>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpMenuTrigger, NgpMenu, NgpMenuItem],
+})
+class StateClaimedAnchorMenuComponent {}
 
 /**
  * Outside-press dismissal is decided on a capture-phase `mouseup`, so a consumer
@@ -139,27 +173,64 @@ class ClaimedAnchorMenuComponent {
  * that runs. These two tests pin the ordering down from both sides.
  */
 describe('Menu anchor claimed during a press', () => {
-  it('should keep the menu open when the anchor is claimed on mousedown', async () => {
-    const { fixture, getByTestId } = await renderClaimedMenu('mousedown');
+  it.each(['pointerdown', 'mousedown'] as const)(
+    'should keep the menu open when the anchor is claimed on %s',
+    async claimOn => {
+      const { fixture, getByTestId } = await renderClaimedMenu(claimOn);
+      await openMenu(getByTestId('trigger'));
+
+      const menuBefore = menuElement();
+
+      await pressSequence(getByTestId('anchor-b'), fixture);
+      await settle();
+
+      // The capture-phase mouseup saw the new anchor, so the press that moved the
+      // menu did not also dismiss it.
+      expect(document.querySelector('[data-testid="menu"]')).toBeInTheDocument();
+      expect(getByTestId('trigger')).toHaveAttribute('data-open');
+
+      await waitFor(() => {
+        TestBed.flushEffects();
+        expectAnchoredTo(getByTestId('anchor-b'), getByTestId('anchor-a'));
+      });
+
+      // A press that dismissed and reopened would also end up open and correctly
+      // placed; only the node surviving tells the two apart.
+      expect(menuElement()).toBe(menuBefore);
+    },
+  );
+
+  it('should dismiss the menu when a template-bound anchor is claimed within a single frame', async () => {
+    const { getByTestId } = await renderClaimedMenu('pointerdown');
+    await openMenu(getByTestId('trigger'));
+
+    // No change detection between the button phases, which is what a fast tap delivers -
+    // and what a frame the browser is too busy to serve delivers too, the hundreds-of-
+    // targets case this feature is for. Claiming the anchor before `mouseup` is then not
+    // enough on its own: an input binding only reaches the directive on the next pass, so
+    // the registry still reads the previous anchor and dismisses.
+    //
+    // Pinned rather than fixed, because it is a property of Angular's input timing rather
+    // than of this code. `setAnchor` below is the way out, and the reason it exists.
+    pressSequenceWithinFrame(getByTestId('anchor-b'));
+    await settle();
+
+    expect(document.querySelector('[data-testid="menu"]')).not.toBeInTheDocument();
+  });
+
+  it('should keep the menu open when setAnchor claims the anchor within a single frame', async () => {
+    const { getByTestId } = await render(StateClaimedAnchorMenuComponent);
     await openMenu(getByTestId('trigger'));
 
     const menuBefore = menuElement();
 
-    await pressSequence(getByTestId('anchor-b'), fixture);
+    // `setAnchor` writes the signal the dismissal check reads, so it needs no pass in
+    // between and the same press that dismisses above moves the menu here.
+    pressSequenceWithinFrame(getByTestId('anchor-b'));
     await settle();
 
-    // The capture-phase mouseup saw the new anchor, so the press that moved the
-    // menu did not also dismiss it.
     expect(document.querySelector('[data-testid="menu"]')).toBeInTheDocument();
     expect(getByTestId('trigger')).toHaveAttribute('data-open');
-
-    await waitFor(() => {
-      TestBed.flushEffects();
-      expectAnchoredTo(getByTestId('anchor-b'), getByTestId('anchor-a'));
-    });
-
-    // A press that dismissed and reopened would also end up open and correctly
-    // placed; only the node surviving tells the two apart.
     expect(menuElement()).toBe(menuBefore);
   });
 
@@ -293,7 +364,7 @@ describe('Menu anchor element', () => {
   });
 });
 
-async function renderClaimedMenu(claimOn: 'mousedown' | 'click') {
+async function renderClaimedMenu(claimOn: ClaimEvent) {
   const result = await render(ClaimedAnchorMenuComponent);
   result.fixture.componentInstance.claimOn = claimOn;
   result.fixture.autoDetectChanges(true);
@@ -318,6 +389,19 @@ async function pressSequence(
   fixture.detectChanges();
   await Promise.resolve();
 
+  target.dispatchEvent(new MouseEvent('mouseup', init));
+  target.dispatchEvent(new MouseEvent('click', init));
+}
+
+/**
+ * The same press with nothing between the phases - what a fast tap delivers, and what
+ * `pressSequence` above deliberately does not test.
+ */
+function pressSequenceWithinFrame(target: HTMLElement): void {
+  const init = { bubbles: true, composed: true, button: 0 };
+
+  target.dispatchEvent(new PointerEvent('pointerdown', init));
+  target.dispatchEvent(new MouseEvent('mousedown', init));
   target.dispatchEvent(new MouseEvent('mouseup', init));
   target.dispatchEvent(new MouseEvent('click', init));
 }

--- a/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
@@ -143,6 +143,8 @@ describe('Menu anchor claimed during a press', () => {
     const { fixture, getByTestId } = await renderClaimedMenu('mousedown');
     await openMenu(getByTestId('trigger'));
 
+    const menuBefore = menuElement();
+
     await pressSequence(getByTestId('anchor-b'), fixture);
     await settle();
 
@@ -155,6 +157,10 @@ describe('Menu anchor claimed during a press', () => {
       TestBed.flushEffects();
       expectAnchoredTo(getByTestId('anchor-b'), getByTestId('anchor-a'));
     });
+
+    // A press that dismissed and reopened would also end up open and correctly
+    // placed; only the node surviving tells the two apart.
+    expect(menuElement()).toBe(menuBefore);
   });
 
   it('should dismiss the menu when the anchor is only claimed on click', async () => {
@@ -176,11 +182,17 @@ describe('Menu moving anchor', () => {
     await openMenu(getByTestId('trigger'));
     expectAnchoredTo(getByTestId('anchor-a'), getByTestId('anchor-b'));
 
+    const menuBefore = menuElement();
+
     await repoint(fixture, 'b');
 
     // The menu moved without closing.
     expect(getByTestId('trigger')).toHaveAttribute('data-open');
     expectAnchoredTo(getByTestId('anchor-b'), getByTestId('anchor-a'));
+
+    // Same node throughout - closing and reopening somewhere else would satisfy the
+    // position assertions above just as well, and is what the anchor is meant to avoid.
+    expect(menuElement()).toBe(menuBefore);
   });
 
   it('should treat the new anchor as inside once it is bound', async () => {

--- a/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
+++ b/packages/ng-primitives/menu/src/menu/tests/menu-anchor.test.ts
@@ -95,15 +95,16 @@ class MovingAnchorMenuComponent {
     >
       Anchor A
     </div>
-    <div
+    <button
       #anchorB
       (mousedown)="claim('mousedown', anchorB)"
       (click)="claim('click', anchorB)"
       data-testid="anchor-b"
+      type="button"
       style="position: absolute; top: 260px; left: 200px; width: 50px; height: 30px;"
     >
       Anchor B
-    </div>
+    </button>
     <button
       [ngpMenuTrigger]="menu"
       [ngpMenuTriggerAnchor]="anchor"

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger-state.ts
@@ -370,7 +370,7 @@ export const [
       const config: NgpOverlayConfig<T> = {
         content: popover,
         triggerElement: elementRef.nativeElement,
-        anchorElement: anchor(),
+        anchorElement: anchor,
         injector: injector,
         context: context,
         container: container(),

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
@@ -157,9 +157,10 @@ export class NgpPopoverTrigger<T = null> {
    * Define an anchor element for positioning the popover.
    * If provided, the popover will be positioned relative to this element instead of the trigger.
    *
-   * The anchor is live, so rebinding it moves an open popover. When the new anchor comes
-   * from a press, bind it on `mousedown` rather than `click` - outside-press dismissal is
-   * decided on a capture-phase `mouseup`, so an anchor arriving with `click` is too late.
+   * The anchor is live, so rebinding it moves an open popover.
+   *
+   * An input only reaches this directive on the next change detection pass, which a press
+   * can outrun - use `setAnchor()` instead when the anchor is claimed during one.
    */
   readonly anchor = input<HTMLElement | null>(null, {
     alias: 'ngpPopoverTriggerAnchor',
@@ -245,5 +246,20 @@ export class NgpPopoverTrigger<T = null> {
    */
   hide(origin: FocusOrigin = 'program'): Promise<void> {
     return this.state.hide(origin);
+  }
+
+  /**
+   * Set the anchor the popover is positioned against, taking effect immediately rather than
+   * on the next change detection pass.
+   *
+   * Reach for this over `ngpPopoverTriggerAnchor` when the anchor is claimed during a press.
+   * Outside-press dismissal is decided on a capture-phase `mouseup`, which a fast tap can
+   * deliver in the same frame as the `pointerdown` that claimed the anchor - before the
+   * binding has reached this directive, so the press dismisses the popover instead of moving
+   * it. Writing the anchor here is visible to that check straight away.
+   * @param anchor - The new anchor element
+   */
+  setAnchor(anchor: HTMLElement | null): void {
+    this.state.setAnchor(anchor);
   }
 }

--- a/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
+++ b/packages/ng-primitives/popover/src/popover-trigger/popover-trigger.ts
@@ -156,6 +156,10 @@ export class NgpPopoverTrigger<T = null> {
   /**
    * Define an anchor element for positioning the popover.
    * If provided, the popover will be positioned relative to this element instead of the trigger.
+   *
+   * The anchor is live, so rebinding it moves an open popover. When the new anchor comes
+   * from a press, bind it on `mousedown` rather than `click` - outside-press dismissal is
+   * decided on a capture-phase `mouseup`, so an anchor arriving with `click` is too late.
    */
   readonly anchor = input<HTMLElement | null>(null, {
     alias: 'ngpPopoverTriggerAnchor',

--- a/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
+++ b/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
@@ -1058,6 +1058,83 @@ describe('NgpPopover', () => {
         expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
       });
     });
+
+    it('should move an open popover to a rebound anchor and treat it as inside', async () => {
+      @Component({
+        template: `
+          <div
+            #anchorA
+            data-testid="anchor-a"
+            style="position: absolute; top: 100px; left: 200px; width: 50px; height: 30px;"
+          >
+            Anchor A
+          </div>
+          <div
+            #anchorB
+            data-testid="anchor-b"
+            style="position: absolute; top: 400px; left: 200px; width: 50px; height: 30px;"
+          >
+            Anchor B
+          </div>
+          <button
+            [ngpPopoverTrigger]="content"
+            [ngpPopoverTriggerAnchor]="useB ? anchorB : anchorA"
+            style="position: absolute; top: 700px; left: 400px;"
+          >
+            Trigger
+          </button>
+
+          <ng-template #content>
+            <div ngpPopover>Popover content</div>
+          </ng-template>
+        `,
+        imports: [NgpPopoverTrigger, NgpPopover],
+      })
+      class MovingAnchorTestComponent {
+        useB = false;
+      }
+
+      const { fixture, getByRole, getByTestId } = await render(MovingAnchorTestComponent);
+      fireEvent.click(getByRole('button'));
+
+      const anchorA = getByTestId('anchor-a');
+      const anchorB = getByTestId('anchor-b');
+      // The computed offset, not the rendered box: a bare `[ngpPopover]` in a test has no
+      // `position`, so the coordinates the directive writes never move its rect.
+      const popoverTop = () =>
+        parseFloat((document.querySelector('[ngpPopover]') as HTMLElement).style.top);
+
+      // Default placement is `bottom`, so the popover sits just below whichever element it
+      // follows, and the two anchors are far enough apart that only one can be true.
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+        expect(popoverTop()).toBeGreaterThanOrEqual(anchorA.getBoundingClientRect().bottom);
+        expect(popoverTop()).toBeLessThan(anchorB.getBoundingClientRect().top);
+      });
+
+      const popoverBefore = document.querySelector('[ngpPopover]');
+
+      fixture.componentInstance.useB = true;
+      fixture.detectChanges();
+
+      await waitFor(() => {
+        expect(popoverTop()).toBeGreaterThanOrEqual(anchorB.getBoundingClientRect().bottom);
+      });
+      // It moved rather than closing and reopening somewhere else.
+      expect(document.querySelector('[ngpPopover]')).toBe(popoverBefore);
+
+      // The element the popover now follows counts as inside for outside-press dismissal.
+      fireEvent.mouseUp(anchorB);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+      });
+
+      // ...and the one it left behind does not.
+      fireEvent.mouseUp(anchorA);
+      await waitFor(() => {
+        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('control container isolation', () => {

--- a/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
+++ b/packages/ng-primitives/popover/src/popover/tests/popover-primitive.test.ts
@@ -1012,7 +1012,13 @@ describe('NgpPopover', () => {
           </button>
 
           <ng-template #content>
-            <div ngpPopover>Popover content</div>
+            <div
+              ngpPopover
+              data-testid="anchored"
+              style="position: fixed; width: 120px; height: 60px;"
+            >
+              Popover content
+            </div>
           </ng-template>
         `,
         imports: [NgpPopoverTrigger, NgpPopover],
@@ -1022,14 +1028,22 @@ describe('NgpPopover', () => {
       const { getByRole } = await render(AnchorTestComponent);
       fireEvent.click(getByRole('button'));
 
+      // The popover should be positioned relative to the anchor (top 100px, left 200px) rather
+      // than the trigger (top 300px, left 400px).
+      //
+      // Two things have to be true for that to be observable at all, and neither was: the panel
+      // needs an explicit size and position, because Floating UI writes `top`/`left` which a
+      // static element ignores; and the assertion has to wait for the position, because
+      // `computePosition` resolves a task after the element is in the document. Without both,
+      // the popover measures 0,0 and "left is less than 300" holds vacuously.
       await waitFor(() => {
-        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
-      });
+        const rect = document.querySelector('[data-testid="anchored"]')!.getBoundingClientRect();
 
-      // The popover should be positioned relative to the anchor (left 200px) rather than
-      // the trigger (left 400px).
-      const popover = document.querySelector('[ngpPopover]') as HTMLElement;
-      expect(popover.getBoundingClientRect().left).toBeLessThan(300);
+        expect(rect.left).toBeGreaterThan(100);
+        expect(rect.left).toBeLessThan(300);
+        expect(rect.top).toBeGreaterThanOrEqual(130);
+        expect(rect.top).toBeLessThan(300);
+      });
     });
 
     it('should fall back to the trigger element when the anchor is null', async () => {
@@ -1085,7 +1099,13 @@ describe('NgpPopover', () => {
           </button>
 
           <ng-template #content>
-            <div ngpPopover>Popover content</div>
+            <div
+              ngpPopover
+              data-testid="moving"
+              style="position: fixed; width: 120px; height: 60px;"
+            >
+              Popover content
+            </div>
           </ng-template>
         `,
         imports: [NgpPopoverTrigger, NgpPopover],
@@ -1099,40 +1119,42 @@ describe('NgpPopover', () => {
 
       const anchorA = getByTestId('anchor-a');
       const anchorB = getByTestId('anchor-b');
-      // The computed offset, not the rendered box: a bare `[ngpPopover]` in a test has no
-      // `position`, so the coordinates the directive writes never move its rect.
-      const popoverTop = () =>
-        parseFloat((document.querySelector('[ngpPopover]') as HTMLElement).style.top);
+      const popover = () => document.querySelector('[data-testid="moving"]');
+      const popoverRect = () => popover()!.getBoundingClientRect();
 
       // Default placement is `bottom`, so the popover sits just below whichever element it
-      // follows, and the two anchors are far enough apart that only one can be true.
+      // follows, and the two anchors are far enough apart that only one can be true. `left`
+      // is the settle gate - it is the same for both anchors, and an unpositioned panel
+      // reads 0 while `computePosition` is still resolving.
       await waitFor(() => {
-        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
-        expect(popoverTop()).toBeGreaterThanOrEqual(anchorA.getBoundingClientRect().bottom);
-        expect(popoverTop()).toBeLessThan(anchorB.getBoundingClientRect().top);
+        expect(popover()).toBeInTheDocument();
+        expect(popoverRect().left).toBeGreaterThan(100);
+        expect(popoverRect().top).toBeGreaterThanOrEqual(anchorA.getBoundingClientRect().bottom);
+        expect(popoverRect().top).toBeLessThan(anchorB.getBoundingClientRect().top);
       });
 
-      const popoverBefore = document.querySelector('[ngpPopover]');
+      const popoverBefore = popover();
 
       fixture.componentInstance.useB = true;
       fixture.detectChanges();
 
       await waitFor(() => {
-        expect(popoverTop()).toBeGreaterThanOrEqual(anchorB.getBoundingClientRect().bottom);
+        expect(popoverRect().top).toBeGreaterThanOrEqual(anchorB.getBoundingClientRect().bottom);
       });
+
       // It moved rather than closing and reopening somewhere else.
-      expect(document.querySelector('[ngpPopover]')).toBe(popoverBefore);
+      expect(popover()).toBe(popoverBefore);
 
       // The element the popover now follows counts as inside for outside-press dismissal.
       fireEvent.mouseUp(anchorB);
       await waitFor(() => {
-        expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+        expect(popover()).toBeInTheDocument();
       });
 
       // ...and the one it left behind does not.
       fireEvent.mouseUp(anchorA);
       await waitFor(() => {
-        expect(document.querySelector('[ngpPopover]')).not.toBeInTheDocument();
+        expect(popover()).not.toBeInTheDocument();
       });
     });
   });

--- a/packages/ng-primitives/portal/src/overlay-registry.ts
+++ b/packages/ng-primitives/portal/src/overlay-registry.ts
@@ -1,6 +1,6 @@
 import { FocusOrigin } from '@angular/cdk/a11y';
 import { DOCUMENT } from '@angular/common';
-import { inject, Injectable, NgZone } from '@angular/core';
+import { inject, Injectable, isSignal, NgZone, Signal } from '@angular/core';
 import { Subject } from 'rxjs';
 
 /**
@@ -59,8 +59,11 @@ export interface NgpOverlayEntry {
   getElements: () => HTMLElement[];
   /** The trigger element */
   triggerElement: HTMLElement;
-  /** Optional anchor element */
-  anchorElement?: HTMLElement | null;
+  /**
+   * Optional anchor element. Pass a signal when the anchor can change while the overlay
+   * is open - an entry is registered once per open and is not re-registered on a change.
+   */
+  anchorElement?: HTMLElement | null | Signal<HTMLElement | null | undefined>;
   /** Per-instance dismiss configuration */
   dismissPolicy: NgpDismissPolicy;
   /** If true, clicks on the trigger element are treated as outside clicks */
@@ -389,7 +392,10 @@ export class NgpOverlayRegistry {
     const isInsideElements = entry.getElements().some(el => path.includes(el));
     const isInsideTrigger =
       !entry.treatTriggerClickAsOutside && path.includes(entry.triggerElement);
-    const isInsideAnchor = entry.anchorElement ? path.includes(entry.anchorElement) : false;
+    const anchorElement = isSignal(entry.anchorElement)
+      ? entry.anchorElement()
+      : entry.anchorElement;
+    const isInsideAnchor = anchorElement ? path.includes(anchorElement) : false;
     return !(isInsideElements || isInsideTrigger || isInsideAnchor);
   }
 

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -528,7 +528,11 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
 
     if (outletElement && this.disposePositioning) {
       this.disposePositioning();
+      // `autoUpdate` positions once as it binds, so the overlay is already over the new
+      // anchor - repositioning again here would compute a second time and run change
+      // detection over the portal twice for one anchor change.
       this.setupPositioning(outletElement);
+      return;
     }
 
     this.updatePosition();

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -11,6 +11,7 @@ import {
   ViewContainerRef,
   computed,
   inject,
+  isSignal,
   runInInjectionContext,
   signal,
 } from '@angular/core';
@@ -27,7 +28,7 @@ import {
 } from '@floating-ui/dom';
 import { explicitEffect, fromResizeEvent } from 'ng-primitives/internal';
 import { injectDisposables, safeTakeUntilDestroyed, uniqueId } from 'ng-primitives/utils';
-import { Subject } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { NgpFlip, NgpFlipOptions } from './flip';
 import { NgpOffset } from './offset';
 import { CooldownOverlay, NgpOverlayCooldownManager } from './overlay-cooldown';
@@ -148,8 +149,13 @@ export interface NgpOverlayConfig<T = unknown> {
   /** The element that triggers the overlay */
   triggerElement: HTMLElement;
 
-  /** The element to use for positioning the overlay (if different from trigger) */
-  anchorElement?: HTMLElement | null;
+  /**
+   * The element to use for positioning the overlay (if different from trigger).
+   *
+   * Pass a signal to re-anchor an overlay that is already open - a plain element is
+   * read once, when the overlay is created, and never revisited.
+   */
+  anchorElement?: HTMLElement | null | Signal<HTMLElement | null | undefined>;
 
   /** The injector to use for creating the portal */
   injector: Injector;
@@ -366,6 +372,21 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    */
   readonly instantTransition = signal(false);
 
+  /**
+   * The configured anchor, normalised to a signal so that a caller passing a plain
+   * element and one passing a signal are handled the same way downstream.
+   */
+  private readonly anchorElement: Signal<HTMLElement | null | undefined>;
+
+  /**
+   * Resize monitoring for the current reference element. Held so it can be moved to a
+   * new element when the anchor changes.
+   */
+  private resizeSubscription?: Subscription;
+
+  /** The element resizeSubscription is currently watching. */
+  private monitoredElement?: HTMLElement;
+
   /** Store the arrow element */
   private arrowElement: HTMLElement | null = null;
 
@@ -387,6 +408,10 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     // we cannot inject the viewContainerRef as this can throw an error during hydration in SSR
     this.viewContainerRef = config.viewContainerRef;
 
+    this.anchorElement = isSignal(config.anchorElement)
+      ? config.anchorElement
+      : signal(config.anchorElement);
+
     // Listen for placement signal changes to update position
     // eslint-disable-next-line @angular-eslint/no-uncalled-signals -- checking whether the optional signal was provided, not its value
     if (config.placement !== undefined) {
@@ -407,15 +432,45 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     this.transformOrigin.set(this.getTransformOrigin());
 
     // Monitor trigger element resize
-    const elementToMonitor = this.config.anchorElement || this.config.triggerElement;
-    let hasMeasuredNonZeroTrigger = false;
-    fromResizeEvent(elementToMonitor)
+    this.monitorReferenceResize();
+
+    // A signal anchor can change while the overlay is open, and everything bound to the
+    // previous element has to follow it - not just the computed position.
+    if (isSignal(config.anchorElement)) {
+      explicitEffect([config.anchorElement], () => this.handleAnchorChange());
+    }
+
+    // Ensure cleanup on destroy
+    this.destroyRef.onDestroy(() => {
+      this.destroy();
+    });
+  }
+
+  /**
+   * Watch the reference element for resizes, replacing any previous subscription so a
+   * changed anchor is measured instead of the element it replaced.
+   */
+  private monitorReferenceResize(): void {
+    const element = this.referenceElement;
+
+    // Re-running for the same element would restart the zero-measurement guard below,
+    // which is what keeps a trigger that has not been laid out yet from closing itself.
+    if (this.monitoredElement === element) {
+      return;
+    }
+
+    this.monitoredElement = element;
+    this.resizeSubscription?.unsubscribe();
+
+    let hasMeasuredNonZeroReference = false;
+    // An anchor change reaches this from an effect, where there is no injection context.
+    this.resizeSubscription = fromResizeEvent(element, { injector: this.config.injector })
       .pipe(safeTakeUntilDestroyed(this.destroyRef))
       .subscribe(({ width, height }) => {
         this.triggerWidth.set(width);
 
         if (width !== 0 && height !== 0) {
-          hasMeasuredNonZeroTrigger = true;
+          hasMeasuredNonZeroReference = true;
           return;
         }
 
@@ -425,15 +480,49 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
         // 0x0, and both the initial measurement and the observer's first callback
         // report it). Closing on those tears down an overlay that was only just
         // opened, and the trigger may still be about to grow.
-        if (hasMeasuredNonZeroTrigger) {
+        if (hasMeasuredNonZeroReference) {
           this.hideImmediate();
         }
       });
+  }
 
-    // Ensure cleanup on destroy
-    this.destroyRef.onDestroy(() => {
-      this.destroy();
-    });
+  /**
+   * Move everything bound to the previous anchor across to the new one. The resize
+   * observer, the close-scroll strategy's overflow ancestors and floating-ui's
+   * `autoUpdate` reference all capture the element when they are created, so a changed
+   * anchor has to rebuild them rather than just recompute the position.
+   */
+  private handleAnchorChange(): void {
+    this.monitorReferenceResize();
+
+    if (!this.isOpen()) {
+      return;
+    }
+
+    // CloseScrollStrategy resolves the reference's overflow ancestors in enable().
+    if (this.config.scrollBehaviour === 'close') {
+      this.scrollStrategy.disable();
+      this.scrollStrategy = this.createScrollStrategy();
+      this.scrollStrategy.enable();
+    }
+
+    const portal = this.portal();
+    const outletElement = portal ? this.findOutletElement(portal) : null;
+
+    if (outletElement && this.disposePositioning) {
+      this.disposePositioning();
+      this.setupPositioning(outletElement);
+    }
+
+    this.updatePosition();
+  }
+
+  /**
+   * The element the overlay is positioned and tracked against - the anchor when one is
+   * configured, otherwise the trigger.
+   */
+  private get referenceElement(): HTMLElement {
+    return this.anchorElement() ?? this.config.triggerElement;
   }
 
   /**
@@ -899,7 +988,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       overlay: this,
       getElements: () => this.getElements(),
       triggerElement: this.config.triggerElement,
-      anchorElement: this.config.anchorElement,
+      anchorElement: this.anchorElement,
       dismissPolicy: {
         outsidePress: this.config.closeOnOutsideClick ?? false,
         escapeKey: this.config.closeOnEscape ?? false,
@@ -1002,7 +1091,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
         return new BlockScrollStrategy(this.viewportRuler, this.document);
       case 'close':
         return new CloseScrollStrategy(
-          this.config.anchorElement || this.config.triggerElement,
+          this.referenceElement,
           () => this.hide({ immediate: true }),
           () => this.getElements(),
         );
@@ -1017,11 +1106,9 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   private setupPositioning(overlayElement: HTMLElement): void {
     // Get the reference for auto-update - use trigger element for resize/scroll tracking
     // even when using programmatic position (the virtual element is created dynamically in computePosition)
-    const referenceElement = this.config.anchorElement || this.config.triggerElement;
-
     // Setup auto-update for positioning
     this.disposePositioning = autoUpdate(
-      referenceElement,
+      this.referenceElement,
       overlayElement,
       () => this.computePosition(overlayElement),
       { animationFrame: this.config.trackPosition ?? false },
@@ -1151,7 +1238,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
         contextElement: this.config.triggerElement,
       };
     }
-    return this.config.anchorElement || this.config.triggerElement;
+    return this.referenceElement;
   }
 
   /**

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -373,10 +373,19 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   readonly instantTransition = signal(false);
 
   /**
-   * The configured anchor, normalised to a signal so that a caller passing a plain
-   * element and one passing a signal are handled the same way downstream.
+   * The configured anchor as given, kept in a signal of its own so `updateConfig()`
+   * can replace it wholesale - including swapping between an element and a signal.
    */
-  private readonly anchorElement: Signal<HTMLElement | null | undefined>;
+  private readonly anchorSource = signal<NgpOverlayConfig<T>['anchorElement']>(undefined);
+
+  /**
+   * The anchor resolved to an element, so a caller passing an element, a caller passing
+   * a signal, and a later `updateConfig()` are all handled the same way downstream.
+   */
+  private readonly anchorElement = computed(() => {
+    const source = this.anchorSource();
+    return isSignal(source) ? source() : source;
+  });
 
   /**
    * Resize monitoring for the current reference element. Held so it can be moved to a
@@ -408,9 +417,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     // we cannot inject the viewContainerRef as this can throw an error during hydration in SSR
     this.viewContainerRef = config.viewContainerRef;
 
-    this.anchorElement = isSignal(config.anchorElement)
-      ? config.anchorElement
-      : signal(config.anchorElement);
+    this.anchorSource.set(config.anchorElement);
 
     // Listen for placement signal changes to update position
     // eslint-disable-next-line @angular-eslint/no-uncalled-signals -- checking whether the optional signal was provided, not its value
@@ -434,11 +441,9 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     // Monitor trigger element resize
     this.monitorReferenceResize();
 
-    // A signal anchor can change while the overlay is open, and everything bound to the
+    // The anchor can change while the overlay is open, and everything bound to the
     // previous element has to follow it - not just the computed position.
-    if (isSignal(config.anchorElement)) {
-      explicitEffect([config.anchorElement], () => this.handleAnchorChange());
-    }
+    explicitEffect([this.anchorElement], () => this.handleAnchorChange());
 
     // Ensure cleanup on destroy
     this.destroyRef.onDestroy(() => {
@@ -502,7 +507,13 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
 
     this.monitorReferenceResize();
 
-    if (!this.isOpen()) {
+    // `isOpen` stays true for the length of the exit animation, but the portal is
+    // cleared and the scroll strategy disabled as soon as teardown begins. Rebuilding
+    // either of them in that window installs listeners nothing disables again, so the
+    // live portal - not `isOpen` - is what says there is something to move.
+    const portal = this.portal();
+
+    if (!portal || !this.isOpen()) {
       return;
     }
 
@@ -513,8 +524,7 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
       this.scrollStrategy.enable();
     }
 
-    const portal = this.portal();
-    const outletElement = portal ? this.findOutletElement(portal) : null;
+    const outletElement = this.findOutletElement(portal);
 
     if (outletElement && this.disposePositioning) {
       this.disposePositioning();
@@ -781,6 +791,12 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    */
   updateConfig(config: Partial<NgpOverlayConfig<T>>): void {
     this.config = { ...this.config, ...config };
+
+    // Everything anchor-bound reads the resolved signal rather than the config, so a
+    // replacement anchor has to reach it or the overlay keeps using the original.
+    if ('anchorElement' in config) {
+      this.anchorSource.set(config.anchorElement);
+    }
 
     // If the overlay is already open, update its position
     if (this.isOpen()) {

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -396,6 +396,14 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
   /** The element resizeSubscription is currently watching. */
   private monitoredElement?: HTMLElement;
 
+  /**
+   * The reference the anchor-bound bindings were last built against. Kept apart from
+   * `monitoredElement` so that whether the anchor has moved is not answered by where the
+   * resize observer happens to be pointed - they agree today, and a second reason to move
+   * the observer would silently stop anchor changes being noticed at all.
+   */
+  private boundReference?: HTMLElement;
+
   /** Store the arrow element */
   private arrowElement: HTMLElement | null = null;
 
@@ -442,7 +450,10 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
     this.monitorReferenceResize();
 
     // The anchor can change while the overlay is open, and everything bound to the
-    // previous element has to follow it - not just the computed position.
+    // previous element has to follow it - not just the computed position. Seeded with the
+    // reference monitored above, so the effect's first run - which carries the initial
+    // anchor, not a change - has nothing to move.
+    this.boundReference = this.referenceElement;
     explicitEffect([this.anchorElement], () => this.handleAnchorChange());
 
     // Ensure cleanup on destroy
@@ -498,13 +509,16 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    * anchor has to rebuild them rather than just recompute the position.
    */
   private handleAnchorChange(): void {
-    // The effect also runs once on creation, and a controlled input can notify without
-    // the resolved element differing. Rebuilding for a reference that has not moved
-    // would tear down `autoUpdate` under an overlay mid-flight for nothing.
-    if (this.monitoredElement === this.referenceElement) {
+    const reference = this.referenceElement;
+
+    // A controlled input can notify without the resolved element differing. Rebuilding for
+    // a reference that has not moved would tear down `autoUpdate` under an overlay
+    // mid-flight for nothing.
+    if (this.boundReference === reference) {
       return;
     }
 
+    this.boundReference = reference;
     this.monitorReferenceResize();
 
     // `isOpen` stays true for the length of the exit animation, but the portal is

--- a/packages/ng-primitives/portal/src/overlay.ts
+++ b/packages/ng-primitives/portal/src/overlay.ts
@@ -493,6 +493,13 @@ export class NgpOverlay<T = unknown> implements CooldownOverlay {
    * anchor has to rebuild them rather than just recompute the position.
    */
   private handleAnchorChange(): void {
+    // The effect also runs once on creation, and a controlled input can notify without
+    // the resolved element differing. Rebuilding for a reference that has not moved
+    // would tear down `autoUpdate` under an overlay mid-flight for nothing.
+    if (this.monitoredElement === this.referenceElement) {
+      return;
+    }
+
     this.monitorReferenceResize();
 
     if (!this.isOpen()) {

--- a/packages/ng-primitives/portal/src/tests/overlay-anchor.test-d.ts
+++ b/packages/ng-primitives/portal/src/tests/overlay-anchor.test-d.ts
@@ -1,0 +1,29 @@
+import { signal } from '@angular/core';
+import { describe, expectTypeOf, it } from 'vitest';
+import type { NgpOverlayConfig } from '../overlay';
+import type { NgpOverlayEntry } from '../overlay-registry';
+
+type ConfigAnchor = NgpOverlayConfig['anchorElement'];
+type EntryAnchor = NgpOverlayEntry['anchorElement'];
+
+/**
+ * A signal anchor is what lets an open overlay be re-anchored, but `anchorElement` was a
+ * plain element first and both `NgpOverlayConfig` and `NgpOverlayEntry` are public. Callers
+ * still passing an element must keep compiling, so the widening is asserted rather than
+ * left to the one caller that happens to exercise it.
+ */
+describe('anchorElement types', () => {
+  it('accepts a plain element, null and undefined', () => {
+    expectTypeOf<HTMLElement>().toExtend<ConfigAnchor>();
+    expectTypeOf<null>().toExtend<ConfigAnchor>();
+    expectTypeOf<undefined>().toExtend<ConfigAnchor>();
+
+    expectTypeOf<HTMLElement>().toExtend<EntryAnchor>();
+    expectTypeOf<null>().toExtend<EntryAnchor>();
+  });
+
+  it('accepts a signal of an element', () => {
+    expectTypeOf(signal<HTMLElement | null>(null)).toExtend<ConfigAnchor>();
+    expectTypeOf(signal<HTMLElement | null>(null)).toExtend<EntryAnchor>();
+  });
+});

--- a/packages/ng-primitives/portal/src/tests/overlay-anchor.test.ts
+++ b/packages/ng-primitives/portal/src/tests/overlay-anchor.test.ts
@@ -39,6 +39,126 @@ class OverlayHostComponent {
 }
 
 /**
+ * Two anchors, each inside its own scroll container, so "which element is this bound to"
+ * can be asked of the resize observer and of the close-scroll strategy independently.
+ */
+@Component({
+  template: `
+    <div
+      data-testid="scroller-a"
+      style="position: absolute; top: 0; left: 0; width: 120px; height: 80px; overflow: auto;"
+    >
+      <div #anchorA data-testid="anchor-a" style="width: 50px; height: 30px;">A</div>
+      <div style="height: 400px"></div>
+    </div>
+    <div
+      data-testid="scroller-b"
+      style="position: absolute; top: 200px; left: 0; width: 120px; height: 80px; overflow: auto;"
+    >
+      <div #anchorB data-testid="anchor-b" style="width: 50px; height: 30px;">B</div>
+      <div style="height: 400px"></div>
+    </div>
+    <button data-testid="trigger" type="button" style="position: absolute; top: 500px; left: 40px;">
+      Trigger
+    </button>
+
+    <ng-template #content>
+      <div data-testid="overlay" style="position: absolute; width: 80px; height: 40px;">
+        Overlay
+      </div>
+    </ng-template>
+  `,
+})
+class TwoAnchorHostComponent {
+  readonly content = viewChild.required<TemplateRef<NgpOverlayTemplateContext<unknown>>>('content');
+  readonly viewContainerRef = inject(ViewContainerRef);
+  readonly injector = inject(Injector);
+}
+
+/**
+ * Positioning re-reads the anchor on every pass, so it keeps working on its own. What does
+ * not are the things that capture an element when they are built - these cover the two that
+ * nothing else exercises, each from both sides, so a rebuild that never happens and one
+ * wired to the wrong element are told apart.
+ */
+describe('overlay anchorElement bindings follow the anchor', () => {
+  let overlay: NgpOverlay<unknown> | null = null;
+
+  afterEach(() => {
+    overlay?.destroy();
+    overlay = null;
+    document.querySelectorAll('[data-testid="overlay"]').forEach(el => el.remove());
+  });
+
+  async function openAnchoredToA(scrollBehaviour?: 'close') {
+    const { fixture, getByTestId } = await render(TwoAnchorHostComponent);
+    fixture.autoDetectChanges(true);
+
+    const host = fixture.componentInstance;
+    const anchor = signal<HTMLElement | null>(getByTestId('anchor-a'));
+
+    overlay = TestBed.runInInjectionContext(() =>
+      createOverlay({
+        content: host.content,
+        triggerElement: getByTestId('trigger'),
+        injector: host.injector,
+        viewContainerRef: host.viewContainerRef,
+        anchorElement: anchor,
+        scrollBehaviour,
+      }),
+    );
+
+    await overlay.show();
+    await waitFor(() => expect(overlay!.position().y).toBeDefined());
+
+    anchor.set(getByTestId('anchor-b'));
+    TestBed.flushEffects();
+
+    // The replacement subscription takes its baseline measurement in a microtask, and
+    // only a reference that has measured a real size closes the overlay when it collapses.
+    await waitFor(() => expect(overlay!.triggerWidth()).not.toBeNull());
+
+    return getByTestId;
+  }
+
+  it('should stop watching the previous anchor for a collapse', async () => {
+    const getByTestId = await openAnchoredToA();
+
+    getByTestId('anchor-a').style.display = 'none';
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(overlay!.isOpen()).toBe(true);
+  });
+
+  it('should close when the new anchor collapses', async () => {
+    const getByTestId = await openAnchoredToA();
+
+    getByTestId('anchor-b').style.display = 'none';
+
+    await waitFor(() => expect(overlay!.isOpen()).toBe(false));
+  });
+
+  it('should stop closing on scroll of the previous anchor ancestors', async () => {
+    const getByTestId = await openAnchoredToA('close');
+
+    getByTestId('scroller-a').scrollTop = 40;
+    getByTestId('scroller-a').dispatchEvent(new Event('scroll'));
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    expect(overlay!.isOpen()).toBe(true);
+  });
+
+  it('should close on scroll of the new anchor ancestors', async () => {
+    const getByTestId = await openAnchoredToA('close');
+
+    getByTestId('scroller-b').scrollTop = 40;
+    getByTestId('scroller-b').dispatchEvent(new Event('scroll'));
+
+    await waitFor(() => expect(overlay!.isOpen()).toBe(false));
+  });
+});
+
+/**
  * `updateConfig()` is the overlay's only supported way to replace configuration after
  * construction. Everything anchor-bound reads a resolved signal rather than the config
  * object, so unless the two are wired together a replacement anchor is accepted and then

--- a/packages/ng-primitives/portal/src/tests/overlay-anchor.test.ts
+++ b/packages/ng-primitives/portal/src/tests/overlay-anchor.test.ts
@@ -1,0 +1,132 @@
+import {
+  Component,
+  Injector,
+  TemplateRef,
+  ViewContainerRef,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { render, waitFor } from '@testing-library/angular';
+import { afterEach, describe, expect, it } from 'vitest';
+import { NgpOverlay, createOverlay } from '../overlay';
+
+@Component({
+  template: `
+    <div
+      #anchor
+      data-testid="anchor"
+      style="position: absolute; top: 100px; left: 40px; width: 50px; height: 30px;"
+    >
+      Anchor
+    </div>
+    <button data-testid="trigger" type="button" style="position: absolute; top: 500px; left: 40px;">
+      Trigger
+    </button>
+
+    <ng-template #content>
+      <div data-testid="overlay" style="position: absolute; width: 80px; height: 40px;">
+        Overlay
+      </div>
+    </ng-template>
+  `,
+})
+class OverlayHostComponent {
+  readonly content = viewChild.required<TemplateRef<unknown>>('content');
+  readonly viewContainerRef = inject(ViewContainerRef);
+  readonly injector = inject(Injector);
+}
+
+/**
+ * `updateConfig()` is the overlay's only supported way to replace configuration after
+ * construction. Everything anchor-bound reads a resolved signal rather than the config
+ * object, so unless the two are wired together a replacement anchor is accepted and then
+ * ignored - which is worse than rejecting it.
+ *
+ * Assertions read the computed position rather than the DOM: `computePosition` publishes
+ * coordinates to a signal and leaves applying them to the content directive, so a bare
+ * template is never laid out.
+ */
+describe('overlay anchorElement via updateConfig', () => {
+  let overlay: NgpOverlay<unknown> | null = null;
+
+  afterEach(() => {
+    overlay?.destroy();
+    overlay = null;
+    document.querySelectorAll('[data-testid="overlay"]').forEach(el => el.remove());
+  });
+
+  it('should move an open overlay to an anchor supplied by updateConfig', async () => {
+    const { fixture, getByTestId } = await render(OverlayHostComponent);
+    fixture.autoDetectChanges(true);
+
+    const host = fixture.componentInstance;
+    const anchor = getByTestId('anchor');
+    const trigger = getByTestId('trigger');
+
+    overlay = TestBed.runInInjectionContext(() =>
+      createOverlay({
+        content: host.content,
+        triggerElement: trigger,
+        injector: host.injector,
+        viewContainerRef: host.viewContainerRef,
+      }),
+    );
+
+    await overlay.show();
+
+    // Default placement is `top`, so the overlay sits just above whichever element it
+    // follows. The anchor and the trigger are far enough apart that "above the anchor"
+    // and "above the trigger" cannot both be true.
+    await waitFor(() => expect(overlay!.position().y).toBeDefined());
+    expect(overlay.position().y).toBeGreaterThan(anchor.getBoundingClientRect().bottom);
+
+    overlay.updateConfig({ anchorElement: anchor });
+
+    await waitFor(() => {
+      TestBed.flushEffects();
+      expect(overlay!.position().y).toBeLessThan(anchor.getBoundingClientRect().top);
+    });
+  });
+
+  it('should follow a signal anchor supplied by updateConfig', async () => {
+    const { fixture, getByTestId } = await render(OverlayHostComponent);
+    fixture.autoDetectChanges(true);
+
+    const host = fixture.componentInstance;
+    const anchor = getByTestId('anchor');
+    const trigger = getByTestId('trigger');
+
+    overlay = TestBed.runInInjectionContext(() =>
+      createOverlay({
+        content: host.content,
+        triggerElement: trigger,
+        injector: host.injector,
+        viewContainerRef: host.viewContainerRef,
+      }),
+    );
+
+    await overlay.show();
+    await waitFor(() => expect(overlay!.position().y).toBeDefined());
+
+    // Swapping a plain-element config for a signal one has to take effect too, since
+    // `updateConfig` replaces the anchor wholesale rather than its value.
+    const anchorSignal = signal<HTMLElement | null>(anchor);
+    overlay.updateConfig({ anchorElement: anchorSignal });
+
+    await waitFor(() => {
+      TestBed.flushEffects();
+      expect(overlay!.position().y).toBeLessThan(anchor.getBoundingClientRect().top);
+    });
+
+    // And the swapped-in signal stays live rather than being read once - clearing it
+    // sends the overlay back to the trigger.
+    anchorSignal.set(null);
+
+    await waitFor(() => {
+      TestBed.flushEffects();
+      expect(overlay!.position().y).toBeGreaterThan(anchor.getBoundingClientRect().bottom);
+    });
+  });
+});

--- a/packages/ng-primitives/portal/src/tests/overlay-anchor.test.ts
+++ b/packages/ng-primitives/portal/src/tests/overlay-anchor.test.ts
@@ -10,7 +10,7 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { render, waitFor } from '@testing-library/angular';
 import { afterEach, describe, expect, it } from 'vitest';
-import { NgpOverlay, createOverlay } from '../overlay';
+import { NgpOverlay, NgpOverlayTemplateContext, createOverlay } from '../overlay';
 
 @Component({
   template: `
@@ -33,7 +33,7 @@ import { NgpOverlay, createOverlay } from '../overlay';
   `,
 })
 class OverlayHostComponent {
-  readonly content = viewChild.required<TemplateRef<unknown>>('content');
+  readonly content = viewChild.required<TemplateRef<NgpOverlayTemplateContext<unknown>>>('content');
   readonly viewContainerRef = inject(ViewContainerRef);
   readonly injector = inject(Injector);
 }

--- a/packages/ng-primitives/portal/src/tests/overlay-anchor.test.ts
+++ b/packages/ng-primitives/portal/src/tests/overlay-anchor.test.ts
@@ -55,7 +55,8 @@ class OverlayHostComponent {
       data-testid="scroller-b"
       style="position: absolute; top: 200px; left: 0; width: 120px; height: 80px; overflow: auto;"
     >
-      <div #anchorB data-testid="anchor-b" style="width: 50px; height: 30px;">B</div>
+      <!-- A different width to A, so the resize handover has an observable signature. -->
+      <div #anchorB data-testid="anchor-b" style="width: 70px; height: 30px;">B</div>
       <div style="height: 400px"></div>
     </div>
     <button data-testid="trigger" type="button" style="position: absolute; top: 500px; left: 40px;">
@@ -114,9 +115,11 @@ describe('overlay anchorElement bindings follow the anchor', () => {
     anchor.set(getByTestId('anchor-b'));
     TestBed.flushEffects();
 
-    // The replacement subscription takes its baseline measurement in a microtask, and
-    // only a reference that has measured a real size closes the overlay when it collapses.
-    await waitFor(() => expect(overlay!.triggerWidth()).not.toBeNull());
+    // Wait for the replacement subscription to report B's width, not merely for some width
+    // to exist - A's is already there, so a "not null" gate would wait for nothing and let
+    // the collapse assertions race the handover. Only a reference that has measured a real
+    // size closes the overlay when it collapses, so that baseline has to have landed.
+    await waitFor(() => expect(overlay!.triggerWidth()).toBe(70));
 
     return getByTestId;
   }
@@ -153,6 +156,18 @@ describe('overlay anchorElement bindings follow the anchor', () => {
 
     getByTestId('scroller-b').scrollTop = 40;
     getByTestId('scroller-b').dispatchEvent(new Event('scroll'));
+
+    await waitFor(() => expect(overlay!.isOpen()).toBe(false));
+  });
+
+  it('should close when the anchor is removed from the DOM', async () => {
+    const getByTestId = await openAnchoredToA();
+
+    // Re-anchoring across a virtualized list is what this is for, and there the anchor is
+    // taken out of the document rather than hidden. A detached element is reported at zero
+    // size, which the collapse guard already reads as "the reference is gone" - covered
+    // because that is what stops a recycled row leaving the overlay stranded.
+    getByTestId('anchor-b').remove();
 
     await waitFor(() => expect(overlay!.isOpen()).toBe(false));
   });

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tests/tooltip-primitive.test.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tests/tooltip-primitive.test.ts
@@ -1,6 +1,6 @@
 import { Directive, effect, input, OnInit, TemplateRef } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import {
   injectTooltipTriggerState,
   NgpTooltip,
@@ -1861,6 +1861,66 @@ describe('NgpTooltipTrigger (primitive)', () => {
       await waitFor(() => {
         expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
       });
+    });
+
+    it('should move a showing tooltip to a rebound anchor', async () => {
+      const { fixture, getByRole } = await render(
+        `
+          <div
+            #anchorA
+            data-testid="anchor-a"
+            style="position: absolute; top: 100px; left: 200px; width: 50px; height: 30px;"
+          >
+            Anchor A
+          </div>
+          <div
+            #anchorB
+            data-testid="anchor-b"
+            style="position: absolute; top: 400px; left: 200px; width: 50px; height: 30px;"
+          >
+            Anchor B
+          </div>
+          <button
+            [ngpTooltipTrigger]="content"
+            [ngpTooltipTriggerAnchor]="useB ? anchorB : anchorA"
+            style="position: absolute; top: 700px; left: 400px;"
+          >
+            Trigger
+          </button>
+
+          <ng-template #content>
+            <div ngpTooltip>Tooltip content</div>
+          </ng-template>
+        `,
+        { imports: [NgpTooltipTrigger, NgpTooltip], componentProperties: { useB: false } },
+      );
+
+      fireEvent.mouseEnter(getByRole('button'));
+
+      const anchorA = screen.getByTestId('anchor-a');
+      const anchorB = screen.getByTestId('anchor-b');
+      // The computed offset, not the rendered box: a bare `[ngpTooltip]` in a test has no
+      // `position`, so the coordinates the directive writes never move its rect.
+      const tooltipTop = () =>
+        parseFloat((document.querySelector('[ngpTooltip]') as HTMLElement).style.top);
+
+      await waitFor(() => {
+        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
+        expect(tooltipTop()).toBeLessThan(anchorA.getBoundingClientRect().top);
+      });
+
+      const tooltipBefore = document.querySelector('[ngpTooltip]');
+
+      fixture.componentInstance.useB = true;
+      fixture.detectChanges();
+
+      await waitFor(() => {
+        expect(tooltipTop()).toBeGreaterThan(anchorA.getBoundingClientRect().bottom);
+      });
+
+      expect(tooltipTop()).toBeLessThan(anchorB.getBoundingClientRect().top);
+      // The tooltip moved rather than being closed and shown again somewhere else.
+      expect(document.querySelector('[ngpTooltip]')).toBe(tooltipBefore);
     });
   });
 

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tests/tooltip-primitive.test.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tests/tooltip-primitive.test.ts
@@ -1792,7 +1792,9 @@ describe('NgpTooltipTrigger (primitive)', () => {
           </button>
 
           <ng-template #content>
-            <div ngpTooltip>Tooltip content</div>
+            <div ngpTooltip data-testid="anchored" style="position: fixed; width: 120px; height: 60px;">
+              Tooltip content
+            </div>
           </ng-template>
         `,
         { imports: [NgpTooltipTrigger, NgpTooltip] },
@@ -1800,18 +1802,21 @@ describe('NgpTooltipTrigger (primitive)', () => {
 
       fireEvent.mouseEnter(getByRole('button'));
 
-      await waitFor(() => {
-        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
-      });
-
       // The tooltip should be positioned relative to the anchor element (top: 100px, left: 200px)
-      // rather than the trigger element (top: 300px, left: 400px)
-      const tooltip = document.querySelector('[ngpTooltip]') as HTMLElement;
-      const tooltipRect = tooltip.getBoundingClientRect();
+      // rather than the trigger element (top: 300px, left: 400px).
+      //
+      // Two things have to be true for that to be observable at all, and neither was: the panel
+      // needs an explicit size and position, because Floating UI writes `top`/`left` which a
+      // static element ignores; and the assertion has to wait for the position, because
+      // `computePosition` resolves a task after the element is in the document. Without both,
+      // the tooltip measures 0,0 and every "is it near the anchor" bound holds vacuously.
+      await waitFor(() => {
+        const rect = document.querySelector('[data-testid="anchored"]')!.getBoundingClientRect();
 
-      // The tooltip should be positioned close to the anchor's position (200px left)
-      // rather than near the trigger's position (400px left)
-      expect(tooltipRect.left).toBeLessThan(300);
+        expect(rect.left).toBeGreaterThan(100);
+        expect(rect.left).toBeLessThan(300);
+        expect(rect.bottom).toBeLessThanOrEqual(100);
+      });
     });
 
     it('should fall back to trigger element when anchor is null', async () => {
@@ -1889,7 +1894,9 @@ describe('NgpTooltipTrigger (primitive)', () => {
           </button>
 
           <ng-template #content>
-            <div ngpTooltip>Tooltip content</div>
+            <div ngpTooltip data-testid="moving" style="position: fixed; width: 120px; height: 60px;">
+              Tooltip content
+            </div>
           </ng-template>
         `,
         { imports: [NgpTooltipTrigger, NgpTooltip], componentProperties: { useB: false } },
@@ -1899,28 +1906,30 @@ describe('NgpTooltipTrigger (primitive)', () => {
 
       const anchorA = screen.getByTestId('anchor-a');
       const anchorB = screen.getByTestId('anchor-b');
-      // The computed offset, not the rendered box: a bare `[ngpTooltip]` in a test has no
-      // `position`, so the coordinates the directive writes never move its rect.
-      const tooltipTop = () =>
-        parseFloat((document.querySelector('[ngpTooltip]') as HTMLElement).style.top);
+      const tooltip = () => document.querySelector('[data-testid="moving"]');
+      const tooltipRect = () => tooltip()!.getBoundingClientRect();
 
+      // Default placement is `top`, so the tooltip sits above whichever element it follows,
+      // and the two anchors are far enough apart that only one can be true. `left` is the
+      // settle gate - it is the same for both anchors, and an unpositioned panel reads 0.
       await waitFor(() => {
-        expect(document.querySelector('[ngpTooltip]')).toBeInTheDocument();
-        expect(tooltipTop()).toBeLessThan(anchorA.getBoundingClientRect().top);
+        expect(tooltip()).toBeInTheDocument();
+        expect(tooltipRect().left).toBeGreaterThan(100);
+        expect(tooltipRect().bottom).toBeLessThanOrEqual(anchorA.getBoundingClientRect().top);
       });
 
-      const tooltipBefore = document.querySelector('[ngpTooltip]');
+      const tooltipBefore = tooltip();
 
       fixture.componentInstance.useB = true;
       fixture.detectChanges();
 
       await waitFor(() => {
-        expect(tooltipTop()).toBeGreaterThan(anchorA.getBoundingClientRect().bottom);
+        expect(tooltipRect().top).toBeGreaterThan(anchorA.getBoundingClientRect().bottom);
       });
 
-      expect(tooltipTop()).toBeLessThan(anchorB.getBoundingClientRect().top);
+      expect(tooltipRect().bottom).toBeLessThanOrEqual(anchorB.getBoundingClientRect().top);
       // The tooltip moved rather than being closed and shown again somewhere else.
-      expect(document.querySelector('[ngpTooltip]')).toBe(tooltipBefore);
+      expect(tooltip()).toBe(tooltipBefore);
     });
   });
 

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger-state.ts
@@ -663,7 +663,7 @@ export const [
       const config: NgpOverlayConfig<T | string> = {
         content,
         triggerElement: trigger.nativeElement,
-        anchorElement: anchor(),
+        anchorElement: anchor,
         injector: injector,
         context,
         container: container(),

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -127,6 +127,10 @@ export class NgpTooltipTrigger<T = null> {
   /**
    * Define an anchor element for positioning the tooltip.
    * If provided, the tooltip will be positioned relative to this element instead of the trigger.
+   *
+   * The anchor is live, so rebinding it moves an open tooltip. When the new anchor comes
+   * from a press, bind it on `mousedown` rather than `click` - outside-press dismissal is
+   * decided on a capture-phase `mouseup`, so an anchor arriving with `click` is too late.
    */
   readonly anchor = input<HTMLElement | null>(null, { alias: 'ngpTooltipTriggerAnchor' });
 

--- a/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
+++ b/packages/ng-primitives/tooltip/src/tooltip-trigger/tooltip-trigger.ts
@@ -128,9 +128,10 @@ export class NgpTooltipTrigger<T = null> {
    * Define an anchor element for positioning the tooltip.
    * If provided, the tooltip will be positioned relative to this element instead of the trigger.
    *
-   * The anchor is live, so rebinding it moves an open tooltip. When the new anchor comes
-   * from a press, bind it on `mousedown` rather than `click` - outside-press dismissal is
-   * decided on a capture-phase `mouseup`, so an anchor arriving with `click` is too late.
+   * The anchor is live, so rebinding it moves an open tooltip.
+   *
+   * An input only reaches this directive on the next change detection pass, which a press
+   * can outrun - use `setAnchor()` instead when the anchor is claimed during one.
    */
   readonly anchor = input<HTMLElement | null>(null, { alias: 'ngpTooltipTriggerAnchor' });
 
@@ -232,6 +233,21 @@ export class NgpTooltipTrigger<T = null> {
    */
   hide(immediate = false): void {
     return this.state.hide(immediate);
+  }
+
+  /**
+   * Set the anchor the tooltip is positioned against, taking effect immediately rather than
+   * on the next change detection pass.
+   *
+   * Reach for this over `ngpTooltipTriggerAnchor` when the anchor is claimed during a press.
+   * Outside-press dismissal is decided on a capture-phase `mouseup`, which a fast tap can
+   * deliver in the same frame as the `pointerdown` that claimed the anchor - before the
+   * binding has reached this directive, so the press dismisses the overlay instead of moving
+   * it. Writing the anchor here is visible to that check straight away.
+   * @param anchor - The new anchor element
+   */
+  setAnchor(anchor: HTMLElement | null): void {
+    this.state.setAnchor(anchor);
   }
 
   /**


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #921.** It targets `next` because the base branch lives on a fork and GitHub can't stack across forks, so the first two commits here are #921 and appear in this diff.
>
> Review the last two commits only — `feat(portal): let an open overlay follow a changing anchor` and `fix(portal): only rebuild anchor bindings when the reference moves`. Once #921 merges, rebasing collapses this to just those.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

No linked issue. This follows directly from the limitation both reviewers independently raised on #921 — that `setAnchor()` and `[ngpMenuTriggerAnchor]` have no effect after the first open. Happy to move this to a discussion first if you'd rather settle the direction before reviewing code, since it touches the shared portal layer rather than one primitive.

## What does this PR implement/fix?

`anchorElement` was read once, when the overlay was created, so the anchor inputs on the tooltip, popover and menu triggers only ever described *where the overlay opened*. Rebinding one afterwards did nothing.

It now also accepts a `Signal`, alongside the config's other reactive fields (`content`, `placement`, `position`, `context`), and tooltip, popover and menu pass theirs straight through.

### Why it isn't just a type change

`getPositionReference()` already re-read the anchor on every pass, so the positioning *maths* was nearly there. What wasn't were the four places that captured an **element** when they were built rather than reading one. Each now moves with the anchor:

| Capture | Why it has to follow |
| --- | --- |
| resize observer | watches the reference for a collapse to zero size, and hides the overlay when it goes |
| `CloseScrollStrategy` | resolves the reference's overflow ancestors in `enable()` |
| `autoUpdate` reference | closed over for the overlay's lifetime |
| registry entry | `register()` no-ops on a duplicate id, so the outside-press decision was frozen at open time |

That last one is what makes the current anchor count as inside for dismissal and the one it replaced count as outside — so exactly one element is inside at a time.

### Not a breaking change

`anchorElement` stays assignable from a plain element on both `NgpOverlayConfig` and `NgpOverlayEntry`, which are public. A plain element still means a fixed anchor, so existing `createOverlay` callers are unaffected. `overlay-anchor.test-d.ts` asserts the widening rather than leaving it to whichever caller happens to exercise it.

### Motivation

One menu shared across hundreds of interactive tokens — a virtualized JSON tree, also rendered as a grid cell renderer across many rows — where a trigger per token is far too much machinery. #921 alone doesn't help there: a static anchor gives nothing that moving a zero-size `position: fixed` span doesn't already give. Re-pointing a live anchor does, and deletes the workaround.

## Tests

Four tests in `menu-anchor.test.ts` covering the behaviours that only hold with a live anchor: an open menu moves to the new anchor; the new anchor is inside; the **previous** anchor becomes outside; unsetting the anchor while open falls back to the trigger. Reverting the portal change fails exactly those four and leaves #921's four passing.

Plus `overlay-anchor.test-d.ts` for the type compatibility above.

## Notes for review

Two things worth a second opinion:

**`handleAnchorChange` bails when the resolved element is unchanged.** Without that guard it disposed and re-created `autoUpdate` under a live overlay whenever a `controlled` input notified without the element actually differing, which made `menu-trigger-group-cooldown` fail intermittently — roughly 2 runs in 3, against 3 clean runs on #921's branch. With the guard, three consecutive full runs are clean. Flagging it because it was a genuine intermittent failure I introduced, not a pre-existing flake.

**`fromResizeEvent` is now passed an explicit `injector`.** An anchor change reaches it from an effect, where there is no injection context, and it calls `inject(PLATFORM_ID)`. This is equivalent to the previous implicit behaviour — `createOverlay` already runs construction inside `runInInjectionContext(config.injector, …)` — it just also works off the effect path.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open overlays now follow a changing anchor and treat the current anchor as inside for outside‑press. Previously the anchor was captured on open; now `anchorElement` can be a signal so menus, popovers, and tooltips re‑anchor live without closing, and re‑anchoring avoids double position computation.

- `NgpOverlay` accepts `anchorElement` as an element or signal, tracks it in an internal signal, and updates all anchor‑bound bindings when the reference actually changes: resize observer (now created with the provided injector), floating‑ui `autoUpdate` reference, `CloseScrollStrategy` overflow ancestors, and the outside‑press registry (which now reads a live signal). `updateConfig({ anchorElement })` can swap between an element and a signal; anchor removal/zero‑size closes the overlay. Position is computed once when rebinding; teardown windows no longer leak listeners.
- `NgpMenuTrigger`, `NgpPopoverTrigger`, and `NgpTooltipTrigger` forward anchor signals and expose `setAnchor(element|null)` to claim anchors immediately. Docs include a dynamic‑anchor example and press timing guidance; tests cover live re‑anchoring, inside/outside behavior, press ordering, node survival, and type widening.

**Rollout**
- No breaking change; passing a plain element still yields a fixed anchor.
- If you re‑anchor during a press, call `setAnchor` on `pointerdown`. Setting the input or using `click` may dismiss instead of move.

<sup>Written for commit 93079cf1f05cb26f032a5c2798e3a8654495c5a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Menus, popovers and tooltips can now be positioned against custom anchor elements.
  - Changing the anchor while an overlay is open automatically repositions it and updates its dismissal boundary.
  - Menus support dynamically selecting targets while preserving consistent press, outside-click and keyboard behaviour.

- **Documentation**
  - Expanded custom-anchor guidance and examples, including keyboard accessibility and press interactions.

- **Tests**
  - Added coverage for dynamic repositioning, fallback behaviour, anchor replacement and dismissal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->