### PR TITLE
fix(internal): stop a stale enter frame overwriting the exit state

### DIFF
--- a/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
@@ -122,6 +122,12 @@ export function setupExitAnimation({
     setState('enter');
   } else {
     pendingEnterFrame = requestAnimationFrame(() => {
+      // `exit()` clears the handle to supersede this callback, so a cleared handle means
+      // the element left before the frame arrived and is no longer entering.
+      if (pendingEnterFrame === null) {
+        return;
+      }
+
       pendingEnterFrame = null;
       setState('enter');
     });
@@ -132,12 +138,11 @@ export function setupExitAnimation({
       return new Promise<void>(resolve => {
         exitResolve = resolve;
 
-        // Drop the queued enter frame. Leaving before it arrives would otherwise let the
-        // callback for an entrance that never happened land afterwards and mark an element
-        // on its way out as entering, so its exit animation never plays.
-        if (pendingEnterFrame !== null && typeof cancelAnimationFrame === 'function') {
-          cancelAnimationFrame(pendingEnterFrame);
-        }
+        // Supersede the queued enter frame. Leaving before it arrives would otherwise let
+        // the callback for an entrance that never happened land afterwards and mark an
+        // element on its way out as entering, so its exit animation never plays. The
+        // callback checks the handle, so clearing it is enough - there is nothing to gain
+        // from also cancelling a frame whose callback now returns immediately.
         pendingEnterFrame = null;
 
         setState('exit');

--- a/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/exit-animation.ts
@@ -112,6 +112,8 @@ export function setupExitAnimation({
     }
   }
 
+  let pendingEnterFrame: number | null = null;
+
   // Set the initial state to 'enter' - immediately if instant or if there is no
   // `requestAnimationFrame` to defer to (e.g. server-side rendering), otherwise
   // next frame so the browser registers the "from" state and plays the enter
@@ -119,13 +121,25 @@ export function setupExitAnimation({
   if (immediate || typeof requestAnimationFrame !== 'function') {
     setState('enter');
   } else {
-    requestAnimationFrame(() => setState('enter'));
+    pendingEnterFrame = requestAnimationFrame(() => {
+      pendingEnterFrame = null;
+      setState('enter');
+    });
   }
 
   return {
     exit: () => {
       return new Promise<void>(resolve => {
         exitResolve = resolve;
+
+        // Drop the queued enter frame. Leaving before it arrives would otherwise let the
+        // callback for an entrance that never happened land afterwards and mark an element
+        // on its way out as entering, so its exit animation never plays.
+        if (pendingEnterFrame !== null && typeof cancelAnimationFrame === 'function') {
+          cancelAnimationFrame(pendingEnterFrame);
+        }
+        pendingEnterFrame = null;
+
         setState('exit');
 
         const settle = () => {

--- a/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
@@ -270,6 +270,35 @@ describe('setupExitAnimation', () => {
     element.remove();
   });
 
+  /**
+   * Cancellation cannot be relied on: an environment can expose `requestAnimationFrame`
+   * without `cancelAnimationFrame`, and the queued callback then runs regardless. The
+   * callback itself has to notice it has been superseded.
+   */
+  it('stays in the exit state when the environment has no cancelAnimationFrame', async () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    element.getAnimations = () => [];
+
+    const globals = globalThis as { cancelAnimationFrame?: unknown };
+    const original = globals.cancelAnimationFrame;
+    globals.cancelAnimationFrame = undefined;
+
+    try {
+      const ref = setupExitAnimation({ element, immediate: false });
+      await ref.exit();
+
+      await nextFrame();
+      await nextFrame();
+
+      expect(element).toHaveAttribute('data-exit');
+      expect(element).not.toHaveAttribute('data-enter');
+    } finally {
+      globals.cancelAnimationFrame = original;
+      element.remove();
+    }
+  });
+
   /** The deferred enter still has to arrive for an element that is not leaving. */
   it('still enters on the next frame when no exit interrupts it', async () => {
     const element = document.createElement('div');

--- a/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
+++ b/packages/ng-primitives/internal/src/exit-animation/tests/exit-animation.test.ts
@@ -241,4 +241,53 @@ describe('setupExitAnimation', () => {
     expect(element).toHaveAttribute('data-enter');
     expect(element).not.toHaveAttribute('data-exit');
   });
+
+  /**
+   * The enter state is deferred a frame so the browser registers the "from" state and
+   * plays the entrance transition. An element that leaves inside that frame - a hover
+   * trigger the pointer crosses quickly, a same-type overlay swap - calls `exit()` while
+   * that callback is still queued. It must not land afterwards and mark an element that
+   * is on its way out as entering.
+   */
+  it('stays in the exit state when the deferred enter frame arrives late', async () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    // Nothing to wait on, so `exit()` settles without a timing dependency of its own.
+    element.getAnimations = () => [];
+
+    const ref = setupExitAnimation({ element, immediate: false });
+
+    // Exit before the queued frame runs - the element never reached `data-enter`.
+    await ref.exit();
+    expect(element).toHaveAttribute('data-exit');
+
+    await nextFrame();
+    await nextFrame();
+
+    expect(element).toHaveAttribute('data-exit');
+    expect(element).not.toHaveAttribute('data-enter');
+
+    element.remove();
+  });
+
+  /** The deferred enter still has to arrive for an element that is not leaving. */
+  it('still enters on the next frame when no exit interrupts it', async () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+    element.getAnimations = () => [];
+
+    setupExitAnimation({ element, immediate: false });
+    expect(element).not.toHaveAttribute('data-enter');
+
+    await nextFrame();
+
+    expect(element).toHaveAttribute('data-enter');
+    expect(element).not.toHaveAttribute('data-exit');
+
+    element.remove();
+  });
 });
+
+function nextFrame(): Promise<void> {
+  return new Promise(resolve => requestAnimationFrame(() => resolve()));
+}

--- a/packages/ng-primitives/portal/src/tests/portal.test.ts
+++ b/packages/ng-primitives/portal/src/tests/portal.test.ts
@@ -69,4 +69,69 @@ describe('NgpComponentPortal', () => {
     expect(finished()).toBe(false);
     expect(portal.getAttached()).toBe(true);
   });
+
+  /**
+   * The enter state is deferred a frame. A portal detached inside that frame - the shape a
+   * quick hover or a same-type overlay swap produces - must not have the queued callback
+   * land afterwards and mark a node that is leaving as entering. Driven through the portal
+   * rather than the animation ref so the wiring is covered, not just the helper.
+   */
+  it('detaching before the first frame leaves the node in the exit state', async () => {
+    const portal = attachPortal();
+    const node = portal.getElements()[0];
+    node.getAnimations = () => [];
+
+    await portal.detach();
+
+    expect(node).toHaveAttribute('data-exit');
+    expect(node).not.toHaveAttribute('data-enter');
+
+    await nextFrame();
+    await nextFrame();
+
+    expect(node).toHaveAttribute('data-exit');
+    expect(node).not.toHaveAttribute('data-enter');
+  });
+
+  /** The deferred enter still has to arrive for a portal that stays attached. */
+  it('a portal that is not detached still reaches the enter state', async () => {
+    const portal = attachPortal();
+    const node = portal.getElements()[0];
+    node.getAnimations = () => [];
+
+    await nextFrame();
+
+    expect(node).toHaveAttribute('data-enter');
+    expect(node).not.toHaveAttribute('data-exit');
+  });
+
+  /**
+   * `cancelDetach()` returns a node to the enter state directly rather than through a
+   * frame, so cancelling an exit that pre-empted the deferred enter still enters.
+   */
+  it('cancelling a detach that pre-empted the first frame returns to the enter state', async () => {
+    const portal = attachPortal();
+    const node = portal.getElements()[0];
+    const { animation } = pendingAnimation();
+    node.getAnimations = () => [animation];
+
+    const detach = portal.detach();
+    expect(node).toHaveAttribute('data-exit');
+
+    portal.cancelDetach();
+    await detach;
+
+    expect(node).toHaveAttribute('data-enter');
+    expect(node).not.toHaveAttribute('data-exit');
+
+    await nextFrame();
+    await nextFrame();
+
+    expect(node).toHaveAttribute('data-enter');
+    expect(node).not.toHaveAttribute('data-exit');
+  });
 });
+
+function nextFrame(): Promise<void> {
+  return new Promise(resolve => requestAnimationFrame(() => resolve()));
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

No docs change: this is internal animation state handling with no public surface.

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Closes #

No linked issue. Found while investigating an intermittent CI failure in `menu-trigger-group-cooldown`, which turned out not to be a test problem.

## What does this PR implement/fix?

`setupExitAnimation` defers the enter state a frame so the browser registers the "from" state and plays the entrance transition, but the frame handle was dropped:

```ts
requestAnimationFrame(() => setState('enter'));
```

Nothing cancels it. An element that leaves inside that frame calls `exit()` while the callback is still queued, and the callback then lands and overwrites `data-exit` with `data-enter` - marking something on its way out as entering.

Logging the transitions during a failing run makes it unambiguous:

```
FAILING:  menu-a -> exit,  menu-a -> enter     <- the stale frame wins
PASSING:  menu-a -> enter, menu-a -> exit
```

The fix keeps the handle and cancels it when the exit starts. `cancel()` already sets the enter state directly rather than through a frame, so the exit -> cancel -> enter path is unaffected.

### How bad is this in practice?

Worth being straight about: the window is one animation frame, and the effect on a real overlay is cosmetic. `exit()` captures `getAnimations()` before the flip, so the detach promise still settles, teardown completes and the element is removed. It just plays its entrance rather than its exit on the way out.

The concrete cost was the flake. `menu-trigger-group-cooldown` (added in #909, unrelated to this code) failed roughly 2 runs in 8 of the full suite, because the outgoing menu was flipped back to `data-enter` mid-exit. That flake has already cost review time on #922, where it was mistaken for a regression introduced by that PR.

### Verification

- Full suite over 8 runs: **2 failures before, 0 after**. The cooldown file alone: 2-in-20 before, 0-in-40 after.
- Reverting the fix fails exactly two of the new tests, one at each level.
- Three of the five tests are controls that pass either way, so they cannot mask a bad fix:
  - the deferred enter still arrives for an element that is not leaving
  - a portal that is not detached still reaches the enter state
  - cancelling a detach that pre-empted the first frame returns to the enter state

### Notes for review

- `setupExitAnimation` has one consumer, `portal.ts` (four call sites plus the `NgpExitAnimation` base class). Tests cover both the helper directly and the portal path.
- SSR is unaffected: when `requestAnimationFrame` is not a function the existing branch sets the state synchronously and no frame is ever queued.
- The bug is only reachable at machine speed, so it cannot be reproduced by hand in the docs site. The automated tests are the proof; manual checking is only useful for confirming ordinary entrance and exit animations still behave.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

One behaviour does change, in the direction of the documented contract: an element that exits before its first frame now correctly keeps `data-exit` and plays its exit animation, where previously it was left marked `data-enter` and the animation silently did not play.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a queued enter frame from overwriting an element’s exit state by superseding it when exit starts. Previously, if `exit()` ran before the first frame, the `requestAnimationFrame` callback set `data-enter` and the element skipped its exit; now the callback bails when superseded so it stays `data-exit`.

- Store the `requestAnimationFrame` handle; clear it in `exit()` and have the callback return if superseded.
- Do not rely on `cancelAnimationFrame`; behavior is identical when it is missing (SSR unchanged).
- Behavior change: elements that exit before the first frame now play their exit animation.
- `cancel()` path unchanged; it still sets enter immediately.
- Add tests for `setupExitAnimation` and the `portal` path, including the no-`cancelAnimationFrame` case; stabilizes flaky `menu-trigger-group-cooldown`.

<sup>Written for commit e65cf74d447f87082a4f2a808067879cf2156ffc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exit animations so interrupted enter animations no longer override the correct exit state.
  - Fixed portal transitions when detaching or cancelling a detach during an animation frame.
  - Ensured elements and portals enter reliably after deferred animation frames.

- **Tests**
  - Added coverage for interrupted, completed and cancelled animation transitions, including environments without animation-frame cancellation support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->