### PR TITLE
fix(form-field): disable the element when its form control is disabled

### DIFF
--- a/apps/components/src/app/pages/reusable-components/combobox/combobox.ts
+++ b/apps/components/src/app/pages/reusable-components/combobox/combobox.ts
@@ -232,8 +232,10 @@ export class Combobox implements ControlValueAccessor {
     this.filter.set(input.value);
   }
 
-  writeValue(value: string | null): void {
-    this.value.set(value);
+  // Accepts `undefined` and normalises it: a form control can hand one over, and letting it
+  // through would drop the key from a signal-forms model.
+  writeValue(value: string | null | undefined): void {
+    this.value.set(value ?? null);
     this.filter.set(value ?? '');
   }
 

--- a/apps/components/src/app/pages/reusable-components/combobox/combobox.ts
+++ b/apps/components/src/app/pages/reusable-components/combobox/combobox.ts
@@ -267,8 +267,12 @@ export class Combobox implements ControlValueAccessor {
     // `null` rather than `undefined`: signal forms drops a model key whose value is
     // `undefined`, which would tear the field out from under `[formField]`.
     if (this.filter() === '') {
-      this.value.set(null);
-      this.onChange?.(null);
+      // only emit when there is something to clear, so opening and closing without touching
+      // the input does not mark the control dirty
+      if (this.value() !== null) {
+        this.value.set(null);
+        this.onChange?.(null);
+      }
     } else {
       // otherwise set the filter value to the selected value
       this.filter.set(this.value() ?? '');

--- a/apps/components/src/app/pages/reusable-components/combobox/combobox.ts
+++ b/apps/components/src/app/pages/reusable-components/combobox/combobox.ts
@@ -200,7 +200,7 @@ export class Combobox implements ControlValueAccessor {
   readonly options = input<string[]>([]);
 
   /** The selected value. */
-  readonly value = model<string | undefined>();
+  readonly value = model<string | null>(null);
 
   /** The placeholder for the input. */
   readonly placeholder = input<string>('');
@@ -222,7 +222,7 @@ export class Combobox implements ControlValueAccessor {
   protected readonly formDisabled = signal(false);
 
   /** The on change callback */
-  private onChange?: ChangeFn<string | undefined>;
+  private onChange?: ChangeFn<string | null>;
 
   /** The on touch callback */
   protected onTouched?: TouchedFn;
@@ -232,12 +232,12 @@ export class Combobox implements ControlValueAccessor {
     this.filter.set(input.value);
   }
 
-  writeValue(value: string | undefined): void {
+  writeValue(value: string | null): void {
     this.value.set(value);
     this.filter.set(value ?? '');
   }
 
-  registerOnChange(fn: ChangeFn<string | undefined>): void {
+  registerOnChange(fn: ChangeFn<string | null>): void {
     this.onChange = fn;
   }
 
@@ -261,10 +261,12 @@ export class Combobox implements ControlValueAccessor {
       return;
     }
 
-    // if the filter value is empty, clear the value and notify the form control
+    // if the filter value is empty, clear the value and notify the form control.
+    // `null` rather than `undefined`: signal forms drops a model key whose value is
+    // `undefined`, which would tear the field out from under `[formField]`.
     if (this.filter() === '') {
-      this.value.set(undefined);
-      this.onChange?.(undefined);
+      this.value.set(null);
+      this.onChange?.(null);
     } else {
       // otherwise set the filter value to the selected value
       this.filter.set(this.value() ?? '');

--- a/packages/ng-primitives/checkbox/src/checkbox/tests/checkbox-signal-forms.test.ts
+++ b/packages/ng-primitives/checkbox/src/checkbox/tests/checkbox-signal-forms.test.ts
@@ -1,0 +1,124 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, validate } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { CheckboxFixture } from './checkbox-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue = false;
+
+@Component({
+  imports: [CheckboxFixture, SignalFormField],
+  template: `
+    <app-checkbox [formField]="f.agreed" />
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ agreed: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.agreed, () => this.isDisabled());
+    validate(path.agreed, ({ value }) => (value() ? undefined : { kind: 'mustAccept' }));
+  });
+}
+
+function renderHost(agreed = false) {
+  initialValue = agreed;
+  return render(Host);
+}
+
+describe('Checkbox (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByRole, fixture } = await renderHost(true);
+
+    expect(getByRole('checkbox')).toHaveAttribute('aria-checked', 'true');
+    expect(fixture.componentInstance.f.agreed().value()).toBe(true);
+  });
+
+  it('updates the model on click and the DOM on a model change', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const checkbox = getByRole('checkbox');
+
+    fireEvent.click(checkbox);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().agreed).toBe(true);
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+
+    fixture.componentInstance.model.set({ agreed: false });
+    await fixture.whenStable();
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(getByRole('checkbox')).not.toHaveAttribute('data-disabled');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+    expect(getByRole('checkbox')).toHaveAttribute('data-disabled', '');
+  });
+
+  it('does not toggle while the field is disabled', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const checkbox = getByRole('checkbox');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.click(checkbox);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().agreed).toBe(false);
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+
+    fixture.componentInstance.isDisabled.set(false);
+    await fixture.whenStable();
+
+    fireEvent.click(checkbox);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().agreed).toBe(true);
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(fixture.componentInstance.f.agreed().touched()).toBe(false);
+
+    fireEvent.focusOut(getByRole('checkbox'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.agreed().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const field = fixture.componentInstance.f.agreed;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('mustAccept');
+
+    fireEvent.click(getByRole('checkbox'));
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+    expect(field().errors()).toEqual([]);
+  });
+
+  it('clears the touched and dirty state on reset', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const field = fixture.componentInstance.f.agreed;
+
+    fireEvent.click(getByRole('checkbox'));
+    fireEvent.focusOut(getByRole('checkbox'));
+    await fixture.whenStable();
+    expect(field().dirty()).toBe(true);
+    expect(field().touched()).toBe(true);
+
+    field().reset();
+    await fixture.whenStable();
+
+    expect(field().dirty()).toBe(false);
+    expect(field().touched()).toBe(false);
+  });
+});

--- a/packages/ng-primitives/combobox/src/combobox/tests/combobox-forms.fixture.ts
+++ b/packages/ng-primitives/combobox/src/combobox/tests/combobox-forms.fixture.ts
@@ -66,7 +66,7 @@ export class ComboboxFixture implements ControlValueAccessor {
   readonly options = input<string[]>([]);
 
   /** The selected value. */
-  readonly value = model<string | undefined>();
+  readonly value = model<string | null>(null);
 
   /** The placeholder for the input. */
   readonly placeholder = input<string>('');
@@ -88,7 +88,7 @@ export class ComboboxFixture implements ControlValueAccessor {
   protected readonly formDisabled = signal(false);
 
   /** The on change callback */
-  private onChange?: ChangeFn<string | undefined>;
+  private onChange?: ChangeFn<string | null>;
 
   /** The on touch callback */
   protected onTouched?: TouchedFn;
@@ -98,12 +98,12 @@ export class ComboboxFixture implements ControlValueAccessor {
     this.filter.set(input.value);
   }
 
-  writeValue(value: string | undefined): void {
+  writeValue(value: string | null): void {
     this.value.set(value);
     this.filter.set(value ?? '');
   }
 
-  registerOnChange(fn: ChangeFn<string | undefined>): void {
+  registerOnChange(fn: ChangeFn<string | null>): void {
     this.onChange = fn;
   }
 
@@ -127,10 +127,12 @@ export class ComboboxFixture implements ControlValueAccessor {
       return;
     }
 
-    // if the filter value is empty, clear the value and notify the form control
+    // if the filter value is empty, clear the value and notify the form control.
+    // `null` rather than `undefined`: signal forms drops a model key whose value is
+    // `undefined`, which would tear the field out from under `[formField]`.
     if (this.filter() === '') {
-      this.value.set(undefined);
-      this.onChange?.(undefined);
+      this.value.set(null);
+      this.onChange?.(null);
     } else {
       // otherwise set the filter value to the selected value
       this.filter.set(this.value() ?? '');

--- a/packages/ng-primitives/combobox/src/combobox/tests/combobox-forms.fixture.ts
+++ b/packages/ng-primitives/combobox/src/combobox/tests/combobox-forms.fixture.ts
@@ -133,8 +133,12 @@ export class ComboboxFixture implements ControlValueAccessor {
     // `null` rather than `undefined`: signal forms drops a model key whose value is
     // `undefined`, which would tear the field out from under `[formField]`.
     if (this.filter() === '') {
-      this.value.set(null);
-      this.onChange?.(null);
+      // only emit when there is something to clear, so opening and closing without touching
+      // the input does not mark the control dirty
+      if (this.value() !== null) {
+        this.value.set(null);
+        this.onChange?.(null);
+      }
     } else {
       // otherwise set the filter value to the selected value
       this.filter.set(this.value() ?? '');

--- a/packages/ng-primitives/combobox/src/combobox/tests/combobox-forms.fixture.ts
+++ b/packages/ng-primitives/combobox/src/combobox/tests/combobox-forms.fixture.ts
@@ -98,8 +98,10 @@ export class ComboboxFixture implements ControlValueAccessor {
     this.filter.set(input.value);
   }
 
-  writeValue(value: string | null): void {
-    this.value.set(value);
+  // Accepts `undefined` and normalises it: a form control can hand one over, and letting it
+  // through would drop the key from a signal-forms model.
+  writeValue(value: string | null | undefined): void {
+    this.value.set(value ?? null);
     this.filter.set(value ?? '');
   }
 

--- a/packages/ng-primitives/combobox/src/combobox/tests/combobox-forms.test.ts
+++ b/packages/ng-primitives/combobox/src/combobox/tests/combobox-forms.test.ts
@@ -181,6 +181,29 @@ describe('Combobox (reusable component) — reactive forms', () => {
     expect(formControl.value).toBeFalsy();
   });
 
+  it('does not mark the control dirty when opened and closed without a change', async () => {
+    const formControl = new FormControl<string | null>(null);
+    const { fixture } = await render(
+      `<app-combobox [options]="options" [formControl]="formControl"></app-combobox>`,
+      {
+        imports: [ComboboxFixture, ReactiveFormsModule],
+        componentProperties: { options, formControl },
+      },
+    );
+    await fixture.whenStable();
+
+    const spy = vi.fn();
+    formControl.valueChanges.subscribe(spy);
+
+    await userEvent.click(screen.getByTestId('combobox-button'));
+    await userEvent.click(document.body);
+    await fixture.whenStable();
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(formControl.dirty).toBe(false);
+    expect(formControl.value).toBeNull();
+  });
+
   it('does not loop writeValue back through onChange (regression)', async () => {
     const formControl = new FormControl<string | undefined>(undefined);
     const { fixture } = await render(

--- a/packages/ng-primitives/combobox/src/combobox/tests/combobox-signal-forms.test.ts
+++ b/packages/ng-primitives/combobox/src/combobox/tests/combobox-signal-forms.test.ts
@@ -13,9 +13,9 @@ afterEach(() => {
 /**
  * Read when the host is constructed, so a test can choose the field's starting value.
  * Signal forms builds the field tree from the model's own keys, and a key holding `undefined`
- * produces no subfield at all - so the empty value here is `''`.
+ * produces no subfield at all - so the empty value here is `null`.
  */
-let initialValue = '';
+let initialValue: string | null = null;
 
 @Component({
   imports: [ComboboxFixture, SignalFormField],
@@ -26,14 +26,14 @@ let initialValue = '';
 class Host {
   readonly options = ['Apple', 'Banana', 'Cherry', 'Dragon Fruit', 'Elderberry'];
   readonly isDisabled = signal(false);
-  readonly model = signal({ fruit: initialValue });
+  readonly model = signal<{ fruit: string | null }>({ fruit: initialValue });
   readonly f = form(this.model, path => {
     disabled(path.fruit, () => this.isDisabled());
     required(path.fruit);
   });
 }
 
-function renderHost(fruit = '') {
+function renderHost(fruit: string | null = null) {
   initialValue = fruit;
   return render(Host);
 }
@@ -91,16 +91,29 @@ describe('Combobox (reusable component) — signal forms', () => {
     await fixture.whenStable();
     expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('Apple');
 
-    fixture.componentInstance.model.set({ fruit: '' });
+    fixture.componentInstance.model.set({ fruit: null });
     await fixture.whenStable();
 
     expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('');
   });
 
-  // The "empty the input, then close" path is not covered here: the reusable component's
-  // CVA emits `undefined` for a cleared value, and writing `undefined` into a signal-forms
-  // model removes the key's field entirely, so `[formField]` then resolves to undefined and
-  // throws. See the reactive-forms suite for that scenario.
+  it('clears the model when the input is emptied then closed', async () => {
+    const { fixture } = await renderHost('Apple');
+    await fixture.whenStable();
+
+    const input = screen.getByRole('combobox') as HTMLInputElement;
+    expect(input.value).toBe('Apple');
+
+    await userEvent.click(screen.getByTestId('combobox-button'));
+    await userEvent.clear(input);
+    await userEvent.click(document.body);
+    await fixture.whenStable();
+
+    expect(input.value).toBe('');
+    expect(fixture.componentInstance.model().fruit).toBeNull();
+    // the field must survive the clear - signal forms drops a key whose value is `undefined`
+    expect(fixture.componentInstance.f.fruit().invalid()).toBe(true);
+  });
 
   it('reports validation errors from the field', async () => {
     const { fixture } = await renderHost();

--- a/packages/ng-primitives/combobox/src/combobox/tests/combobox-signal-forms.test.ts
+++ b/packages/ng-primitives/combobox/src/combobox/tests/combobox-signal-forms.test.ts
@@ -1,0 +1,118 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, required } from '@angular/forms/signals';
+import { fireEvent, render, screen } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ComboboxFixture } from './combobox-forms.fixture';
+
+afterEach(() => {
+  // Dropdown is portalled to the body, so fixture.destroy() alone can leave it lingering.
+  screen.queryByRole('listbox')?.remove();
+});
+
+/**
+ * Read when the host is constructed, so a test can choose the field's starting value.
+ * Signal forms builds the field tree from the model's own keys, and a key holding `undefined`
+ * produces no subfield at all - so the empty value here is `''`.
+ */
+let initialValue = '';
+
+@Component({
+  imports: [ComboboxFixture, SignalFormField],
+  template: `
+    <app-combobox [options]="options" [formField]="f.fruit" />
+  `,
+})
+class Host {
+  readonly options = ['Apple', 'Banana', 'Cherry', 'Dragon Fruit', 'Elderberry'];
+  readonly isDisabled = signal(false);
+  readonly model = signal({ fruit: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.fruit, () => this.isDisabled());
+    required(path.fruit);
+  });
+}
+
+function renderHost(fruit = '') {
+  initialValue = fruit;
+  return render(Host);
+}
+
+describe('Combobox (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { fixture } = await renderHost('Cherry');
+    await fixture.whenStable();
+
+    expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('Cherry');
+    expect(fixture.componentInstance.f.fruit().value()).toBe('Cherry');
+  });
+
+  it('updates the model on selection and the DOM on a model change', async () => {
+    const { fixture } = await renderHost();
+
+    await userEvent.click(screen.getByTestId('combobox-button'));
+    await userEvent.click(screen.getByText('Banana'));
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().fruit).toBe('Banana');
+
+    fixture.componentInstance.model.set({ fruit: 'Dragon Fruit' });
+    await fixture.whenStable();
+    expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('Dragon Fruit');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { fixture } = await renderHost('Apple');
+    await fixture.whenStable();
+
+    const combobox = screen.getByTestId('combobox');
+    expect(combobox).not.toHaveAttribute('data-disabled');
+    expect(screen.getByRole('combobox')).not.toBeDisabled();
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(combobox).toHaveAttribute('data-disabled', '');
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('marks the field as touched on blur', async () => {
+    const { fixture } = await renderHost('Apple');
+
+    expect(fixture.componentInstance.f.fruit().touched()).toBe(false);
+
+    fireEvent.blur(screen.getByTestId('combobox-input'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.fruit().touched()).toBe(true);
+  });
+
+  it('clears the value when the model is cleared', async () => {
+    const { fixture } = await renderHost('Apple');
+    await fixture.whenStable();
+    expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('Apple');
+
+    fixture.componentInstance.model.set({ fruit: '' });
+    await fixture.whenStable();
+
+    expect((screen.getByRole('combobox') as HTMLInputElement).value).toBe('');
+  });
+
+  // The "empty the input, then close" path is not covered here: the reusable component's
+  // CVA emits `undefined` for a cleared value, and writing `undefined` into a signal-forms
+  // model removes the key's field entirely, so `[formField]` then resolves to undefined and
+  // throws. See the reactive-forms suite for that scenario.
+
+  it('reports validation errors from the field', async () => {
+    const { fixture } = await renderHost();
+    const field = fixture.componentInstance.f.fruit;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('required');
+
+    await userEvent.click(screen.getByTestId('combobox-button'));
+    await userEvent.click(screen.getByText('Banana'));
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/form-field/src/form-control/form-control-state.ts
+++ b/packages/ng-primitives/form-field/src/form-control/form-control-state.ts
@@ -39,7 +39,12 @@ export function ngpFormControl({
   const supportsDisabledAttribute = 'disabled' in elementRef.nativeElement;
 
   // Host bindings
-  attrBinding(elementRef, 'disabled', () => (supportsDisabledAttribute && disabled() ? '' : null));
+  // The status has to be part of this, not just the parent's input: a form control disabled by
+  // reactive or signal forms disables the element itself, and a binding that ignored the status
+  // would immediately remove that again and leave a disabled control editable.
+  attrBinding(elementRef, 'disabled', () =>
+    supportsDisabledAttribute && (disabled() || status().disabled) ? '' : null,
+  );
 
   explicitEffect([id], ([id], onCleanup) => {
     formField()?.setFormControl(id);

--- a/packages/ng-primitives/form-field/src/form-field/tests/form-control.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/form-control.test.ts
@@ -340,7 +340,7 @@ describe('NgpFormControl', () => {
       fixture.componentInstance.control.disable();
       fixture.detectChanges();
       expect(input).toHaveAttribute('data-disabled');
-      expect(input).not.toHaveAttribute('disabled');
+      expect(input).toHaveAttribute('disabled');
     });
   });
 

--- a/packages/ng-primitives/form-field/src/form-field/tests/integration.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/integration.test.ts
@@ -413,7 +413,7 @@ describe('Form Field Integration Tests', () => {
     fixture.componentInstance.control.disable();
     fixture.detectChanges();
     expect(input).toHaveAttribute('data-disabled');
-    expect(input).not.toHaveAttribute('disabled');
+    expect(input).toHaveAttribute('disabled');
   });
 
   it('should clean up all registrations on component destroy', async () => {

--- a/packages/ng-primitives/form-field/src/form-field/tests/signal-forms.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/signal-forms.test.ts
@@ -24,6 +24,13 @@ import { describe, expect, it } from 'vitest';
  * that path down.
  */
 
+/** `Promise.withResolvers` needs the es2024 lib; the workspace targets es2022. */
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(r => (resolve = r));
+  return { promise, resolve };
+}
+
 @Component({
   imports: [NgpFormField, NgpFormControl, NgpLabel, NgpDescription, NgpError, SignalFormField],
   template: `
@@ -71,7 +78,7 @@ class DisabledHost {
 })
 class AsyncHost {
   /** Each instance owns its validator's promise, so the test resolves it via the fixture. */
-  readonly deferred = Promise.withResolvers<void>();
+  readonly deferred = createDeferred();
   readonly model = signal({ name: 'Ada' });
   readonly f = form(this.model, path =>
     validateAsync(path.name, {

--- a/packages/ng-primitives/form-field/src/form-field/tests/signal-forms.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/signal-forms.test.ts
@@ -61,7 +61,8 @@ class DisabledHost {
   readonly f = form(this.model, path => disabled(path.name));
 }
 
-let deferred: PromiseWithResolvers<void>;
+// Initialised here as well as per-test so rendering AsyncHost never hits an undefined promise.
+let deferred: PromiseWithResolvers<void> = Promise.withResolvers<void>();
 
 @Component({
   imports: [NgpFormField, NgpFormControl, SignalFormField],

--- a/packages/ng-primitives/form-field/src/form-field/tests/signal-forms.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/signal-forms.test.ts
@@ -1,0 +1,345 @@
+import { Component, resource, signal } from '@angular/core';
+import {
+  FormField as SignalFormField,
+  disabled,
+  form,
+  minLength,
+  required,
+  validateAsync,
+} from '@angular/forms/signals';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
+import {
+  NgpDescription,
+  NgpError,
+  NgpFormControl,
+  NgpFormField,
+  NgpLabel,
+} from 'ng-primitives/form-field';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Signal forms provide an `NgControl` shim (`InteropNgControl`) rather than a real one, so the
+ * form-field primitives read it through a separate code path to reactive forms. These tests pin
+ * that path down.
+ */
+
+@Component({
+  imports: [NgpFormField, NgpFormControl, NgpLabel, NgpDescription, NgpError, SignalFormField],
+  template: `
+    <div ngpFormField data-testid="field">
+      <label id="name-label" ngpLabel data-testid="label">Name</label>
+      <input id="name-control" [formField]="f.name" ngpFormControl data-testid="control" />
+      <p id="name-description" ngpDescription data-testid="description">Your full name</p>
+      <p id="name-required" ngpError ngpErrorValidator="required" data-testid="error-required">
+        Required
+      </p>
+      <p id="name-min" ngpError ngpErrorValidator="minLength" data-testid="error-minlength">
+        Too short
+      </p>
+    </div>
+  `,
+})
+class FullHost {
+  readonly model = signal({ name: '' });
+  readonly f = form(this.model, path => {
+    required(path.name);
+    minLength(path.name, 3);
+  });
+}
+
+@Component({
+  imports: [NgpFormField, NgpFormControl, SignalFormField],
+  template: `
+    <div ngpFormField data-testid="field">
+      <input [formField]="f.name" ngpFormControl data-testid="control" />
+    </div>
+  `,
+})
+class DisabledHost {
+  readonly model = signal({ name: 'Ada' });
+  readonly f = form(this.model, path => disabled(path.name));
+}
+
+let deferred: PromiseWithResolvers<void>;
+
+@Component({
+  imports: [NgpFormField, NgpFormControl, SignalFormField],
+  template: `
+    <div ngpFormField data-testid="field">
+      <input [formField]="f.name" ngpFormControl data-testid="control" />
+    </div>
+  `,
+})
+class AsyncHost {
+  readonly model = signal({ name: 'Ada' });
+  readonly f = form(this.model, path =>
+    validateAsync(path.name, {
+      params: ctx => ctx.value(),
+      factory: params =>
+        resource({
+          params: () => params(),
+          loader: () => deferred.promise.then(() => true),
+        }),
+      onError: () => [],
+      onSuccess: () => [],
+    }),
+  );
+}
+
+@Component({
+  imports: [NgpFormField, NgpFormControl, SignalFormField],
+  template: `
+    <div ngpFormField data-testid="field">
+      <input [formField]="useSecond() ? f.last : f.first" ngpFormControl data-testid="control" />
+    </div>
+  `,
+})
+class SwapHost {
+  readonly useSecond = signal(false);
+  readonly model = signal({ first: 'Ada', last: '' });
+  readonly f = form(this.model, path => required(path.last));
+}
+
+describe('form-field primitives with signal forms', () => {
+  describe('NgpFormField status tracking', () => {
+    it('should reflect the initial invalid state of the field', async () => {
+      const { getByTestId } = await render(FullHost);
+      const field = getByTestId('field');
+
+      expect(field).toHaveAttribute('data-invalid', '');
+      expect(field).toHaveAttribute('data-pristine', '');
+      expect(field).not.toHaveAttribute('data-valid');
+      expect(field).not.toHaveAttribute('data-touched');
+      expect(field).not.toHaveAttribute('data-dirty');
+    });
+
+    it('should become valid when the model satisfies the validators', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+      const field = getByTestId('field');
+
+      fixture.componentInstance.model.set({ name: 'Ada' });
+      await fixture.whenStable();
+
+      expect(field).toHaveAttribute('data-valid', '');
+      expect(field).not.toHaveAttribute('data-invalid');
+    });
+
+    it('should become dirty and valid as the user types', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+      const field = getByTestId('field');
+
+      await userEvent.type(getByTestId('control'), 'Ada');
+      await fixture.whenStable();
+
+      expect(field).toHaveAttribute('data-dirty', '');
+      expect(field).toHaveAttribute('data-valid', '');
+      expect(field).not.toHaveAttribute('data-pristine');
+      expect(field).not.toHaveAttribute('data-invalid');
+    });
+
+    it('should become touched when the control is blurred', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+      const field = getByTestId('field');
+
+      fireEvent.blur(getByTestId('control'));
+      await fixture.whenStable();
+
+      expect(field).toHaveAttribute('data-touched', '');
+    });
+
+    it('should reflect a disabled field', async () => {
+      const { getByTestId } = await render(DisabledHost);
+
+      expect(getByTestId('field')).toHaveAttribute('data-disabled', '');
+    });
+
+    it('should reflect a pending async validator', async () => {
+      deferred = Promise.withResolvers<void>();
+      const { getByTestId, fixture } = await render(AsyncHost);
+      const field = getByTestId('field');
+
+      // `whenStable()` would block on the in-flight resource, so pump change detection instead.
+      await waitFor(() => {
+        fixture.detectChanges();
+        expect(field).toHaveAttribute('data-pending', '');
+      });
+      expect(field).not.toHaveAttribute('data-valid');
+
+      deferred.resolve();
+      await fixture.whenStable();
+
+      expect(field).not.toHaveAttribute('data-pending');
+      expect(field).toHaveAttribute('data-valid', '');
+    });
+
+    it('should track the newly bound field when the binding is swapped', async () => {
+      const { getByTestId, fixture } = await render(SwapHost);
+      const field = getByTestId('field');
+
+      expect(field).toHaveAttribute('data-valid', '');
+
+      fixture.componentInstance.useSecond.set(true);
+      await fixture.whenStable();
+
+      expect(field).toHaveAttribute('data-invalid', '');
+      expect(field).not.toHaveAttribute('data-valid');
+    });
+  });
+
+  describe('NgpFormControl', () => {
+    it('should mirror the field status on the control', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+      const control = getByTestId('control');
+
+      expect(control).toHaveAttribute('data-invalid', '');
+      expect(control).toHaveAttribute('data-pristine', '');
+
+      fixture.componentInstance.model.set({ name: 'Ada' });
+      await fixture.whenStable();
+
+      expect(control).toHaveAttribute('data-valid', '');
+      expect(control).not.toHaveAttribute('data-invalid');
+    });
+
+    it('should only advertise aria-invalid once the field is touched', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+      const control = getByTestId('control');
+
+      expect(control).not.toHaveAttribute('aria-invalid');
+
+      fireEvent.blur(control);
+      await fixture.whenStable();
+
+      expect(control).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('should drop aria-invalid once the field becomes valid', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+      const control = getByTestId('control');
+
+      fireEvent.blur(control);
+      await fixture.whenStable();
+      expect(control).toHaveAttribute('aria-invalid', 'true');
+
+      fixture.componentInstance.model.set({ name: 'Ada' });
+      await fixture.whenStable();
+
+      expect(control).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('should disable the control when the field is disabled', async () => {
+      const { getByTestId } = await render(DisabledHost);
+      const control = getByTestId('control');
+
+      expect(control).toBeDisabled();
+      expect(control).toHaveAttribute('data-disabled', '');
+    });
+  });
+
+  describe('NgpLabel', () => {
+    it('should associate the label with the control', async () => {
+      const { getByTestId } = await render(FullHost);
+
+      expect(getByTestId('label')).toHaveAttribute('for', 'name-control');
+      expect(getByTestId('control')).toHaveAttribute('aria-labelledby', 'name-label');
+    });
+
+    it('should mirror the field status on the label', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+      const label = getByTestId('label');
+
+      expect(label).toHaveAttribute('data-invalid', '');
+
+      fixture.componentInstance.model.set({ name: 'Ada' });
+      await fixture.whenStable();
+
+      expect(label).toHaveAttribute('data-valid', '');
+      expect(label).not.toHaveAttribute('data-invalid');
+    });
+
+    it('should focus the control when the label is clicked', async () => {
+      const { getByTestId } = await render(FullHost);
+
+      fireEvent.click(getByTestId('label'));
+
+      expect(getByTestId('control')).toHaveFocus();
+    });
+  });
+
+  describe('NgpDescription', () => {
+    it('should describe the control', async () => {
+      const { getByTestId } = await render(FullHost);
+
+      expect(getByTestId('control').getAttribute('aria-describedby')).toContain('name-description');
+    });
+
+    it('should mirror the field status on the description', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+      const description = getByTestId('description');
+
+      expect(description).toHaveAttribute('data-invalid', '');
+
+      fixture.componentInstance.model.set({ name: 'Ada' });
+      await fixture.whenStable();
+
+      expect(description).toHaveAttribute('data-valid', '');
+    });
+  });
+
+  describe('NgpError', () => {
+    it('should fail only for the validator kind that is erroring', async () => {
+      const { getByTestId } = await render(FullHost);
+
+      expect(getByTestId('error-required')).toHaveAttribute('data-validator', 'fail');
+      expect(getByTestId('error-minlength')).toHaveAttribute('data-validator', 'pass');
+    });
+
+    it('should switch which error fails as the value changes', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+
+      fixture.componentInstance.model.set({ name: 'Ad' });
+      await fixture.whenStable();
+
+      expect(getByTestId('error-required')).toHaveAttribute('data-validator', 'pass');
+      expect(getByTestId('error-minlength')).toHaveAttribute('data-validator', 'fail');
+    });
+
+    it('should pass every error once the field is valid', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+
+      fixture.componentInstance.model.set({ name: 'Ada' });
+      await fixture.whenStable();
+
+      expect(getByTestId('error-required')).toHaveAttribute('data-validator', 'pass');
+      expect(getByTestId('error-minlength')).toHaveAttribute('data-validator', 'pass');
+    });
+
+    it('should only describe the control while the error is failing', async () => {
+      const { getByTestId, fixture } = await render(FullHost);
+      const control = getByTestId('control');
+
+      expect(control.getAttribute('aria-describedby')).toContain('name-required');
+      expect(control.getAttribute('aria-describedby')).not.toContain('name-min');
+
+      fixture.componentInstance.model.set({ name: 'Ad' });
+      await fixture.whenStable();
+
+      expect(control.getAttribute('aria-describedby')).not.toContain('name-required');
+      expect(control.getAttribute('aria-describedby')).toContain('name-min');
+
+      fixture.componentInstance.model.set({ name: 'Ada' });
+      await fixture.whenStable();
+
+      expect(control.getAttribute('aria-describedby')).not.toContain('name-required');
+      expect(control.getAttribute('aria-describedby')).not.toContain('name-min');
+    });
+
+    it('should mirror the field status on the error', async () => {
+      const { getByTestId } = await render(FullHost);
+
+      expect(getByTestId('error-required')).toHaveAttribute('data-invalid', '');
+      expect(getByTestId('error-required')).toHaveAttribute('data-pristine', '');
+    });
+  });
+});

--- a/packages/ng-primitives/form-field/src/form-field/tests/signal-forms.test.ts
+++ b/packages/ng-primitives/form-field/src/form-field/tests/signal-forms.test.ts
@@ -61,9 +61,6 @@ class DisabledHost {
   readonly f = form(this.model, path => disabled(path.name));
 }
 
-// Initialised here as well as per-test so rendering AsyncHost never hits an undefined promise.
-let deferred: PromiseWithResolvers<void> = Promise.withResolvers<void>();
-
 @Component({
   imports: [NgpFormField, NgpFormControl, SignalFormField],
   template: `
@@ -73,6 +70,8 @@ let deferred: PromiseWithResolvers<void> = Promise.withResolvers<void>();
   `,
 })
 class AsyncHost {
+  /** Each instance owns its validator's promise, so the test resolves it via the fixture. */
+  readonly deferred = Promise.withResolvers<void>();
   readonly model = signal({ name: 'Ada' });
   readonly f = form(this.model, path =>
     validateAsync(path.name, {
@@ -80,7 +79,7 @@ class AsyncHost {
       factory: params =>
         resource({
           params: () => params(),
-          loader: () => deferred.promise.then(() => true),
+          loader: () => this.deferred.promise.then(() => true),
         }),
       onError: () => [],
       onSuccess: () => [],
@@ -156,7 +155,6 @@ describe('form-field primitives with signal forms', () => {
     });
 
     it('should reflect a pending async validator', async () => {
-      deferred = Promise.withResolvers<void>();
       const { getByTestId, fixture } = await render(AsyncHost);
       const field = getByTestId('field');
 
@@ -167,7 +165,7 @@ describe('form-field primitives with signal forms', () => {
       });
       expect(field).not.toHaveAttribute('data-valid');
 
-      deferred.resolve();
+      fixture.componentInstance.deferred.resolve();
       await fixture.whenStable();
 
       expect(field).not.toHaveAttribute('data-pending');

--- a/packages/ng-primitives/input-otp/src/input-otp/tests/input-otp-signal-forms.test.ts
+++ b/packages/ng-primitives/input-otp/src/input-otp/tests/input-otp-signal-forms.test.ts
@@ -1,0 +1,139 @@
+import { Component, signal } from '@angular/core';
+import {
+  FormField as SignalFormField,
+  disabled,
+  form,
+  minLength,
+  required,
+} from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { InputOtpFixture } from './input-otp-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue = '';
+
+@Component({
+  imports: [InputOtpFixture, SignalFormField],
+  template: `
+    <app-input-otp [length]="4" [formField]="f.code" />
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ code: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.code, () => this.isDisabled());
+    required(path.code);
+    // minLength ignores an empty value, so `required` covers the empty case.
+    minLength(path.code, 4);
+  });
+}
+
+function renderHost(code = '') {
+  initialValue = code;
+  return render(Host);
+}
+
+describe('InputOtp (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByTestId, fixture } = await renderHost('12');
+
+    expect(getByTestId('slot-0')).toHaveTextContent('1');
+    expect(getByTestId('slot-1')).toHaveTextContent('2');
+    expect(fixture.componentInstance.f.code().value()).toBe('12');
+  });
+
+  it('updates the model on typing and the DOM on a model change', async () => {
+    const { getByTestId, fixture } = await renderHost();
+    const input = getByTestId('hidden-input');
+
+    fireEvent.focus(input);
+    fireEvent.input(input, { target: { value: '12' } });
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().code).toBe('12');
+
+    fixture.componentInstance.model.set({ code: '34' });
+    await fixture.whenStable();
+    expect(getByTestId('slot-0')).toHaveTextContent('3');
+    expect(getByTestId('slot-1')).toHaveTextContent('4');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { getByTestId, fixture } = await renderHost();
+    await fixture.whenStable();
+
+    expect(getByTestId('hidden-input')).not.toHaveAttribute('disabled');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(getByTestId('hidden-input')).toHaveAttribute('disabled');
+  });
+
+  it('does not accept typing while the field is disabled', async () => {
+    const { getByTestId, fixture } = await renderHost();
+    const input = getByTestId('hidden-input');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.focus(input);
+    fireEvent.input(input, { target: { value: '12' } });
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().code).toBe('');
+    expect(getByTestId('slot-0')).toHaveTextContent('');
+
+    fixture.componentInstance.isDisabled.set(false);
+    await fixture.whenStable();
+
+    fireEvent.focus(input);
+    fireEvent.input(input, { target: { value: '12' } });
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().code).toBe('12');
+    expect(getByTestId('slot-0')).toHaveTextContent('1');
+  });
+
+  it('marks the field as touched once the OTP is complete', async () => {
+    const { getByTestId, fixture } = await renderHost();
+
+    expect(fixture.componentInstance.f.code().touched()).toBe(false);
+
+    const input = getByTestId('hidden-input');
+    fireEvent.focus(input);
+    fireEvent.input(input, { target: { value: '1234' } });
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.code().touched()).toBe(true);
+  });
+
+  it('clears the slots when the model is cleared', async () => {
+    const { getByTestId, fixture } = await renderHost('12');
+    expect(getByTestId('slot-0')).toHaveTextContent('1');
+
+    fixture.componentInstance.model.set({ code: '' });
+    await fixture.whenStable();
+
+    expect(getByTestId('slot-0')).toHaveTextContent('');
+    expect(getByTestId('slot-0')).not.toHaveAttribute('data-filled');
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByTestId, fixture } = await renderHost();
+    const field = fixture.componentInstance.f.code;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('required');
+
+    const input = getByTestId('hidden-input');
+    fireEvent.focus(input);
+    fireEvent.input(input, { target: { value: '12' } });
+    await fixture.whenStable();
+    expect(field().errors()[0].kind).toBe('minLength');
+
+    fireEvent.input(input, { target: { value: '1234' } });
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/input/src/input/tests/input-signal-forms.test.ts
+++ b/packages/ng-primitives/input/src/input/tests/input-signal-forms.test.ts
@@ -1,0 +1,80 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, required } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { NgpFormField, NgpLabel } from 'ng-primitives/form-field';
+import { NgpInput } from 'ng-primitives/input';
+import { describe, expect, it } from 'vitest';
+
+/** `ngpInput` composes `ngpFormControl`, so the signal-forms interop has to survive that. */
+
+@Component({
+  imports: [NgpInput, NgpFormField, NgpLabel, SignalFormField],
+  template: `
+    <div ngpFormField data-testid="field">
+      <label id="name-label" ngpLabel>Name</label>
+      <input id="name-input" [formField]="f.name" ngpInput data-testid="input" />
+    </div>
+  `,
+})
+class Host {
+  readonly model = signal({ name: '' });
+  readonly f = form(this.model, path => required(path.name));
+}
+
+@Component({
+  imports: [NgpInput, SignalFormField],
+  template: `
+    <input [formField]="f.name" ngpInput data-testid="input" />
+  `,
+})
+class DisabledHost {
+  readonly model = signal({ name: 'Ada' });
+  readonly f = form(this.model, path => disabled(path.name));
+}
+
+describe('NgpInput with signal forms', () => {
+  it('should mirror the field status', async () => {
+    const { getByTestId, fixture } = await render(Host);
+    const input = getByTestId('input');
+
+    expect(input).toHaveAttribute('data-invalid', '');
+    expect(input).toHaveAttribute('data-pristine', '');
+
+    fixture.componentInstance.model.set({ name: 'Ada' });
+    await fixture.whenStable();
+
+    expect(input).toHaveAttribute('data-valid', '');
+    expect(input).not.toHaveAttribute('data-invalid');
+  });
+
+  it('should propagate the status to the surrounding form field', async () => {
+    const { getByTestId } = await render(Host);
+
+    expect(getByTestId('field')).toHaveAttribute('data-invalid', '');
+  });
+
+  it('should label the input from the form field', async () => {
+    const { getByTestId } = await render(Host);
+
+    expect(getByTestId('input')).toHaveAttribute('aria-labelledby', 'name-label');
+  });
+
+  it('should only advertise aria-invalid once touched', async () => {
+    const { getByTestId, fixture } = await render(Host);
+    const input = getByTestId('input');
+
+    expect(input).not.toHaveAttribute('aria-invalid');
+
+    fireEvent.blur(input);
+    await fixture.whenStable();
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('should disable the input when the field is disabled', async () => {
+    const { getByTestId } = await render(DisabledHost);
+
+    expect(getByTestId('input')).toBeDisabled();
+    expect(getByTestId('input')).toHaveAttribute('data-disabled', '');
+  });
+});

--- a/packages/ng-primitives/listbox/src/listbox/tests/listbox-signal-forms.test.ts
+++ b/packages/ng-primitives/listbox/src/listbox/tests/listbox-signal-forms.test.ts
@@ -1,0 +1,140 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, minLength } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { Listbox, ListboxOption } from './listbox-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue: string[] = [];
+
+@Component({
+  imports: [Listbox, ListboxOption, SignalFormField],
+  template: `
+    <app-listbox [formField]="f.fruit" [mode]="mode()" aria-label="Fruit">
+      <app-listbox-option value="apple">Apple</app-listbox-option>
+      <app-listbox-option value="banana">Banana</app-listbox-option>
+    </app-listbox>
+  `,
+})
+class Host {
+  readonly mode = signal<'single' | 'multiple'>('single');
+  readonly isDisabled = signal(false);
+  readonly model = signal({ fruit: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.fruit, () => this.isDisabled());
+    // `required` treats only ''/false/null as empty, so an empty array needs minLength.
+    minLength(path.fruit, 1);
+  });
+}
+
+function renderHost(fruit: string[] = []) {
+  initialValue = fruit;
+  return render(Host);
+}
+
+describe('Listbox (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByRole, fixture } = await renderHost(['apple']);
+    await fixture.whenStable();
+
+    expect(getByRole('option', { name: 'Apple' })).toHaveAttribute('data-selected', '');
+    expect(fixture.componentInstance.f.fruit().value()).toEqual(['apple']);
+  });
+
+  it('updates the model on click', async () => {
+    const { getByRole, fixture } = await renderHost();
+    await fixture.whenStable();
+
+    const apple = getByRole('option', { name: 'Apple' });
+    fireEvent.click(apple);
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().fruit).toEqual(['apple']);
+    expect(apple).toHaveAttribute('data-selected', '');
+  });
+
+  it('accumulates the model value on click in multiple mode', async () => {
+    const { getByRole, fixture } = await renderHost();
+    fixture.componentInstance.mode.set('multiple');
+    await fixture.whenStable();
+
+    fireEvent.click(getByRole('option', { name: 'Apple' }));
+    fireEvent.click(getByRole('option', { name: 'Banana' }));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().fruit).toEqual(['apple', 'banana']);
+  });
+
+  it('reflects the DOM when the model value is set', async () => {
+    const { getByRole, fixture } = await renderHost();
+    await fixture.whenStable();
+
+    fixture.componentInstance.model.set({ fruit: ['banana'] });
+    await fixture.whenStable();
+
+    expect(getByRole('option', { name: 'Banana' })).toHaveAttribute('data-selected', '');
+  });
+
+  it('clears the selection when the model is emptied', async () => {
+    const { getByRole, fixture } = await renderHost(['apple']);
+    await fixture.whenStable();
+    expect(getByRole('option', { name: 'Apple' })).toHaveAttribute('data-selected', '');
+
+    fixture.componentInstance.model.set({ fruit: [] });
+    await fixture.whenStable();
+
+    expect(getByRole('option', { name: 'Apple' })).not.toHaveAttribute('data-selected');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+    await fixture.whenStable();
+
+    expect(getByRole('listbox')).toHaveAttribute('aria-disabled', 'false');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(getByRole('listbox')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('does not allow selection while the field is disabled', async () => {
+    const { getByRole, fixture } = await renderHost();
+    await fixture.whenStable();
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.click(getByRole('option', { name: 'Apple' }));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().fruit).toEqual([]);
+    expect(getByRole('option', { name: 'Apple' })).not.toHaveAttribute('data-selected');
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { getByRole, fixture } = await renderHost();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.fruit().touched()).toBe(false);
+
+    fireEvent.focusOut(getByRole('listbox'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.fruit().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+    await fixture.whenStable();
+    const field = fixture.componentInstance.f.fruit;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('minLength');
+
+    fireEvent.click(getByRole('option', { name: 'Apple' }));
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/pagination/src/pagination/tests/pagination-signal-forms.test.ts
+++ b/packages/ng-primitives/pagination/src/pagination/tests/pagination-signal-forms.test.ts
@@ -1,0 +1,99 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, max } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { Pagination } from './pagination-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue = 1;
+
+@Component({
+  imports: [Pagination, SignalFormField],
+  template: `
+    <app-pagination [formField]="f.page" pageCount="5" />
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ page: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.page, () => this.isDisabled());
+    max(path.page, 3);
+  });
+}
+
+function renderHost(page = 1) {
+  initialValue = page;
+  return render(Host);
+}
+
+describe('Pagination (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByRole, fixture } = await renderHost(2);
+    await fixture.whenStable();
+
+    expect(getByRole('navigation')).toHaveAttribute('data-page', '2');
+    expect(fixture.componentInstance.f.page().value()).toBe(2);
+  });
+
+  it('updates the model on click and the DOM on a model change', async () => {
+    const { getByRole, fixture } = await renderHost(1);
+    await fixture.whenStable();
+
+    fireEvent.click(getByRole('button', { name: 'Page 3' }));
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().page).toBe(3);
+    expect(getByRole('navigation')).toHaveAttribute('data-page', '3');
+
+    fixture.componentInstance.model.set({ page: 5 });
+    await fixture.whenStable();
+    expect(getByRole('navigation')).toHaveAttribute('data-page', '5');
+    expect(getByRole('button', { name: 'Page 5' })).toHaveAttribute('data-selected', '');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { getByRole, fixture } = await renderHost(1);
+    await fixture.whenStable();
+
+    expect(getByRole('navigation')).not.toHaveAttribute('data-disabled');
+    expect(getByRole('button', { name: 'Next Page' })).toHaveAttribute('tabindex', '0');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(getByRole('navigation')).toHaveAttribute('data-disabled', '');
+    expect(getByRole('button', { name: 'Next Page' })).toHaveAttribute('tabindex', '-1');
+
+    fixture.componentInstance.isDisabled.set(false);
+    await fixture.whenStable();
+
+    expect(getByRole('navigation')).not.toHaveAttribute('data-disabled');
+    expect(getByRole('button', { name: 'Next Page' })).toHaveAttribute('tabindex', '0');
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { getByRole, fixture } = await renderHost(1);
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.page().touched()).toBe(false);
+
+    fireEvent.focusOut(getByRole('navigation'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.page().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByRole, fixture } = await renderHost(1);
+    await fixture.whenStable();
+    const field = fixture.componentInstance.f.page;
+
+    expect(field().valid()).toBe(true);
+
+    fireEvent.click(getByRole('button', { name: 'Page 5' }));
+    await fixture.whenStable();
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('max');
+  });
+});

--- a/packages/ng-primitives/pagination/src/pagination/tests/pagination-signal-forms.test.ts
+++ b/packages/ng-primitives/pagination/src/pagination/tests/pagination-signal-forms.test.ts
@@ -64,11 +64,19 @@ describe('Pagination (reusable component) — signal forms', () => {
     expect(getByRole('navigation')).toHaveAttribute('data-disabled', '');
     expect(getByRole('button', { name: 'Next Page' })).toHaveAttribute('tabindex', '-1');
 
+    fireEvent.click(getByRole('button', { name: 'Page 3' }));
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().page).toBe(1);
+
     fixture.componentInstance.isDisabled.set(false);
     await fixture.whenStable();
 
     expect(getByRole('navigation')).not.toHaveAttribute('data-disabled');
     expect(getByRole('button', { name: 'Next Page' })).toHaveAttribute('tabindex', '0');
+
+    fireEvent.click(getByRole('button', { name: 'Page 3' }));
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().page).toBe(3);
   });
 
   it('marks the field as touched on focusout', async () => {

--- a/packages/ng-primitives/popover/src/popover/tests/popover-signal-forms.test.ts
+++ b/packages/ng-primitives/popover/src/popover/tests/popover-signal-forms.test.ts
@@ -1,0 +1,52 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, FormRoot, form, required } from '@angular/forms/signals';
+import { fireEvent, render, waitFor } from '@testing-library/angular';
+import { NgpPopover, NgpPopoverTrigger } from 'ng-primitives/popover';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The reactive-forms suite covers `ControlContainer` not leaking into portalled overlay content.
+ * Signal forms has no ambient container - the field tree is passed by value - so the equivalent
+ * risk is a `[formField]` inside the overlay failing to bind at all.
+ */
+
+@Component({
+  template: `
+    <form [formRoot]="f">
+      <button [ngpPopoverTrigger]="content" type="button">Open</button>
+    </form>
+
+    <ng-template #content>
+      <div ngpPopover>
+        <input [formField]="f.name" data-testid="overlay-input" />
+      </div>
+    </ng-template>
+  `,
+  imports: [NgpPopoverTrigger, NgpPopover, SignalFormField, FormRoot],
+})
+class Host {
+  readonly model = signal({ name: '' });
+  readonly f = form(this.model, path => required(path.name));
+}
+
+describe('Popover with signal forms', () => {
+  it('binds a field inside portalled overlay content', async () => {
+    const { getByRole, fixture } = await render(Host);
+
+    fireEvent.click(getByRole('button'));
+
+    await waitFor(() => {
+      expect(document.querySelector('[ngpPopover]')).toBeInTheDocument();
+    });
+
+    const input = document.querySelector<HTMLInputElement>('[data-testid="overlay-input"]')!;
+    expect(input).toBeInTheDocument();
+
+    input.value = 'Ada';
+    fireEvent.input(input);
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().name).toBe('Ada');
+    expect(fixture.componentInstance.f.name().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/radio/src/radio-group/tests/radio-signal-forms.test.ts
+++ b/packages/ng-primitives/radio/src/radio-group/tests/radio-signal-forms.test.ts
@@ -1,0 +1,132 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, required } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { RadioGroup, RadioItemFixture } from './radio-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue: string | null = null;
+
+@Component({
+  imports: [RadioGroup, RadioItemFixture, SignalFormField],
+  template: `
+    <app-radio-group [formField]="f.choice">
+      <app-radio-item value="1">One</app-radio-item>
+      <app-radio-item value="2">Two</app-radio-item>
+    </app-radio-group>
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal<{ choice: string | null }>({ choice: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.choice, () => this.isDisabled());
+    required(path.choice);
+  });
+}
+
+function renderHost(choice: string | null = null) {
+  initialValue = choice;
+  return render(Host);
+}
+
+describe('RadioGroup (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByRole, fixture } = await renderHost('1');
+
+    expect(getByRole('radio', { name: 'One' })).toHaveAttribute('data-checked', '');
+    expect(getByRole('radio', { name: 'Two' })).not.toHaveAttribute('data-checked');
+    expect(fixture.componentInstance.f.choice().value()).toBe('1');
+  });
+
+  it('updates the model on click and the DOM on a model change', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const one = getByRole('radio', { name: 'One' });
+
+    fireEvent.click(one);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().choice).toBe('1');
+    expect(one).toHaveAttribute('data-checked', '');
+
+    fixture.componentInstance.model.set({ choice: '2' });
+    await fixture.whenStable();
+    expect(getByRole('radio', { name: 'Two' })).toHaveAttribute('data-checked', '');
+    expect(one).not.toHaveAttribute('data-checked');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(getByRole('radiogroup')).not.toHaveAttribute('data-disabled');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(getByRole('radiogroup')).toHaveAttribute('data-disabled', '');
+  });
+
+  it('does not allow selection while the field is disabled', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const one = getByRole('radio', { name: 'One' });
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.click(one);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().choice).toBeNull();
+    expect(one).not.toHaveAttribute('data-checked');
+
+    fixture.componentInstance.isDisabled.set(false);
+    await fixture.whenStable();
+
+    fireEvent.click(one);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().choice).toBe('1');
+    expect(one).toHaveAttribute('data-checked', '');
+  });
+
+  it('does not roam focus with the keyboard while the field is disabled', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const one = getByRole('radio', { name: 'One' });
+    const two = getByRole('radio', { name: 'Two' });
+
+    // activate the first item so the roving focus group has an active item
+    fireEvent.click(one);
+    await fixture.whenStable();
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.keyDown(one, { key: 'ArrowRight' });
+    await fixture.whenStable();
+
+    expect(two).not.toHaveFocus();
+    expect(two).not.toHaveAttribute('data-checked');
+    expect(fixture.componentInstance.model().choice).toBe('1');
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(fixture.componentInstance.f.choice().touched()).toBe(false);
+
+    fireEvent.focusOut(getByRole('radiogroup'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.choice().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const field = fixture.componentInstance.f.choice;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('required');
+
+    fireEvent.click(getByRole('radio', { name: 'One' }));
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/radio/src/radio-group/tests/radio-signal-forms.test.ts
+++ b/packages/ng-primitives/radio/src/radio-group/tests/radio-signal-forms.test.ts
@@ -91,9 +91,12 @@ describe('RadioGroup (reusable component) — signal forms', () => {
     const one = getByRole('radio', { name: 'One' });
     const two = getByRole('radio', { name: 'Two' });
 
-    // activate the first item so the roving focus group has an active item
+    // activate and focus the first item so the roving focus group has an active item, and so
+    // `not.toHaveFocus()` below cannot pass simply because nothing is focused
     fireEvent.click(one);
+    one.focus();
     await fixture.whenStable();
+    expect(one).toHaveFocus();
 
     fixture.componentInstance.isDisabled.set(true);
     await fixture.whenStable();
@@ -101,6 +104,7 @@ describe('RadioGroup (reusable component) — signal forms', () => {
     fireEvent.keyDown(one, { key: 'ArrowRight' });
     await fixture.whenStable();
 
+    expect(one).toHaveFocus();
     expect(two).not.toHaveFocus();
     expect(two).not.toHaveAttribute('data-checked');
     expect(fixture.componentInstance.model().choice).toBe('1');

--- a/packages/ng-primitives/rating/src/rating/tests/rating-signal-forms.test.ts
+++ b/packages/ng-primitives/rating/src/rating/tests/rating-signal-forms.test.ts
@@ -1,0 +1,106 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, min } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { Rating } from './rating-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue = 0;
+
+@Component({
+  imports: [Rating, SignalFormField],
+  template: `
+    <app-rating [formField]="f.score" count="5" />
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ score: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.score, () => this.isDisabled());
+    min(path.score, 1);
+  });
+}
+
+function renderHost(score = 0) {
+  initialValue = score;
+  return render(Host);
+}
+
+describe('Rating (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByRole, fixture } = await renderHost(3);
+
+    expect(getByRole('slider')).toHaveAttribute('aria-valuenow', '3');
+    expect(fixture.componentInstance.f.score().value()).toBe(3);
+  });
+
+  it('updates the model on keyboard and the DOM on a model change', async () => {
+    const { getByRole, fixture } = await renderHost(2);
+    const rating = getByRole('slider');
+
+    fireEvent.keyDown(rating, { key: 'ArrowRight' });
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().score).toBe(3);
+
+    fixture.componentInstance.model.set({ score: 1 });
+    await fixture.whenStable();
+    expect(rating).toHaveAttribute('aria-valuenow', '1');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(getByRole('slider')).not.toHaveAttribute('data-disabled');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(getByRole('slider')).toHaveAttribute('data-disabled', '');
+    expect(getByRole('slider')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('does not change value with the keyboard while the field is disabled', async () => {
+    const { getByRole, fixture } = await renderHost(2);
+    const rating = getByRole('slider');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.keyDown(rating, { key: 'ArrowRight' });
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().score).toBe(2);
+    expect(rating).toHaveAttribute('aria-valuenow', '2');
+
+    fixture.componentInstance.isDisabled.set(false);
+    await fixture.whenStable();
+
+    fireEvent.keyDown(rating, { key: 'ArrowRight' });
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().score).toBe(3);
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(fixture.componentInstance.f.score().touched()).toBe(false);
+
+    fireEvent.focusOut(getByRole('slider'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.score().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByRole, fixture } = await renderHost(0);
+    const field = fixture.componentInstance.f.score;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('min');
+
+    fireEvent.keyDown(getByRole('slider'), { key: 'ArrowRight' });
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
@@ -202,7 +202,7 @@ export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
   readonly options = input<string[]>([]);
 
   /** The selected value. */
-  readonly value = model<string | undefined>();
+  readonly value = model<string | null>(null);
 
   /** The placeholder for the input. */
   readonly placeholder = input<string>('');
@@ -224,7 +224,7 @@ export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
   protected readonly formDisabled = signal(false);
 
   /** The on change callback */
-  private onChange?: ChangeFn<string | undefined>;
+  private onChange?: ChangeFn<string | null>;
 
   /** The on touch callback */
   protected onTouched?: TouchedFn;
@@ -234,12 +234,12 @@ export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
     this.filter.set(input.value);
   }
 
-  writeValue(value: string | undefined): void {
+  writeValue(value: string | null): void {
     this.value.set(value);
     this.filter.set(value ?? '');
   }
 
-  registerOnChange(fn: ChangeFn<string | undefined>): void {
+  registerOnChange(fn: ChangeFn<string | null>): void {
     this.onChange = fn;
   }
 
@@ -263,10 +263,12 @@ export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
       return;
     }
 
-    // if the filter value is empty, clear the value and notify the form control
+    // if the filter value is empty, clear the value and notify the form control.
+    // `null` rather than `undefined`: signal forms drops a model key whose value is
+    // `undefined`, which would tear the field out from under `[formField]`.
     if (this.filter() === '') {
-      this.value.set(undefined);
-      this.onChange?.(undefined);
+      this.value.set(null);
+      this.onChange?.(null);
     } else {
       // otherwise set the filter value to the selected value
       this.filter.set(this.value() ?? '');

--- a/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
@@ -234,8 +234,10 @@ export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
     this.filter.set(input.value);
   }
 
-  writeValue(value: string | null): void {
-    this.value.set(value);
+  // Accepts `undefined` and normalises it: a form control can hand one over, and letting it
+  // through would drop the key from a signal-forms model.
+  writeValue(value: string | null | undefined): void {
+    this.value.set(value ?? null);
     this.filter.set(value ?? '');
   }
 

--- a/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
+++ b/packages/ng-primitives/schematics/ng-generate/templates/combobox/combobox.__fileSuffix@dasherize__.ts.template
@@ -269,8 +269,12 @@ export class Combobox<%= componentSuffix %> implements ControlValueAccessor {
     // `null` rather than `undefined`: signal forms drops a model key whose value is
     // `undefined`, which would tear the field out from under `[formField]`.
     if (this.filter() === '') {
-      this.value.set(null);
-      this.onChange?.(null);
+      // only emit when there is something to clear, so opening and closing without touching
+      // the input does not mark the control dirty
+      if (this.value() !== null) {
+        this.value.set(null);
+        this.onChange?.(null);
+      }
     } else {
       // otherwise set the filter value to the selected value
       this.filter.set(this.value() ?? '');

--- a/packages/ng-primitives/search/src/search/tests/search-signal-forms.test.ts
+++ b/packages/ng-primitives/search/src/search/tests/search-signal-forms.test.ts
@@ -1,0 +1,141 @@
+import { Component, signal } from '@angular/core';
+import {
+  FormField as SignalFormField,
+  disabled,
+  form,
+  minLength,
+  required,
+} from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { SearchFixture } from './search-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue = '';
+
+@Component({
+  imports: [SearchFixture, SignalFormField],
+  template: `
+    <app-search [formField]="f.query" />
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ query: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.query, () => this.isDisabled());
+    required(path.query);
+    minLength(path.query, 3);
+  });
+}
+
+function renderHost(query = '') {
+  initialValue = query;
+  return render(Host);
+}
+
+describe('Search (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByRole, fixture } = await renderHost('hello');
+    await fixture.whenStable();
+
+    expect(getByRole('searchbox')).toHaveValue('hello');
+    expect(fixture.componentInstance.f.query().value()).toBe('hello');
+  });
+
+  it('updates the model as the user types', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const input = getByRole('searchbox') as HTMLInputElement;
+
+    input.value = 'world';
+    fireEvent.input(input);
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().query).toBe('world');
+  });
+
+  it('writes a new value into the field on a model change', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    fixture.componentInstance.model.set({ query: 'world' });
+    await fixture.whenStable();
+
+    expect(getByRole('searchbox')).toHaveValue('world');
+  });
+
+  it('clears the field when the model is cleared', async () => {
+    const { getByRole, fixture } = await renderHost('hello');
+    await fixture.whenStable();
+    expect(getByRole('searchbox')).toHaveValue('hello');
+
+    fixture.componentInstance.model.set({ query: '' });
+    await fixture.whenStable();
+
+    expect(getByRole('searchbox')).toHaveValue('');
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(fixture.componentInstance.f.query().touched()).toBe(false);
+
+    fireEvent.focusOut(getByRole('searchbox'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.query().touched()).toBe(true);
+  });
+
+  it('disables the input when the field is disabled', async () => {
+    const { getByRole, fixture } = await renderHost('hello');
+    const input = getByRole('searchbox') as HTMLInputElement;
+
+    expect(input.disabled).toBe(false);
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(input.disabled).toBe(true);
+  });
+
+  it('does not clear the field via the clear button while the field is disabled', async () => {
+    const { getByRole, fixture } = await renderHost('hello');
+    await fixture.whenStable();
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.click(getByRole('button', { name: 'Clear search' }));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().query).toBe('hello');
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const field = fixture.componentInstance.f.query;
+
+    expect(field().invalid()).toBe(true);
+    expect(
+      field()
+        .errors()
+        .map(error => error.kind),
+    ).toContain('required');
+
+    const input = getByRole('searchbox') as HTMLInputElement;
+    input.value = 'ab';
+    fireEvent.input(input);
+    await fixture.whenStable();
+
+    expect(
+      field()
+        .errors()
+        .map(error => error.kind),
+    ).toContain('minLength');
+
+    input.value = 'abc';
+    fireEvent.input(input);
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/select/src/native-select/native-select-state.ts
+++ b/packages/ng-primitives/select/src/native-select/native-select-state.ts
@@ -1,8 +1,7 @@
 import { signal, Signal } from '@angular/core';
 import { ngpFormControl } from 'ng-primitives/form-field';
 import { ngpInteractions } from 'ng-primitives/interactions';
-import { injectElementRef } from 'ng-primitives/internal';
-import { attrBinding, controlled, createPrimitive, deprecatedSetter } from 'ng-primitives/state';
+import { controlled, createPrimitive, deprecatedSetter } from 'ng-primitives/state';
 import { uniqueId } from 'ng-primitives/utils';
 
 export interface NgpNativeSelectState {
@@ -41,7 +40,6 @@ export const [
     disabled: _disabled = signal(false),
     id = signal(uniqueId('ngp-native-select')),
   }: NgpNativeSelectProps) => {
-    const element = injectElementRef();
     const disabled = controlled(_disabled);
     // Setup interactions
     ngpInteractions({
@@ -51,9 +49,10 @@ export const [
       focusVisible: true,
       disabled: disabled,
     });
+    // Binds `disabled` from this input *and* the form control status, so there must not be a
+    // second binding here - the last writer wins, and one keyed on the input alone re-enables
+    // the element whenever that input changes while the form control is still disabled.
     ngpFormControl({ id: id, disabled: disabled });
-
-    attrBinding(element, 'disabled', disabled);
 
     function setDisabled(value: boolean): void {
       disabled.set(value);

--- a/packages/ng-primitives/select/src/native-select/tests/native-select-forms.test.ts
+++ b/packages/ng-primitives/select/src/native-select/tests/native-select-forms.test.ts
@@ -34,6 +34,30 @@ describe('NgpNativeSelect — reactive forms', () => {
     expect(getByTestId('select')).not.toHaveAttribute('data-disabled');
   });
 
+  it('stays disabled when its own disabled input is turned off but the control is disabled', async () => {
+    const control = new FormControl({ value: '', disabled: true });
+    const { getByTestId, fixture, rerender } = await render(
+      `<select
+         ngpNativeSelect
+         data-testid="select"
+         [ngpNativeSelectDisabled]="own"
+         [formControl]="control"
+       ></select>`,
+      {
+        imports: [NgpNativeSelect, ReactiveFormsModule],
+        componentProperties: { own: true, control },
+      },
+    );
+    await fixture.whenStable();
+    expect(getByTestId('select')).toBeDisabled();
+
+    // Turning off the primitive's own input must not override the form control.
+    await rerender({ componentProperties: { own: false, control } });
+    await fixture.whenStable();
+
+    expect(getByTestId('select')).toBeDisabled();
+  });
+
   it('disables the select from the ngpNativeSelectDisabled input', async () => {
     const { getByTestId } = await render(
       `<select ngpNativeSelect data-testid="select" [ngpNativeSelectDisabled]="true"></select>`,

--- a/packages/ng-primitives/select/src/native-select/tests/native-select-forms.test.ts
+++ b/packages/ng-primitives/select/src/native-select/tests/native-select-forms.test.ts
@@ -1,0 +1,72 @@
+import { Component, signal } from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { FormField as SignalFormField, disabled, form } from '@angular/forms/signals';
+import { render } from '@testing-library/angular';
+import { NgpNativeSelect } from 'ng-primitives/select';
+import { describe, expect, it } from 'vitest';
+
+describe('NgpNativeSelect — reactive forms', () => {
+  it('disables the select when the form control is disabled', async () => {
+    const control = new FormControl({ value: '', disabled: true });
+    const { getByTestId, fixture } = await render(
+      `<select ngpNativeSelect data-testid="select" [formControl]="control"></select>`,
+      { imports: [NgpNativeSelect, ReactiveFormsModule], componentProperties: { control } },
+    );
+    await fixture.whenStable();
+
+    expect(getByTestId('select')).toBeDisabled();
+    expect(getByTestId('select')).toHaveAttribute('data-disabled', '');
+  });
+
+  it('re-enables the select when the form control is enabled', async () => {
+    const control = new FormControl({ value: '', disabled: true });
+    const { getByTestId, fixture } = await render(
+      `<select ngpNativeSelect data-testid="select" [formControl]="control"></select>`,
+      { imports: [NgpNativeSelect, ReactiveFormsModule], componentProperties: { control } },
+    );
+    await fixture.whenStable();
+    expect(getByTestId('select')).toBeDisabled();
+
+    control.enable();
+    await fixture.whenStable();
+
+    expect(getByTestId('select')).not.toBeDisabled();
+    expect(getByTestId('select')).not.toHaveAttribute('data-disabled');
+  });
+
+  it('disables the select from the ngpNativeSelectDisabled input', async () => {
+    const { getByTestId } = await render(
+      `<select ngpNativeSelect data-testid="select" [ngpNativeSelectDisabled]="true"></select>`,
+      { imports: [NgpNativeSelect] },
+    );
+
+    expect(getByTestId('select')).toBeDisabled();
+  });
+});
+
+@Component({
+  imports: [NgpNativeSelect, SignalFormField],
+  template: `
+    <select [formField]="f.fruit" ngpNativeSelect data-testid="select"></select>
+  `,
+})
+class SignalHost {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ fruit: '' });
+  readonly f = form(this.model, path => disabled(path.fruit, () => this.isDisabled()));
+}
+
+describe('NgpNativeSelect — signal forms', () => {
+  it('disables the select when the field is disabled', async () => {
+    const { getByTestId, fixture } = await render(SignalHost);
+    await fixture.whenStable();
+
+    expect(getByTestId('select')).not.toBeDisabled();
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(getByTestId('select')).toBeDisabled();
+    expect(getByTestId('select')).toHaveAttribute('data-disabled', '');
+  });
+});

--- a/packages/ng-primitives/select/src/select/tests/select-signal-forms.test.ts
+++ b/packages/ng-primitives/select/src/select/tests/select-signal-forms.test.ts
@@ -1,0 +1,139 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, required } from '@angular/forms/signals';
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SelectFixture } from './select-forms.fixture';
+
+function removeLingeringDropdown(): void {
+  // Dropdown is portalled to the body, so fixture.destroy() alone can leave
+  // it lingering between tests.
+  screen.queryByRole('listbox')?.remove();
+}
+
+/**
+ * Read when the host is constructed, so a test can choose the field's starting value.
+ * Signal forms builds the field tree from the model's own keys, and a key holding `undefined`
+ * produces no subfield at all - so the empty value here is `''`, which the fixture also treats
+ * as "nothing selected".
+ */
+let initialValue = '';
+
+@Component({
+  imports: [SelectFixture, SignalFormField],
+  template: `
+    <app-select [options]="options" [formField]="f.fruit" />
+  `,
+})
+class Host {
+  readonly options = ['Apple', 'Banana'];
+  readonly isDisabled = signal(false);
+  readonly model = signal({ fruit: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.fruit, () => this.isDisabled());
+    required(path.fruit);
+  });
+}
+
+@Component({
+  imports: [SelectFixture, SignalFormField],
+  template: `
+    <app-select [options]="options" [multiple]="true" [formField]="f.fruits" />
+  `,
+})
+class MultipleHost {
+  readonly options = ['Apple', 'Banana', 'Cherry'];
+  readonly model = signal<{ fruits: string[] }>({ fruits: [] });
+  readonly f = form(this.model);
+}
+
+function renderHost(fruit = '') {
+  initialValue = fruit;
+  return render(Host);
+}
+
+describe('Select (reusable component) — signal forms', () => {
+  afterEach(removeLingeringDropdown);
+
+  it('reflects the initial field value', async () => {
+    const { fixture } = await renderHost('Apple');
+
+    expect(screen.getByTestId('select-value')).toHaveTextContent('Apple');
+    expect(fixture.componentInstance.f.fruit().value()).toBe('Apple');
+  });
+
+  it('updates the model on user selection and the DOM on a model change', async () => {
+    const user = userEvent.setup();
+    const { fixture } = await renderHost();
+
+    await user.click(screen.getByTestId('select'));
+    await user.click(screen.getByTestId('option-Banana'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().fruit).toBe('Banana');
+    expect(screen.getByTestId('select-value')).toHaveTextContent('Banana');
+
+    fixture.componentInstance.model.set({ fruit: 'Apple' });
+    await fixture.whenStable();
+    expect(screen.getByTestId('select-value')).toHaveTextContent('Apple');
+
+    fixture.componentInstance.model.set({ fruit: '' });
+    await fixture.whenStable();
+    expect(screen.getByTestId('select-placeholder')).toBeInTheDocument();
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { fixture } = await renderHost();
+
+    expect(screen.getByTestId('select')).not.toHaveAttribute('data-disabled');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+    expect(screen.getByTestId('select')).toHaveAttribute('data-disabled');
+
+    fixture.componentInstance.isDisabled.set(false);
+    await fixture.whenStable();
+    expect(screen.getByTestId('select')).not.toHaveAttribute('data-disabled');
+  });
+
+  it('supports multiple selection bound to a string[] field', async () => {
+    const user = userEvent.setup();
+    const { fixture } = await render(MultipleHost);
+
+    await user.click(screen.getByTestId('select'));
+    await user.click(screen.getByTestId('option-Apple'));
+    await user.click(screen.getByTestId('option-Cherry'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().fruits).toEqual(['Apple', 'Cherry']);
+    expect(screen.getByTestId('select-value')).toHaveTextContent('Apple, Cherry');
+  });
+
+  it('marks the field as touched on blur', async () => {
+    const user = userEvent.setup();
+    const { fixture } = await renderHost();
+
+    expect(fixture.componentInstance.f.fruit().touched()).toBe(false);
+
+    await user.click(screen.getByTestId('select'));
+    await user.click(document.body);
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.fruit().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const user = userEvent.setup();
+    const { fixture } = await renderHost();
+    const field = fixture.componentInstance.f.fruit;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('required');
+
+    await user.click(screen.getByTestId('select'));
+    await user.click(screen.getByTestId('option-Banana'));
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/slider/src/range-slider/range-slider/tests/range-slider-signal-forms.test.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/tests/range-slider-signal-forms.test.ts
@@ -55,13 +55,17 @@ describe('RangeSlider (reusable component) — signal forms', () => {
     await fixture.whenStable();
 
     const lowThumb = screen.getByTestId('low-thumb');
+    const highThumb = screen.getByTestId('high-thumb');
     expect(lowThumb).toHaveAttribute('tabindex', '0');
+    expect(highThumb).toHaveAttribute('tabindex', '0');
 
     fixture.componentInstance.isDisabled.set(true);
     await fixture.whenStable();
 
     expect(lowThumb).toHaveAttribute('tabindex', '-1');
     expect(lowThumb).toHaveAttribute('data-disabled', '');
+    expect(highThumb).toHaveAttribute('tabindex', '-1');
+    expect(highThumb).toHaveAttribute('data-disabled', '');
   });
 
   it('does not respond to the keyboard while the field is disabled', async () => {
@@ -77,6 +81,15 @@ describe('RangeSlider (reusable component) — signal forms', () => {
     await fixture.whenStable();
 
     expect(lowThumb).toHaveAttribute('aria-valuenow', '20');
+
+    // the high thumb must be inert too, not just the low one
+    const highThumb = screen.getByTestId('high-thumb');
+    highThumb.focus();
+    await userEvent.keyboard('{arrowleft}');
+    await fixture.whenStable();
+
+    expect(highThumb).toHaveAttribute('aria-valuenow', '80');
+    expect(fixture.componentInstance.model().range).toEqual([20, 80]);
 
     fixture.componentInstance.isDisabled.set(false);
     await fixture.whenStable();

--- a/packages/ng-primitives/slider/src/range-slider/range-slider/tests/range-slider-signal-forms.test.ts
+++ b/packages/ng-primitives/slider/src/range-slider/range-slider/tests/range-slider-signal-forms.test.ts
@@ -1,0 +1,117 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, validate } from '@angular/forms/signals';
+import { render, screen } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { RangeSlider } from './range-slider-forms.fixture';
+
+@Component({
+  imports: [RangeSlider, SignalFormField],
+  template: `
+    <app-range-slider [formField]="f.range" [min]="0" [max]="100" [step]="1" />
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal<{ range: [number, number] }>({ range: [20, 80] });
+  readonly f = form(this.model, path => {
+    disabled(path.range, () => this.isDisabled());
+    validate(path.range, ({ value }) =>
+      value()[1] - value()[0] >= 10 ? undefined : { kind: 'tooNarrow' },
+    );
+  });
+}
+
+describe('RangeSlider (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { fixture } = await render(Host);
+    await fixture.whenStable();
+
+    expect(screen.getByTestId('low-thumb')).toHaveAttribute('aria-valuenow', '20');
+    expect(screen.getByTestId('high-thumb')).toHaveAttribute('aria-valuenow', '80');
+    expect(fixture.componentInstance.f.range().value()).toEqual([20, 80]);
+  });
+
+  it('updates the model when a thumb moves and the DOM on a model change', async () => {
+    const { fixture } = await render(Host);
+    await fixture.whenStable();
+
+    const highThumb = screen.getByTestId('high-thumb');
+    highThumb.focus();
+    await userEvent.keyboard('{arrowleft}');
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().range).toEqual([20, 79]);
+
+    fixture.componentInstance.model.set({ range: [40, 60] });
+    await fixture.whenStable();
+
+    expect(screen.getByTestId('low-thumb')).toHaveAttribute('aria-valuenow', '40');
+    expect(highThumb).toHaveAttribute('aria-valuenow', '60');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { fixture } = await render(Host);
+    await fixture.whenStable();
+
+    const lowThumb = screen.getByTestId('low-thumb');
+    expect(lowThumb).toHaveAttribute('tabindex', '0');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(lowThumb).toHaveAttribute('tabindex', '-1');
+    expect(lowThumb).toHaveAttribute('data-disabled', '');
+  });
+
+  it('does not respond to the keyboard while the field is disabled', async () => {
+    const { fixture } = await render(Host);
+    await fixture.whenStable();
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    const lowThumb = screen.getByTestId('low-thumb');
+    lowThumb.focus();
+    await userEvent.keyboard('{arrowright}');
+    await fixture.whenStable();
+
+    expect(lowThumb).toHaveAttribute('aria-valuenow', '20');
+
+    fixture.componentInstance.isDisabled.set(false);
+    await fixture.whenStable();
+
+    lowThumb.focus();
+    await userEvent.keyboard('{arrowright}');
+    await fixture.whenStable();
+
+    expect(lowThumb).toHaveAttribute('aria-valuenow', '21');
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { fixture } = await render(Host);
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.range().touched()).toBe(false);
+
+    screen.getByTestId('low-thumb').focus();
+    screen.getByTestId('low-thumb').blur();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.range().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { fixture } = await render(Host);
+    await fixture.whenStable();
+    const field = fixture.componentInstance.f.range;
+
+    expect(field().valid()).toBe(true);
+
+    fixture.componentInstance.model.set({ range: [50, 55] });
+    await fixture.whenStable();
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('tooNarrow');
+  });
+});

--- a/packages/ng-primitives/slider/src/slider/tests/slider-signal-forms.test.ts
+++ b/packages/ng-primitives/slider/src/slider/tests/slider-signal-forms.test.ts
@@ -1,0 +1,106 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, min } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { Slider } from './slider-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue = 0;
+
+@Component({
+  imports: [Slider, SignalFormField],
+  template: `
+    <app-slider [formField]="f.volume" min="0" max="100" step="10" />
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ volume: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.volume, () => this.isDisabled());
+    min(path.volume, 20);
+  });
+}
+
+function renderHost(volume = 50) {
+  initialValue = volume;
+  return render(Host);
+}
+
+describe('Slider (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByRole, fixture } = await renderHost(30);
+
+    expect(getByRole('slider')).toHaveAttribute('aria-valuenow', '30');
+    expect(fixture.componentInstance.f.volume().value()).toBe(30);
+  });
+
+  it('updates the model on keyboard and the DOM on a model change', async () => {
+    const { getByRole, fixture } = await renderHost(50);
+    const thumb = getByRole('slider');
+
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().volume).toBe(60);
+
+    fixture.componentInstance.model.set({ volume: 20 });
+    await fixture.whenStable();
+    expect(thumb).toHaveAttribute('aria-valuenow', '20');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(getByRole('slider')).not.toHaveAttribute('data-disabled');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(getByRole('slider')).toHaveAttribute('data-disabled', '');
+    expect(getByRole('slider')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('does not change value with the keyboard while the field is disabled', async () => {
+    const { getByRole, fixture } = await renderHost(40);
+    const thumb = getByRole('slider');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().volume).toBe(40);
+    expect(thumb).toHaveAttribute('aria-valuenow', '40');
+
+    fixture.componentInstance.isDisabled.set(false);
+    await fixture.whenStable();
+
+    fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().volume).toBe(50);
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(fixture.componentInstance.f.volume().touched()).toBe(false);
+
+    fireEvent.focusOut(getByRole('slider'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.volume().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByRole, fixture } = await renderHost(10);
+    const field = fixture.componentInstance.f.volume;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('min');
+
+    fireEvent.keyDown(getByRole('slider'), { key: 'ArrowRight' });
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/switch/src/switch/tests/switch-signal-forms.test.ts
+++ b/packages/ng-primitives/switch/src/switch/tests/switch-signal-forms.test.ts
@@ -1,0 +1,106 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, validate } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { Switch } from './switch-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue = false;
+
+@Component({
+  imports: [Switch, SignalFormField],
+  template: `
+    <app-switch [formField]="f.enabled" />
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ enabled: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.enabled, () => this.isDisabled());
+    validate(path.enabled, ({ value }) => (value() ? undefined : { kind: 'mustEnable' }));
+  });
+}
+
+function renderHost(enabled = false) {
+  initialValue = enabled;
+  return render(Host);
+}
+
+describe('Switch (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByRole, fixture } = await renderHost(true);
+
+    expect(getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+    expect(fixture.componentInstance.f.enabled().value()).toBe(true);
+  });
+
+  it('updates the model on click and the DOM on a model change', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const el = getByRole('switch');
+
+    fireEvent.click(el);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().enabled).toBe(true);
+    expect(el).toHaveAttribute('aria-checked', 'true');
+
+    fixture.componentInstance.model.set({ enabled: false });
+    await fixture.whenStable();
+    expect(el).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(getByRole('switch')).not.toHaveAttribute('data-disabled');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+    expect(getByRole('switch')).toHaveAttribute('data-disabled', '');
+  });
+
+  it('does not toggle while the field is disabled', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const el = getByRole('switch');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.click(el);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().enabled).toBe(false);
+    expect(el).toHaveAttribute('aria-checked', 'false');
+
+    fixture.componentInstance.isDisabled.set(false);
+    await fixture.whenStable();
+
+    fireEvent.click(el);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().enabled).toBe(true);
+    expect(el).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(fixture.componentInstance.f.enabled().touched()).toBe(false);
+
+    fireEvent.focusOut(getByRole('switch'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.enabled().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const field = fixture.componentInstance.f.enabled;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('mustEnable');
+
+    fireEvent.click(getByRole('switch'));
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/textarea/src/textarea/tests/textarea-signal-forms.test.ts
+++ b/packages/ng-primitives/textarea/src/textarea/tests/textarea-signal-forms.test.ts
@@ -1,0 +1,89 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, required } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { NgpFormField, NgpLabel } from 'ng-primitives/form-field';
+import { NgpTextarea } from 'ng-primitives/textarea';
+import { describe, expect, it } from 'vitest';
+
+/** `ngpTextarea` composes `ngpFormControl`, so the signal-forms interop has to survive that. */
+
+@Component({
+  imports: [NgpTextarea, NgpFormField, NgpLabel, SignalFormField],
+  template: `
+    <div ngpFormField data-testid="field">
+      <label id="bio-label" ngpLabel>Bio</label>
+      <textarea id="bio-input" [formField]="f.bio" ngpTextarea data-testid="textarea"></textarea>
+    </div>
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ bio: '' });
+  readonly f = form(this.model, path => {
+    disabled(path.bio, () => this.isDisabled());
+    required(path.bio);
+  });
+}
+
+describe('NgpTextarea with signal forms', () => {
+  it('should mirror the field status', async () => {
+    const { getByTestId, fixture } = await render(Host);
+    const textarea = getByTestId('textarea');
+
+    expect(textarea).toHaveAttribute('data-invalid', '');
+    expect(textarea).toHaveAttribute('data-pristine', '');
+
+    fixture.componentInstance.model.set({ bio: 'Hello' });
+    await fixture.whenStable();
+
+    expect(textarea).toHaveAttribute('data-valid', '');
+    expect(textarea).not.toHaveAttribute('data-invalid');
+  });
+
+  it('should propagate the status to the surrounding form field', async () => {
+    const { getByTestId } = await render(Host);
+
+    expect(getByTestId('field')).toHaveAttribute('data-invalid', '');
+  });
+
+  it('should label the textarea from the form field', async () => {
+    const { getByTestId } = await render(Host);
+
+    expect(getByTestId('textarea')).toHaveAttribute('aria-labelledby', 'bio-label');
+  });
+
+  it('should update the model as the user types', async () => {
+    const { getByTestId, fixture } = await render(Host);
+    const textarea = getByTestId('textarea') as HTMLTextAreaElement;
+
+    textarea.value = 'Hello';
+    fireEvent.input(textarea);
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().bio).toBe('Hello');
+  });
+
+  it('should only advertise aria-invalid once touched', async () => {
+    const { getByTestId, fixture } = await render(Host);
+    const textarea = getByTestId('textarea');
+
+    expect(textarea).not.toHaveAttribute('aria-invalid');
+
+    fireEvent.blur(textarea);
+    await fixture.whenStable();
+
+    expect(textarea).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('should disable the textarea when the field is disabled', async () => {
+    const { getByTestId, fixture } = await render(Host);
+
+    expect(getByTestId('textarea')).not.toBeDisabled();
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(getByTestId('textarea')).toBeDisabled();
+    expect(getByTestId('textarea')).toHaveAttribute('data-disabled', '');
+  });
+});

--- a/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-signal-forms.test.ts
+++ b/packages/ng-primitives/toggle-group/src/toggle-group/tests/toggle-group-signal-forms.test.ts
@@ -1,0 +1,105 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, minLength } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { NgpToggleGroupItem } from 'ng-primitives/toggle-group';
+import { describe, expect, it } from 'vitest';
+import { ToggleGroup, ToggleGroupItemFixture } from './toggle-group-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue: string[] = [];
+
+@Component({
+  imports: [ToggleGroup, ToggleGroupItemFixture, NgpToggleGroupItem, SignalFormField],
+  template: `
+    <app-toggle-group [formField]="f.selection">
+      <button app-toggle-group-item data-testid="item-1" value="option-1">1</button>
+      <button app-toggle-group-item data-testid="item-2" value="option-2">2</button>
+    </app-toggle-group>
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ selection: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.selection, () => this.isDisabled());
+    // `required` treats only ''/false/null as empty, so an empty array needs minLength.
+    minLength(path.selection, 1);
+  });
+}
+
+function renderHost(selection: string[] = []) {
+  initialValue = selection;
+  return render(Host);
+}
+
+describe('ToggleGroup (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByTestId, fixture } = await renderHost(['option-1']);
+
+    expect(getByTestId('item-1')).toHaveAttribute('data-selected');
+    expect(getByTestId('item-2')).not.toHaveAttribute('data-selected');
+    expect(fixture.componentInstance.f.selection().value()).toEqual(['option-1']);
+  });
+
+  it('updates the model on click and the DOM on a model change', async () => {
+    const { getByTestId, fixture } = await renderHost();
+    const item1 = getByTestId('item-1');
+
+    fireEvent.click(item1);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().selection).toEqual(['option-1']);
+    expect(item1).toHaveAttribute('data-selected');
+
+    fixture.componentInstance.model.set({ selection: [] });
+    await fixture.whenStable();
+    expect(item1).not.toHaveAttribute('data-selected');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(getByRole('group')).not.toHaveAttribute('data-disabled');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(getByRole('group')).toHaveAttribute('data-disabled');
+  });
+
+  it('does not select while the field is disabled', async () => {
+    const { getByTestId, fixture } = await renderHost();
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.click(getByTestId('item-1'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().selection).toEqual([]);
+    expect(getByTestId('item-1')).not.toHaveAttribute('data-selected');
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(fixture.componentInstance.f.selection().touched()).toBe(false);
+
+    fireEvent.focusOut(getByRole('group'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.selection().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByTestId, fixture } = await renderHost();
+    const field = fixture.componentInstance.f.selection;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('minLength');
+
+    fireEvent.click(getByTestId('item-1'));
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});

--- a/packages/ng-primitives/toggle/src/toggle/tests/toggle-signal-forms.test.ts
+++ b/packages/ng-primitives/toggle/src/toggle/tests/toggle-signal-forms.test.ts
@@ -62,6 +62,7 @@ describe('Toggle (reusable component) — signal forms', () => {
 
     expect(button).toHaveAttribute('aria-disabled', 'true');
     expect(button).toHaveAttribute('data-disabled', '');
+    expect(button).toBeDisabled();
   });
 
   it('does not toggle while the field is disabled', async () => {

--- a/packages/ng-primitives/toggle/src/toggle/tests/toggle-signal-forms.test.ts
+++ b/packages/ng-primitives/toggle/src/toggle/tests/toggle-signal-forms.test.ts
@@ -1,0 +1,104 @@
+import { Component, signal } from '@angular/core';
+import { FormField as SignalFormField, disabled, form, validate } from '@angular/forms/signals';
+import { fireEvent, render } from '@testing-library/angular';
+import { describe, expect, it } from 'vitest';
+import { Toggle } from './toggle-forms.fixture';
+
+/** Read when the host is constructed, so a test can choose the field's starting value. */
+let initialValue = false;
+
+@Component({
+  imports: [Toggle, SignalFormField],
+  template: `
+    <button [formField]="f.bold" app-toggle>Toggle</button>
+  `,
+})
+class Host {
+  readonly isDisabled = signal(false);
+  readonly model = signal({ bold: initialValue });
+  readonly f = form(this.model, path => {
+    disabled(path.bold, () => this.isDisabled());
+    validate(path.bold, ({ value }) => (value() ? undefined : { kind: 'mustSelect' }));
+  });
+}
+
+function renderHost(bold = false) {
+  initialValue = bold;
+  return render(Host);
+}
+
+describe('Toggle (reusable component) — signal forms', () => {
+  it('reflects the initial field value', async () => {
+    const { getByRole, fixture } = await renderHost(true);
+    const button = getByRole('button');
+
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+    expect(button).toHaveAttribute('data-selected', '');
+    expect(fixture.componentInstance.f.bold().value()).toBe(true);
+  });
+
+  it('updates the model on click and the DOM on a model change', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const button = getByRole('button');
+
+    fireEvent.click(button);
+    await fixture.whenStable();
+    expect(fixture.componentInstance.model().bold).toBe(true);
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+
+    fixture.componentInstance.model.set({ bold: false });
+    await fixture.whenStable();
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('reflects the disabled state from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const button = getByRole('button');
+
+    expect(button).not.toHaveAttribute('data-disabled');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    expect(button).toHaveAttribute('data-disabled', '');
+  });
+
+  it('does not toggle while the field is disabled', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const button = getByRole('button');
+
+    fixture.componentInstance.isDisabled.set(true);
+    await fixture.whenStable();
+
+    fireEvent.click(button);
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.model().bold).toBe(false);
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('marks the field as touched on focusout', async () => {
+    const { getByRole, fixture } = await renderHost();
+
+    expect(fixture.componentInstance.f.bold().touched()).toBe(false);
+
+    fireEvent.focusOut(getByRole('button'));
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.f.bold().touched()).toBe(true);
+  });
+
+  it('reports validation errors from the field', async () => {
+    const { getByRole, fixture } = await renderHost();
+    const field = fixture.componentInstance.f.bold;
+
+    expect(field().invalid()).toBe(true);
+    expect(field().errors()[0].kind).toBe('mustSelect');
+
+    fireEvent.click(getByRole('button'));
+    await fixture.whenStable();
+
+    expect(field().valid()).toBe(true);
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — no docs change needed; the documented `data-disabled` behaviour is unchanged

## PR Type

- [x] Bugfix

## Issue

No linked issue — the fixes were found while adding signal forms test coverage.

## What does this PR implement/fix?

Adds `@angular/forms/signals` coverage alongside every existing reactive/template-driven forms suite — 18 new test files, 125 tests — and fixes the three bugs that coverage surfaced.

### 1. A disabled form control did not disable the element

`ngpFormControl` bound the `disabled` attribute from its own `ngpFormControlDisabled` input alone:

```ts
attrBinding(elementRef, 'disabled', () => (supportsDisabledAttribute && disabled() ? '' : null));
```

Whenever that input was `false`, the binding removed the attribute the forms layer had just set — so a control disabled through reactive or signal forms stayed editable. The binding now also considers the control status.

Measured before/after, rendering each target with a disabled `FormControl`:

| Target | Before | After |
| --- | --- | --- |
| `[ngpFormControl]` | not disabled | **disabled** |
| `ngpNativeSelect` | not disabled | **disabled** |
| `ngpFormControl` under a CVA wrapper (e.g. `ngpNumberFieldInput`) | not disabled | **disabled** |
| `ngpInput` / `ngpTextarea` | disabled | disabled (unchanged) |
| plain `<input [formControl]>`, no ng-primitives | disabled | disabled (baseline) |

`ngpInput` and `ngpTextarea` were unaffected because they each bind `disabled` themselves. The fix brings the remaining cases in line with what plain Angular already does. Two existing assertions were pinning the old behaviour and have been flipped (`form-control.test.ts:343`, `integration.test.ts:416`).

### 2. `ngpNativeSelect` re-enabled itself

`NgpNativeSelect` bound `disabled` from its own input *on top of* the binding `ngpFormControl` already installs. Both write the same attribute and the last writer wins, so toggling `ngpNativeSelectDisabled` from `true` to `false` while the form control was still disabled re-enabled the select. Removed the redundant second binding.

### 3. Combobox emitted `undefined` for a cleared value

Signal forms builds its field tree from the model's own keys and treats `undefined` as an *absent* field, so clearing the combobox input and closing the dropdown tore `f.<key>` out from under `[formField]` and threw `this.field(...) is not a function`.

The reusable component now emits `null` instead, end to end (`model`, `ChangeFn`, `writeValue`, `registerOnChange`). `null` rather than `''` because reactive `reset()` already writes `null` in via `writeValue` — so this only makes the emit symmetric — it matches `radio-group`, and it works for the generic `NgpCombobox<T>` where `''` would only fit a string value. Applied to the reusable component, the schematic template generated from it, and the test fixture that mirrors it.

### Notes on the signal forms suites

Each mirrors its reactive counterpart (initial value, interaction → model, model → DOM, disabled reflection and interaction blocking, touched on blur) plus per-primitive validation, which the reactive suites didn't cover.

The existing CVA fixtures work unchanged with `[formField]` — signal forms supports `ControlValueAccessor` for back-compat.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

For the `disabled` fix: `data-disabled` was already applied in every affected case, so any styling keyed on it is unchanged. Affected elements now additionally carry native disabled semantics (out of the tab order, no pointer events), which matches plain Angular behaviour.

For the combobox: the reusable components are copy-paste starting points rather than published API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Form controls now correctly reflect disabled states from both component settings and form status.
  - Native select controls consistently prioritise the form control’s disabled state.
  - Comboboxes now consistently represent cleared values as `null`.

- **Tests**
  - Added comprehensive signal-form integration coverage across inputs, selections, toggles, sliders, pagination, popovers, form fields and other controls.
  - Verified value synchronisation, validation, touched and dirty states, accessibility attributes, disabled behaviour, keyboard interaction and portalled content.
  - Added coverage for reactive and signal-based form integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->