### PR TITLE
fix(combobox): ignore synthetic keydown events with no key

### DIFF
--- a/packages/ng-primitives/combobox/src/combobox-input/combobox-input.ts
+++ b/packages/ng-primitives/combobox/src/combobox-input/combobox-input.ts
@@ -121,18 +121,26 @@ export class NgpComboboxInput {
           this.state().openDropdown();
         }
         break;
-      default:
+      default: {
+        // Synthetic events (e.g. browser autofill) can omit `key`.
+        // See angular/components#33359.
+        const key = event.key;
+        if (key == null) {
+          return;
+        }
+
         // Ignore keys with length > 1 (e.g., 'Shift', 'ArrowLeft', 'Enter', etc.)
         // Filter out control/meta key combos (e.g., Ctrl+C)
         if (
-          event.key !== 'Unidentified' &&
-          (event.key.length > 1 || event.ctrlKey || event.metaKey || event.altKey)
+          key !== 'Unidentified' &&
+          (key.length > 1 || event.ctrlKey || event.metaKey || event.altKey)
         ) {
           return;
         }
 
         // if this was a character key, we want to open the dropdown
         this.state().openDropdown();
+      }
     }
   }
 

--- a/packages/ng-primitives/combobox/src/combobox/tests/combobox-primitive.test.ts
+++ b/packages/ng-primitives/combobox/src/combobox/tests/combobox-primitive.test.ts
@@ -721,6 +721,17 @@ describe('NgpComboboxInput', () => {
     await userEvent.type(input, 'Nonexistent Option');
     expect(async () => await userEvent.keyboard('{enter}')).not.toThrow();
   });
+
+  it('should not throw when a synthetic keydown omits key (browser autofill)', async () => {
+    await render(TestComponent);
+    const input = screen.getByRole('combobox');
+
+    const event = new KeyboardEvent('keydown', { bubbles: true });
+    Object.defineProperty(event, 'key', { value: undefined });
+
+    expect(() => input.dispatchEvent(event)).not.toThrow();
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
 });
 
 describe('NgpComboboxPortal', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

Chromium (and other browsers) dispatch a synthetic `keydown` during **autofill** where `event.key` is `undefined`. `NgpComboboxInput.handleKeydown` then reads `event.key.length` in the `default` branch and throws:

```
TypeError: Cannot read properties of undefined (reading 'length')
```

`autocomplete="off"` on the input does not prevent this. We hit this in production on Spark UI combobox fields (hosted check-in forms).

This is the same class of bug Angular fixed in the aria combobox keyboard manager:

- https://github.com/angular/components/issues/33359
- https://github.com/angular/components/pull/33360 (`KeyboardEventManager._isMatch` returns false when `event.key == null`)

## What does this PR implement/fix?

Guard the `default` branch so a missing `key` is ignored (do not open the dropdown). Character keys and `'Unidentified'` (IME) still open as before.

Adds a unit test that dispatches a `keydown` with `key: undefined` and asserts no throw.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes combobox input crash when browser autofill dispatches synthetic keydown events with no `key` value. These events are now ignored instead of throwing a TypeError, and the dropdown remains closed.

<sup>Written for commit f5642fbeedc7d0e9785703d610e4c25b9135eff3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the combobox dropdown from opening when handling synthetic keyboard events without a key value, such as those triggered by browser autofill.
  * Improved stability by safely ignoring incomplete keyboard events.

* **Tests**
  * Added coverage to verify that incomplete keyboard events do not cause errors or open the dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->