### PR TITLE
fix(interactions): avoid NG0600 when a binding disables a focused element

### DIFF
--- a/packages/ng-primitives/interactions/src/focus-visible/focus-visible-interaction.ts
+++ b/packages/ng-primitives/interactions/src/focus-visible/focus-visible-interaction.ts
@@ -1,5 +1,5 @@
 import { FocusMonitor, FocusOrigin } from '@angular/cdk/a11y';
-import { ElementRef, inject, Renderer2, Signal, signal } from '@angular/core';
+import { ElementRef, inject, Renderer2, Signal, signal, untracked } from '@angular/core';
 import { onBooleanChange, safeTakeUntilDestroyed } from 'ng-primitives/utils';
 import { isFocusVisibleEnabled } from '../config/interactions-config';
 
@@ -33,12 +33,19 @@ export function ngpFocusVisible({
   const isFocused = signal<boolean>(false);
 
   // handle focus state
+  //
+  // A browser can dispatch focus or blur synchronously while Angular renders - a binding
+  // writing the DOM `disabled` property of a focused element blurs it there - so the
+  // subscriber would inherit the render pass's reactive consumer and the `isFocused` write
+  // would throw NG0600. `listener` wraps DOM handlers the same way.
   focusMonitor
     .monitor(elementRef.nativeElement)
     .pipe(safeTakeUntilDestroyed())
     .subscribe(origin =>
-      // null indicates the element was blurred
-      origin === null ? onBlur() : onFocus(origin),
+      untracked(() =>
+        // null indicates the element was blurred
+        origin === null ? onBlur() : onFocus(origin),
+      ),
     );
 
   // if the component becomes disabled and it is focused, hide the focus

--- a/packages/ng-primitives/interactions/src/focus-visible/tests/focus-visible.test.ts
+++ b/packages/ng-primitives/interactions/src/focus-visible/tests/focus-visible.test.ts
@@ -1,8 +1,10 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
+import { Component, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { fireEvent, render } from '@testing-library/angular';
 import { NgpFocusVisible, provideInteractionsConfig } from 'ng-primitives/interactions';
 import { describe, expect, it, vi } from 'vitest';
+import { collectUncaughtErrors } from '../../tests/uncaught-errors';
 
 describe('NgpFocusVisible', () => {
   it('should not set data-focus-visible to true when mouse focused', async () => {
@@ -229,6 +231,46 @@ describe('NgpFocusVisible', () => {
     expect(trigger).toHaveAttribute('data-focus-visible');
 
     await container.rerender({ componentProperties: { focusChange, disabled: true } });
+    expect(trigger).not.toHaveAttribute('data-focus-visible');
+  });
+
+  it('should report the blur when a binding disables the focused element', async () => {
+    // A binding that disables a focused element blurs it synchronously, mid-render.
+    @Component({
+      selector: 'ngp-test',
+      imports: [NgpFocusVisible],
+      template: `
+        <input
+          [disabled]="disabled()"
+          (ngpFocusVisible)="focusChange($event)"
+          data-testid="trigger"
+          ngpFocusVisible
+        />
+      `,
+    })
+    class NgpTest {
+      readonly disabled = signal(false);
+      readonly focusChange = vi.fn();
+    }
+
+    const container = await render(NgpTest);
+    const trigger = container.getByTestId('trigger') as HTMLInputElement;
+    const { disabled, focusChange } = container.fixture.componentInstance;
+
+    TestBed.inject(FocusMonitor).focusVia(trigger, 'keyboard');
+    container.detectChanges();
+    expect(focusChange).toHaveBeenLastCalledWith(true);
+    expect(trigger).toHaveAttribute('data-focus-visible');
+
+    const uncaught = await collectUncaughtErrors(() => {
+      disabled.set(true);
+      container.detectChanges();
+    });
+
+    expect(uncaught).toBe('');
+    expect(trigger.disabled).toBe(true);
+    expect(document.activeElement).not.toBe(trigger);
+    expect(focusChange).toHaveBeenLastCalledWith(false);
     expect(trigger).not.toHaveAttribute('data-focus-visible');
   });
 

--- a/packages/ng-primitives/interactions/src/focus/focus-interaction.ts
+++ b/packages/ng-primitives/interactions/src/focus/focus-interaction.ts
@@ -1,5 +1,5 @@
 import { FocusMonitor } from '@angular/cdk/a11y';
-import { ElementRef, Renderer2, Signal, inject, signal } from '@angular/core';
+import { ElementRef, Renderer2, Signal, inject, signal, untracked } from '@angular/core';
 import { safeTakeUntilDestroyed } from 'ng-primitives/utils';
 import { isFocusEnabled } from '../config/interactions-config';
 
@@ -48,27 +48,33 @@ export function ngpFocus({
    */
   const isFocused = signal<boolean>(false);
 
+  // A browser can dispatch focus or blur synchronously while Angular renders - a binding
+  // writing the DOM `disabled` property of a focused element blurs it there - so the
+  // subscriber would inherit the render pass's reactive consumer and the `isFocused` write
+  // would throw NG0600. `listener` wraps DOM handlers the same way.
   focusMonitor
     .monitor(elementRef, focusWithin)
     .pipe(safeTakeUntilDestroyed())
-    .subscribe(focusOrigin => {
-      if (disabled()) {
-        return;
-      }
+    .subscribe(focusOrigin =>
+      untracked(() => {
+        if (disabled()) {
+          return;
+        }
 
-      isFocused.set(focusOrigin !== null);
-      if (focusOrigin !== null) {
-        if (onFocus) {
-          onFocus();
+        isFocused.set(focusOrigin !== null);
+        if (focusOrigin !== null) {
+          if (onFocus) {
+            onFocus();
+          }
+          renderer.setAttribute(elementRef.nativeElement, 'data-focus', '');
+        } else {
+          if (onBlur) {
+            onBlur();
+          }
+          renderer.removeAttribute(elementRef.nativeElement, 'data-focus');
         }
-        renderer.setAttribute(elementRef.nativeElement, 'data-focus', '');
-      } else {
-        if (onBlur) {
-          onBlur();
-        }
-        renderer.removeAttribute(elementRef.nativeElement, 'data-focus');
-      }
-    });
+      }),
+    );
 
   return { isFocused };
 }

--- a/packages/ng-primitives/interactions/src/focus/tests/focus.test.ts
+++ b/packages/ng-primitives/interactions/src/focus/tests/focus.test.ts
@@ -1,6 +1,8 @@
+import { Component, signal } from '@angular/core';
 import { fireEvent, render } from '@testing-library/angular';
 import { NgpFocus, provideInteractionsConfig } from 'ng-primitives/interactions';
 import { describe, expect, it, vi } from 'vitest';
+import { collectUncaughtErrors } from '../../tests/uncaught-errors';
 
 describe('NgpFocus', () => {
   it('should apply the data-focus attribute', async () => {
@@ -51,6 +53,46 @@ describe('NgpFocus', () => {
 
     fireEvent.focus(trigger);
     expect(stateChange).not.toHaveBeenCalled();
+  });
+
+  // A binding that disables a focused element blurs it synchronously, mid-render.
+  it('should report the blur when a binding disables the focused element', async () => {
+    @Component({
+      selector: 'ngp-test',
+      imports: [NgpFocus],
+      template: `
+        <input
+          [disabled]="disabled()"
+          (ngpFocus)="stateChange($event)"
+          data-testid="trigger"
+          ngpFocus
+        />
+      `,
+    })
+    class NgpTest {
+      readonly disabled = signal(false);
+      readonly stateChange = vi.fn();
+    }
+
+    const container = await render(NgpTest);
+    const trigger = container.getByTestId('trigger') as HTMLInputElement;
+    const { disabled, stateChange } = container.fixture.componentInstance;
+
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+    expect(stateChange).toHaveBeenLastCalledWith(true);
+    expect(trigger).toHaveAttribute('data-focus');
+
+    const uncaught = await collectUncaughtErrors(() => {
+      disabled.set(true);
+      container.detectChanges();
+    });
+
+    expect(uncaught).toBe('');
+    expect(trigger.disabled).toBe(true);
+    expect(document.activeElement).not.toBe(trigger);
+    expect(stateChange).toHaveBeenLastCalledWith(false);
+    expect(trigger).not.toHaveAttribute('data-focus');
   });
 
   describe('global configuration', () => {

--- a/packages/ng-primitives/interactions/src/tests/uncaught-errors.ts
+++ b/packages/ng-primitives/interactions/src/tests/uncaught-errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Collect errors the browser reports as uncaught while `run` and the macrotask after it
+ * complete. RxJS rethrows a subscriber error asynchronously, so it never reaches the call
+ * that triggered it. Swallowing each error as well as recording it keeps it from failing the
+ * whole file as an unhandled error.
+ */
+export async function collectUncaughtErrors(run: () => void): Promise<string> {
+  const messages: string[] = [];
+  const onError = (event: ErrorEvent): void => {
+    messages.push(String(event.error?.message ?? event.message));
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  window.addEventListener('error', onError, true);
+
+  try {
+    run();
+  } finally {
+    await new Promise(resolve => setTimeout(resolve));
+    window.removeEventListener('error', onError, true);
+  }
+
+  return messages.join('\n');
+}


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — internal fix, no public API change

## PR Type

- [x] Bugfix

## Issue

No linked issue.

## What does this PR implement/fix?

Writing the DOM `disabled` property of a focused element blurs it synchronously, so
`FocusMonitor` emits while Angular is still rendering the template. The `isFocused` write in
the `ngpFocus` / `ngpFocusVisible` subscribers then inherits the render pass's reactive
consumer and throws `NG0600: Writing to signals is not allowed while Angular renders the
template`, and the blur is lost — the element keeps `data-focus` / `data-focus-visible` and
no `false` is emitted.

Both subscribers now run inside `untracked()`, the same wrapping `listener()` in
`ng-primitives/state` applies to DOM handlers.

Tests assert the state the blur produces (native `disabled` set, focus moved off the element,
`false` emitted, attribute removed) alongside the absence of the error, so silencing the error
while dropping the blur would still fail. Both new tests fail on `next` with NG0600.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes NG0600 errors in `ngpFocus` and `ngpFocusVisible` when a binding disables a focused element during render.

- Writes to the focus signals now run inside `untracked()`, matching how DOM handlers are already wrapped.
- Tests assert the full blur effect (native `disabled` set, focus moved, `false` emitted, attribute removed), so dropping the blur would still fail without the fix.

<sup>Written for commit f81c24ab8aff931af18c2cffb63888cdc71c59ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when focused elements are synchronously blurred or disabled during rendering.
  * Focus and focus-visible state now update correctly, including emitted blur events and removed focus attributes.

* **Tests**
  * Added coverage for disabling focused elements during rendering.
  * Added checks ensuring no uncaught browser errors occur in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->