### PR TITLE
fix(tabs): isolate roving focus to tab list

### DIFF
--- a/packages/ng-primitives/tabs/src/tab-list/tab-list-state.ts
+++ b/packages/ng-primitives/tabs/src/tab-list/tab-list-state.ts
@@ -1,4 +1,6 @@
+import { signal } from '@angular/core';
 import { injectElementRef } from 'ng-primitives/internal';
+import { ngpRovingFocusGroup } from 'ng-primitives/roving-focus';
 import { attrBinding, createPrimitive, dataBinding } from 'ng-primitives/state';
 import { injectTabsetState } from '../tabset/tabset-state';
 
@@ -20,6 +22,14 @@ export const [NgpTabListStateToken, ngpTabList, injectTabListState, provideTabLi
   createPrimitive('NgpTabList', ({}: NgpTabListProps) => {
     const element = injectElementRef();
     const tabsetState = injectTabsetState();
+
+    ngpRovingFocusGroup({
+      orientation: tabsetState().orientation,
+      disabled: signal(false),
+      wrap: tabsetState().wrap,
+      homeEnd: signal(true),
+      inherit: false,
+    });
 
     // Host bindings
     attrBinding(element, 'role', 'tablist');

--- a/packages/ng-primitives/tabs/src/tab-list/tab-list.ts
+++ b/packages/ng-primitives/tabs/src/tab-list/tab-list.ts
@@ -1,4 +1,5 @@
 import { Directive } from '@angular/core';
+import { provideRovingFocusGroupState } from 'ng-primitives/roving-focus';
 import { ngpTabList, provideTabListState } from './tab-list-state';
 
 /**
@@ -7,7 +8,7 @@ import { ngpTabList, provideTabListState } from './tab-list-state';
 @Directive({
   selector: '[ngpTabList]',
   exportAs: 'ngpTabList',
-  providers: [provideTabListState()],
+  providers: [provideTabListState(), provideRovingFocusGroupState({ inherit: false })],
 })
 export class NgpTabList {
   constructor() {

--- a/packages/ng-primitives/tabs/src/tabset/tabset-state.ts
+++ b/packages/ng-primitives/tabs/src/tabset/tabset-state.ts
@@ -23,6 +23,10 @@ export interface NgpTabsetState {
    * The orientation of the tabset.
    */
   readonly orientation: WritableSignal<NgpOrientation>;
+  /**
+   * Whether keyboard focus wraps around the tab list.
+   */
+  readonly wrap: WritableSignal<boolean>;
 
   /**
    * Whether tabs should activate on focus.
@@ -83,6 +87,10 @@ export interface NgpTabsetProps {
    * The orientation of the tabset.
    */
   readonly orientation?: Signal<NgpOrientation>;
+  /**
+   * Whether keyboard focus wraps around the tab list.
+   */
+  readonly wrap?: Signal<boolean>;
 
   /**
    * Whether tabs should activate on focus.
@@ -102,6 +110,7 @@ export const [NgpTabsetStateToken, ngpTabset, injectTabsetState, provideTabsetSt
       id = signal(uniqueId('ngp-tabset')),
       value: _value = signal(undefined),
       orientation: _orientation = signal('horizontal'),
+      wrap: _wrap = signal(true),
       activateOnFocus: _activateOnFocus = signal(false),
       onValueChange,
     }: NgpTabsetProps) => {
@@ -111,6 +120,7 @@ export const [NgpTabsetStateToken, ngpTabset, injectTabsetState, provideTabsetSt
       // Controlled properties
       const value = controlled(_value);
       const orientation = controlled(_orientation);
+      const wrap = controlled(_wrap);
       const activateOnFocus = controlled(_activateOnFocus);
 
       // Host bindings
@@ -171,6 +181,7 @@ export const [NgpTabsetStateToken, ngpTabset, injectTabsetState, provideTabsetSt
       return {
         id,
         orientation: deprecatedSetter(orientation, 'setOrientation', setOrientation),
+        wrap,
         activateOnFocus: deprecatedSetter(
           activateOnFocus,
           'setActivateOnFocus',

--- a/packages/ng-primitives/tabs/src/tabset/tabset.ts
+++ b/packages/ng-primitives/tabs/src/tabset/tabset.ts
@@ -1,7 +1,6 @@
 import { BooleanInput } from '@angular/cdk/coercion';
-import { booleanAttribute, Directive, input, output, signal } from '@angular/core';
+import { booleanAttribute, Directive, input, output } from '@angular/core';
 import { NgpOrientation } from 'ng-primitives/common';
-import { ngpRovingFocusGroup, provideRovingFocusGroupState } from 'ng-primitives/roving-focus';
 import { uniqueId } from 'ng-primitives/utils';
 import { injectTabsConfig } from '../config/tabs-config';
 import { ngpTabset, provideTabsetState } from './tabset-state';
@@ -12,10 +11,7 @@ import { ngpTabset, provideTabsetState } from './tabset-state';
 @Directive({
   selector: '[ngpTabset]',
   exportAs: 'ngpTabset',
-  providers: [
-    provideTabsetState({ inherit: false }),
-    provideRovingFocusGroupState({ inherit: false }),
-  ],
+  providers: [provideTabsetState({ inherit: false })],
 })
 export class NgpTabset {
   /**
@@ -71,6 +67,7 @@ export class NgpTabset {
     id: this.id,
     value: this.value,
     orientation: this.orientation,
+    wrap: this.wrap,
     activateOnFocus: this.activateOnFocus,
     onValueChange: value => this.valueChange.emit(value),
   });
@@ -80,15 +77,6 @@ export class NgpTabset {
    * Get the id of the selected tab
    */
   readonly selectedTab = this.state.selectedTab;
-
-  constructor() {
-    ngpRovingFocusGroup({
-      orientation: this.orientation,
-      disabled: signal(false),
-      wrap: this.wrap,
-      homeEnd: signal(true),
-    });
-  }
 
   /**
    * Select a tab by its value

--- a/packages/ng-primitives/tabs/src/tabset/tests/tabs-primitive.test.ts
+++ b/packages/ng-primitives/tabs/src/tabset/tests/tabs-primitive.test.ts
@@ -2,6 +2,7 @@ import { Dir } from '@angular/cdk/bidi';
 import { By } from '@angular/platform-browser';
 import { fireEvent, render } from '@testing-library/angular';
 import { NgpTabButton, NgpTabList, NgpTabPanel, NgpTabset } from 'ng-primitives/tabs';
+import { NgpToggleGroup, NgpToggleGroupItem } from 'ng-primitives/toggle-group';
 import { describe, expect, it, vi } from 'vitest';
 
 const imports = [NgpTabset, NgpTabButton, NgpTabList, NgpTabPanel];
@@ -201,6 +202,41 @@ describe('NgpTabset (primitive)', () => {
   });
 
   describe('roving focus (tabindex)', () => {
+    it('should not include nested roving-focus items', async () => {
+      const { getByRole } = await render(
+        `<div ngpTabset>
+          <div ngpTabList>
+            <button ngpTabButton ngpTabButtonValue="overview">Overview</button>
+            <button ngpTabButton ngpTabButtonValue="features">Features</button>
+          </div>
+          <div ngpTabPanel ngpTabPanelValue="overview">
+            <div ngpToggleGroup>
+              <button data-testid="toggle-1" ngpToggleGroupItem ngpToggleGroupItemValue="one">One</button>
+              <button data-testid="toggle-2" ngpToggleGroupItem ngpToggleGroupItemValue="two">Two</button>
+            </div>
+          </div>
+          <div ngpTabPanel ngpTabPanelValue="features">Features content</div>
+        </div>`,
+        {
+          imports: [...imports, NgpToggleGroup, NgpToggleGroupItem],
+        },
+      );
+
+      const overviewTab = getByRole('tab', { name: 'Overview' });
+      const featuresTab = getByRole('tab', { name: 'Features' });
+
+      expect(overviewTab).toHaveAttribute('tabindex', '0');
+      overviewTab.focus();
+      fireEvent.keyDown(overviewTab, { key: 'ArrowLeft' });
+
+      expect(featuresTab).toHaveAttribute('tabindex', '0');
+      expect(document.activeElement).toBe(featuresTab);
+      fireEvent.keyDown(featuresTab, { key: 'ArrowRight' });
+
+      expect(overviewTab).toHaveAttribute('tabindex', '0');
+      expect(document.activeElement).toBe(overviewTab);
+    });
+
     it('should place tabindex="0" on one tab and "-1" on the others', async () => {
       const { getByRole } = await render(threeTabs(), { imports });
 


### PR DESCRIPTION
Closes #929

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## Issue

Closes #929 

## What does this PR implement/fix?

Scopes the tab roving-focus group to `ngpTabList` rather than the entire `ngpTabset`.
Toggle groups and other roving-focus primitives inside tab panels now retain independent keyboard navigation and tab stops.

Adds a regression test covering tab navigation alongside a nested toggle group.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard navigation in the tabs component so roving focus is applied only to the tab list, not the entire tabset. Nested roving-focus primitives such as toggle groups inside tab panels now keep their own keyboard navigation and tab stops.

- Moves the roving-focus group from `ngpTabset` to `ngpTabList`.
- Wires the `wrap` input from the tabset through to the tab list's roving focus group.
- Adds a regression test covering tab navigation alongside a nested toggle group.

Closes #929.

<sup>Written for commit 7517e70eaef3584e6422d65f44f059a347dc8413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable focus wrapping for tab sets, allowing keyboard navigation to loop from the last tab to the first.
  * Improved arrow-key navigation across tab lists with support for Home and End keys.

* **Bug Fixes**
  * Prevented tab-set keyboard navigation from interfering with nested focusable controls, such as toggle groups within tab panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->