### PR TITLE
ci(release): cut hotfix releases from a prepared branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       # The default branch, and where PRs merge to. Codecov needs a report on each
       # of its commits to have a baseline to compare pull requests against.
       - next
+      # A hotfix branch is a tree that has never existed anywhere else, so it gets
+      # its own run rather than relying on whoever prepared it locally.
+      - 'hotfix/v*'
   pull_request:
 
 permissions:
@@ -52,6 +55,10 @@ jobs:
           git diff --exit-code -- packages/ng-primitives/schematics/ng-generate/templates \
             || { echo "::error::Schematic templates are stale. Run: nx run ng-primitives:build:templates"; exit 1; }
           pnpm exec nx run ng-primitives:test-node
+
+      # scripts/ is not an nx project, so `nx affected` never covers it.
+      - name: Release script tests
+        run: pnpm test:scripts
 
       - run: pnpm exec nx affected -t lint,build,test
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+# Runs from `next` for an ordinary release, or from a `hotfix/v*` branch prepared
+# by `pnpm release:hotfix` to ship a subset of what is merged. Publishing lives
+# here and nowhere else: npm's trusted publisher is bound to this exact file.
 on:
   workflow_dispatch:
     inputs:
@@ -11,15 +14,28 @@ on:
           - patch
           - minor
           - major
+      publish_only:
+        description: 'Recovery: publish the version already tagged on this ref, without versioning again'
+        type: boolean
+        default: false
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
+permissions: {}
+
+# A release and a hotfix must never interleave.
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release:
+    if: ${{ !inputs.publish_only }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -49,35 +65,360 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Version
-        run: pnpm exec nx release version ${{ inputs.version }}
+      - name: Check the release ref
+        env:
+          REF: ${{ github.ref_name }}
+          BUMP: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          # The exact shape `pnpm release:hotfix` creates - a glob cannot express
+          # "digits only", so the hotfix case is matched with an anchored regex.
+          case "$REF" in
+            next) ;;
+            hotfix/v*)
+              echo "$REF" | grep -qE '^hotfix/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' ||
+                { echo "::error::${REF} is not a hotfix branch this workflow can release."; exit 1; }
 
+              [ "$BUMP" = 'patch' ] ||
+                { echo "::error::A hotfix ships one patch, not a ${BUMP} release."; exit 1; }
+              ;;
+            *)
+              echo "::error::Releases run from next or a hotfix/v* branch, not ${REF}."
+              exit 1
+              ;;
+          esac
+
+      # Both checks exist to stop a half-merged hotfix producing a broken release,
+      # and they run before anything is published so a mistake costs nothing.
+      - name: Check main is merged and the base is current
+        run: |
+          set -euo pipefail
+          git fetch -q origin main --tags
+
+          # A commit that is already tagged has been released. Versioning again here is
+          # how a failed publish turns into a skipped version: the recovery is
+          # publish_only, not another bump.
+          RELEASED=$(git describe --tags --exact-match --match 'v[0-9]*' --exclude '*-*' HEAD 2>/dev/null || true)
+          [ -z "$RELEASED" ] ||
+            { echo "::error::${RELEASED} is already tagged at this commit. To finish a release that failed after tagging, rerun this workflow with publish_only instead of versioning again."; exit 1; }
+
+          git merge-base --is-ancestor origin/main HEAD ||
+            { echo "::error::main is ahead of this branch - an earlier hotfix is unmerged. Merge main into next first."; exit 1; }
+
+          # Plain releases only: a prerelease tag would sort first and break both sides.
+          NEWEST=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
+          # --exclude, not a stricter --match: the glob `v[0-9]*.[0-9]*.[0-9]*` still
+          # admits v1.2.3-rc.1, which would reject a perfectly good release.
+          BASE=$(git describe --tags --abbrev=0 --match 'v[0-9]*' --exclude '*-*' HEAD)
+          [ "$BASE" = "$NEWEST" ] ||
+            { echo "::error::This branch is built on ${BASE} but ${NEWEST} is already released - publishing it would move npm's 'latest' backwards."; exit 1; }
+
+      - name: Version
+        env:
+          BUMP: ${{ inputs.version }}
+        run: pnpm exec nx release version "$BUMP"
+
+      # Validated before it reaches an output: package.json is repository content, and
+      # an unchecked value here could inject extra outputs or shell into later steps.
+      - name: Resolve the version
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./packages/ng-primitives/package.json').version")
+
+          [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] ||
+            { echo "::error::package.json does not hold a plain version - refusing to release it."; exit 1; }
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # Commits the bump and the changelog, tags it, pushes, and creates the
+      # GitHub release - in that order.
+      - name: Changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: pnpm exec nx release changelog "$VERSION"
+
+      - name: Push
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          git push origin --atomic --follow-tags --no-verify \
+            "HEAD:refs/heads/${REF}" HEAD:main
+
+      # Last, because it is the only step that cannot be undone.
       - name: Publish to npm
         run: pnpm exec nx release publish
 
-      - name: Changelog
-        run: |
-          VERSION=$(node -p "require('./packages/ng-primitives/package.json').version")
-          pnpm exec nx release changelog ${VERSION}
+      # By this point the tag, the GitHub release and main have all moved, so the
+      # recovery is to finish the publish - never to cut a new version.
+      - name: How to recover
+        if: failure()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+          REF: ${{ github.ref_name }}
+        run: |
+          {
+            echo "## ❌ Release did not finish"
+            echo
+            if [ -n "${VERSION:-}" ] && git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" > /dev/null 2>&1; then
+              echo "**v${VERSION} is already tagged on the remote**, so this run got at least as far as the changelog."
+              echo
+              echo "Do **not** rerun this workflow normally: it would run \`nx release version\` again and bump past"
+              echo "the version that may be missing from npm. Check what npm has:"
+              echo
+              echo '```'
+              echo "npm view ng-primitives@${VERSION} version"
+              echo '```'
+              echo
+              echo "If it is missing, rerun **this workflow from \`${REF}\` with \`publish_only\` ticked** - that"
+              echo "publishes the version the ref already carries, catches \`main\` up to it, and skips versioning."
 
-      - name: Push to next
-        run: git push origin HEAD:next --follow-tags --no-verify
-
-      - name: Push to main
-        run: git push origin HEAD:main --follow-tags --no-verify
+              if [ "${REF}" != 'next' ]; then
+                echo
+                echo "\`next\` has **not** been back-merged, so the next ordinary release stays blocked by the"
+                echo "'main is merged' check until [main → next](https://github.com/${{ github.repository }}/compare/next...main) lands."
+              fi
+            else
+              echo "**Nothing is tagged on the remote**, so nothing was published and no ref moved."
+              echo
+              echo "Fix the cause and rerun this workflow as normal."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Release Summary
+        env:
+          REF: ${{ github.ref_name }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BUMP: ${{ inputs.version }}
         run: |
+          {
+            echo "## 🚀 Release Complete"
+            echo
+            echo "**Version:** v${VERSION}"
+            echo "**Type:** ${BUMP}"
+            echo "**From:** \`${REF}\`"
+            echo
+            echo "✅ Versions bumped"
+            echo "✅ Changelog updated"
+            echo "✅ Changes committed and tagged"
+            echo "✅ Published to npm"
+            echo "✅ GitHub Release created"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Recovery for a run that tagged and pushed but failed to publish. It versions
+  # nothing - it publishes whatever the ref already carries - so it can safely be
+  # run against a ref whose package.json is already at the released version.
+  republish:
+    name: Publish only
+    if: ${{ inputs.publish_only }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm
+        run: npm install -g npm@11.5.1
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # A tag ref is allowed here and nowhere else: once next moves on from a failed
+      # release, the tag may be the only ref left pointing at that commit. What is
+      # published is guarded by the tag-at-HEAD check below, not by the ref name.
+      - name: Check the release ref
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          SEMVER='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
+          echo "$REF" | grep -qE "^(next|hotfix/v${SEMVER}|v${SEMVER})$" ||
+            { echo "::error::Recovery runs from next, a hotfix/v<version> branch or a v<version> tag, not ${REF}."; exit 1; }
+
+      # The tag has to be on this commit, not merely somewhere in the repository, or
+      # a stale branch could publish contents that were never part of that release.
+      - name: Check this commit is the tagged release
+        id: version
+        run: |
+          set -euo pipefail
           VERSION=$(node -p "require('./packages/ng-primitives/package.json').version")
-          echo "## 🚀 Release Complete" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** v${VERSION}" >> $GITHUB_STEP_SUMMARY
-          echo "**Type:** ${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Versions bumped" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Changelog updated" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Changes committed and tagged" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Published to npm" >> $GITHUB_STEP_SUMMARY
-          echo "✅ GitHub Release created" >> $GITHUB_STEP_SUMMARY
+
+          [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] ||
+            { echo "::error::package.json does not hold a plain version - refusing to publish it."; exit 1; }
+
+          TAGGED=$(git rev-parse -q --verify "refs/tags/v${VERSION}^{commit}") ||
+            { echo "::error::v${VERSION} is not tagged - publish_only only finishes a release that got as far as tagging."; exit 1; }
+
+          [ "$TAGGED" = "$(git rev-parse HEAD)" ] ||
+            { echo "::error::v${VERSION} is tagged at ${TAGGED}, not at this commit. Dispatch publish_only from the ref that was released."; exit 1; }
+
+          NEWEST=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
+          [ "v${VERSION}" = "$NEWEST" ] ||
+            { echo "::error::v${VERSION} is not the newest release (${NEWEST}) - publishing it would move npm's 'latest' backwards."; exit 1; }
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      # The interrupted run may have died between the changelog and the push, leaving
+      # main behind the tag. Completing it here keeps the release commit reachable
+      # once back-merge deletes the hotfix branch.
+      - name: Catch main up to the release
+        run: |
+          set -euo pipefail
+          git fetch -q origin main
+
+          if git merge-base --is-ancestor origin/main HEAD; then
+            git push origin --atomic --follow-tags --no-verify HEAD:main
+          else
+            echo "::error::main is ahead of the release commit - reconcile it before recovering."
+            exit 1
+          fi
+
+      # These targets are plain `npm publish`, which rejects a version already on the
+      # registry. A partial publish would therefore block its own recovery, so only
+      # the packages actually missing are published.
+      - name: Publish what is missing from npm
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          MISSING=()
+
+          for project in ng-primitives state mcp; do
+            name=$(node -p "require('./packages/${project}/package.json').name")
+
+            if npm view "${name}@${VERSION}" version > /dev/null 2>&1; then
+              echo "${name}@${VERSION} is already published - skipping"
+            else
+              MISSING+=("$project")
+            fi
+          done
+
+          if [ ${#MISSING[@]} -eq 0 ]; then
+            echo "::notice::Every package is already published at ${VERSION} - nothing to do."
+          else
+            printf 'publishing: %s\n' "${MISSING[*]}"
+            pnpm exec nx release publish --projects="$(IFS=,; echo "${MISSING[*]}")"
+          fi
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "## 📦 Published v${VERSION}"
+            echo
+            echo "Recovery run - nothing was versioned or tagged; main was caught up to the release commit."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # A hotfix release lands on main without going through next, so next has to be
+  # caught up or the following release collides on the version, duplicates the
+  # changelog entry and cannot fast-forward main. The merge is mechanical - the
+  # picked change is identical on both sides - so it is done here, and escalated
+  # to a pull request only when it isn't.
+  back-merge:
+    name: Back-merge into next
+    needs: [release, republish]
+    # Runs after whichever of the two actually published - a recovery run is exactly
+    # the case where next is still behind, because the original run never got here.
+    if: >-
+      always() && github.ref_name != 'next' &&
+      (needs.release.result == 'success' || needs.republish.result == 'success')
+    runs-on: ubuntu-latest
+    # Merges and opens a pull request - it never publishes, so no id-token here.
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout next
+        uses: actions/checkout@v7
+        with:
+          ref: next
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Merge main into next
+        id: merge
+        env:
+          VERSION: ${{ needs.release.outputs.version || needs.republish.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch -q origin main
+
+          merged=false
+          if git merge --no-edit -m "chore: back-merge v${VERSION} into next" origin/main; then
+            if git push origin HEAD:next --no-verify; then
+              merged=true
+            fi
+          else
+            git merge --abort || true
+          fi
+
+          echo "merged=${merged}" >> "$GITHUB_OUTPUT"
+
+      - name: Open a pull request instead
+        # Also on a hard failure of the merge step, or a published release would be
+        # left with no escalation at all.
+        if: ${{ !cancelled() && steps.merge.outputs.merged != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.release.outputs.version || needs.republish.outputs.version }}
+        run: |
+          gh pr create --base next --head main \
+            --title "chore: back-merge v${VERSION} into next" \
+            --body "The v${VERSION} hotfix could not be merged into \`next\` automatically. Resolve it here - until it lands, the next release is blocked by the 'main is merged' check." ||
+            echo "::warning::Could not open the pull request - open main → next by hand."
+
+          {
+            echo "## ⚠️ Back-merge needs a human"
+            echo
+            echo "v${VERSION} shipped, but \`main\` could not be merged into \`next\` automatically."
+            echo
+            echo "[Open main → next](https://github.com/${{ github.repository }}/compare/next...main)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::v${VERSION} released, but the back-merge into next needs resolving by hand."
+          exit 1
+
+      - name: Delete the hotfix branch
+        if: steps.merge.outputs.merged == 'true' && startsWith(github.ref_name, 'hotfix/v')
+        env:
+          REF: ${{ github.ref_name }}
+        run: |
+          # refs/heads/ is load-bearing: a bare v0.130.2 would resolve to the tag.
+          git push origin --delete "refs/heads/${REF}" || echo "::warning::Could not delete ${REF}."
+
+      - name: Back-merge summary
+        if: steps.merge.outputs.merged == 'true'
+        env:
+          VERSION: ${{ needs.release.outputs.version || needs.republish.outputs.version }}
+        run: |
+          {
+            echo "## ✅ Back-merged into next"
+            echo
+            echo "\`main\` (v${VERSION}) is merged into \`next\`. Ordinary releases can carry on."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,12 @@ When creating a pull request, follow the template at `.github/PULL_REQUEST_TEMPL
 ## Release Process
 
 - Follows Conventional Commits for automated changelog generation
-- Release projects: `ng-primitives` and `state`
-- Use `pnpm release:version` and `pnpm release:publish` commands
+- Release projects: `ng-primitives`, `state` and `mcp`
+- Releases run from the **Release** GitHub Actions workflow, never locally - npm's trusted
+  publisher is bound to `.github/workflows/release.yml`, so a local publish has no OIDC
+  credentials and no provenance
+- To ship a subset of what is on `next`, prepare a branch with `pnpm release:hotfix` and let the
+  workflow release it. See the Releasing section in `CONTRIBUTING.md`
 
 <!-- nx configuration start-->
 <!-- Leave the start & end comments to automatically receive updates. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,41 @@ This can be added as an example in the documentation site, like so:
 <docs-snippet name="button"></docs-snippet>
 ```
 
+## Releasing
+
+Releases run from the **Release** workflow in GitHub Actions - never locally. npm's trusted
+publisher is bound to that one workflow file, so a publish from anywhere else has no OIDC
+credentials and produces a package without provenance.
+
+An ordinary release ships everything merged into `next`: run the workflow from `next` and pick
+`patch`, `minor` or `major`.
+
+### Hotfixes
+
+To ship some of what is on `next` without the rest - an urgent fix while other work is still
+settling - prepare a branch first:
+
+```bash
+pnpm release:hotfix
+```
+
+It lists what is unreleased, cherry-picks the commits you tick onto the last release tag, runs
+lint, build and test against that tree, shows you the changelog it would generate, then pushes
+`hotfix/v<version>` and dispatches the Release workflow against it. Pass `--commits 934,#927` to
+name them by pull request or sha instead of picking, `--dry-run` to stop before anything is
+pushed, and `--resume` to carry on after resolving a cherry-pick conflict. A scripted run needs
+`--yes` alongside `--commits`, since there is no terminal to confirm on.
+
+A hotfix reaches `main` without passing through `next`, so the workflow merges `main` back into
+`next` afterwards and deletes the branch. If that merge conflicts it opens a pull request
+instead - **merge it before the next release**, which is blocked until `main` is an ancestor of
+`next` again.
+
+If a release fails after it has tagged - the job summary tells you which side of that line it
+fell on - do **not** rerun the workflow normally, or it will version again and bump past the
+version missing from npm. Rerun it from the same ref with **`publish_only`** ticked: that
+publishes the version the ref already carries, catches `main` up to it, and versions nothing.
+
 ## Coding standards
 
 ### Naming conventions

--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
     "test:browser": "nx run ng-primitives:test-browser",
     "test:node": "nx run ng-primitives:test-node",
     "build": "NODE_OPTIONS='--max-old-space-size=8192' nx run-many -t build",
-    "release:version": "nx release version minor",
-    "release:changelog": "nx release changelog",
-    "release:publish": "nx release publish && git push origin HEAD:main --no-verify"
+    "test:scripts": "node --test scripts/*.test.mjs",
+    "release:hotfix": "node scripts/hotfix.mjs"
   },
   "devDependencies": {
     "@analogjs/platform": "2.6.0",
@@ -31,6 +30,7 @@
     "@angular/compiler-cli": "21.2.14",
     "@angular/language-service": "21.2.14",
     "@eslint/eslintrc": "^2.1.4",
+    "@inquirer/prompts": "^7.10.1",
     "@nx/angular": "22.7.5",
     "@nx/eslint": "22.7.5",
     "@nx/eslint-plugin": "22.7.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^2.1.4
         version: 2.1.4
+      '@inquirer/prompts':
+        specifier: ^7.10.1
+        version: 7.10.1(@types/node@22.19.1)
       '@nx/angular':
         specifier: 22.7.5
         version: 22.7.5(adb4cae420421510143c9543dad4a6bd)

--- a/scripts/hotfix.lib.mjs
+++ b/scripts/hotfix.lib.mjs
@@ -1,0 +1,144 @@
+// The decisions a hotfix turns on - which commits, in what order, at what version -
+// kept free of git and gh so they can be tested directly.
+
+export class HotfixError extends Error {
+  constructor(message, hint) {
+    super(message);
+    this.name = 'HotfixError';
+    this.hint = hint;
+  }
+}
+
+/** Parses `git log --format=%H%x00%h%x00%s` output into commits, oldest first. */
+export function parseLog(log) {
+  if (!log) return [];
+
+  return log
+    .split('\n')
+    .filter(Boolean)
+    .map(line => {
+      const [sha, short, subject] = line.split('\0');
+      // Dimmed in the picker as unlikely to be wanted - not forbidden, because a
+      // chore(deps) bump of a shipped dependency is a fair thing to hotfix.
+      const noise = /^(docs|chore)(\(.+\))?:/.test(subject);
+      return { sha, short, subject, noise };
+    });
+}
+
+// A semver numeric identifier: no leading zeros, so v01.2.3 is not a release tag.
+const NUMBER = String.raw`(?:0|[1-9]\d*)`;
+const RELEASE_TAG = new RegExp(`^v(${NUMBER})\\.(${NUMBER})\\.(${NUMBER})$`);
+const HOTFIX_BRANCH = new RegExp(`^hotfix/(v${NUMBER}\\.${NUMBER}\\.${NUMBER})$`);
+
+/** The patch version a tag releases next: v0.130.1 -> 0.130.2. */
+export function bumpPatch(tag) {
+  const match = RELEASE_TAG.exec(tag);
+  if (!match) throw new HotfixError(`${tag} is not a plain version tag.`);
+
+  const [, major, minor, patch] = match;
+  return `${major}.${minor}.${Number(patch) + 1}`;
+}
+
+/**
+ * Resolves `--commits 934,#927,c081a23` against the unreleased list. Every token
+ * must name a merged, unreleased commit, and the result is ordered by when the
+ * commits landed rather than how they were typed. `lookupPr` returns null when no
+ * such pull request exists.
+ */
+export function selectCommits(spec, commits, base, { lookupPr, resolveSha }) {
+  const picked = [];
+
+  for (const token of spec.split(/[\s,]+/).filter(Boolean)) {
+    let sha;
+
+    const explicitPr = token.startsWith('#');
+
+    if (explicitPr || /^\d+$/.test(token)) {
+      const pr = token.replace('#', '');
+      const found = lookupPr(pr);
+
+      // A bare number is a pull request; only if no such pull request exists is it
+      // worth trying as a revision, which is how an all-digit short sha gets through.
+      if (!found && !explicitPr) {
+        sha = resolveSha(token);
+        if (!sha) throw new HotfixError(`${token} is neither a pull request nor a commit.`);
+      } else {
+        if (!found) throw new HotfixError(`Could not read PR #${pr}.`);
+
+        const { state, mergeCommit } = found;
+        if (state !== 'MERGED') throw new HotfixError(`PR #${pr} is ${state}, not MERGED.`);
+        if (!mergeCommit?.oid) {
+          throw new HotfixError(
+            `PR #${pr} has no merge commit.`,
+            'Only a squash- or merge-committed PR can be cherry-picked by number.',
+          );
+        }
+        sha = mergeCommit.oid;
+      }
+    } else {
+      sha = resolveSha(token);
+      if (!sha) throw new HotfixError(`${token} is not a commit in this repository.`);
+    }
+
+    const commit = commits.find(candidate => candidate.sha === sha);
+    if (!commit) {
+      throw new HotfixError(
+        `${token} is not in ${base}..next.`,
+        'A hotfix can only ship commits that are merged and unreleased.',
+      );
+    }
+
+    if (!picked.includes(commit)) picked.push(commit);
+  }
+
+  return picked.sort((a, b) => commits.indexOf(a) - commits.indexOf(b));
+}
+
+/**
+ * Resume state is stamped with the branch that owns it, so an abandoned hotfix
+ * cannot feed its leftover picks to a different branch later.
+ */
+export function encodePicks(branch, shas) {
+  return `${[branch, ...shas].join('\n')}\n`;
+}
+
+export function decodePicks(contents, branch) {
+  const [owner, ...shas] = (contents ?? '').split('\n').filter(Boolean);
+  return owner === branch ? shas : [];
+}
+
+/** An already-applied commit fails the same way a conflict does, but needs different advice. */
+export function classifyPickFailure(output) {
+  return /is now empty|nothing to commit/i.test(output) ? 'empty' : 'conflict';
+}
+
+/** The newest tag a patch bump can be derived from, ignoring prereleases and the like. */
+export function pickNewestTag(tags) {
+  return tags.find(tag => RELEASE_TAG.test(tag));
+}
+
+/** The version a hotfix branch names, rejecting anything a release could not carry. */
+export function versionFromBranch(branch) {
+  const match = HOTFIX_BRANCH.exec(branch);
+
+  if (!match) {
+    throw new HotfixError(
+      `${branch} is not a hotfix branch.`,
+      '--resume expects the hotfix/v<major>.<minor>.<patch> branch a previous run created.',
+    );
+  }
+
+  return match[1].slice(1);
+}
+
+/**
+ * Which recorded picks a branch does not already carry. `cherry-pick -x` records
+ * the origin of each applied commit, so a pick that was aborted or skipped rather
+ * than continued still shows as pending and is re-attempted instead of dropped.
+ */
+export function unappliedPicks(pending, log) {
+  // The whole trailer line, so a message merely quoting the phrase cannot be read
+  // as the commit having landed - which would drop it from the release silently.
+  const trailer = sha => new RegExp(String.raw`^\(cherry picked from commit ${sha}\)$`, 'm');
+  return pending.filter(sha => !trailer(sha).test(log ?? ''));
+}

--- a/scripts/hotfix.mjs
+++ b/scripts/hotfix.mjs
@@ -1,0 +1,454 @@
+#!/usr/bin/env node
+// Prepares a hotfix: pick which of next's unreleased commits to ship, cherry-pick
+// them onto the last release tag, verify that tree, and hand the branch to the
+// Release workflow.
+//
+// Publishing deliberately stays in CI. npm's trusted publisher is bound to one
+// exact workflow file (.github/workflows/release.yml), so anything that publishes
+// from anywhere else - including a laptop - loses OIDC and provenance.
+//
+//   pnpm release:hotfix                      pick the commits interactively
+//   pnpm release:hotfix --commits 934,#927   pick them by PR number or sha
+//   pnpm release:hotfix --dry-run            stop before the push and dispatch
+//   pnpm release:hotfix --resume             continue after resolving a conflict
+import { checkbox, confirm } from '@inquirer/prompts';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+import {
+  HotfixError,
+  bumpPatch,
+  classifyPickFailure,
+  decodePicks,
+  encodePicks,
+  parseLog,
+  pickNewestTag,
+  selectCommits,
+  unappliedPicks,
+  versionFromBranch,
+} from './hotfix.lib.mjs';
+
+const RELEASE_PROJECTS = 'ng-primitives,state,mcp';
+
+let options;
+
+try {
+  ({ values: options } = parseArgs({
+    options: {
+      commits: { type: 'string' },
+      'dry-run': { type: 'boolean', default: false },
+      resume: { type: 'boolean', default: false },
+      yes: { type: 'boolean', default: false },
+    },
+  }));
+} catch (error) {
+  console.error(`\n\x1b[31m✗\x1b[0m ${error.message}`);
+  console.error(
+    '  \x1b[2mUsage: pnpm release:hotfix [--commits <prs or shas>] [--dry-run] [--resume] [--yes]\x1b[0m',
+  );
+  process.exit(1);
+}
+
+const dryRun = options['dry-run'];
+const resuming = options.resume;
+
+const bold = s => `\x1b[1m${s}\x1b[0m`;
+const dim = s => `\x1b[2m${s}\x1b[0m`;
+const red = s => `\x1b[31m${s}\x1b[0m`;
+const green = s => `\x1b[32m${s}\x1b[0m`;
+
+function fail(message, hint) {
+  console.error(`\n${red('✗')} ${message}`);
+  if (hint) console.error(`  ${dim(hint)}`);
+  process.exit(1);
+}
+
+function step(message) {
+  console.log(`${green('→')} ${message}`);
+}
+
+function git(...args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function tryGit(...args) {
+  const result = spawnSync('git', args, { encoding: 'utf8' });
+  return { ok: result.status === 0, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+}
+
+function runInherit(command, args) {
+  return spawnSync(command, args, { stdio: 'inherit' }).status === 0;
+}
+
+main().catch(error => {
+  // Ctrl-C out of a prompt is a choice, not a crash.
+  if (error?.name === 'ExitPromptError') process.exit(130);
+  // git and gh throw; report them the way every other failure is reported.
+  fail(error.hint ? error.message : (error.message ?? String(error)).split('\n')[0], error.hint);
+});
+
+async function main() {
+  requireTools();
+
+  const branch = resuming ? resumeBranch() : null;
+  const head = git('rev-parse', '--abbrev-ref', 'HEAD');
+  const returnTo = head === 'HEAD' ? git('rev-parse', 'HEAD') : head;
+
+  // Always: on resume, uncommitted edits would be verified but never pushed.
+  requireCleanTree();
+
+  // Also on resume: a release or back-merge may have landed while a conflict was
+  // being resolved, and the guards below are only meaningful against current refs.
+  step('fetching origin');
+  git('fetch', 'origin', 'next', 'main', '--tags', '--prune');
+
+  const base = newestTag();
+  const version = resuming ? versionFromBranch(branch) : nextVersion(base);
+  const target = resuming ? branch : `hotfix/v${version}`;
+
+  guardBase(base);
+
+  if (resuming && version !== bumpPatch(base)) {
+    fail(
+      `${branch} would release v${version}, but ${base} is now the newest release.`,
+      'Something was released while you were resolving. Start over from the current tag.',
+    );
+  }
+
+  if (!resuming) {
+    const commits = unreleasedCommits(base);
+    if (commits.length === 0) fail(`next has nothing unreleased since ${base}.`);
+
+    const picked = options.commits
+      ? resolve(options.commits, commits, base)
+      : await pick(commits, base);
+
+    if (picked.length === 0) fail('Nothing selected.');
+
+    console.log(`\n${bold(`${base} → v${version}`)} on ${bold(target)}\n`);
+    for (const commit of picked) {
+      console.log(`  ${dim(commit.short)}  ${commit.subject}`);
+    }
+    console.log();
+
+    if (!(await ask(`Cherry-pick ${picked.length === 1 ? 'this' : 'these'} onto ${base}?`))) {
+      process.exit(0);
+    }
+
+    createBranch(target, base);
+    cherryPick(picked, base, target);
+  } else {
+    const pending = unappliedPicks(readPicks(target), git('log', '--format=%B', `${base}..HEAD`));
+
+    if (pending.length > 0) {
+      step(`continuing ${pending.length} remaining cherry-pick(s)`);
+      cherryPick(
+        pending.map(sha => ({ sha, short: sha.slice(0, 8) })),
+        base,
+        target,
+      );
+    }
+  }
+
+  if (git('rev-list', '--count', `${base}..HEAD`) === '0') {
+    fail(
+      `${target} carries nothing beyond ${base} - there is nothing to release.`,
+      `Start over: git checkout - && git branch -D ${target}`,
+    );
+  }
+
+  step('verifying the picked tree - lint, build and test');
+  const verified = runInherit('pnpm', [
+    'exec',
+    'nx',
+    'run-many',
+    '-t',
+    'lint,build,test',
+    `--projects=${RELEASE_PROJECTS}`,
+  ]);
+
+  if (!verified) {
+    fail(
+      'The hotfix tree does not pass lint, build and test.',
+      `Fix it on ${target}, commit, then rerun with --resume.`,
+    );
+  }
+
+  previewChangelog(version);
+
+  if (dryRun) {
+    console.log(`\n${dim('--dry-run: nothing pushed, nothing dispatched.')}`);
+    console.log(
+      dim(`  You are on ${target}. To discard it: git checkout - && git branch -D ${target}`),
+    );
+    return;
+  }
+
+  if (!(await ask(`Push ${target} and dispatch the Release workflow?`))) {
+    console.log(dim(`\nLeft ${target} local. Rerun with --resume when you are ready.`));
+    return;
+  }
+
+  step(`pushing ${target}`);
+  git('push', 'origin', `HEAD:refs/heads/${target}`, '--no-verify');
+
+  step(`dispatching Release against ${target}`);
+  if (
+    !runInherit('gh', ['workflow', 'run', 'release.yml', '--ref', target, '-f', 'version=patch'])
+  ) {
+    fail(
+      'Could not dispatch the workflow.',
+      `Run it by hand: gh workflow run release.yml --ref ${target} -f version=patch`,
+    );
+  }
+
+  // Cosmetic cleanup: the release is already away, so a failure here is a warning,
+  // not a failed run.
+  if (!resuming && !tryGit('checkout', returnTo).ok) {
+    console.error(dim(`  Could not return to ${returnTo}; you are on ${target}.`));
+  }
+
+  console.log(`\n${green('✓')} v${version} is releasing from ${bold(target)}.`);
+  if (resuming) console.log(dim(`  You are still on ${target}; \`git checkout -\` to leave it.`));
+  console.log(dim('  Watch it: gh run watch'));
+  console.log(
+    dim(
+      '  The workflow back-merges main into next itself; check that job before the next release.',
+    ),
+  );
+}
+
+function requireTools() {
+  // Checked even for --dry-run: `nx release changelog` shells out to `gh auth token`
+  // for the preview, so an unauthenticated rehearsal fails several minutes in instead.
+  if (spawnSync('gh', ['auth', 'status'], { stdio: 'ignore' }).status !== 0) {
+    fail('The GitHub CLI is not available or not authenticated.', 'Run: gh auth login');
+  }
+
+  if (resuming && options.commits) {
+    fail(
+      '--commits has no effect with --resume.',
+      'A resume continues the selection already recorded.',
+    );
+  }
+
+  // A resume has nothing to pick, so it only needs the confirmations waived.
+  if (!process.stdin.isTTY && !((options.commits || resuming) && options.yes)) {
+    fail(
+      'No terminal to prompt on.',
+      'Non-interactively, pass --yes plus --commits <prs or shas> (or --resume).',
+    );
+  }
+}
+
+function requireCleanTree() {
+  if (git('status', '--porcelain') !== '') {
+    fail('The working tree is not clean.', 'Commit or stash before cutting a hotfix.');
+  }
+}
+
+function resumeBranch() {
+  const branch = git('rev-parse', '--abbrev-ref', 'HEAD');
+  versionFromBranch(branch);
+
+  if (tryGit('rev-parse', '--verify', 'CHERRY_PICK_HEAD').ok) {
+    fail(
+      'A cherry-pick is still in progress.',
+      'Finish it with `git cherry-pick --continue` (or `--skip` if resolving left nothing to apply), then rerun with --resume.',
+    );
+  }
+  return branch;
+}
+
+function newestTag() {
+  const tag = pickNewestTag(git('tag', '--list', 'v*', '--sort=-v:refname').split('\n'));
+  if (!tag) fail('No release tags found.');
+  return tag;
+}
+
+// A hotfix is always built on the newest tag. `npm publish --tag latest` is
+// hardcoded in project.json, so releasing an older line would drag npm's `latest`
+// backwards for everyone.
+function guardBase(base) {
+  // An unmerged hotfix makes the unreleased list wrong: next does not contain the
+  // last release, so commits already shipped still show up as unreleased.
+  if (!tryGit('merge-base', '--is-ancestor', 'origin/main', 'origin/next').ok) {
+    fail(
+      'main is not merged into next - an earlier hotfix is unmerged.',
+      'Merge the back-merge pull request first, then cut this one.',
+    );
+  }
+
+  // The release pushes the hotfix branch to main, so main has to be behind the tag
+  // it is built on or that push is not a fast-forward.
+  if (!tryGit('merge-base', '--is-ancestor', 'origin/main', `${base}^{commit}`).ok) {
+    fail(
+      `origin/main is ahead of ${base}.`,
+      'Something was pushed to main outside a release; reconcile it before cutting a hotfix.',
+    );
+  }
+}
+
+function unreleasedCommits(base) {
+  // --first-parent lists what landed on next, so a merge commit appears once rather
+  // than alongside the commits it brought in - picking both would abort as empty.
+  // --topo-order, not the default date order: picks are applied parents-first, and
+  // the two only coincide while the history stays linear.
+  return parseLog(
+    git(
+      'log',
+      '--first-parent',
+      '--reverse',
+      '--topo-order',
+      '--format=%H%x00%h%x00%s',
+      `${base}..origin/next`,
+    ),
+  );
+}
+
+function pick(commits, base) {
+  return checkbox({
+    message: `Commits on next since ${base}`,
+    pageSize: 20,
+    loop: false,
+    choices: commits.map(commit => ({
+      value: commit,
+      name: `${commit.short}  ${commit.noise ? dim(commit.subject) : commit.subject}`,
+    })),
+  });
+}
+
+// Non-interactive selection, validated and ordered by the same rules as the picker.
+function resolve(spec, commits, base) {
+  return selectCommits(spec, commits, base, {
+    lookupPr: pr => {
+      const view = spawnSync('gh', ['pr', 'view', pr, '--json', 'state,mergeCommit'], {
+        encoding: 'utf8',
+      });
+
+      if (view.status !== 0) {
+        // No such pull request is an answer; anything else is a failure.
+        if (/could not resolve|not found|no pull requests/i.test(view.stderr ?? '')) return null;
+        throw new HotfixError(`Could not read PR #${pr}.`, view.stderr?.trim().split('\n')[0]);
+      }
+
+      return JSON.parse(view.stdout);
+    },
+    resolveSha: token => {
+      const parsed = tryGit('rev-parse', '--verify', `${token}^{commit}`);
+      return parsed.ok ? parsed.stdout.trim() : null;
+    },
+  });
+}
+
+function nextVersion(tag) {
+  const version = bumpPatch(tag);
+
+  if (tryGit('rev-parse', '--verify', `refs/tags/v${version}`).ok) {
+    fail(`Tag v${version} already exists.`);
+  }
+  return version;
+}
+
+function createBranch(branch, base) {
+  if (tryGit('rev-parse', '--verify', branch).ok) {
+    fail(`Branch ${branch} already exists locally.`, `Delete it: git branch -D ${branch}`);
+  }
+
+  if (git('ls-remote', '--heads', 'origin', branch) !== '') {
+    fail(
+      `Branch ${branch} already exists on origin - an earlier hotfix was prepared but never released.`,
+      `Release it, or delete it: git push origin --delete ${branch}`,
+    );
+  }
+  git('checkout', '-b', branch, base);
+}
+
+// The picks still to apply, kept in .git so a conflict can be resolved and resumed
+// without the file itself dirtying the tree.
+function picksFile() {
+  return join(git('rev-parse', '--absolute-git-dir'), 'hotfix-picks');
+}
+
+function readPicks(branch) {
+  const file = picksFile();
+  return decodePicks(existsSync(file) ? readFileSync(file, 'utf8') : undefined, branch);
+}
+
+function writePicks(branch, shas) {
+  if (shas.length === 0) rmSync(picksFile(), { force: true });
+  else writeFileSync(picksFile(), encodePicks(branch, shas));
+}
+
+function cherryPick(commits, base, branch) {
+  const remaining = commits.map(commit => commit.sha);
+
+  for (const commit of commits) {
+    // A merge commit needs a mainline; a squash commit does not.
+    const parents = git('rev-list', '--parents', '-n', '1', commit.sha).split(' ').length - 1;
+    const args = parents > 1 ? ['cherry-pick', '-x', '-m', '1'] : ['cherry-pick', '-x'];
+
+    const attempt = tryGit(...args, commit.sha);
+
+    if (!attempt.ok) {
+      // An already-applied commit leaves an empty pick, which `--continue` cannot
+      // finish - and it means the selection is wrong, not that a merge needs help.
+      if (classifyPickFailure(attempt.stderr + attempt.stdout) === 'empty') {
+        tryGit('cherry-pick', '--abort');
+        writePicks(branch, []);
+        fail(
+          `${commit.short} has nothing left to apply - its change is already on ${branch}.`,
+          `The run was aborted, so any earlier picks were undone too. Start over without it: git checkout - && git branch -D ${branch}`,
+        );
+      }
+
+      // The conflicted pick stays recorded: --resume decides whether it landed by
+      // looking at the branch, so an --abort cannot silently drop it.
+      writePicks(branch, remaining);
+      console.error(`\n${red('✗')} ${commit.short} does not apply cleanly onto ${base}.`);
+      console.error(dim('\n  The conflict is in your working tree. Resolve it, then:'));
+      console.error(
+        dim('    git cherry-pick --continue    # or --skip, if resolving left nothing to apply'),
+      );
+      console.error(dim('    pnpm release:hotfix --resume'));
+      console.error(
+        dim(
+          `\n  Or start over: git cherry-pick --abort && git checkout - && git branch -D ${branch}`,
+        ),
+      );
+      process.exit(1);
+    }
+
+    remaining.shift();
+    writePicks(branch, remaining);
+  }
+}
+
+function previewChangelog(version) {
+  console.log(`\n${bold('Changelog preview')}\n`);
+  const result = spawnSync('pnpm', ['exec', 'nx', 'release', 'changelog', version, '--dry-run'], {
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    fail('Could not generate the changelog preview.', result.stderr?.trim().split('\n')[0]);
+  }
+
+  const lines = (result.stdout ?? '').split('\n');
+  const start = lines.findIndex(line => line.startsWith('+ ## '));
+  const body = start === -1 ? [] : lines.slice(start).filter(line => line.startsWith('+'));
+  // nx prints the same diff more than once; one copy is enough.
+  const repeat = body.findIndex((line, index) => index > 0 && line.startsWith('+ ## '));
+  const preview = repeat === -1 ? body : body.slice(0, repeat);
+
+  if (preview.length === 0) {
+    console.log(dim('  (nx produced no preview - check `nx release changelog` by hand)'));
+  } else {
+    for (const line of preview) console.log(`  ${line.replace(/^\+ ?/, '')}`);
+  }
+}
+
+function ask(message) {
+  return options.yes ? Promise.resolve(true) : confirm({ message, default: false });
+}

--- a/scripts/hotfix.test.mjs
+++ b/scripts/hotfix.test.mjs
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  HotfixError,
+  bumpPatch,
+  classifyPickFailure,
+  decodePicks,
+  encodePicks,
+  parseLog,
+  pickNewestTag,
+  selectCommits,
+  unappliedPicks,
+  versionFromBranch,
+} from './hotfix.lib.mjs';
+
+const log = [
+  'aaa1\0aaa1\0fix(a): one',
+  'bbb2\0bbb2\0docs: contributor',
+  'ccc3\0ccc3\0fix(b): two',
+].join('\n');
+const commits = parseLog(log);
+const merged = { 934: 'ccc3', 927: 'aaa1' };
+const io = {
+  lookupPr: pr => (merged[pr] ? { state: 'MERGED', mergeCommit: { oid: merged[pr] } } : null),
+  resolveSha: token => (commits.some(commit => commit.sha === token) ? token : null),
+};
+
+describe('parseLog', () => {
+  it('keeps log order and flags bookkeeping commits', () => {
+    assert.equal(commits.length, 3);
+    assert.deepEqual(
+      commits.map(commit => commit.noise),
+      [false, true, false],
+    );
+  });
+
+  it('returns nothing for empty output', () => {
+    assert.deepEqual(parseLog(''), []);
+  });
+
+  it('ignores the trailing newline git leaves behind', () => {
+    assert.equal(parseLog(`${log}\n`).length, 3);
+  });
+});
+
+describe('bumpPatch', () => {
+  it('bumps the patch segment', () => {
+    assert.equal(bumpPatch('v0.130.1'), '0.130.2');
+    assert.equal(bumpPatch('v1.0.9'), '1.0.10');
+  });
+
+  it('rejects a tag that is not plain semver', () => {
+    assert.throws(() => bumpPatch('v0.130.1-beta.1'), HotfixError);
+  });
+
+  it('rejects leading-zero components, which are not valid semver', () => {
+    assert.throws(() => bumpPatch('v01.2.3'), HotfixError);
+    assert.throws(() => bumpPatch('v1.02.3'), HotfixError);
+    assert.throws(() => bumpPatch('v1.2.03'), HotfixError);
+  });
+});
+
+describe('selectCommits', () => {
+  it('applies commits in the order they landed, not the order given', () => {
+    const picked = selectCommits('934,927', commits, 'v0.130.1', io);
+    assert.deepEqual(
+      picked.map(commit => commit.sha),
+      ['aaa1', 'ccc3'],
+    );
+  });
+
+  it('accepts shas, # prefixes and whitespace', () => {
+    const picked = selectCommits('#927 ccc3', commits, 'v0.130.1', io);
+    assert.deepEqual(
+      picked.map(commit => commit.sha),
+      ['aaa1', 'ccc3'],
+    );
+  });
+
+  it('deduplicates a commit named twice', () => {
+    const picked = selectCommits('927,#927,aaa1', commits, 'v0.130.1', io);
+    assert.deepEqual(
+      picked.map(commit => commit.sha),
+      ['aaa1'],
+    );
+  });
+
+  it('refuses a pull request that is not merged', () => {
+    const open = { ...io, lookupPr: () => ({ state: 'OPEN', mergeCommit: null }) };
+    assert.throws(() => selectCommits('930', commits, 'v0.130.1', open), /is OPEN, not MERGED/);
+  });
+
+  it('refuses a merged pull request with no merge commit', () => {
+    const noCommit = { ...io, lookupPr: () => ({ state: 'MERGED', mergeCommit: null }) };
+    assert.throws(() => selectCommits('930', commits, 'v0.130.1', noCommit), /no merge commit/);
+  });
+
+  it('refuses a commit that is not in the unreleased range', () => {
+    const other = { ...io, resolveSha: () => 'zzz9' };
+    assert.throws(
+      () => selectCommits('zzz9', commits, 'v0.130.1', other),
+      /is not in v0.130.1..next/,
+    );
+  });
+
+  it('falls back to a revision when a bare number is not a pull request', () => {
+    const digits = parseLog('1234\x001234\x00fix(c): three');
+    const numericSha = {
+      lookupPr: () => null,
+      resolveSha: token => (token === '1234' ? '1234' : null),
+    };
+    assert.deepEqual(
+      selectCommits('1234', digits, 'v0.130.1', numericSha).map(commit => commit.sha),
+      ['1234'],
+    );
+  });
+
+  it('never falls back to a revision for an explicit # form', () => {
+    const missing = { ...io, lookupPr: () => null };
+    assert.throws(() => selectCommits('#1234', commits, 'v0.130.1', missing), /Could not read PR/);
+  });
+
+  it('refuses a bare number that is neither a pull request nor a revision', () => {
+    const nothing = { lookupPr: () => null, resolveSha: () => null };
+    assert.throws(
+      () => selectCommits('1234', commits, 'v0.130.1', nothing),
+      /neither a pull request nor a commit/,
+    );
+  });
+
+  it('refuses an unknown revision', () => {
+    assert.throws(() => selectCommits('nope', commits, 'v0.130.1', io), /not a commit/);
+  });
+});
+
+describe('pick state', () => {
+  it('round-trips the picks it was given', () => {
+    assert.deepEqual(decodePicks(encodePicks('hotfix/v1.2.3', ['aaa1', 'ccc3']), 'hotfix/v1.2.3'), [
+      'aaa1',
+      'ccc3',
+    ]);
+  });
+
+  it('ignores state left behind by a different branch', () => {
+    // An abandoned hotfix must not feed its leftovers to the next one.
+    assert.deepEqual(decodePicks(encodePicks('hotfix/v1.2.3', ['aaa1']), 'hotfix/v9.9.9'), []);
+  });
+
+  it('treats missing or empty state as nothing to resume', () => {
+    assert.deepEqual(decodePicks(undefined, 'hotfix/v1.2.3'), []);
+    assert.deepEqual(decodePicks('', 'hotfix/v1.2.3'), []);
+    assert.deepEqual(decodePicks(encodePicks('hotfix/v1.2.3', []), 'hotfix/v1.2.3'), []);
+  });
+});
+
+describe('classifyPickFailure', () => {
+  it('recognises an already-applied commit', () => {
+    assert.equal(
+      classifyPickFailure(
+        'The previous cherry-pick is now empty, possibly due to conflict resolution.',
+      ),
+      'empty',
+    );
+    assert.equal(classifyPickFailure('nothing to commit, working tree clean'), 'empty');
+  });
+
+  it('treats anything else as a conflict', () => {
+    assert.equal(
+      classifyPickFailure('CONFLICT (content): Merge conflict in packages/ng-primitives/x.ts'),
+      'conflict',
+    );
+    assert.equal(classifyPickFailure(''), 'conflict');
+  });
+});
+
+describe('bookkeeping commits', () => {
+  it('can be selected deliberately - noise only dims them in the picker', () => {
+    // chore(deps) bumps are legitimately hotfixable, so `noise` is a hint, not a veto.
+    const log = ['aaa1\x00aaa1\x00chore(deps): bump a shipped dependency'].join('\n');
+    const chore = parseLog(log);
+
+    assert.equal(chore[0].noise, true);
+    assert.deepEqual(
+      selectCommits('aaa1', chore, 'v0.130.1', {
+        lookupPr: () => null,
+        resolveSha: token => token,
+      }).map(commit => commit.sha),
+      ['aaa1'],
+    );
+  });
+});
+
+describe('pickNewestTag', () => {
+  it('takes the newest plain release tag', () => {
+    // git has already sorted these by -v:refname.
+    assert.equal(pickNewestTag(['v1.4.0', 'v1.3.0', 'v0.130.1']), 'v1.4.0');
+  });
+
+  it('skips tags a patch bump cannot be derived from', () => {
+    assert.equal(pickNewestTag(['v1.4.0-rc.1', 'v1.3.0']), 'v1.3.0');
+    assert.equal(pickNewestTag(['vnext', 'v1.3.0']), 'v1.3.0');
+    assert.equal(pickNewestTag(['v01.4.0', 'v1.3.0']), 'v1.3.0');
+  });
+
+  it('returns nothing when there is no release tag', () => {
+    assert.equal(pickNewestTag([]), undefined);
+    assert.equal(pickNewestTag(['vnext', '']), undefined);
+  });
+});
+
+describe('versionFromBranch', () => {
+  it('reads the version a hotfix branch names', () => {
+    assert.equal(versionFromBranch('hotfix/v0.130.2'), '0.130.2');
+  });
+
+  it('rejects a branch that is not a hotfix branch', () => {
+    assert.throws(() => versionFromBranch('feat/hotfix-workflow'), HotfixError);
+  });
+
+  it('rejects a hotfix branch whose version is not plain semver', () => {
+    // Otherwise the derived version reaches the dispatch and the release workflow.
+    assert.throws(() => versionFromBranch('hotfix/vfoo'), HotfixError);
+    assert.throws(() => versionFromBranch('hotfix/v1.2'), HotfixError);
+    assert.throws(() => versionFromBranch('hotfix/v01.2.3'), HotfixError);
+  });
+});
+
+describe('unappliedPicks', () => {
+  const log = 'fix(a): one\n\n(cherry picked from commit aaa1)\n';
+
+  it('drops a pick that has landed, so --continue resumes the rest', () => {
+    assert.deepEqual(unappliedPicks(['aaa1', 'ccc3'], log), ['ccc3']);
+  });
+
+  it('keeps a pick that never landed, so an abort cannot silently drop it', () => {
+    // git cherry-pick --abort leaves no trailer: the commit must be re-attempted,
+    // not quietly omitted from the release.
+    assert.deepEqual(unappliedPicks(['aaa1', 'ccc3'], ''), ['aaa1', 'ccc3']);
+  });
+
+  it('is not fooled by the sha appearing outside a cherry-pick trailer', () => {
+    assert.deepEqual(unappliedPicks(['aaa1'], 'see aaa1 for context'), ['aaa1']);
+  });
+
+  it('matches the whole trailer line, not a mention of one', () => {
+    // A message quoting the phrase must not be read as the commit having landed,
+    // or the pick is dropped from the release without a word.
+    const quoted =
+      'revert: undo the backport\n\nthis reverted a (cherry picked from commit aaa1) change\n';
+    assert.deepEqual(unappliedPicks(['aaa1'], quoted), ['aaa1']);
+    assert.deepEqual(unappliedPicks(['aaa1'], '(cherry picked from commit aaa1)'), []);
+  });
+
+  it('handles an empty pending list', () => {
+    assert.deepEqual(unappliedPicks([], log), []);
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

No issue - came out of wanting to release a single fix from `next` without the rest of the unreleased queue.

## What does this PR implement/fix?

Releasing today ships everything merged into `next`. This adds a way to ship a subset.

**`pnpm release:hotfix`** lists what is unreleased, cherry-picks the commits you pick onto the last release tag, runs lint/build/test against that tree, previews the changelog, then pushes `hotfix/v<version>` and dispatches the Release workflow against it. `--commits 934,#927` names them by PR or sha instead of picking, `--dry-run` stops before anything is pushed, `--resume` carries on after a conflict. Commits are validated against `next` and applied in the order they landed, not the order given.

Publishing stays in `release.yml` because npm's trusted publisher is bound to one exact workflow file - a publish from anywhere else has no OIDC credentials and no provenance. The workflow now accepts a `hotfix/v*` ref alongside `next` and, before publishing, refuses:

- a ref that is neither `next` nor `hotfix/v*`
- a hotfix asking for anything other than `patch`
- a branch with `main` unmerged (an earlier hotfix not backed out to `next`)
- a branch built on anything but the newest tag, which would drag npm's `latest` backwards since the publish target hardcodes `--tag latest`

`npm publish` also moves to the end, after the changelog and the pushes, so the only irreversible step runs once everything recoverable has succeeded. A failed run writes recovery guidance to the job summary rather than going silently red.

A hotfix reaches `main` without passing through `next`, so a `back-merge` job merges `main` into `next` and deletes the branch; if that conflicts it opens a PR instead, and the next ordinary release stays blocked until it lands.

### Notes for review

- The decision logic lives in `scripts/hotfix.lib.mjs` with git and gh injected, so it is testable: `pnpm test:scripts` (11 tests, wired into CI since `nx affected` cannot see a plain script).
- `release:version`, `release:changelog` and `release:publish` are removed. `release:publish` ran `nx release publish && git push origin HEAD:main` locally, bypassing every guard, OIDC and provenance.
- `@inquirer/prompts` is pinned to `^7.10.1` to dedupe with the copy `@angular/cli` already pulls.
- **Neither workflow has executed yet**, and the interactive picker has not been rendered in a real terminal - only the `--commits` path has been exercised. Every guard runs before the publish step, so a first attempt fails safe.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The removed `release:*` scripts were maintainer-only and are replaced by the workflow, which is how releases have actually been cut.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ships a selected subset of `next` as a hotfix release instead of everything merged into it.

- `pnpm release:hotfix` cherry-picks chosen commits onto the newest tag, verifies lint/build/test, previews the changelog, then pushes `hotfix/v<version>` and dispatches the Release workflow.
- Commits are picked interactively or named with `--commits 934,#927`; `--dry-run` and `--resume` cover scripted and conflict-recovery runs, with resume state stamped per branch and already-applied commits failing with a distinct message.
- Before publishing, the workflow refuses a ref other than `next` or `hotfix/v*`, a non-patch hotfix, a branch where `main` is unmerged, and a branch not built on the newest tag.
- `npm publish` runs last; a failed run records recovery steps in the job summary, and a `publish_only` dispatch re-publishes an already-tagged version without versioning again, from the tag itself when no branch points at the release commit.
- After a hotfix release, a back-merge job merges `main` into `next` (or opens a PR on conflict) and deletes the branch.
- The maintainer scripts `release:version`, `release:changelog`, and `release:publish` are removed.
- Hotfix branches get their own CI run, and `pnpm test:scripts` covers the hotfix logic since `nx affected` can't see plain scripts.
- The workflow and interactive picker have not run end-to-end yet; only the `--commits` path has been exercised.

<sup>Written for commit 084868460e23189dcd3753eb9f3d7c56692e2c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a guided hotfix release command for selecting specific changes and publishing through the release workflow.
  - Added dry-run, resume, and non-interactive options.
  - Added automated hotfix back-merging into the development branch, with pull-request recovery for conflicts.
  - Improved release validation, hotfix branch support, publishing, and recovery for failed releases.

- **Documentation**
  - Added guidance for standard releases, hotfixes, supported options, and recovery steps.

- **Tests**
  - Added hotfix logic tests and CI coverage for release scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->