### PR TITLE
fix(dialog): remove unnecessary event.stopPropagation() call that blocked document click listeners

### DIFF
--- a/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
+++ b/packages/ng-primitives/dialog/src/dialog/dialog-state.ts
@@ -3,7 +3,6 @@ import { injectElementRef } from 'ng-primitives/internal';
 import {
   attrBinding,
   createPrimitive,
-  listener,
   onDestroy,
   StateInjectionOptions,
 } from 'ng-primitives/state';
@@ -60,18 +59,11 @@ export const [NgpDialogStateToken, ngpDialog, _injectDialogState, provideDialogS
       attrBinding(elementRef, 'aria-labelledby', () => labelledBy().join(' ') || null);
       attrBinding(elementRef, 'aria-describedby', () => describedBy().join(' ') || null);
 
-      // Listener
-      listener(elementRef, 'click', handleOnClick);
-
       // Close the dialog when the directive is destroyed.
       onDestroy(() => close());
 
       function close(result?: R): void {
         dialogRef.close(result);
-      }
-
-      function handleOnClick(event: Event): void {
-        event.stopPropagation();
       }
 
       function setLabelledBy(id: string): void {

--- a/packages/ng-primitives/dialog/src/dialog/tests/dialog-primitive.test.ts
+++ b/packages/ng-primitives/dialog/src/dialog/tests/dialog-primitive.test.ts
@@ -55,6 +55,32 @@ class BareDialogHost {
   template: `
     <ng-template #dialogTemplate let-close="close">
       <div ngpDialogOverlay data-testid="overlay">
+        <div ngpDialog data-testid="dialog">
+          <button [ngpMenuTrigger]="menu" data-testid="menu-trigger">Open menu</button>
+
+          <ng-template #menu>
+            <div ngpMenu data-testid="menu">
+              <button ngpMenuItem data-testid="menu-item">Item</button>
+            </div>
+          </ng-template>
+
+          <p data-testid="description">Dialog Description</p>
+          <button (click)="close()" data-testid="close-btn">Close</button>
+        </div>
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpDialog, NgpDialogOverlay, NgpMenuTrigger, NgpMenu, NgpMenuItem],
+})
+class MenuInDialogHost {
+  readonly dialogTemplate = viewChild.required<TemplateRef<NgpDialogContext>>('dialogTemplate');
+  readonly viewContainerRef = inject(ViewContainerRef);
+}
+
+@Component({
+  template: `
+    <ng-template #dialogTemplate let-close="close">
+      <div ngpDialogOverlay data-testid="overlay">
         <div ngpDialog ngpDialogRole="alertdialog" data-testid="dialog">
           <button (click)="close()" data-testid="close-btn">Close</button>
         </div>
@@ -85,6 +111,18 @@ describe('NgpDialog', () => {
 
   async function openBareDialog(config?: Partial<NgpDialogConfig>) {
     const view = await render(BareDialogHost);
+    dialogManager = TestBed.inject(NgpDialogManager);
+    const component = view.fixture.componentInstance;
+    const ref = dialogManager.open(component.dialogTemplate(), {
+      viewContainerRef: component.viewContainerRef,
+      ...config,
+    });
+    await view.fixture.whenStable();
+    return { view, ref };
+  }
+
+  async function openMenuDialog(config?: Partial<NgpDialogConfig>) {
+    const view = await render(MenuInDialogHost);
     dialogManager = TestBed.inject(NgpDialogManager);
     const component = view.fixture.componentInstance;
     const ref = dialogManager.open(component.dialogTemplate(), {
@@ -340,16 +378,26 @@ describe('NgpDialog', () => {
       }
     });
 
-    it('should still close the dialog when the close button inside the panel is clicked', async () => {
-      const { ref } = await openDialog();
+    it('should close a menu opened inside the dialog panel on an outside click, without closing the dialog', async () => {
+      const { view, ref } = await openMenuDialog();
       const closedSpy = vi.fn();
       ref.closed.subscribe(closedSpy);
 
-      const closeBtn = document.querySelector('[data-testid="close-btn"]') as HTMLElement;
-      closeBtn.click();
+      const trigger = document.querySelector('[data-testid="menu-trigger"]') as HTMLElement;
+      fireEvent.click(trigger, { detail: 1 });
+      await view.fixture.whenStable();
       await new Promise(r => setTimeout(r, 0));
 
-      expect(closedSpy).toHaveBeenCalled();
+      expect(document.querySelector('[data-testid="menu"]')).toBeTruthy();
+
+      const description = document.querySelector('[data-testid="description"]') as HTMLElement;
+      fireEvent.mouseUp(description);
+      fireEvent.click(description);
+      await view.fixture.whenStable();
+      await new Promise(r => setTimeout(r, 0));
+
+      expect(document.querySelector('[data-testid="menu"]')).toBeFalsy();
+      expect(closedSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/ng-primitives/dialog/src/dialog/tests/dialog-primitive.test.ts
+++ b/packages/ng-primitives/dialog/src/dialog/tests/dialog-primitive.test.ts
@@ -323,6 +323,36 @@ describe('NgpDialog', () => {
     });
   });
 
+  describe('document click propagation', () => {
+    it('should not prevent a click inside the dialog panel from reaching a document click listener', async () => {
+      await openDialog();
+
+      const documentClickSpy = vi.fn();
+      document.addEventListener('click', documentClickSpy);
+
+      try {
+        const description = document.querySelector('[data-testid="description"]') as HTMLElement;
+        description.click();
+
+        expect(documentClickSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        document.removeEventListener('click', documentClickSpy);
+      }
+    });
+
+    it('should still close the dialog when the close button inside the panel is clicked', async () => {
+      const { ref } = await openDialog();
+      const closedSpy = vi.fn();
+      ref.closed.subscribe(closedSpy);
+
+      const closeBtn = document.querySelector('[data-testid="close-btn"]') as HTMLElement;
+      closeBtn.click();
+      await new Promise(r => setTimeout(r, 0));
+
+      expect(closedSpy).toHaveBeenCalled();
+    });
+  });
+
   describe('escape key close', () => {
     it('should close on Escape via the overlay registry', async () => {
       const { ref } = await openDialog();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue
Closes #918

## What does this PR implement/fix?

The `[ngpDialog]` directive (applied to the dialog panel) registers a `click` listener on its host element that unconditionally calls `event.stopPropagation()`:

```ts
listener(elementRef, 'click', handleOnClick);
...
function handleOnClick(event: Event): void {
  event.stopPropagation();
}
```

This stops any click inside the dialog panel from reaching `document`. It breaks `document:click` listeners set up by components rendered inside the dialog, such as third-party dropdowns or date pickers that rely on an outside click to close themselves.

Clicks on the backdrop (`[ngpDialogOverlay]`) are not affected since they never bubble through the panel. This creates an inconsistent behavior: outside clicks are detected correctly, but clicks inside the dialog are silently swallowed.

The `stopPropagation()` call is not needed. `NgpDialogOverlay` (`dialog-overlay-state.ts`) already distinguishes backdrop clicks from panel clicks on its own, using `event.target === event.currentTarget`. Removing the call from `dialog-state.ts` does not change backdrop-click-to-close behavior, which stays entirely under `NgpDialogOverlay`'s control.

### Changes

- Removed the `click` listener and `stopPropagation()` call from `dialog-state.ts` (`[ngpDialog]` directive).
- Added two regression tests in `dialog-primitive.test.ts`:
  - a click inside the panel now reaches a `document` click listener.
  - the close button inside the panel still closes the dialog as before.
- Ran the full `dialog` test suite, plus the `portal`, `menu`, and `popover` suites, to confirm no other dismiss behavior (backdrop click, dismiss guards, nested overlays) was affected.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Documented public behavior (backdrop-click-to-close, `closeOnOutsideClick`, `disableClose`) is unchanged. This removes an undocumented and untested side effect where clicks inside the panel were silently blocked from reaching `document`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unconditional event.stopPropagation() in `[ngpDialog]` that blocked document-level click listeners for clicks inside the dialog. Clicks inside the panel now bubble to `document`; backdrop click-to-close and other dismiss behavior are unchanged.

- Removed the `click` listener in `dialog-state.ts`; no public API changes.
- Tests cover document click propagation, that a menu opened inside the dialog closes on outside click without closing the dialog, and that the close button still closes the dialog; removed a duplicated test.
- Impact: components inside dialogs that rely on document clicks (e.g., dropdowns, date pickers) now work correctly. No migration required.

<sup>Written for commit b82fa77e6a5d58fb92872f3926acf0cfc26b2495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog click handling so interactions inside dialogs propagate correctly.
  * Menus opened within dialogs now close appropriately when clicking elsewhere, without unintentionally closing the parent dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->