### PR TITLE
fix(release): dispatch the workflow from next and name the ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,49 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Runs before anything checks out the target: `ref` is attacker-chosen from the
+  # dispatcher's point of view, and checking it out runs its install scripts with this
+  # workflow's write permissions. Nothing here touches the target's contents.
+  preflight:
+    name: Check the dispatch and the target
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Validate
+        env:
+          REF: ${{ inputs.ref }}
+          BUMP: ${{ inputs.version }}
+          PUBLISH_ONLY: ${{ inputs.publish_only }}
+          DISPATCHED_FROM: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          # This file must be the one on the default branch, or these guards are
+          # whatever the dispatched ref happened to carry.
+          [ "$DISPATCHED_FROM" = 'next' ] ||
+            { echo "::error::Dispatch this workflow from next and name the target with the ref input - running it from ${DISPATCHED_FROM} uses that branch's copy of release.yml."; exit 1; }
+
+          SEMVER='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
+
+          if [ "$PUBLISH_ONLY" = 'true' ]; then
+            # A tag is allowed only here: once next moves on from a failed release, the
+            # tag may be the only ref left pointing at that commit.
+            echo "$REF" | grep -qE "^(next|hotfix/v${SEMVER}|v${SEMVER})$" ||
+              { echo "::error::Recovery runs against next, a hotfix/v<version> branch or a v<version> tag, not ${REF}."; exit 1; }
+          else
+            echo "$REF" | grep -qE "^(next|hotfix/v${SEMVER})$" ||
+              { echo "::error::Releases run against next or a hotfix/v<version> branch, not ${REF}."; exit 1; }
+
+            case "$REF" in
+              hotfix/v*)
+                [ "$BUMP" = 'patch' ] ||
+                  { echo "::error::A hotfix ships one patch, not a ${BUMP} release."; exit 1; }
+                ;;
+            esac
+          fi
+
   release:
+    needs: preflight
     if: ${{ !inputs.publish_only }}
     runs-on: ubuntu-latest
     permissions:
@@ -74,35 +116,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Check the release ref
-        env:
-          REF: ${{ inputs.ref }}
-          BUMP: ${{ inputs.version }}
-          DISPATCHED_FROM: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-
-          # This file must be the one on the default branch, or the guards below are
-          # whatever the dispatched ref happened to carry.
-          [ "$DISPATCHED_FROM" = 'next' ] ||
-            { echo "::error::Dispatch this workflow from next and name the target with the ref input - running it from ${DISPATCHED_FROM} uses that branch's copy of release.yml."; exit 1; }
-          # The exact shape `pnpm release:hotfix` creates - a glob cannot express
-          # "digits only", so the hotfix case is matched with an anchored regex.
-          case "$REF" in
-            next) ;;
-            hotfix/v*)
-              echo "$REF" | grep -qE '^hotfix/v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$' ||
-                { echo "::error::${REF} is not a hotfix branch this workflow can release."; exit 1; }
-
-              [ "$BUMP" = 'patch' ] ||
-                { echo "::error::A hotfix ships one patch, not a ${BUMP} release."; exit 1; }
-              ;;
-            *)
-              echo "::error::Releases run from next or a hotfix/v* branch, not ${REF}."
-              exit 1
-              ;;
-          esac
 
       # Both checks exist to stop a half-merged hotfix producing a broken release,
       # and they run before anything is published so a mistake costs nothing.
@@ -227,6 +240,7 @@ jobs:
   # run against a ref whose package.json is already at the released version.
   republish:
     name: Publish only
+    needs: preflight
     if: ${{ inputs.publish_only }}
     runs-on: ubuntu-latest
     permissions:
@@ -259,18 +273,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-
-      # A tag ref is allowed here and nowhere else: once next moves on from a failed
-      # release, the tag may be the only ref left pointing at that commit. What is
-      # published is guarded by the tag-at-HEAD check below, not by the ref name.
-      - name: Check the release ref
-        env:
-          REF: ${{ inputs.ref }}
-        run: |
-          set -euo pipefail
-          SEMVER='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
-          echo "$REF" | grep -qE "^(next|hotfix/v${SEMVER}|v${SEMVER})$" ||
-            { echo "::error::Recovery runs from next, a hotfix/v<version> branch or a v<version> tag, not ${REF}."; exit 1; }
 
       # The tag has to be on this commit, not merely somewhere in the repository, or
       # a stale branch could publish contents that were never part of that release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,20 @@
 name: Release
 
-# Runs from `next` for an ordinary release, or from a `hotfix/v*` branch prepared
-# by `pnpm release:hotfix` to ship a subset of what is merged. Publishing lives
-# here and nowhere else: npm's trusted publisher is bound to this exact file.
+# Always dispatch this from `next`, and name what to release with the `ref` input:
+# workflow_dispatch loads the workflow file from the ref it is dispatched against, so
+# dispatching against a hotfix branch would run whatever release.yml that branch was
+# cut from - which is the release tag, and therefore always an older file.
+#
+# `ref` is `next` for an ordinary release, or a `hotfix/v*` branch prepared by
+# `pnpm release:hotfix` to ship a subset of what is merged. Publishing lives here and
+# nowhere else: npm's trusted publisher is bound to this exact file.
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: 'Branch or tag to release (default: next)'
+        type: string
+        default: next
       version:
         description: 'Version bump type'
         required: true
@@ -40,6 +49,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -67,10 +77,16 @@ jobs:
 
       - name: Check the release ref
         env:
-          REF: ${{ github.ref_name }}
+          REF: ${{ inputs.ref }}
           BUMP: ${{ inputs.version }}
+          DISPATCHED_FROM: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+
+          # This file must be the one on the default branch, or the guards below are
+          # whatever the dispatched ref happened to carry.
+          [ "$DISPATCHED_FROM" = 'next' ] ||
+            { echo "::error::Dispatch this workflow from next and name the target with the ref input - running it from ${DISPATCHED_FROM} uses that branch's copy of release.yml."; exit 1; }
           # The exact shape `pnpm release:hotfix` creates - a glob cannot express
           # "digits only", so the hotfix case is matched with an anchored regex.
           case "$REF" in
@@ -141,7 +157,7 @@ jobs:
 
       - name: Push
         env:
-          REF: ${{ github.ref_name }}
+          REF: ${{ inputs.ref }}
         run: |
           git push origin --atomic --follow-tags --no-verify \
             "HEAD:refs/heads/${REF}" HEAD:main
@@ -156,7 +172,7 @@ jobs:
         if: failure()
         env:
           VERSION: ${{ steps.version.outputs.version }}
-          REF: ${{ github.ref_name }}
+          REF: ${{ inputs.ref }}
         run: |
           {
             echo "## ❌ Release did not finish"
@@ -188,7 +204,7 @@ jobs:
 
       - name: Release Summary
         env:
-          REF: ${{ github.ref_name }}
+          REF: ${{ inputs.ref }}
           VERSION: ${{ steps.version.outputs.version }}
           BUMP: ${{ inputs.version }}
         run: |
@@ -223,6 +239,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -248,7 +265,7 @@ jobs:
       # published is guarded by the tag-at-HEAD check below, not by the ref name.
       - name: Check the release ref
         env:
-          REF: ${{ github.ref_name }}
+          REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           SEMVER='(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)'
@@ -341,7 +358,7 @@ jobs:
     # Runs after whichever of the two actually published - a recovery run is exactly
     # the case where next is still behind, because the original run never got here.
     if: >-
-      always() && github.ref_name != 'next' &&
+      always() && inputs.ref != 'next' &&
       (needs.release.result == 'success' || needs.republish.result == 'success')
     runs-on: ubuntu-latest
     # Merges and opens a pull request - it never publishes, so no id-token here.
@@ -405,9 +422,9 @@ jobs:
           exit 1
 
       - name: Delete the hotfix branch
-        if: steps.merge.outputs.merged == 'true' && startsWith(github.ref_name, 'hotfix/v')
+        if: steps.merge.outputs.merged == 'true' && startsWith(inputs.ref, 'hotfix/v')
         env:
-          REF: ${{ github.ref_name }}
+          REF: ${{ inputs.ref }}
         run: |
           # refs/heads/ is load-bearing: a bare v0.130.2 would resolve to the tag.
           git push origin --delete "refs/heads/${REF}" || echo "::warning::Could not delete ${REF}."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,8 +119,14 @@ Releases run from the **Release** workflow in GitHub Actions - never locally. np
 publisher is bound to that one workflow file, so a publish from anywhere else has no OIDC
 credentials and produces a package without provenance.
 
-An ordinary release ships everything merged into `next`: run the workflow from `next` and pick
-`patch`, `minor` or `major`.
+**Always dispatch the workflow from `next`**, and name what to release with the `ref` input.
+`workflow_dispatch` loads the workflow file from the ref it runs against, so dispatching against
+a hotfix branch would run whatever `release.yml` that branch's release tag was cut from - an
+older file, without the current guards. The workflow refuses to run if dispatched from anywhere
+but `next`.
+
+An ordinary release ships everything merged into `next`: run the workflow from `next`, leave
+`ref` as `next`, and pick `patch`, `minor` or `major`.
 
 ### Hotfixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,8 @@ pnpm release:hotfix
 
 It lists what is unreleased, cherry-picks the commits you tick onto the last release tag, runs
 lint, build and test against that tree, shows you the changelog it would generate, then pushes
-`hotfix/v<version>` and dispatches the Release workflow against it. Pass `--commits 934,#927` to
+`hotfix/v<version>` and dispatches the Release workflow from `next`, passing that branch as the
+`ref` input - never from the hotfix branch itself, which the preflight refuses. Pass `--commits 934,#927` to
 name them by pull request or sha instead of picking, `--dry-run` to stop before anything is
 pushed, and `--resume` to carry on after resolving a cherry-pick conflict. A scripted run needs
 `--yes` alongside `--commits`, since there is no terminal to confirm on.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,11 +119,16 @@ Releases run from the **Release** workflow in GitHub Actions - never locally. np
 publisher is bound to that one workflow file, so a publish from anywhere else has no OIDC
 credentials and produces a package without provenance.
 
-**Always dispatch the workflow from `next`**, and name what to release with the `ref` input.
-`workflow_dispatch` loads the workflow file from the ref it runs against, so dispatching against
-a hotfix branch would run whatever `release.yml` that branch's release tag was cut from - an
-older file, without the current guards. The workflow refuses to run if dispatched from anywhere
-but `next`.
+Two different refs are involved, and it is worth keeping them apart:
+
+- **Where the workflow is dispatched from** - always `next`. `workflow_dispatch` loads the
+  workflow file from the ref it runs against, so dispatching against a hotfix branch would run
+  whatever `release.yml` that branch's release tag was cut from: an older file, without the
+  current guards. Every path, releases and recoveries alike, refuses to run when dispatched
+  from anywhere else.
+- **What gets released** - the `ref` input. `next` for an ordinary release, a `hotfix/v<version>`
+  branch for a hotfix, and for a `publish_only` recovery a `v<version>` tag as well, since a
+  failed release can leave no branch pointing at the commit.
 
 An ordinary release ships everything merged into `next`: run the workflow from `next`, leave
 `ref` as `next`, and pick `patch`, `minor` or `major`.

--- a/scripts/hotfix.mjs
+++ b/scripts/hotfix.mjs
@@ -193,14 +193,24 @@ async function main() {
   step(`pushing ${target}`);
   git('push', 'origin', `HEAD:refs/heads/${target}`, '--no-verify');
 
+  // Dispatched from next, not from the hotfix branch: workflow_dispatch loads the
+  // workflow file from the ref it runs against, and a hotfix branch carries whatever
+  // release.yml its release tag was cut from.
+  const dispatch = [
+    'workflow',
+    'run',
+    'release.yml',
+    '--ref',
+    'next',
+    '-f',
+    'version=patch',
+    '-f',
+    `ref=${target}`,
+  ];
+
   step(`dispatching Release against ${target}`);
-  if (
-    !runInherit('gh', ['workflow', 'run', 'release.yml', '--ref', target, '-f', 'version=patch'])
-  ) {
-    fail(
-      'Could not dispatch the workflow.',
-      `Run it by hand: gh workflow run release.yml --ref ${target} -f version=patch`,
-    );
+  if (!runInherit('gh', dispatch)) {
+    fail('Could not dispatch the workflow.', `Run it by hand: gh ${dispatch.join(' ')}`);
   }
 
   // Cosmetic cleanup: the release is already away, so a failure here is a warning,


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ng-primitives/ng-primitives/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation changes
- [ ] Other... Please describe:

## Issue

No issue - found by releasing v0.130.2 through #935 and watching it fail.

## What does this PR implement/fix?

`workflow_dispatch` loads the workflow file **from the ref it is dispatched against**. `release:hotfix` dispatched Release against the hotfix branch, and a hotfix branch is cut from the last release tag - so the run used whatever `release.yml` that tag carried, which is always an older file.

v0.130.2 was released exactly this way. The run used the pre-#935 workflow: it published all three packages successfully, then failed at `Push to next` (correctly rejected as a non-fast-forward), with none of #935's guards, recovery path or back-merge job present. `main` had to be advanced and back-merged by hand afterwards. Nothing in #935 was wrong - the file simply was not the one that ran.

It would not have healed on its own: `v0.130.2` is `v0.130.1` + one fix + the release commit, so it does not contain the new workflow either, and the next hotfix would have repeated it.

**Fix:** Release takes a `ref` input naming what to release, and is always dispatched from `next`, so the workflow file is the one on the default branch while the job checks out the ref being released.

- `release` and `republish` check out `${{ inputs.ref }}`; `back-merge` still checks out `next`
- every `github.ref_name` guard now reads `inputs.ref`
- the workflow refuses to run when dispatched from anywhere but `next` - the mistake is otherwise invisible from inside the run
- `pnpm release:hotfix` dispatches `--ref next -f ref=hotfix/v<version>`

npm's trusted publisher is bound to the workflow filename, so it is unaffected.

### Verification

The guards were exercised by running the step's script directly:

```
from next               ref next               patch  -> allowed
from next               ref hotfix/v0.130.3    patch  -> allowed
from next               ref hotfix/v0.130.3    minor  -> REFUSED: A hotfix ships one patch, not a minor release.
from next               ref hotfix/vfoo        patch  -> REFUSED: hotfix/vfoo is not a hotfix branch this workflow can release.
from hotfix/v0.130.3    ref hotfix/v0.130.3    patch  -> REFUSED: dispatch from next...
from some-branch        ref next               patch  -> REFUSED: dispatch from next...
```

33 script tests pass; 31 `run:` blocks parse under `bash -n`; no inline expressions remain in any `run:` block. A `--dry-run` against the new base produces `v0.130.2 -> v0.130.3` correctly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The `ref` input defaults to `next`, so an ordinary release is dispatched exactly as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hotfix releases running an older copy of the release workflow by always dispatching from `next` and naming the release target with a `ref` input.

- `workflow_dispatch` loads the workflow file from the ref it is dispatched against, so hotfix runs used the `release.yml` from the branch's release tag, missing the current guards, recovery path, and back-merge job.
- Validation now runs in a new preflight job that checks out nothing, so an invalid target never executes install scripts with the workflow's write permissions.
- The workflow checks out `inputs.ref` and refuses to run when dispatched from anywhere but `next`.
- `pnpm release:hotfix` now dispatches against `next` with the hotfix branch passed as the `ref` input.
- `ref` defaults to `next`, so ordinary releases are unchanged.
- Contributing docs now separate the dispatch ref from the release target, including tag refs for recovery runs.

<sup>Written for commit 6e7c1d61c98382e102a452823fb4282b551335a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ng-primitives/ng-primitives/pull/936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release workflows support explicit branch or tag targets.
  * Hotfix releases can be initiated through the standard release workflow from `next`.

* **Bug Fixes**
  * Release validation now runs before release jobs begin, rejecting invalid dispatch sources and targets.
  * Hotfix releases target the specified hotfix branch while dispatching from `next`.

* **Documentation**
  * Updated release guidance clarifies target selection for standard releases, hotfixes and recovery publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->