### PR TITLE
fix(switch): support Space and Enter activation on both button and non-button elements

### DIFF
--- a/apps/documentation/src/app/pages/(documentation)/primitives/switch.md
+++ b/apps/documentation/src/app/pages/(documentation)/primitives/switch.md
@@ -99,5 +99,5 @@ Adheres to the [WAI-ARIA switch design pattern](https://www.w3.org/WAI/ARIA/apg/
 
 ### Keyboard Interactions
 
-- <kbd>Space</kbd> - Toggle the switch state (when switch is a button).
+- <kbd>Space</kbd> - Toggle the switch state.
 - <kbd>Enter</kbd> - Toggle the switch state.

--- a/packages/ng-primitives/switch/src/switch/switch-state.ts
+++ b/packages/ng-primitives/switch/src/switch/switch-state.ts
@@ -126,10 +126,15 @@ export const [NgpSwitchStateToken, ngpSwitch, injectSwitchState, provideSwitchSt
       // Listeners
       listener(element, 'click', event => toggle(event));
       listener(element, 'keydown', (event: KeyboardEvent) => {
-        const isActivationKey = event.key === ' ' || event.key === 'Space' || event.key === 'Enter';
+        const isActivationKey = event.key === ' ' || event.key === 'Enter';
         if (isActivationKey && !isButton) {
+          // prevented on every repeat too, otherwise a held Space scrolls the page
           event.preventDefault();
-          toggle(event);
+
+          // a native button activates once per press, so autorepeat must not keep toggling
+          if (!event.repeat) {
+            toggle(event);
+          }
         }
       });
 

--- a/packages/ng-primitives/switch/src/switch/switch-state.ts
+++ b/packages/ng-primitives/switch/src/switch/switch-state.ts
@@ -131,7 +131,8 @@ export const [NgpSwitchStateToken, ngpSwitch, injectSwitchState, provideSwitchSt
           // prevented on every repeat too, otherwise a held Space scrolls the page
           event.preventDefault();
 
-          // mirror a native button: Enter clicks on every keydown, Space activates once on keyup
+          // mirror a native button's toggle count: Enter activates on every keydown, Space only
+          // once per press (native does that on keyup; we ignore the autorepeat instead)
           if (event.key === 'Enter' || !event.repeat) {
             toggle(event);
           }

--- a/packages/ng-primitives/switch/src/switch/switch-state.ts
+++ b/packages/ng-primitives/switch/src/switch/switch-state.ts
@@ -126,11 +126,10 @@ export const [NgpSwitchStateToken, ngpSwitch, injectSwitchState, provideSwitchSt
       // Listeners
       listener(element, 'click', event => toggle(event));
       listener(element, 'keydown', (event: KeyboardEvent) => {
-        if (event.key === ' ' || event.key === 'Space') {
+        const isActivationKey = event.key === ' ' || event.key === 'Space' || event.key === 'Enter';
+        if (isActivationKey && !isButton) {
           event.preventDefault();
-          if (!isButton) {
-            toggle(event);
-          }
+          toggle(event);
         }
       });
 

--- a/packages/ng-primitives/switch/src/switch/switch-state.ts
+++ b/packages/ng-primitives/switch/src/switch/switch-state.ts
@@ -131,8 +131,8 @@ export const [NgpSwitchStateToken, ngpSwitch, injectSwitchState, provideSwitchSt
           // prevented on every repeat too, otherwise a held Space scrolls the page
           event.preventDefault();
 
-          // a native button activates once per press, so autorepeat must not keep toggling
-          if (!event.repeat) {
+          // mirror a native button: Enter clicks on every keydown, Space activates once on keyup
+          if (event.key === 'Enter' || !event.repeat) {
             toggle(event);
           }
         }

--- a/packages/ng-primitives/switch/src/switch/tests/switch-primitive.test.ts
+++ b/packages/ng-primitives/switch/src/switch/tests/switch-primitive.test.ts
@@ -4,12 +4,6 @@ import { userEvent } from '@testing-library/user-event';
 import { NgpSwitch } from 'ng-primitives/switch';
 import { describe, expect, it, vi } from 'vitest';
 
-function keydown(element: HTMLElement, key: string, repeat = false): KeyboardEvent {
-  const event = new KeyboardEvent('keydown', { key, repeat, bubbles: true, cancelable: true });
-  element.dispatchEvent(event);
-  return event;
-}
-
 describe('NgpSwitch', () => {
   describe('roles & attributes', () => {
     it('should render with a generated id and default unchecked state', async () => {
@@ -180,13 +174,13 @@ describe('NgpSwitch', () => {
 
       const switchDiv = getByRole('switch');
       fireEvent.keyDown(switchDiv, { key: ' ' });
-      const repeat = keydown(switchDiv, ' ', true);
+      const notPrevented = fireEvent.keyDown(switchDiv, { key: ' ', repeat: true });
 
       // a native button activates on keyup, so a held Space toggles once
       expect(checkedChange).toHaveBeenCalledTimes(1);
       expect(switchDiv).toHaveAttribute('aria-checked', 'true');
       // still prevented, otherwise a held Space scrolls the page
-      expect(repeat.defaultPrevented).toBe(true);
+      expect(notPrevented).toBe(false);
     });
 
     it('should toggle on every repeat while Enter is held on a non-button', async () => {
@@ -198,8 +192,8 @@ describe('NgpSwitch', () => {
 
       const switchDiv = getByRole('switch');
       fireEvent.keyDown(switchDiv, { key: 'Enter' });
-      keydown(switchDiv, 'Enter', true);
-      keydown(switchDiv, 'Enter', true);
+      fireEvent.keyDown(switchDiv, { key: 'Enter', repeat: true });
+      fireEvent.keyDown(switchDiv, { key: 'Enter', repeat: true });
 
       // a native button clicks on every Enter keydown, autorepeat included
       expect(checkedChange).toHaveBeenCalledTimes(3);

--- a/packages/ng-primitives/switch/src/switch/tests/switch-primitive.test.ts
+++ b/packages/ng-primitives/switch/src/switch/tests/switch-primitive.test.ts
@@ -1,5 +1,6 @@
 import { By } from '@angular/platform-browser';
 import { fireEvent, render } from '@testing-library/angular';
+import { userEvent } from '@testing-library/user-event';
 import { NgpSwitch } from 'ng-primitives/switch';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -132,15 +133,75 @@ describe('NgpSwitch', () => {
       expect(switchDiv).toHaveAttribute('aria-checked', 'true');
     });
 
-    it('should not toggle twice when Space is pressed on a non-button (no duplicate handling)', async () => {
+    it('should toggle once on the Space key when the element is a button', async () => {
+      const checkedChange = vi.fn();
+      const { getByRole } = await render(
+        `<button ngpSwitch (ngpSwitchCheckedChange)="checkedChange($event)"></button>`,
+        { imports: [NgpSwitch], componentProperties: { checkedChange } },
+      );
+
+      const button = getByRole('switch');
+      button.focus();
+      // a real key press, so the browser's native button activation applies
+      await userEvent.keyboard(' ');
+
+      expect(checkedChange).toHaveBeenCalledTimes(1);
+      expect(checkedChange).toHaveBeenCalledWith(true);
+      expect(button).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('should toggle once on the Enter key when the element is a button', async () => {
+      const checkedChange = vi.fn();
+      const { getByRole } = await render(
+        `<button ngpSwitch (ngpSwitchCheckedChange)="checkedChange($event)"></button>`,
+        { imports: [NgpSwitch], componentProperties: { checkedChange } },
+      );
+
+      const button = getByRole('switch');
+      button.focus();
+      await userEvent.keyboard('{Enter}');
+
+      expect(checkedChange).toHaveBeenCalledTimes(1);
+      expect(button).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('should not toggle repeatedly while an activation key is held on a non-button', async () => {
       const checkedChange = vi.fn();
       const { getByRole } = await render(
         `<div ngpSwitch tabindex="0" (ngpSwitchCheckedChange)="checkedChange($event)"></div>`,
         { imports: [NgpSwitch], componentProperties: { checkedChange } },
       );
 
-      fireEvent.keyDown(getByRole('switch'), { key: ' ' });
+      const switchDiv = getByRole('switch');
+      fireEvent.keyDown(switchDiv, { key: ' ' });
+
+      const repeat = new KeyboardEvent('keydown', {
+        key: ' ',
+        repeat: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      switchDiv.dispatchEvent(repeat);
+
       expect(checkedChange).toHaveBeenCalledTimes(1);
+      expect(switchDiv).toHaveAttribute('aria-checked', 'true');
+      // still prevented, otherwise a held Space scrolls the page
+      expect(repeat.defaultPrevented).toBe(true);
+    });
+
+    it('should not toggle on activation keys when a non-button is disabled', async () => {
+      const checkedChange = vi.fn();
+      const { getByRole } = await render(
+        `<div ngpSwitch ngpSwitchDisabled tabindex="0" (ngpSwitchCheckedChange)="checkedChange($event)"></div>`,
+        { imports: [NgpSwitch], componentProperties: { checkedChange } },
+      );
+
+      const switchDiv = getByRole('switch');
+      fireEvent.keyDown(switchDiv, { key: ' ' });
+      fireEvent.keyDown(switchDiv, { key: 'Enter' });
+
+      expect(checkedChange).not.toHaveBeenCalled();
+      expect(switchDiv).toHaveAttribute('aria-checked', 'false');
     });
 
     it('should not toggle on unrelated keys', async () => {

--- a/packages/ng-primitives/switch/src/switch/tests/switch-primitive.test.ts
+++ b/packages/ng-primitives/switch/src/switch/tests/switch-primitive.test.ts
@@ -117,6 +117,42 @@ describe('NgpSwitch', () => {
       expect(checkedChange).toHaveBeenCalledWith(true);
       expect(switchDiv).toHaveAttribute('aria-checked', 'true');
     });
+
+    it('should toggle on the Enter key when the element is not a button', async () => {
+      const checkedChange = vi.fn();
+      const { getByRole } = await render(
+        `<div ngpSwitch tabindex="0" (ngpSwitchCheckedChange)="checkedChange($event)"></div>`,
+        { imports: [NgpSwitch], componentProperties: { checkedChange } },
+      );
+
+      const switchDiv = getByRole('switch');
+      fireEvent.keyDown(switchDiv, { key: 'Enter' });
+
+      expect(checkedChange).toHaveBeenCalledWith(true);
+      expect(switchDiv).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('should not toggle twice when Space is pressed on a non-button (no duplicate handling)', async () => {
+      const checkedChange = vi.fn();
+      const { getByRole } = await render(
+        `<div ngpSwitch tabindex="0" (ngpSwitchCheckedChange)="checkedChange($event)"></div>`,
+        { imports: [NgpSwitch], componentProperties: { checkedChange } },
+      );
+
+      fireEvent.keyDown(getByRole('switch'), { key: ' ' });
+      expect(checkedChange).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not toggle on unrelated keys', async () => {
+      const checkedChange = vi.fn();
+      const { getByRole } = await render(
+        `<div ngpSwitch tabindex="0" (ngpSwitchCheckedChange)="checkedChange($event)"></div>`,
+        { imports: [NgpSwitch], componentProperties: { checkedChange } },
+      );
+
+      fireEvent.keyDown(getByRole('switch'), { key: 'Tab' });
+      expect(checkedChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('controlled mode', () => {

--- a/packages/ng-primitives/switch/src/switch/tests/switch-primitive.test.ts
+++ b/packages/ng-primitives/switch/src/switch/tests/switch-primitive.test.ts
@@ -4,6 +4,12 @@ import { userEvent } from '@testing-library/user-event';
 import { NgpSwitch } from 'ng-primitives/switch';
 import { describe, expect, it, vi } from 'vitest';
 
+function keydown(element: HTMLElement, key: string, repeat = false): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { key, repeat, bubbles: true, cancelable: true });
+  element.dispatchEvent(event);
+  return event;
+}
+
 describe('NgpSwitch', () => {
   describe('roles & attributes', () => {
     it('should render with a generated id and default unchecked state', async () => {
@@ -165,7 +171,7 @@ describe('NgpSwitch', () => {
       expect(button).toHaveAttribute('aria-checked', 'true');
     });
 
-    it('should not toggle repeatedly while an activation key is held on a non-button', async () => {
+    it('should not toggle repeatedly while Space is held on a non-button', async () => {
       const checkedChange = vi.fn();
       const { getByRole } = await render(
         `<div ngpSwitch tabindex="0" (ngpSwitchCheckedChange)="checkedChange($event)"></div>`,
@@ -174,19 +180,30 @@ describe('NgpSwitch', () => {
 
       const switchDiv = getByRole('switch');
       fireEvent.keyDown(switchDiv, { key: ' ' });
+      const repeat = keydown(switchDiv, ' ', true);
 
-      const repeat = new KeyboardEvent('keydown', {
-        key: ' ',
-        repeat: true,
-        bubbles: true,
-        cancelable: true,
-      });
-      switchDiv.dispatchEvent(repeat);
-
+      // a native button activates on keyup, so a held Space toggles once
       expect(checkedChange).toHaveBeenCalledTimes(1);
       expect(switchDiv).toHaveAttribute('aria-checked', 'true');
       // still prevented, otherwise a held Space scrolls the page
       expect(repeat.defaultPrevented).toBe(true);
+    });
+
+    it('should toggle on every repeat while Enter is held on a non-button', async () => {
+      const checkedChange = vi.fn();
+      const { getByRole } = await render(
+        `<div ngpSwitch tabindex="0" (ngpSwitchCheckedChange)="checkedChange($event)"></div>`,
+        { imports: [NgpSwitch], componentProperties: { checkedChange } },
+      );
+
+      const switchDiv = getByRole('switch');
+      fireEvent.keyDown(switchDiv, { key: 'Enter' });
+      keydown(switchDiv, 'Enter', true);
+      keydown(switchDiv, 'Enter', true);
+
+      // a native button clicks on every Enter keydown, autorepeat included
+      expect(checkedChange).toHaveBeenCalledTimes(3);
+      expect(switchDiv).toHaveAttribute('aria-checked', 'true');
     });
 
     it('should not toggle on activation keys when a non-button is disabled', async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue
Closes #916

## What does this PR implement/fix?
`NgpSwitch` was calling `event.preventDefault()` unconditionally on Space keydown. This suppressed the browser's native activation behavior for `<button>` elements (Space triggers a `click` on keyup natively). As a result, Space didn't toggle the switch when it was rendered on a `<button>`, even though Enter did.

Per the WAI-ARIA APG Switch Pattern (https://www.w3.org/WAI/ARIA/apg/patterns/switch/), Space is required to toggle the switch and Enter is optional, regardless of the underlying element.

This PR:
- Updates the keydown handler so both Space and Enter are treated as activation keys, and only intercepted manually (preventDefault + toggle()) when the element is not a button. Native button activation handles both keys through the existing click listener.
- Adds tests covering: Enter toggling a non-button element, no duplicate toggle on Space for non-buttons, and no toggle on unrelated keys.
- Updates the documentation's Keyboard Interactions section:
  - `Space` - Toggle the switch state.
  - `Enter` - Toggle the switch state.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `NgpSwitch` keyboard activation so Space and Enter toggle the switch on both button and non-button elements. Previously Space was prevented on keydown, which blocked native button activation and stopped the toggle on `<button>`; now buttons use native click, and non-buttons handle activation keys directly.

- Treats Space and Enter as activation keys; only non-buttons are intercepted to avoid double toggles from the button's native click.
- Mirrors native button behavior for held keys on non-buttons: a held Space toggles once, while Enter toggles on every repeat; the default is still prevented so a held Space doesn't scroll the page.
- Adds tests for Enter on non-buttons, single vs repeated toggles, disabled switch activation keys, and ignoring unrelated keys.
- Updates docs: Space and Enter both toggle the switch, matching the WAI-ARIA switch pattern; no API changes or migrations.

<sup>Written for commit 003a6ae0d4f6c6c2840be4214c2e8d945b25bff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Switches on non-button elements now toggle with **Space** or **Enter**.
  - Repeated **Space** presses no longer toggle switches multiple times, while repeated **Enter** presses behave consistently.
  - Unrelated keyboard input is ignored, with default behaviour prevented where appropriate.
  - Disabled non-button switches no longer respond to activation keys.
  - Button-based switches retain native keyboard behaviour.

- **Documentation**
  - Updated Switch keyboard interaction guidance to describe Space-key support across switch types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->